### PR TITLE
remove -j option in tests #39

### DIFF
--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -152,7 +152,7 @@ setlocal
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-result.xml
     call :del "%EXPECTED_REPORT%"
 
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
     call :end
@@ -164,7 +164,7 @@ setlocal
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-result.html
     call :del "%EXPECTED_REPORT%"
 
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
     call :end

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -90,14 +90,14 @@
 
 
 @test "invoking xspec generates XML report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
 	echo $output
     [ "$status" -eq 0 ]
 }
 
 @test "invoking xspec generates HTML report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.html
 	echo $output
     [ "$status" -eq 0 ]


### PR DESCRIPTION
This pull request addresses #39. 

It amends two bats tests which should be testing that XSpec is generating the XML and HTML reports when it is executed without any option. The ```-j``` option was erroneous so I removed it.