### PR TITLE
retrieve Saxon processor from Maven repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
     # install xspec
-    - git clone -b feature/saxon https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b develop https://github.com/xspec/xspec.git /tmp/xspec
     # install saxon
     - mkdir -p /tmp/xspec/saxon 
     - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ before_script:
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    # install saxon
-    - mkdir -p /tmp/saxon 
-    - wget -O /tmp/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
-    - chmod +x /tmp/saxon/saxon9he.jar
-    - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
     # install xspec
     - git clone -b feature/saxon https://github.com/xspec/xspec.git /tmp/xspec
+    # install saxon
+    - mkdir -p /tmp/xspec/saxon 
+    - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
+    - chmod +x /tmp/xspec/saxon/saxon9he.jar
+    - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
 
 script:
     - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
     # install saxon
     - mkdir -p /tmp/saxon 
     - wget -O /tmp/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
-    # - chmod +x /tmp/saxon/saxon9he.jar
+    - chmod +x /tmp/saxon/saxon9he.jar
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
     # install xspec
     - git clone -b feature/saxon https://github.com/xspec/xspec.git /tmp/xspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 before_script:
+    # install bats
     - git clone https://github.com/sstephenson/bats.git /tmp/bats
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    - git clone -b develop https://github.com/xspec/xspec.git /tmp/xspec
+    # install saxon
+    - mkdir -p /tmp/saxon 
+    - wget -O /tmp/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
+    # - chmod +x /tmp/saxon/saxon9he.jar
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
+    # install xspec
+    - git clone -b feature/saxon https://github.com/xspec/xspec.git /tmp/xspec
 
 script:
     - cd test

--- a/saxon/README.md
+++ b/saxon/README.md
@@ -1,1 +1,0 @@
-The Saxon processor is a product of [Saxonica](http://www.saxonica.com). From version 9.5, the open-source Saxon-HE product is offered under the [Mozilla Public License version 2.0](https://www.mozilla.org/en-US/MPL/2.0/).


### PR DESCRIPTION
As described in #20, retrieve Saxon from a Maven repository instead of uploading the binaries in XSpec.