### PR TITLE
Fix appveyor badge click link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Travis Build Status](https://api.travis-ci.org/xspec/xspec.svg?branch=master "Travis Build Status")
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=master&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/xspec/xspec/branch/master)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=master&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/cirulls/xspec/branch/master)
 
 ## XSpec
 


### PR DESCRIPTION
Thanks for integrating AppVeyor.
When you click the badge, it takes you to the page `Project not found or access denied.`
This change should fix the click link.