### PR TITLE
add bats test issue #46 / pr #48

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
+env:
+    matrix:
+        - SAXON_VERSION=9.7.0-14
+        - SAXON_VERSION=9.6.0-7
+
 before_script:
     # install bats
     - git clone https://github.com/sstephenson/bats.git /tmp/bats
     - mkdir -p /tmp/local
     - bash /tmp/bats/install.sh /tmp/local
     - export PATH=$PATH:/tmp/local/bin
-    # install xspec
-    - git clone -b master https://github.com/xspec/xspec.git /tmp/xspec
-    # install saxon
+    # install Saxon
     - mkdir -p /tmp/xspec/saxon 
-    - wget -O /tmp/xspec/saxon/saxon9he.jar http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.7.0-14/Saxon-HE-9.7.0-14.jar
-    - chmod +x /tmp/xspec/saxon/saxon9he.jar
     - export SAXON_CP=/tmp/xspec/saxon/saxon9he.jar
+    - wget -O ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+    - chmod +x ${SAXON_CP}
 
 script:
     - cd test

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -349,7 +349,7 @@
           <variable name="impl:boolean-test" as="xs:boolean"
             select="$impl:test-result instance of xs:boolean" />
           <variable name="impl:successful" as="xs:boolean"
-            select="if ($impl:boolean-test) then $impl:test-result
+            select="if ($impl:boolean-test) then $impl:test-result cast as xs:boolean
                     else test:deep-equal($impl:expected, $impl:test-result, {$version})" />
         </xsl:when>
         <xsl:otherwise>

--- a/test/xspec-46.xsl
+++ b/test/xspec-46.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template as="node()" match="node()">
+		<xsl:sequence select="." />
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/xspec-46.xspec
+++ b/test/xspec-46.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" stylesheet="xspec-46.xsl">
+  <x:scenario label="Scenario-1">
+    <x:context>
+      <foo/>
+    </x:context>
+    <x:expect label="Expect-1" select="1" test="count(foo)"/>
+  </x:scenario>
+</x:description>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -25,148 +25,148 @@
 }
 
 
-# @test "invoking code coverage with Saxon9HE returns error message" {
-#     export SAXON_CP=/path/to/saxon9he.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-# }
+@test "invoking code coverage with Saxon9HE returns error message" {
+    export SAXON_CP=/path/to/saxon9he.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
 
 
-# @test "invoking code coverage with Saxon9SA returns error message" {
-#     export SAXON_CP=/path/to/saxon9sa.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-# }
+@test "invoking code coverage with Saxon9SA returns error message" {
+    export SAXON_CP=/path/to/saxon9sa.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
 
 
-# @test "invoking code coverage with Saxon9 returns error message" {
-#     export SAXON_CP=/path/to/saxon9.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-# }
+@test "invoking code coverage with Saxon9 returns error message" {
+    export SAXON_CP=/path/to/saxon9.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
 
 
-# @test "invoking code coverage with Saxon8SA returns error message" {
-#     export SAXON_CP=/path/to/saxon8sa.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-# }
+@test "invoking code coverage with Saxon8SA returns error message" {
+    export SAXON_CP=/path/to/saxon8sa.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
 
 
-# @test "invoking code coverage with Saxon8 returns error message" {
-#     export SAXON_CP=/path/to/saxon8.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-# }
+@test "invoking code coverage with Saxon8 returns error message" {
+    export SAXON_CP=/path/to/saxon8.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
 
 
-# # this test must run first to create xspec directory
-# @test "invoking code coverage with Saxon9EE creates test stylesheet" {
-#     export SAXON_CP=/path/to/saxon9ee.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-#   	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[2]}" = "Creating Test Stylesheet..." ]
-# }
+# this test must run first to create xspec directory
+@test "invoking code coverage with Saxon9EE creates test stylesheet" {
+    export SAXON_CP=/path/to/saxon9ee.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+  	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
+}
 
 
-# @test "invoking code coverage with Saxon9PE creates test stylesheet" {
-#     export SAXON_CP=/path/to/saxon9pe.jar
-#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
-# }
+@test "invoking code coverage with Saxon9PE creates test stylesheet" {
+    export SAXON_CP=/path/to/saxon9pe.jar
+    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Creating Test Stylesheet..." ]
+}
 
 
-# @test "invoking xspec generates XML report file" {
-#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-#     run stat ../tutorial/xspec/escape-for-regex-result.xml
-# 	echo $output
-#     [ "$status" -eq 0 ]
-# }
+@test "invoking xspec generates XML report file" {
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    run stat ../tutorial/xspec/escape-for-regex-result.xml
+	echo $output
+    [ "$status" -eq 0 ]
+}
 
-# @test "invoking xspec generates HTML report file" {
-#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-#     run stat ../tutorial/xspec/escape-for-regex-result.html
-# 	echo $output
-#     [ "$status" -eq 0 ]
-# }
+@test "invoking xspec generates HTML report file" {
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    run stat ../tutorial/xspec/escape-for-regex-result.html
+	echo $output
+    [ "$status" -eq 0 ]
+}
 
-# @test "invoking xspec with -j option with Saxon8 returns error message" {
-#     export SAXON_CP=/path/to/saxon8.jar
-#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-# }
-
-
-# @test "invoking xspec with -j option with Saxon8-SA returns error message" {
-#     export SAXON_CP=/path/to/saxon8sa.jar
-#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 1 ]
-#     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-# }
+@test "invoking xspec with -j option with Saxon8 returns error message" {
+    export SAXON_CP=/path/to/saxon8.jar
+    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
+}
 
 
-# @test "invoking xspec with -j option generates message with JUnit report location" {
-#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 0 ]
-#     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
-# }
-
-# @test "invoking xspec with -j option generates XML report file" {
-#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-#     run stat ../tutorial/xspec/escape-for-regex-result.xml
-# 	echo $output
-#     [ "$status" -eq 0 ]
-# }
-
-# @test "invoking xspec with -j option generates JUnit report file" {
-#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-#     run stat ../tutorial/xspec/escape-for-regex-junit.xml
-# 	echo $output
-#     [ "$status" -eq 0 ]
-# }
+@test "invoking xspec with -j option with Saxon8-SA returns error message" {
+    export SAXON_CP=/path/to/saxon8sa.jar
+    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
+}
 
 
-# @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
-#     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
-# 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-# 	echo $output
-# 	[ "$status" -eq 1 ]
-#   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
-# }
+@test "invoking xspec with -j option generates message with JUnit report location" {
+    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
+}
+
+@test "invoking xspec with -j option generates XML report file" {
+    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+    run stat ../tutorial/xspec/escape-for-regex-result.xml
+	echo $output
+    [ "$status" -eq 0 ]
+}
+
+@test "invoking xspec with -j option generates JUnit report file" {
+    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+    run stat ../tutorial/xspec/escape-for-regex-junit.xml
+	echo $output
+    [ "$status" -eq 0 ]
+}
 
 
-# @test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
-#     export TEST_DIR=/tmp
-#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 0 ]
-#     [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
-# }
+@test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
+    export SAXON_CP=/path/to/saxonb9-1-0-8.jar
+	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo $output
+	[ "$status" -eq 1 ]
+  	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
+}
 
 
-# @test "invoking xspec.sh without TEST_DIR generates files in default location" {
-#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-# 	echo $output
-#     [ "$status" -eq 0 ]
-#     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
-# }
+@test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
+    export TEST_DIR=/tmp
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
+}
+
+
+@test "invoking xspec.sh without TEST_DIR generates files in default location" {
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+}
 
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -25,145 +25,153 @@
 }
 
 
-@test "invoking code coverage with Saxon9HE returns error message" {
-    export SAXON_CP=/path/to/saxon9he.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-}
+# @test "invoking code coverage with Saxon9HE returns error message" {
+#     export SAXON_CP=/path/to/saxon9he.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+# }
 
 
-@test "invoking code coverage with Saxon9SA returns error message" {
-    export SAXON_CP=/path/to/saxon9sa.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-}
+# @test "invoking code coverage with Saxon9SA returns error message" {
+#     export SAXON_CP=/path/to/saxon9sa.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+# }
 
 
-@test "invoking code coverage with Saxon9 returns error message" {
-    export SAXON_CP=/path/to/saxon9.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-}
+# @test "invoking code coverage with Saxon9 returns error message" {
+#     export SAXON_CP=/path/to/saxon9.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+# }
 
 
-@test "invoking code coverage with Saxon8SA returns error message" {
-    export SAXON_CP=/path/to/saxon8sa.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-}
+# @test "invoking code coverage with Saxon8SA returns error message" {
+#     export SAXON_CP=/path/to/saxon8sa.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+# }
 
 
-@test "invoking code coverage with Saxon8 returns error message" {
-    export SAXON_CP=/path/to/saxon8.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
-}
+# @test "invoking code coverage with Saxon8 returns error message" {
+#     export SAXON_CP=/path/to/saxon8.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+# }
 
 
-# this test must run first to create xspec directory
-@test "invoking code coverage with Saxon9EE creates test stylesheet" {
-    export SAXON_CP=/path/to/saxon9ee.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-  	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
-}
+# # this test must run first to create xspec directory
+# @test "invoking code coverage with Saxon9EE creates test stylesheet" {
+#     export SAXON_CP=/path/to/saxon9ee.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+#   	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[2]}" = "Creating Test Stylesheet..." ]
+# }
 
 
-@test "invoking code coverage with Saxon9PE creates test stylesheet" {
-    export SAXON_CP=/path/to/saxon9pe.jar
-    run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Creating Test Stylesheet..." ]
-}
+# @test "invoking code coverage with Saxon9PE creates test stylesheet" {
+#     export SAXON_CP=/path/to/saxon9pe.jar
+#     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
+# }
 
 
-@test "invoking xspec generates XML report file" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
+# @test "invoking xspec generates XML report file" {
+#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+#     run stat ../tutorial/xspec/escape-for-regex-result.xml
+# 	echo $output
+#     [ "$status" -eq 0 ]
+# }
+
+# @test "invoking xspec generates HTML report file" {
+#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+#     run stat ../tutorial/xspec/escape-for-regex-result.html
+# 	echo $output
+#     [ "$status" -eq 0 ]
+# }
+
+# @test "invoking xspec with -j option with Saxon8 returns error message" {
+#     export SAXON_CP=/path/to/saxon8.jar
+#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
+# }
+
+
+# @test "invoking xspec with -j option with Saxon8-SA returns error message" {
+#     export SAXON_CP=/path/to/saxon8sa.jar
+#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 1 ]
+#     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
+# }
+
+
+# @test "invoking xspec with -j option generates message with JUnit report location" {
+#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 0 ]
+#     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
+# }
+
+# @test "invoking xspec with -j option generates XML report file" {
+#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+#     run stat ../tutorial/xspec/escape-for-regex-result.xml
+# 	echo $output
+#     [ "$status" -eq 0 ]
+# }
+
+# @test "invoking xspec with -j option generates JUnit report file" {
+#     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+#     run stat ../tutorial/xspec/escape-for-regex-junit.xml
+# 	echo $output
+#     [ "$status" -eq 0 ]
+# }
+
+
+# @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
+#     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
+# 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+# 	echo $output
+# 	[ "$status" -eq 1 ]
+#   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
+# }
+
+
+# @test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
+#     export TEST_DIR=/tmp
+#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 0 ]
+#     [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
+# }
+
+
+# @test "invoking xspec.sh without TEST_DIR generates files in default location" {
+#     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+# 	echo $output
+#     [ "$status" -eq 0 ]
+#     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+# }
+
+
+@test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
+    run ../bin/xspec.sh ../test/xspec-46.xspec
 	echo $output
     [ "$status" -eq 0 ]
-}
-
-@test "invoking xspec generates HTML report file" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-    run stat ../tutorial/xspec/escape-for-regex-result.html
-	echo $output
-    [ "$status" -eq 0 ]
-}
-
-@test "invoking xspec with -j option with Saxon8 returns error message" {
-    export SAXON_CP=/path/to/saxon8.jar
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-}
-
-
-@test "invoking xspec with -j option with Saxon8-SA returns error message" {
-    export SAXON_CP=/path/to/saxon8sa.jar
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-}
-
-
-@test "invoking xspec with -j option generates message with JUnit report location" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
-}
-
-@test "invoking xspec with -j option generates XML report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo $output
-    [ "$status" -eq 0 ]
-}
-
-@test "invoking xspec with -j option generates JUnit report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-    run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	echo $output
-    [ "$status" -eq 0 ]
-}
-
-
-@test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
-    export SAXON_CP=/path/to/saxonb9-1-0-8.jar
-	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
-	[ "$status" -eq 1 ]
-  	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
-}
-
-
-@test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
-    export TEST_DIR=/tmp
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
-}
-
-
-@test "invoking xspec.sh without TEST_DIR generates files in default location" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
-    [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+    [[ "${lines[3]}" =~ "Testing with" ]]
 }


### PR DESCRIPTION
I implemented a bats test for the shell script that covers issue #46 and pr #48. This test uses the examples in #46 and checks that a warning is not raised. The bats test is using the `=~` operator for testing a partial match in line 3 of the shell output. This operator is bash specific (as opposed to POSIX shell) but works fine when run via Travis.

