### PR TITLE
use lazy evaluation to fix data type error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    - git clone -b bugfix/lazy-evaluation https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b bugfix/lazy-evaluation https://github.com/xspec/xspec.git /tmp/xspec
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
 
 script:

--- a/src/compiler/generate-query-utils.xql
+++ b/src/compiler/generate-query-utils.xql
@@ -64,7 +64,7 @@ declare function test:node-deep-equal($node1 as node(), $node2 as node()) as xs:
       let $atts2 as attribute()* := test:sort-named-nodes($node2/@*)
         return
           if ( test:deep-equal($atts1, $atts2) ) then
-            if ( $node1/text() = '...' and fn:count($node1/node()) = 1 ) then
+            if ( fn:count($node1/node()) = 1 and $node1/text() = '...' ) then
               fn:true()
             else
               test:deep-equal(test:sorted-children($node1), test:sorted-children($node2))
@@ -80,9 +80,9 @@ declare function test:node-deep-equal($node1 as node(), $node2 as node()) as xs:
             or ( $node1 instance of processing-instruction()
                  and $node2 instance of processing-instruction()) ) then
     fn:node-name($node1) eq fn:node-name($node2)
-      and ( $node1 = '...' or fn:string($node1) eq fn:string($node2) )
+      and ( fn:string($node1) eq fn:string($node2) or $node1 = '...' )
   else if ( $node1 instance of comment() and $node2 instance of comment() ) then
-    $node1 = '...' or fn:string($node1) eq fn:string($node2)
+    fn:string($node1) eq fn:string($node2) or $node1 = '...' 
   else
     fn:false()
 };

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -450,11 +450,12 @@
                     ($node1 instance of processing-instruction() and
                      $node2 instance of processing-instruction())">
       <xsl:sequence select="node-name($node1) eq node-name($node2) and
-                            ($node1 = '...' or string($node1) eq string($node2))" />      
+                            (string($node1) eq string($node2) or $node1 = '...')" />      
+
     </xsl:when>
     <xsl:when test="$node1 instance of comment() and
                     $node2 instance of comment()">
-      <xsl:sequence select="$node1 = '...' or string($node1) eq string($node2)" />
+      <xsl:sequence select="string($node1) eq string($node2) or $node1 = '...'" />
     </xsl:when>
     <xsl:otherwise>
       <xsl:sequence select="false()" />

--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -6,113 +6,89 @@
 <!--  Tags:                                                                -->
 <!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-
 <?oxygen RNGSchema="http://xspec.googlecode.com/svn/trunk/xspec.rnc" type="compact"?>
-
-<t:description xmlns:t="http://www.jenitennison.com/xslt/xspec"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:test="http://www.jenitennison.com/xslt/unit-test"
-               query="http://www.jenitennison.com/xslt/unit-test"
-               query-at="../src/compiler/generate-query-utils.xql"
-               stylesheet="../src/compiler/generate-tests-utils.xsl">
-
-   <!--
+<t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" query="http://www.jenitennison.com/xslt/unit-test" query-at="../src/compiler/generate-query-utils.xql" stylesheet="../src/compiler/generate-tests-utils.xsl">
+  <!--
        Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
    -->
-
-   <!--
+  <!--
        Function test:deep-equal($seq1, $seq2).
    -->
-   <t:scenario label="test:deep-equal($seq1, $seq2)">
-
-      <t:scenario label="Identical Sequences">
-         <t:call function="test:deep-equal">
-            <t:param select="1, 2"/>
-            <t:param select="1, 2"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq true()"/>
-         <t:expect label="the result" assert="$x:result eq true()"/>
-      </t:scenario>
-
-      <t:scenario label="Non-Identical Sequences">
-         <t:call function="test:deep-equal">
-            <t:param select="1, 2"/>
-            <t:param select="1, 3"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq false()"/>
-         <t:expect label="the result" assert="$x:result eq false()"/>
-      </t:scenario>
-
-      <t:scenario label="Sequences with Same Items in Different Orders">
-         <t:call function="test:deep-equal">
-            <t:param select="1, 2"/>
-            <t:param select="2, 1"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq false()"/>
-         <t:expect label="the result" assert="$x:result eq false()"/>
-      </t:scenario>
-
-      <t:scenario label="Empty Sequences">
-         <t:call function="test:deep-equal">
-            <t:param select="()"/>
-            <t:param select="()"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq true()"/>
-         <t:expect label="the result" assert="$x:result eq true()"/>
-      </t:scenario>
-
-      <t:scenario label="One empty sequence">
-         <t:call function="test:deep-equal">
-            <t:param select="()"/>
-            <t:param select="1"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq false()"/>
-         <t:expect label="the result" assert="$x:result eq false()"/>
-      </t:scenario>
-
-      <t:scenario label="A text node and several text nodes">
-         <t:variable name="elems" as="element()+">
-            <e>foo</e>
-            <e>bar</e>
-         </t:variable>
-         <t:call function="test:deep-equal">
-            <t:param as="text()">foobar</t:param>
-            <t:param select="$elems/text()"/>
-         </t:call>
-         <t:expect label="the result" test="$x:result eq true()"/>
-         <t:expect label="the result" assert="$x:result eq true()"/>
-      </t:scenario>
-
-   </t:scenario>
-
+  <t:scenario label="test:deep-equal($seq1, $seq2)">
+    <t:scenario label="Identical Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="1, 2"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+      <t:expect label="the result" assert="$x:result eq true()"/>
+    </t:scenario>
+    <t:scenario label="Non-Identical Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="1, 3"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+      <t:expect label="the result" assert="$x:result eq false()"/>
+    </t:scenario>
+    <t:scenario label="Sequences with Same Items in Different Orders">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="2, 1"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+      <t:expect label="the result" assert="$x:result eq false()"/>
+    </t:scenario>
+    <t:scenario label="Empty Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="()"/>
+        <t:param select="()"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+      <t:expect label="the result" assert="$x:result eq true()"/>
+    </t:scenario>
+    <t:scenario label="One empty sequence">
+      <t:call function="test:deep-equal">
+        <t:param select="()"/>
+        <t:param select="1"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+      <t:expect label="the result" assert="$x:result eq false()"/>
+    </t:scenario>
+    <t:scenario label="A text node and several text nodes">
+      <t:variable name="elems" as="element()+">
+        <e>foo</e>
+        <e>bar</e>
+      </t:variable>
+      <t:call function="test:deep-equal">
+        <t:param as="text()">foobar</t:param>
+        <t:param select="$elems/text()"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+      <t:expect label="the result" assert="$x:result eq true()"/>
+    </t:scenario>
+  </t:scenario>
+  <!--
+       Function test:node-deep-equal($seq1, $seq2).
+   -->
+  <t:scenario label="test:node-deep-equal($seq1, $seq2)">
+    <t:scenario label="Identical Element Sequences">
+      <t:call function="test:node-deep-equal">
+        <t:param name="node1">foobar</t:param>
+        <t:param name="node2">foobar</t:param>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+    <t:scenario label="Identical Attribute Sequences">
+      <t:call function="test:node-deep-equal">
+        <t:param name="node1" select="/node/@attribute" as="node()">
+          <node attribute="foobar"/>
+        </t:param>
+        <t:param name="node2" select="/node/@attribute" as="node()">
+          <node attribute="foobar"/>
+        </t:param>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+  </t:scenario>
 </t:description>
-
-
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
-<!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
-<!--                                                                       -->
-<!-- The contents of this file are subject to the MIT License (see the URI -->
-<!-- http://www.opensource.org/licenses/mit-license.php for details).      -->
-<!--                                                                       -->
-<!-- Permission is hereby granted, free of charge, to any person obtaining -->
-<!-- a copy of this software and associated documentation files (the       -->
-<!-- "Software"), to deal in the Software without restriction, including   -->
-<!-- without limitation the rights to use, copy, modify, merge, publish,   -->
-<!-- distribute, sublicense, and/or sell copies of the Software, and to    -->
-<!-- permit persons to whom the Software is furnished to do so, subject to -->
-<!-- the following conditions:                                             -->
-<!--                                                                       -->
-<!-- The above copyright notice and this permission notice shall be        -->
-<!-- included in all copies or substantial portions of the Software.       -->
-<!--                                                                       -->
-<!-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       -->
-<!-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    -->
-<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.-->
-<!-- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  -->
-<!-- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  -->
-<!-- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     -->
-<!-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -8,87 +8,99 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <?oxygen RNGSchema="http://xspec.googlecode.com/svn/trunk/xspec.rnc" type="compact"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" query="http://www.jenitennison.com/xslt/unit-test" query-at="../src/compiler/generate-query-utils.xql" stylesheet="../src/compiler/generate-tests-utils.xsl">
-  <!--
-       Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
+	<!--
+	   Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
    -->
   <!--
-       Function test:deep-equal($seq1, $seq2).
+	   Function test:deep-equal($seq1, $seq2).
    -->
   <t:scenario label="test:deep-equal($seq1, $seq2)">
-    <t:scenario label="Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 2"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-      <t:expect label="the result" assert="$x:result eq true()"/>
-    </t:scenario>
-    <t:scenario label="Non-Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-      <t:expect label="the result" assert="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="Sequences with Same Items in Different Orders">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="2, 1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-      <t:expect label="the result" assert="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="Empty Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-      <t:expect label="the result" assert="$x:result eq true()"/>
-    </t:scenario>
-    <t:scenario label="One empty sequence">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-      <t:expect label="the result" assert="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="A text node and several text nodes">
-      <t:variable name="elems" as="element()+">
-        <e>foo</e>
-        <e>bar</e>
-      </t:variable>
-      <t:call function="test:deep-equal">
-        <t:param as="text()">foobar</t:param>
-        <t:param select="$elems/text()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-      <t:expect label="the result" assert="$x:result eq true()"/>
-    </t:scenario>
+
+	  <t:scenario label="Identical Sequences">
+		  <t:call function="test:deep-equal">
+			  <t:param select="1, 2"/>
+			  <t:param select="1, 2"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq true()"/>
+		  <t:expect label="the result" assert="$x:result eq true()"/>
+	  </t:scenario>
+
+	  <t:scenario label="Non-Identical Sequences">
+		  <t:call function="test:deep-equal">
+			  <t:param select="1, 2"/>
+			  <t:param select="1, 3"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq false()"/>
+		  <t:expect label="the result" assert="$x:result eq false()"/>
+	  </t:scenario>
+
+	  <t:scenario label="Sequences with Same Items in Different Orders">
+		  <t:call function="test:deep-equal">
+			  <t:param select="1, 2"/>
+			  <t:param select="2, 1"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq false()"/>
+		  <t:expect label="the result" assert="$x:result eq false()"/>
+	  </t:scenario>
+
+	  <t:scenario label="Empty Sequences">
+		  <t:call function="test:deep-equal">
+			  <t:param select="()"/>
+			  <t:param select="()"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq true()"/>
+		  <t:expect label="the result" assert="$x:result eq true()"/>
+	  </t:scenario>
+
+	  <t:scenario label="One empty sequence">
+		  <t:call function="test:deep-equal">
+			  <t:param select="()"/>
+			  <t:param select="1"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq false()"/>
+		  <t:expect label="the result" assert="$x:result eq false()"/>
+	  </t:scenario>
+
+	  <t:scenario label="A text node and several text nodes">
+		  <t:variable name="elems" as="element()+">
+			  <e>foo</e>
+			  <e>bar</e>
+		  </t:variable>
+		  <t:call function="test:deep-equal">
+			  <t:param as="text()">foobar</t:param>
+			  <t:param select="$elems/text()"/>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq true()"/>
+		  <t:expect label="the result" assert="$x:result eq true()"/>
+	  </t:scenario>
+
   </t:scenario>
+
   <!--
-       Function test:node-deep-equal($seq1, $seq2).
+	   Function test:node-deep-equal($seq1, $seq2).
    -->
   <t:scenario label="test:node-deep-equal($seq1, $seq2)">
-    <t:scenario label="Identical Element Sequences">
-      <t:call function="test:node-deep-equal">
-        <t:param name="node1">foobar</t:param>
-        <t:param name="node2">foobar</t:param>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
-    <t:scenario label="Identical Attribute Sequences">
-      <t:call function="test:node-deep-equal">
-        <t:param name="node1" select="/node/@attribute" as="node()">
-          <node attribute="foobar"/>
-        </t:param>
-        <t:param name="node2" select="/node/@attribute" as="node()">
-          <node attribute="foobar"/>
-        </t:param>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
+
+	  <t:scenario label="Identical Element Sequences">
+		  <t:call function="test:node-deep-equal">
+			  <t:param name="node1">foobar</t:param>
+			  <t:param name="node2">foobar</t:param>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq true()"/>
+	  </t:scenario>
+
+	  <t:scenario label="Identical Attribute Sequences">
+		  <t:call function="test:node-deep-equal">
+			  <t:param name="node1" select="/node/@attribute" as="node()">
+				  <node attribute="foobar"/>
+			  </t:param>
+			  <t:param name="node2" select="/node/@attribute" as="node()">
+				  <node attribute="foobar"/>
+			  </t:param>
+		  </t:call>
+		  <t:expect label="the result" test="$x:result eq true()"/>
+	  </t:scenario>
+
   </t:scenario>
+
 </t:description>


### PR DESCRIPTION
This pull request fixes #23 submitted by @AirQuick

The error occurred because of the order of the conditions in [generate-tests-utils.xsl](https://github.com/xspec/xspec/blob/master/src/compiler/generate-tests-utils.xsl):
```xml
<xsl:sequence select="node-name($node1) eq node-name($node2) and
                            ($node1 = '...' or string($node1) eq string($node2))" />
``` 
The condition ```$node1 = '...'``` is raising a compilation error when the value of the node has data type boolean as in the example submitted in #23. In this case the condition is comparing a boolean with a string, hence the compilation error. Because XPath [supports lazy evaluation](https://www.w3.org/TR/xpath/#booleans), it is sufficient to swap the order of the conditions so that the first condition tested is ```string($node1) eq string($node2)```. Only if this condition returns false, the second condition ```$node1 = '...'``` is evaluated and thus allows to support the [three dots notation](https://github.com/xspec/xspec/wiki/Writing-Scenarios). 

For sake of consistency I modified the order of the conditions in both [generate-tests-utils.xsl](https://github.com/xspec/xspec/blob/master/src/compiler/generate-tests-utils.xsl) and [generate-query-utils.xql](https://github.com/xspec/xspec/blob/master/src/compiler/generate-query-utils.xql). 

I tested this fix locally using Saxon EE 9.6.0.4 and the shell script. Unfortunately, it is not possible to add the example provided in the test suite because it requires a schema-aware processor (Travis is using the open source Saxon HE to run the test suite automatically). However, I added two tests which test the function ```node-deep-equal``` used in this pull request. 