### PR TITLE
 Add a test case for issue #46 / pr #48  for Windows

### DIFF
--- a/test/run-xspec-tests.cmd
+++ b/test/run-xspec-tests.cmd
@@ -5,9 +5,6 @@ rem
 rem    DESCRIPTION:  This script is a Windows version of run-xspec-tests.sh
 rem                  See run-xspec-tests.sh for details
 rem
-rem         OUTPUT:  XSpec outputs are created in .\xspec_win\
-rem                  A log file is created at .\result_win.log
-rem
 rem   DEPENDENCIES:  This script does *not* need to be run from the current directory (i.e. the test directory)
 rem
 rem ============================================================================
@@ -29,14 +26,9 @@ rem
 pushd "%~dp0"
 
 rem
-rem XSpec output directory
-rem
-set TEST_DIR=xspec_win
-
-rem
 rem Result log
 rem
-set RESULT_FILE=result_win.log
+set RESULT_FILE=result.log
 
 rem
 rem Run tests

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -48,7 +48,7 @@ setlocal
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]"
+    call :verify_line 3 x "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]"
 
     call :end
 endlocal
@@ -60,7 +60,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+    call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
     call :end
 endlocal
@@ -72,7 +72,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+    call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
     call :end
 endlocal
@@ -84,7 +84,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+    call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
     call :end
 endlocal
@@ -96,7 +96,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+    call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
     call :end
 endlocal
@@ -108,7 +108,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+    call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
     call :end
 endlocal
@@ -129,7 +129,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 3 "Creating Test Stylesheet..."
+    call :verify_line 3 x "Creating Test Stylesheet..."
 
     call :end
 endlocal
@@ -141,7 +141,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Creating Test Stylesheet..."
+    call :verify_line 2 x "Creating Test Stylesheet..."
 
     call :end
 endlocal
@@ -177,7 +177,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Saxon8 detected. JUnit report requires Saxon9."
+    call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
 
     call :end
 endlocal
@@ -189,7 +189,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Saxon8 detected. JUnit report requires Saxon9."
+    call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
 
     call :end
 endlocal
@@ -199,7 +199,7 @@ setlocal
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 19 "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
+    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
 
     call :end
 endlocal
@@ -235,7 +235,7 @@ setlocal
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 "Creating Test Stylesheet..."
+    call :verify_line 2 x "Creating Test Stylesheet..."
 
     call :end
 endlocal
@@ -248,7 +248,7 @@ setlocal
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 19 "Report available at %TEST_DIR%\escape-for-regex-result.html"
+    call :verify_line 19 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
     call :end
 endlocal
@@ -258,7 +258,17 @@ setlocal
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 19 "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
+    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
+
+    call :end
+endlocal
+
+setlocal
+    call :begin "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46"
+
+    call :run ..\bin\xspec.bat ..\test\xspec-46.xspec
+    call :verify_retval 0
+    call :verify_line 4 r "Testing with"
 
     call :end
 endlocal
@@ -378,18 +388,36 @@ rem
     goto :EOF
 
 :verify_line
+    if defined DEBUG (
+        echo *: %*
+        echo 0: %0
+        echo 1: %1
+        echo 2: %2
+        echo 3: %3
+    )
     rem
     rem Checks to see if the specified line of the output log file matches exactly the specified string
     rem
     rem Parameters:
     rem    1: Line number. Starts with 1, unlike Bats $lines which starts with 0.
-    rem    2: Expected string
+    rem    2: Operator
+    rem        x : Exact match ("=" on Bats)
+    rem        r : Compare with regular expression ("=~" on Bats)
+    rem    3: Expected string
+    rem        For 'r' operator, always evaluated as if the expression started with "^".
     rem
 
     rem
     rem Search the line-numbered output log file
     rem
-    findstr /l /x /c:"[%~1]%~2" "%OUTPUT_LINENUM%" > NUL
+    if        /i "%~2"=="x" (
+        findstr /l /x /c:"[%~1]%~3" "%OUTPUT_LINENUM%" > NUL
+    ) else if /i "%~2"=="r" (
+        findstr /b /r /c:"\[%~1\]%~3" "%OUTPUT_LINENUM%" > NUL
+    ) else (
+        call :failed "Bad operator: %~2"
+        goto :EOF
+    )
     if errorlevel 1 (
         call :failed "Line %~1 does not match the expected string"
         echo ---------- %OUTPUT_LINENUM%

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -44,17 +44,17 @@ for %%I in (..) do set PARENT_DIR_ABS=%%~fI
 echo === START TEST CASES ================================================
 
 setlocal
-    call :begin "invoking xspec without arguments prints usage"
+    call :setup "invoking xspec without arguments prints usage"
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1
     call :verify_line 3 x "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon9HE returns error message"
+    call :setup "invoking code coverage with Saxon9HE returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9he.jar
 
@@ -62,11 +62,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon9SA returns error message"
+    call :setup "invoking code coverage with Saxon9SA returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9sa.jar
 
@@ -74,11 +74,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon9 returns error message"
+    call :setup "invoking code coverage with Saxon9 returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9.jar
 
@@ -86,11 +86,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon8SA returns error message"
+    call :setup "invoking code coverage with Saxon8SA returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8sa.jar
 
@@ -98,11 +98,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon8 returns error message"
+    call :setup "invoking code coverage with Saxon8 returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8.jar
 
@@ -110,32 +110,23 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
 
-    call :end
+    call :teardown
 endlocal
 
-rem
-rem this test must run first to create xspec directory
-rem
 setlocal
-    call :begin "invoking code coverage with Saxon9EE creates test stylesheet"
+    call :setup "invoking code coverage with Saxon9EE creates test stylesheet"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9ee.jar
 
-    rem
-    rem Clear the residue of xspec directory
-    rem
-    call :del ..\tutorial\xspec\*
-    if exist ..\tutorial\xspec\ rmdir ..\tutorial\xspec\
-
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 3 x "Creating Test Stylesheet..."
+    call :verify_line 2 x "Creating Test Stylesheet..."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking code coverage with Saxon9PE creates test stylesheet"
+    call :setup "invoking code coverage with Saxon9PE creates test stylesheet"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9pe.jar
 
@@ -143,11 +134,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Creating Test Stylesheet..."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec generates XML report file"
+    call :setup "invoking xspec generates XML report file"
 
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-result.xml
     call :del "%EXPECTED_REPORT%"
@@ -155,11 +146,11 @@ setlocal
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec generates HTML report file"
+    call :setup "invoking xspec generates HTML report file"
 
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-result.html
     call :del "%EXPECTED_REPORT%"
@@ -167,11 +158,11 @@ setlocal
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with -j option with Saxon8 returns error message"
+    call :setup "invoking xspec with -j option with Saxon8 returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8.jar
 
@@ -179,11 +170,11 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with -j option with Saxon8-SA returns error message"
+    call :setup "invoking xspec with -j option with Saxon8-SA returns error message"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8sa.jar
 
@@ -191,21 +182,21 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with -j option generates message with JUnit report location"
+    call :setup "invoking xspec with -j option generates message with JUnit report location"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with -j option generates XML report file"
+    call :setup "invoking xspec with -j option generates XML report file"
 
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-junit.xml
     call :del "%EXPECTED_REPORT%"
@@ -213,11 +204,11 @@ setlocal
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with -j option generates JUnit report file"
+    call :setup "invoking xspec with -j option generates JUnit report file"
 
     set EXPECTED_REPORT=..\tutorial\xspec\escape-for-regex-junit.xml
     call :del "%EXPECTED_REPORT%"
@@ -225,11 +216,11 @@ setlocal
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_exist "%EXPECTED_REPORT%"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet"
+    call :setup "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet"
 
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxonb9-1-0-8.jar
 
@@ -237,40 +228,40 @@ setlocal
     call :verify_retval 1
     call :verify_line 2 x "Creating Test Stylesheet..."
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec.bat with TEST_DIR already set externally generates files inside TEST_DIR"
+    call :setup "invoking xspec.bat with TEST_DIR already set externally generates files inside TEST_DIR"
 
     set TEST_DIR=%TEMP%\%~n0
-    if not exist "%TEST_DIR%" mkdir "%TEST_DIR%"
+    call :mkdir "%TEST_DIR%"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec.bat without TEST_DIR generates files in default location"
+    call :setup "invoking xspec.bat without TEST_DIR generates files in default location"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
-    call :end
+    call :teardown
 endlocal
 
 setlocal
-    call :begin "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46"
+    call :setup "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46"
 
     call :run ..\bin\xspec.bat ..\test\xspec-46.xspec
     call :verify_retval 0
     call :verify_line 4 r "Testing with"
 
-    call :end
+    call :teardown
 endlocal
 
 echo === END TEST CASES ==================================================
@@ -310,7 +301,16 @@ rem
     if exist %1 del /q %1
     goto :EOF
 
-:begin
+:mkdir
+    if not exist %1 mkdir %1
+    goto :EOF
+
+:rmdir
+    call :del "%~1\*"
+    if exist %1 rmdir %1
+    goto :EOF
+
+:setup
     set CASE_NAME=%~1
 
     if /i "%APPVEYOR%"=="True" appveyor AddTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Running
@@ -318,9 +318,16 @@ rem
     echo CASE: %CASE_NAME%
 
     (echo # %CASE_NAME%) >> "%RESULTS_FILE%"
+
+    rem
+    rem Create the XSpec output directories
+    rem
+    call :mkdir ..\test\xspec
+    call :mkdir ..\tutorial\xspec
+
     goto :EOF
 
-:end
+:teardown
     if %CASE_RESULT% EQU 0 (
         echo ...PASS
         (echo %CASE_RESULT%) >> "%RESULTS_FILE%"
@@ -332,6 +339,13 @@ rem
     rem
     call :del "%OUTPUT_RAW%"
     call :del "%OUTPUT_LINENUM%"
+
+    rem
+    rem Remove the XSpec output directories
+    rem
+    call :rmdir ..\test\xspec
+    call :rmdir ..\tutorial\xspec
+
     goto :EOF
 
 :verified


### PR DESCRIPTION
This change makes the tests on AppVeyor parity with Travis

* Mimic `=~` operator of Bats
* Copy [the test case](https://github.com/xspec/xspec/blob/ba5f97c903d0022d322d7af7e379b6fbcaf35ee6/test/xspec.bats#L172-L177)