### PR TITLE
test/xspec-junit.xspec fails with Saxon 9.6.0.10

### DIFF
--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -81,7 +81,13 @@
     </xsl:template>
     
     <xsl:template match="x:expect">
-        <xsl:value-of select="fn:serialize(.)"></xsl:value-of>
+        <xsl:variable as="element(output:serialization-parameters)" name="serialization-parameters"
+            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+            <output:serialization-parameters>
+                <output:omit-xml-declaration value="yes"/>
+            </output:serialization-parameters>
+        </xsl:variable>
+        <xsl:value-of select="fn:serialize(., $serialization-parameters)"></xsl:value-of>
     </xsl:template>
     
 </xsl:stylesheet>


### PR DESCRIPTION
With Saxon 9.6.0.10, `test\xspec-junit.xspec` fails.

```
P:\xspec-master>bin\xspec.bat test\xspec-junit.xspec
Creating Test Stylesheet...

Running Tests...
Testing with SAXON HE 9.6.0.10
When processing a successful test
convert it to test case with status passed
When processing a failing test
convert it to test case with status failed
      FAILED
When processing successful and failing tests
convert it to test cases with status passed and failing
      FAILED

Formatting Report...
passed: 1 / pending: 0 / failed: 2 / total: 3
Report available at P:\xspec-master\test\xspec\xspec-junit-result.html
Done.
```

That happens because `fn:serialize()` in `junit-report.xsl` does not omit the XML declaration on Saxon 9.6.
Per the latest [specification](http://www.w3.org/TR/xpath-functions-31/#func-serialize), the default behavior seems to be implementation dependent.

> If the second argument is omitted, ... then the values of any serialization parameters that are not explicitly specified is implementation-defined

This change should stabilize it by explicitly omitting the XML declaration.