### PR TITLE
Always provide xs:boolean in $impl:successful expression

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -349,7 +349,7 @@
           <variable name="impl:boolean-test" as="xs:boolean"
             select="$impl:test-result instance of xs:boolean" />
           <variable name="impl:successful" as="xs:boolean"
-            select="if ($impl:boolean-test) then $impl:test-result
+            select="if ($impl:boolean-test) then $impl:test-result cast as xs:boolean
                     else test:deep-equal($impl:expected, $impl:test-result, {$version})" />
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
Fixes #46 

If `$impl:test-result` happens to be determined statically as a non `xs:boolean`, a warning is raised for `$impl:successful`.

The spec allows raising type errors at XSLT compile time if there is code that would always deliver a value of the wrong type, even if that code is never executed.
So it is `generate-xspec-tests.xsl`'s responsibility to keep the expression valid.
