### PR TITLE
force to return the string value of node to support other data types #23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    - git clone -b bugfix/lazy-evaluation https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b bugfix/lazy-evaluation https://github.com/xspec/xspec.git /tmp/xspec
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
 
 script:

--- a/src/compiler/generate-query-utils.xql
+++ b/src/compiler/generate-query-utils.xql
@@ -80,9 +80,9 @@ declare function test:node-deep-equal($node1 as node(), $node2 as node()) as xs:
             or ( $node1 instance of processing-instruction()
                  and $node2 instance of processing-instruction()) ) then
     fn:node-name($node1) eq fn:node-name($node2)
-      and ( fn:string($node1) eq fn:string($node2) or $node1 = '...' )
+      and ( fn:string($node1) eq fn:string($node2) or fn:string($node1) = '...' )
   else if ( $node1 instance of comment() and $node2 instance of comment() ) then
-    fn:string($node1) eq fn:string($node2) or $node1 = '...' 
+    fn:string($node1) eq fn:string($node2) or fn:string($node1) = '...' 
   else
     fn:false()
 };

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -450,12 +450,12 @@
                     ($node1 instance of processing-instruction() and
                      $node2 instance of processing-instruction())">
       <xsl:sequence select="node-name($node1) eq node-name($node2) and
-                            (string($node1) eq string($node2) or $node1 = '...')" />      
+                            (string($node1) eq string($node2) or string($node1) = '...')" />      
 
     </xsl:when>
     <xsl:when test="$node1 instance of comment() and
                     $node2 instance of comment()">
-      <xsl:sequence select="string($node1) eq string($node2) or $node1 = '...'" />
+      <xsl:sequence select="string($node1) eq string($node2) or string($node1) = '...'" />
     </xsl:when>
     <xsl:otherwise>
       <xsl:sequence select="false()" />


### PR DESCRIPTION
@AirQuick posted an [additional scenario](https://github.com/xspec/xspec/issues/23#issuecomment-266236525) that causes a compilation error in XSpec. This is an example of a test that it is meant to fail but XSpec generates the same error as in #24 at compilation time:
```bash
Type error on line 453 of generate-tests-utils.xsl:
  XPTY0004: Cannot compare xs:boolean to xs:string
Cannot compare xs:boolean to xs:string
```
The error occurs because the node is a boolean in the scenario posted and XSpec is comparing it to a string in [generate-tests-utils.xsl](https://github.com/xspec/xspec/blob/master/src/compiler/generate-tests-utils.xsl):
```bash
$node1 = '...'
```
Forcing the node the return its string value fixes the issue:
```bash
string($node1) = '...'
```
For sake of consistency, I applied the same change to [generate-query-utils.xql](https://github.com/xspec/xspec/blob/master/src/compiler/generate-query-utils.xql).