### PR TITLE
Test with Saxon n and n-0.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,30 @@
 environment:
   SAXON_CP: '%APPVEYOR_BUILD_FOLDER%\saxon\saxon9he.jar'
+  matrix:
+  - SAXON_VER: 9.7.0-14
+  - SAXON_VER: 9.6.0-7
 install:
 - ps: >-
     mkdir -Name "saxon"
 
-    Invoke-WebRequest "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar" -OutFile "saxon\saxon9he.jar"
+    Invoke-WebRequest "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VER}/Saxon-HE-${env:SAXON_VER}.jar" -OutFile "saxon\saxon9he.jar"
 build: off
 test_script:
 - cmd: >-
+    rem Print Java version
+
+    java -version
+
+
+    rem Print Saxon version
+
+    java -cp "%SAXON_CP%" net.sf.saxon.Transform 2>&1 | find /i "saxon-"
+
+
     rem execute xspec.bat unit tests
 
     test\xspec-bat.cmd
+
 
     rem execute XSpec unit tests
 


### PR DESCRIPTION
* Saxonica usually maintains two versions. (Currently 9.7.x and 9.6.x)
* oXygen, who bundles XSpec, does not always bundle the latest version of Saxon. (The latest oXygen has 9.6.0.7.)
* We've actually seen some differences between the versions.

I think those things justify some extra time of testing with the latest Saxon version minus 0.1.
What do you think?

With this change, AppVeyor tests XSpec with Saxon 9.7 and 9.6, and should work like [this](https://ci.appveyor.com/project/AirQuick/xspec/build/13-master) when it detects https://github.com/xspec/xspec/pull/40.

Although the latest 9.6 is 9.6.0.10, I chose 9.6.0.7 just because it's the one bundled currently in oXygen.
