### PR TITLE
Revamp xspec.bat

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -423,33 +423,63 @@ call :xslt -o:"%HTML%" ^
     -xsl:"%XSPEC_HOME%\src\reporter\format-xspec-report.xsl" ^
     || ( call :die "Error formatting the report" & goto :win_main_error_exit )
 
+rem
+rem Absolute path of the XSPEC env var
+rem
+for %%I in ("%XSPEC%") do set WIN_XSPEC_ABS=%%~fI
+
 if defined COVERAGE (
     rem
     rem For $tests and $pwd, convert the native file path to a wannabe-
     rem URI. The peculiar implementation of Java prefers the following
-    rem forms.
+    rem forms (if it's absolute).
+    rem
     rem    For drive: file:/c:/dir/file
-    rem    For UNC: file:////host/share/dir/file
+    rem    For UNC:   file:////host/share/dir/file
     rem
     rem Note that in terms of the native file path, coverage-report.xsl
     rem handles $tests and $pwd differently.
     rem
-    rem    $tests
-    rem        coverage-report.xsl replaces '\' with '/'. You can leave
-    rem        '\' intact here.
+    rem    Scheme ('file:')
     rem
-    rem    $pwd
-    rem        coverage-report.xsl does nothing. You have to replace '\'
-    rem        with '/' here.
+    rem        $tests
+    rem            The XSPEC env var may be absolute or relative. If
+    rem            relative, we need to omit 'file:' from $tests.
+    rem            For simplicity, we always obtain the absolute path of
+    rem            the XSPEC env var and prefix it with 'file:'.
     rem
-    rem For $pwd, you don't have to care about UNC. By default CMD.EXE
-    rem does not accept UNC as the current directory. 
+    rem        $pwd
+    rem            The CD env var is always absolute. So we always prefix
+    rem            it with 'file:'.
+    rem
+    rem    '\' character
+    rem
+    rem        $tests
+    rem            coverage-report.xsl replaces '\' with '/'. You can
+    rem            leave '\' intact here.
+    rem
+    rem        $pwd
+    rem            coverage-report.xsl does nothing. You have to replace
+    rem            '\' with '/' here.
+    rem
+    rem    UNC
+    rem
+    rem        $tests
+    rem            You have to care about UNC.
+    rem
+    rem        $pwd
+    rem            You don't have to care about UNC. By default CMD.EXE
+    rem            does not accept UNC as the current directory.
+    rem
+    rem We don't escape any characters here. Too much for this simple
+    rem batch script. Fortunately Saxon 9.7 seems to be more tolerant of
+    rem space chars than 9.6.
     rem
     call :xslt -l:on ^
         -o:"%COVERAGE_HTML%" ^
         -s:"%COVERAGE_XML%" ^
         -xsl:"%XSPEC_HOME%\src\reporter\coverage-report.xsl" ^
-        tests="file:/%XSPEC:\\=/\\%" ^
+        tests="file:/%WIN_XSPEC_ABS:\\=/\\%" ^
         pwd="file:/%CD:\=/%/" ^
         || ( call :die "Error formating the coverage report" & goto :win_main_error_exit )
     echo Report available at %COVERAGE_HTML%

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -73,7 +73,7 @@ rem ##
 
 :win_xslt_trace
     rem
-    rem Redirect:
+    rem Inner Redirect:
     rem    By swapping stdout and stderr, send stderr to pipe (as stdout)
     rem    while allowing original stdout to survive (as stderr)
     rem
@@ -82,7 +82,10 @@ rem ##
     rem    that don't look like XML element, assuming %COVERAGE_CLASS%
     rem    emits every required line in this format
     rem
-    java -cp "%CP%" net.sf.saxon.Transform %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$"
+    rem Outer Redirect:
+    rem    To restore the original direction, swap stdout and stderr again 
+    rem
+    ( java -cp "%CP%" net.sf.saxon.Transform %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
     goto :EOF
 
 :xquery
@@ -93,7 +96,7 @@ rem ##
     rem
     rem As for redirect and pipe, see :win_xslt_trace
     rem
-    java -cp "%CP%" net.sf.saxon.Query %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$"
+    ( java -cp "%CP%" net.sf.saxon.Query %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
     goto :EOF
 
 :win_reset_options
@@ -388,7 +391,7 @@ if defined XSLT (
         echo Collecting test coverage data; suppressing progress report...
         call :win_xslt_trace -T:%COVERAGE_CLASS% ^
             -o:"%RESULT%" -s:"%XSPEC%" -xsl:"%COMPILED%" ^
-            -it:{http://www.jenitennison.com/xslt/xspec}main > "%COVERAGE_XML%" ^
+            -it:{http://www.jenitennison.com/xslt/xspec}main 2> "%COVERAGE_XML%" ^
             || ( call :die "Error collecting test coverage data" & goto :win_main_error_exit )
     ) else (
         call :xslt -o:"%RESULT%" -s:"%XSPEC%" -xsl:"%COMPILED%" ^
@@ -402,7 +405,7 @@ if defined XSLT (
     if defined COVERAGE (
         echo Collecting test coverage data; suppressing progress report...
         call :win_xquery_trace -T:%COVERAGE_CLASS% ^
-            -o:"%RESULT%" -s:"%XSPEC%" "%COMPILED%" > "%COVERAGE_XML%" ^
+            -o:"%RESULT%" -s:"%XSPEC%" "%COMPILED%" 2> "%COVERAGE_XML%" ^
             || ( call :die "Error collecting test coverage data" & goto :win_main_error_exit )
     ) else (
         call :xquery -o:"%RESULT%" -s:"%XSPEC%" "%COMPILED%" ^

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -1,95 +1,479 @@
 @echo off
 
-SET CP=C:\saxon\saxon9he.jar
+rem
+rem ##############################################################################
+rem ##
+rem ## This script is used to compile a test suite to XSLT, run it, format
+rem ## the report and open it in a browser.
+rem ##
+rem ## It relies on the environment variable SAXON_HOME to be set to the
+rem ## dir Saxon has been installed to (i.e. the containing the Saxon JAR
+rem ## file), or on SAXON_CP to be set to a full classpath containing
+rem ## Saxon (and maybe more).  The latter has precedence over the former.
+rem ##
+rem ## It also uses the environment variable XSPEC_HOME.  It must be set
+rem ## to the XSpec install directory.  By default, it uses this script's
+rem ## parent dir.
+rem ##
+rem ## TODO: Not aware of the EXPath Packaging System
+rem ##
+rem ##############################################################################
+rem
+rem Comments (rem)
+rem    Comments starting with '#' are derived from xspec.sh (possibly with
+rem    some modifications).
+rem
+rem Environment variables (%FOO%)
+rem    Environment variables are tried to be on parity with xspec.sh,
+rem    except that those starting with 'WIN_' are only for this batch
+rem    file.
+rem
+rem Labels (:foo)
+rem    Labels are tried to be on parity with functions in xspec.sh, except
+rem    that those starting with 'win_' are only for this batch file.
+rem
 
-SET XSPEC=%1
+rem
+rem Skip over "utility functions"
+rem
+goto :win_main_enter
 
-REM ==========================================
-REM Check if a parameter was passed
-REM ==========================================
-IF %XSPEC%x == x GOTO notfound
+rem ##
+rem ## utility functions #########################################################
+rem ##
 
-REM ==========================================
-REM Check if xspec document exists
-REM ==========================================
-IF NOT EXIST %XSPEC% GOTO notfound
-GOTO endif1
+:usage
+    if not "%~1"=="" (
+        echo %~1
+        echo:
+    )
+    echo Usage: xspec [-t^|-q^|-c^|-j^|-h] filename [coverage]
+    echo:
+    echo   filename   the XSpec document
+    echo   -t         test an XSLT stylesheet (the default)
+    echo   -q         test an XQuery module (mutually exclusive with -t)
+    echo   -c         output test coverage report
+    echo   -j         output JUnit report
+    echo   -h         display this help message
+    echo   coverage   deprecated, use -c instead
+    goto :EOF
 
-:notfound
-echo File not found.
-echo Usage:
-echo   xspec filename [coverage]
-echo     filename should specify an XSpec document
-echo     if coverage is specified, outputs test coverage report
-GOTO end
-:endif1
+:die
+    echo:
+    echo *** %* >&2
+    rem
+    rem Now, to exit the batch file, you must go to :win_main_error_exit from
+    rem the main code flow.
+    rem
+    goto :EOF
 
+:xslt
+    java -cp "%CP%" net.sf.saxon.Transform %*
+    goto :EOF
 
-SET COVERAGE=%2
+:win_xslt_trace
+    rem
+    rem Redirect:
+    rem    By swapping stdout and stderr, send stderr to pipe (as stdout)
+    rem    while allowing original stdout to survive (as stderr)
+    rem
+    rem Pipe:
+    rem    To keep the output XML well-formed, remove the stdout lines
+    rem    that don't look like XML element, assuming %COVERAGE_CLASS%
+    rem    emits every required line in this format
+    rem
+    java -cp "%CP%" net.sf.saxon.Transform %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$"
+    goto :EOF
 
-IF "%TEST_DIR%"=="" SET TEST_DIR=%~dp1xspec
-SET TARGET_FILE_NAME=%~n1
+:xquery
+    java -cp "%CP%" net.sf.saxon.Query %*
+    goto :EOF
 
-SET TEST_STYLESHEET="%TEST_DIR%\%TARGET_FILE_NAME%.xsl"
-SET COVERAGE_XML="%TEST_DIR%\%TARGET_FILE_NAME%-coverage.xml"
-SET COVERAGE_HTML="%TEST_DIR%\%TARGET_FILE_NAME%-coverage.html"
-SET RESULT="%TEST_DIR%\%TARGET_FILE_NAME%-result.xml"
-SET HTML="%TEST_DIR%\%TARGET_FILE_NAME%-result.html"
+:win_xquery_trace
+    rem
+    rem As for redirect and pipe, see :win_xslt_trace
+    rem
+    java -cp "%CP%" net.sf.saxon.Query %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$"
+    goto :EOF
 
-REM ================================================
-REM Create xspec subdirectory for running the tests
-REM ================================================
-IF NOT EXIST "%TEST_DIR%" GOTO notestdir
-GOTO endif2
-:notestdir
-echo Creating XSpec Directory at "%TEST_DIR%" ...
-mkdir "%TEST_DIR%"
-echo.
-:endif2
+:win_reset_options
+    set XSLT=
+    set XQUERY=
+    set COVERAGE=
+    set JUNIT=
+    set WIN_HELP=
+    set WIN_UNKNOWN_OPTION=
+    set WIN_DEPRECATED_COVERAGE=
+    set WIN_EXTRA_OPTION=
+    set XSPEC=
+    goto :EOF
 
+:win_get_options
+    set WIN_ARGV=%~1
+
+    if not defined WIN_ARGV (
+        goto :EOF
+    ) else if "%WIN_ARGV%"=="-t" (
+        set XSLT=1
+    ) else if "%WIN_ARGV%"=="-q" (
+        set XQUERY=1
+    ) else if "%WIN_ARGV%"=="-c" (
+        set COVERAGE=1
+    ) else if "%WIN_ARGV%"=="-j" (
+        set JUNIT=1
+    ) else if "%WIN_ARGV%"=="-h" (
+        set WIN_HELP=1
+    ) else if "%WIN_ARGV:~0,1%"=="-" (
+        set WIN_UNKNOWN_OPTION=%WIN_ARGV%
+    ) else if defined XSPEC (
+        if "%WIN_ARGV%"=="coverage" (
+            set WIN_DEPRECATED_COVERAGE=1
+        ) else (
+            set WIN_EXTRA_OPTION=%WIN_ARGV%
+            goto :EOF
+        )
+    ) else (
+        set XSPEC=%WIN_ARGV%
+    )
+
+    shift
+
+    rem
+    rem %* doesn't reflect shift. Pass %n individually.
+    rem
+    call :win_get_options %1 %2 %3 %4 %5 %6 %7 %8 %9
+    goto :EOF
+
+rem
+rem Main #########################################################################
+rem
+:win_main_enter
+
+rem
+rem Begin localization of environment changes.
+rem Also make sure the command processor extensions are enabled.
+rem
+verify other 2> NUL
+setlocal enableextensions
+if errorlevel 1 (
+    echo Unable to enable extensions
+    exit /b
+)
+
+rem
+rem ##
+rem ## some variables ############################################################
+rem ##
+rem
+
+rem
+rem # the command to use to open the final HTML report
+rem
+rem Include the command line options (and consequently the double quotes)
+rem if necessary.
+rem
+set OPEN=start "XSpec Report"
+
+rem
+rem # set XSPEC_HOME if it has not been set by the user (set it to the
+rem # parent dir of this script)
+rem
+if not defined XSPEC_HOME set XSPEC_HOME=%~dp0..
+
+rem
+rem # safety checks
+rem
+for %%I in ("%XSPEC_HOME%") do echo "%%~aI" | find "d" > NUL
+if errorlevel 1 (
+    echo ERROR: XSPEC_HOME is not a directory: %XSPEC_HOME%
+    exit /b 1
+)
+if not exist "%XSPEC_HOME%\src\compiler\generate-common-tests.xsl" (
+    echo ERROR: XSPEC_HOME seems to be corrupted: %XSPEC_HOME%
+    exit /b 1
+)
+
+rem
+rem # set SAXON_CP (either it has been by the user, or set it from SAXON_HOME)
+rem
+
+rem
+rem # Set this variable in your environment or here, if you don't set SAXON_CP
+rem # set SAXON_HOME=C:\path\to\saxon\dir
+rem
+rem Since we don't use the delayed environment variable expansion,
+rem SAXON_HOME must be set outside 'if' scope.
+rem
+
+if not defined SAXON_CP (
+    if not defined SAXON_HOME (
+        echo SAXON_CP and SAXON_HOME both not set!
+    )
+    if        exist "%SAXON_HOME%\saxon9ee.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon9ee.jar
+    ) else if exist "%SAXON_HOME%\saxon9pe.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon9pe.jar
+    ) else if exist "%SAXON_HOME%\saxon9he.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon9he.jar
+    ) else if exist "%SAXON_HOME%\saxon9sa.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon9sa.jar
+    ) else if exist "%SAXON_HOME%\saxon9.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon9.jar
+    ) else if exist "%SAXON_HOME%\saxonb9-1-0-8.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxonb9-1-0-8.jar
+    ) else if exist "%SAXON_HOME%\saxon8sa.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon8sa.jar
+    ) else if exist "%SAXON_HOME%\saxon8.jar" (
+        set SAXON_CP=%SAXON_HOME%\saxon8.jar
+    ) else (
+        echo Saxon jar cannot be found in SAXON_HOME: %SAXON_HOME%
+    )
+)
+
+set CP=%SAXON_CP%;%XSPEC_HOME%\java
+
+rem
+rem ##
+rem ## options ###################################################################
+rem ##
+rem
+
+rem
+rem JAR filename
+rem
+for %%I in ("%SAXON_CP%") do set WIN_SAXON_CP_N=%%~nI
+
+rem
+rem Parse command line
+rem
+call :win_reset_options
+call :win_get_options %*
+
+rem
+rem # XSLT
+rem # XQuery
+rem
+if defined XSLT if defined XQUERY (
+    call :usage "-t and -q are mutually exclusive"
+    exit /b 1
+)
+
+rem
+rem # Coverage
+rem
+if defined COVERAGE (
+    if /i not "%WIN_SAXON_CP_N%"=="saxon9pe" if /i not "%WIN_SAXON_CP_N%"=="saxon9ee" (
+        echo Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE.
+        exit /b 1
+    )
+)
+
+rem
+rem # JUnit report
+rem
+if defined JUNIT (
+    if /i "%WIN_SAXON_CP_N:~0,6%"=="saxon8" (
+        echo Saxon8 detected. JUnit report requires Saxon9.
+        exit /b 1
+    )
+)
+
+rem
+rem # Help!
+rem
+if defined WIN_HELP (
+    call :usage
+    exit /b 0
+)
+
+rem
+rem # Unknown option!
+rem
+if defined WIN_UNKNOWN_OPTION (
+    call :usage "Error: Unknown option: %WIN_UNKNOWN_OPTION%"
+    exit /b 1
+)
+
+rem
+rem # set XSLT if XQuery has not been set (that's the default)
+rem
+if not defined XSLT if not defined XQUERY set XSLT=1
+
+if not exist "%XSPEC%" (
+    call :usage "Error: File not found."
+    exit /b 1
+)
+
+rem
+rem Extra option
+rem
+if defined WIN_EXTRA_OPTION (
+    call :usage "Error: Extra option: %WIN_EXTRA_OPTION%"
+    exit /b 1
+)
+
+rem
+rem Deprecated 'coverage' option
+rem
+if defined WIN_DEPRECATED_COVERAGE (
+    echo Long-form option 'coverage' deprecated, use '-c' instead.
+    if /i not "%WIN_SAXON_CP_N%"=="saxon9pe" if /i not "%WIN_SAXON_CP_N%"=="saxon9ee" (
+        echo Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE.
+        exit /b 1
+    )
+    set COVERAGE=1
+)
+
+rem
+rem Env var no longer necessary
+rem
+set WIN_SAXON_CP_N=
+
+rem
+rem ##
+rem ## files and dirs ############################################################
+rem ##
+rem
+
+if not defined TEST_DIR for %%I in ("%XSPEC%") do set TEST_DIR=%%~dpIxspec
+for %%I in ("%XSPEC%") do set TARGET_FILE_NAME=%%~nI
+
+if defined XSLT (
+    set COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xsl
+) else (
+    set COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xq
+)
+set COVERAGE_XML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.xml
+set COVERAGE_HTML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.html
+set RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-result.xml
+set HTML=%TEST_DIR%\%TARGET_FILE_NAME%-result.html
+set JUNIT_RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-junit.xml
+set COVERAGE_CLASS=com.jenitennison.xslt.tests.XSLTCoverageTraceListener
+
+if not exist "%TEST_DIR%" (
+    echo Creating XSpec Directory at %TEST_DIR%...
+    mkdir "%TEST_DIR%"
+    echo:
+)
+
+rem
+rem ##
+rem ## compile the suite #########################################################
+rem ##
+rem
+
+if defined XSLT (
+    set COMPILE_SHEET=generate-xspec-tests.xsl
+) else (
+    set COMPILE_SHEET=generate-query-tests.xsl
+)
 echo Creating Test Stylesheet...
-echo %TEST_STYLESHEET%
-echo %XSPEC%
-java -cp "%CP%" net.sf.saxon.Transform -o:%TEST_STYLESHEET% -s:%XSPEC% -xsl:"%~dp0\..\src\compiler\generate-xspec-tests.xsl"
-echo. 
+call :xslt -o:"%COMPILED%" -s:"%XSPEC%" ^
+    -xsl:"%XSPEC_HOME%\src\compiler\%COMPILE_SHEET%" ^
+    || ( call :die "Error compiling the test suite" & goto :win_main_error_exit )
+echo:
+
+rem
+rem ##
+rem ## run the suite #############################################################
+rem ##
+rem
 
 echo Running Tests...
+if defined XSLT (
+    rem
+    rem # for XSLT
+    rem
+    if defined COVERAGE (
+        echo Collecting test coverage data; suppressing progress report...
+        call :win_xslt_trace -T:%COVERAGE_CLASS% ^
+            -o:"%RESULT%" -s:"%XSPEC%" -xsl:"%COMPILED%" ^
+            -it:{http://www.jenitennison.com/xslt/xspec}main > "%COVERAGE_XML%" ^
+            || ( call :die "Error collecting test coverage data" & goto :win_main_error_exit )
+    ) else (
+        call :xslt -o:"%RESULT%" -s:"%XSPEC%" -xsl:"%COMPILED%" ^
+            -it:{http://www.jenitennison.com/xslt/xspec}main ^
+            || ( call :die "Error running the test suite" & goto :win_main_error_exit )
+    )
+) else (
+    rem
+    rem # for XQuery
+    rem
+    if defined COVERAGE (
+        echo Collecting test coverage data; suppressing progress report...
+        call :win_xquery_trace -T:%COVERAGE_CLASS% ^
+            -o:"%RESULT%" -s:"%XSPEC%" "%COMPILED%" > "%COVERAGE_XML%" ^
+            || ( call :die "Error collecting test coverage data" & goto :win_main_error_exit )
+    ) else (
+        call :xquery -o:"%RESULT%" -s:"%XSPEC%" "%COMPILED%" ^
+            || ( call :die "Error running the test suite" & goto :win_main_error_exit )
+    )
+)
 
-REM =======================================
-REM Check if coverage parameter was passed
-REM =======================================
-IF %COVERAGE%x == coveragex GOTO coverage
-GOTO endif3
-:coverage
-echo Collecting test coverage data; suppressing progress report...
- java -cp "%CP%" net.sf.saxon.Transform -T:com.jenitennison.xslt.tests.XSLTCoverageTraceListener	\
-     -o:%RESULT% -s:%XSPEC% -xsl:%TEST_STYLESHEET% -it:{http://www.jenitennison.com/xslt/xspec}main 2> %COVERAGE_XML%
- 
-:endif3
+rem
+rem ##
+rem ## format the report #########################################################
+rem ##
+rem
 
-REM =======================================
-REM Run the tests
-REM =======================================
-java -cp "%CP%" net.sf.saxon.Transform -o:%RESULT% -s:%XSPEC% -xsl:%TEST_STYLESHEET% -it:{http://www.jenitennison.com/xslt/xspec}main
-
-echo.  
+echo:
 echo Formatting Report...
-java -cp "%CP%" net.sf.saxon.Transform -o:%HTML% -s:%RESULT% -xsl:"%~dp0\..\src\reporter\format-xspec-report.xsl"
+call :xslt -o:"%HTML%" ^
+    -s:"%RESULT%" ^
+    -xsl:"%XSPEC_HOME%\src\reporter\format-xspec-report.xsl" ^
+    || ( call :die "Error formatting the report" & goto :win_main_error_exit )
 
-REM =======================================
-REM Check if coverage parameter was passed
-REM =======================================
-IF %COVERAGE%x == coveragex GOTO coverage2
-GOTO endif4
-:coverage2 
- java -cp "%CP%" net.sf.saxon.Transform -l:on "-o:%COVERAGE_HTML%" "-s:%COVERAGE_XML%" "-xsl:%~dp0\..\src\reporter\coverage-report.xsl" "tests=%XSPEC%" "pwd=file:///%~dp0"
- %COVERAGE_HTML% 
-:endif4
-
-REM =============
-REM Output report
-REM =============
-echo Report available at %HTML%
+if defined COVERAGE (
+    rem
+    rem For $tests and $pwd, convert the native file path to a wannabe-
+    rem URI. The peculiar implementation of Java prefers the following
+    rem forms.
+    rem    For drive: file:/c:/dir/file
+    rem    For UNC: file:////host/share/dir/file
+    rem
+    rem Note that in terms of the native file path, coverage-report.xsl
+    rem handles $tests and $pwd differently.
+    rem
+    rem    $tests
+    rem        coverage-report.xsl replaces '\' with '/'. You can leave
+    rem        '\' intact here.
+    rem
+    rem    $pwd
+    rem        coverage-report.xsl does nothing. You have to replace '\'
+    rem        with '/' here.
+    rem
+    rem For $pwd, you don't have to care about UNC. By default CMD.EXE
+    rem does not accept UNC as the current directory. 
+    rem
+    call :xslt -l:on ^
+        -o:"%COVERAGE_HTML%" ^
+        -s:"%COVERAGE_XML%" ^
+        -xsl:"%XSPEC_HOME%\src\reporter\coverage-report.xsl" ^
+        tests="file:/%XSPEC:\\=/\\%" ^
+        pwd="file:/%CD:\=/%/" ^
+        || ( call :die "Error formating the coverage report" & goto :win_main_error_exit )
+    echo Report available at %COVERAGE_HTML%
+    rem %OPEN% "%COVERAGE_HTML%"
+) else if defined JUNIT (
+    call :xslt -o:"%JUNIT_RESULT%" ^
+        -s:"%RESULT%" ^
+        -xsl:"%XSPEC_HOME%\src\reporter\junit-report.xsl" ^
+        || ( call :die "Error formating the JUnit report" & goto :win_main_error_exit )
+    echo Report available at %JUNIT_RESULT%
+) else (
+    echo Report available at %HTML%
+    rem %OPEN% "%HTML%"
+)
 
 echo Done.
-:end
+exit /b
+
+rem 
+rem Error exit ###################################################################
+rem 
+:win_main_error_exit
+if errorlevel 1 (
+    exit /b
+) else (
+    exit /b 1
+)


### PR DESCRIPTION
## Changes

* Made xspec.bat in sync with [xspec.sh](https://github.com/xspec/xspec/blob/8a412363f6435fb4d7d09a624437974332bb3085/bin/xspec.sh) (except for EXPath Packaging System which I haven't used)
* Fixed https://github.com/xspec/xspec/issues/25

## Tested on

* Windows 7  x86 + Java 6 u45      + Saxon-B  8.9.0.4
* Windows 7  x86 + Java 6 u45      + Saxon-HE 9.7.0.7
* Windows 10 x64 + Java 8 u111 x64 + Saxon-EE 9.6.0.10
* Windows 10 x64 + Java 8 u111 x64 + Saxon-EE 9.7.0.14

## Known issues

### Saxon 8 not supported
Running with Saxon 8, the batch file dies with `Error compiling the test suite`, because of the command line syntax difference between 8 and 9. I presume xspec.sh and xspec.bat no longer support 8.

### XQuery coverage report doesn't make sense
I tested `-q -c` (XQuery + coverage) with [xspec-focus-1.xspec](https://github.com/xspec/xspec/blob/df4959b87cf8054ca4ad8b6d17b627c233dff659/test/xspec-focus-1.xspec) and confirmed that the report HTML was generated. But the HTML content didn't depict the coverage. (Only a cool message, `not used`.) Since [xspec.sh](https://github.com/xspec/xspec/blob/8a412363f6435fb4d7d09a624437974332bb3085/bin/xspec.sh) generated the same report, I presume [coverage-report.xsl](https://github.com/xspec/xspec/blob/d3a9d5e7997208370a030c5e6013f828462a7981/src/reporter/coverage-report.xsl) does not currently support XQuery.

### UNC not recommended
I believe the batch file makes its reasonable effort to handle [UNC](https://en.wikipedia.org/wiki/Uniform_Naming_Convention), but I found these errors.

* If UNC is used for the path to `.bat`, `.xspec` or others, Web browsers may not always recognize `@href` values in the report HTML. I think it's an infamous [Java `file` URI issue](https://wiki.eclipse.org/Eclipse/UNC_Paths#Programming_with_UNC_paths). A workaround would be adjusting a sequence of `/` characters in @href after the report HTML is generated.
* Saxon 9.7 `resolve-uri()` has a [regression](https://saxonica.plan.io/issues/3075) in handling UNC. As a result, if UNC is used for `XSPEC_HOME` or the path to `.bat` or `.xspec`, the batch file dies with `Error running the test suite` or `Error collecting test coverage data`. A workaround would be using Saxon 9.6 or waiting for the next maintenance release (9.7.0.15, most likely).
