### PR TITLE
Run tests in Travis for both Saxon HE 9.7.0-14 and 9.6.0-7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
+env:
+    matrix:
+        - SAXON_VERSION=9.7.0-14
+        - SAXON_VERSION=9.6.0-7
+
 before_script:
     # install bats
     - git clone https://github.com/sstephenson/bats.git /tmp/bats
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    # install xspec
-    - git clone -b $TRAVIS_BRANCH https://github.com/xspec/xspec.git /tmp/xspec
-    # install Saxon 9.7.0-14 and 9.6.0-7 
-    - mkdir -p /tmp/xspec/saxon 
-    - wget -O /tmp/xspec/saxon/saxon-he-9.7.0-14.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
-    - chmod +x /tmp/xspec/saxon/saxon-he-9.7.0-14.jar
-    - wget -O /tmp/xspec/saxon/saxon-he-9.6.0-7.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.6.0-7/Saxon-HE-9.6.0-7.jar
-    - chmod +x /tmp/xspec/saxon/saxon-he-9.6.0-7.jar
-
-env:
-    matrix:
-        - SAXON_CP=/tmp/xspec/saxon/saxon-he-9.7.0-14.jar
-        - SAXON_CP=/tmp/xspec/saxon/saxon-he-9.6.0-7.jar
+    # install Saxon
+    - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
+    - wget -O ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+    - chmod +x ${SAXON_CP}
 
 script:
     - cd test
-    - echo "execute bats unit tests on branch $TRAVIS_BRANCH with $SAXON_CP"
+    - echo "execute bats unit tests"
     - bats --tap xspec.bats
-    - echo "execute XSpec unit tests on branch $TRAVIS_BRANCH with $SAXON_CP"
+    - echo "execute XSpec unit tests"
     - ./run-xspec-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
     # install xspec
-    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b TRAVIS_BRANCH https://github.com/xspec/xspec.git /tmp/xspec
     # install saxon
     - mkdir -p /tmp/xspec/saxon 
     - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 
 script:
     - cd test
-    - echo "execute bats unit tests"
+    - echo "execute bats unit tests on branch $TRAVIS_BRANCH with $SAXON_CP"
     - bats --tap xspec.bats
-    - echo "execute XSpec unit tests"
+    - echo "execute XSpec unit tests on branch $TRAVIS_BRANCH with $SAXON_CP"
     - ./run-xspec-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
     # install Saxon
+    - mkdir -p /tmp/xspec/saxon 
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
     - wget -O ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
     - chmod +x ${SAXON_CP}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,17 @@ before_script:
     - export PATH=$PATH:/tmp/local/bin
     # install xspec
     - git clone -b $TRAVIS_BRANCH https://github.com/xspec/xspec.git /tmp/xspec
-    # install saxon
+    # install Saxon 9.7.0-14 and 9.6.0-7 
     - mkdir -p /tmp/xspec/saxon 
-    - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
-    - chmod +x /tmp/xspec/saxon/saxon9he.jar
-    - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
+    - wget -O /tmp/xspec/saxon/saxon-he-9.7.0-14.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
+    - chmod +x /tmp/xspec/saxon/saxon-he-9.7.0-14.jar
+    - wget -O /tmp/xspec/saxon/saxon-he-9.6.0-7.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.6.0-7/Saxon-HE-9.6.0-7.jar
+    - chmod +x /tmp/xspec/saxon/saxon-he-9.6.0-7.jar
+
+env:
+    matrix:
+        - SAXON_CP=/tmp/xspec/saxon/saxon-he-9.7.0-14.jar
+        - SAXON_CP=/tmp/xspec/saxon/saxon-he-9.6.0-7.jar
 
 script:
     - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
     # install xspec
-    - git clone -b TRAVIS_BRANCH https://github.com/xspec/xspec.git /tmp/xspec
+    - git clone -b $TRAVIS_BRANCH https://github.com/xspec/xspec.git /tmp/xspec
     # install saxon
     - mkdir -p /tmp/xspec/saxon 
     - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis Build Status](https://api.travis-ci.org/xspec/xspec.svg?branch=master "Travis Build Status")
+[![Travis Build Status](https://api.travis-ci.org/xspec/xspec.svg?branch=master "Travis Build Status")](https://travis-ci.org/xspec/xspec)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=master&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/xspec/xspec/branch/master)
 
 ## XSpec


### PR DESCRIPTION
This pull request addresses #44.

Tests are run in parallel by Travis using different values for the environment variable ```SAXON_CP```:

![image](https://cloud.githubusercontent.com/assets/13256236/21700604/260e32d0-d399-11e6-9280-223c648870ae.png)

**Summary of commits**
- 0f3317c replaces the hard-coded branch with the default environment variable ```TRAVIS_BRANCH``` which:
    - for builds not triggered by a pull request it is the name of the branch currently being built; 
    - for builds triggered by a pull request it is the name of the branch targeted by the pull request (usually ```master```).
- 6691792 download the two versions of Saxon and executes a matrix build similar to what @AirQuick implemented with AppVeyor in #43 
-  7258643 add a link to Travis build page

**Reviewer**

@AirQuick, could you please review this pull request?