### PR TITLE
Report all the basic types and valid numeric expressions

### DIFF
--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -635,11 +635,25 @@
                                    replace($value, '''', ''''''),
                                    '''')" />
     </xsl:when>
-    <xsl:when test="$value instance of xs:integer or
-                    $value instance of xs:decimal or
-                    $value instance of xs:double">
+ 
+    <!-- Numeric literals: http://www.w3.org/TR/xpath20/#id-literals -->
+    <!-- Check integer before decimal, because of derivation -->
+    <xsl:when test="$value instance of xs:integer">
       <xsl:value-of select="$value" />
     </xsl:when>
+    <xsl:when test="$value instance of xs:decimal">
+      <xsl:value-of>
+        <xsl:variable as="xs:string" name="decimal-string" select="string($value)"/>
+        <xsl:sequence select="$decimal-string"/>
+        <xsl:sequence select="'.0'[not(contains($decimal-string,'.'))]"/>
+      </xsl:value-of>
+    </xsl:when>
+    <!-- xs:double
+             Just defer it to xsl:otherwise. Justifications below.
+             - Expression is a bit complicated: http://www.w3.org/TR/xpath-functions/#casting-to-string
+             - Not used as frequent as integer
+             - xsl:otherwise will return valid expression. It's just some more verbose then numeric literal. -->
+
     <xsl:when test="$value instance of xs:QName">
       <xsl:value-of 
         select="concat('QName(''', namespace-uri-from-QName($value), 

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -651,8 +651,8 @@
     <!-- xs:double
              Just defer it to xsl:otherwise. Justifications below.
              - Expression is a bit complicated: http://www.w3.org/TR/xpath-functions/#casting-to-string
-             - Not used as frequent as integer
-             - xsl:otherwise will return valid expression. It's just some more verbose then numeric literal. -->
+             - Not used as frequently as integer
+             - xsl:otherwise will return valid expression. It's just some more verbose than numeric literal. -->
 
     <xsl:when test="$value instance of xs:QName">
       <xsl:value-of 

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -659,13 +659,46 @@
 <xsl:function name="test:atom-type" as="xs:string">
   <xsl:param name="value" as="xs:anyAtomicType" />
   <xsl:choose>
+    <!-- Grouped as the spec does.
+         Groups are in the reversed order so that the derived types are before the primitive types,
+         otherwise xs:integer is recognised as xs:decimal, xs:yearMonthDuration as xs:duration, and so on. -->
+
+    <!-- http://www.w3.org/TR/xslt20/#built-in-types
+            Every XSLT 2.0 processor includes the following named type definitions in the in-scope schema components: -->
+
+    <!--    * The following types defined in [XPath 2.0] -->
+    <xsl:when test="$value instance of xs:yearMonthDuration">xs:yearMonthDuration</xsl:when>
+    <xsl:when test="$value instance of xs:dayTimeDuration">xs:dayTimeDuration</xsl:when>
+    <!-- xs:anyAtomicType: Abstract -->
+    <!-- xs:untyped: Not atomic -->
+    <xsl:when test="$value instance of xs:untypedAtomic">xs:untypedAtomic</xsl:when>
+
+    <!--    * The types xs:anyType and xs:anySimpleType. -->
+    <!-- Not atomic -->
+
+    <!--    * The derived atomic type xs:integer defined in [XML Schema Part 2]. -->
+    <xsl:when test="$value instance of xs:integer">xs:integer</xsl:when>
+
+    <!--    * All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION. -->
     <xsl:when test="$value instance of xs:string">xs:string</xsl:when>
     <xsl:when test="$value instance of xs:boolean">xs:boolean</xsl:when>
+    <xsl:when test="$value instance of xs:decimal">xs:decimal</xsl:when>
     <xsl:when test="$value instance of xs:double">xs:double</xsl:when>
-    <xsl:when test="$value instance of xs:anyURI">xs:anyURI</xsl:when>
-    <xsl:when test="$value instance of xs:dateTime">xs:dateTime</xsl:when>
+    <xsl:when test="$value instance of xs:float">xs:float</xsl:when>
     <xsl:when test="$value instance of xs:date">xs:date</xsl:when>
     <xsl:when test="$value instance of xs:time">xs:time</xsl:when>
+    <xsl:when test="$value instance of xs:dateTime">xs:dateTime</xsl:when>
+    <xsl:when test="$value instance of xs:duration">xs:duration</xsl:when>
+    <xsl:when test="$value instance of xs:QName">xs:QName</xsl:when>
+    <xsl:when test="$value instance of xs:anyURI">xs:anyURI</xsl:when>
+    <xsl:when test="$value instance of xs:gDay">xs:gDay</xsl:when>
+    <xsl:when test="$value instance of xs:gMonthDay">xs:gMonthDay</xsl:when>
+    <xsl:when test="$value instance of xs:gMonth">xs:gMonth</xsl:when>
+    <xsl:when test="$value instance of xs:gYearMonth">xs:gYearMonth</xsl:when>
+    <xsl:when test="$value instance of xs:gYear">xs:gYear</xsl:when>
+    <xsl:when test="$value instance of xs:base64Binary">xs:base64Binary</xsl:when>
+    <xsl:when test="$value instance of xs:hexBinary">xs:hexBinary</xsl:when>
+
     <xsl:otherwise>xs:anyAtomicType</xsl:otherwise>
   </xsl:choose>  
 </xsl:function>

--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -85,6 +85,186 @@
       <t:expect label="the result" test="$x:result eq true()"/>
     </t:scenario>
   </t:scenario>
+
+  <!--
+    Function test:atom-type
+        http://www.w3.org/TR/xslt20/#built-in-types
+   -->
+  <t:scenario label="test:atom-type">
+
+    <t:scenario label="All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION">
+
+      <t:scenario label="xs:string">
+        <t:call function="test:atom-type">
+          <t:param select="xs:string('foo')" />
+        </t:call>
+        <t:expect label="xs:string" select="'xs:string'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:boolean">
+        <t:call function="test:atom-type">
+          <t:param select="xs:boolean('true')" />
+        </t:call>
+        <t:expect label="xs:boolean" select="'xs:boolean'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:decimal">
+        <t:call function="test:atom-type">
+          <t:param select="xs:decimal(1)" />
+        </t:call>
+        <t:expect label="xs:decimal" select="'xs:decimal'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:double">
+        <t:call function="test:atom-type">
+          <t:param select="xs:double(1)" />
+        </t:call>
+        <t:expect label="xs:double" select="'xs:double'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:float">
+        <t:call function="test:atom-type">
+          <t:param select="xs:float(1)" />
+        </t:call>
+        <t:expect label="xs:float" select="'xs:float'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:date">
+        <t:call function="test:atom-type">
+          <t:param select="xs:date('1111-11-11')" />
+        </t:call>
+        <t:expect label="xs:date" select="'xs:date'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:time">
+        <t:call function="test:atom-type">
+          <t:param select="xs:time('11:11:11')" />
+        </t:call>
+        <t:expect label="xs:time" select="'xs:time'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:dateTime">
+        <t:call function="test:atom-type">
+          <t:param select="xs:dateTime('1111-11-11T11:11:11')" />
+        </t:call>
+        <t:expect label="xs:dateTime" select="'xs:dateTime'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:duration">
+        <t:call function="test:atom-type">
+          <t:param select="xs:duration('PT1S')" />
+        </t:call>
+        <t:expect label="xs:duration" select="'xs:duration'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:QName">
+        <t:call function="test:atom-type">
+          <t:param select="xs:QName('foo')" />
+        </t:call>
+        <t:expect label="xs:QName" select="'xs:QName'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:anyURI">
+        <t:call function="test:atom-type">
+          <t:param select="xs:anyURI('foo')" />
+        </t:call>
+        <t:expect label="xs:anyURI" select="'xs:anyURI'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:gDay">
+        <t:call function="test:atom-type">
+          <t:param select="xs:gDay('---11')" />
+        </t:call>
+        <t:expect label="xs:gDay" select="'xs:gDay'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:gMonthDay">
+        <t:call function="test:atom-type">
+          <t:param select="xs:gMonthDay('--11-11')" />
+        </t:call>
+        <t:expect label="xs:gMonthDay" select="'xs:gMonthDay'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:gMonth">
+        <t:call function="test:atom-type">
+          <t:param select="xs:gMonth('--11')" />
+        </t:call>
+        <t:expect label="xs:gMonth" select="'xs:gMonth'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:gYearMonth">
+        <t:call function="test:atom-type">
+          <t:param select="xs:gYearMonth('1111-11')" />
+        </t:call>
+        <t:expect label="xs:gYearMonth" select="'xs:gYearMonth'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:gYear">
+        <t:call function="test:atom-type">
+          <t:param select="xs:gYear('1111')" />
+        </t:call>
+        <t:expect label="xs:gYear" select="'xs:gYear'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:base64Binary">
+        <t:call function="test:atom-type">
+          <t:param select="xs:base64Binary(xs:hexBinary('11'))" />
+        </t:call>
+        <t:expect label="xs:base64Binary" select="'xs:base64Binary'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:hexBinary">
+        <t:call function="test:atom-type">
+          <t:param select="xs:hexBinary('11')" />
+        </t:call>
+        <t:expect label="xs:hexBinary" select="'xs:hexBinary'"/>
+      </t:scenario>
+
+    </t:scenario>
+
+    <t:scenario label="The derived atomic type xs:integer defined in [XML Schema Part 2]">
+
+      <t:scenario label="xs:integer">
+        <t:call function="test:atom-type">
+          <t:param select="xs:integer(1)" />
+        </t:call>
+        <t:expect label="xs:integer" select="'xs:integer'"/>
+      </t:scenario>
+
+    </t:scenario>
+
+    <!-- The types xs:anyType and xs:anySimpleType: Not atomic -->
+
+    <t:scenario label="The following types defined in [XPath 2.0]">
+
+      <t:scenario label="xs:yearMonthDuration">
+        <t:call function="test:atom-type">
+          <t:param select="xs:yearMonthDuration('P1M')" />
+        </t:call>
+        <t:expect label="xs:yearMonthDuration" select="'xs:yearMonthDuration'"/>
+      </t:scenario>
+
+      <t:scenario label="xs:dayTimeDuration">
+        <t:call function="test:atom-type">
+          <t:param select="xs:dayTimeDuration('PT1S')" />
+        </t:call>
+        <t:expect label="xs:dayTimeDuration" select="'xs:dayTimeDuration'"/>
+      </t:scenario>
+
+      <!-- xs:anyAtomicType: Abstract -->
+
+      <!-- xs:untyped: Not atomic -->
+
+      <t:scenario label="xs:untypedAtomic">
+        <t:call function="test:atom-type">
+          <t:param select="xs:untypedAtomic('foo')" />
+        </t:call>
+        <t:expect label="xs:untypedAtomic" select="'xs:untypedAtomic'"/>
+      </t:scenario>
+
+    </t:scenario>
+
+  </t:scenario>
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->

--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -87,6 +87,167 @@
   </t:scenario>
 
   <!--
+    Function test:report-atomic-value
+  -->
+  <t:scenario label="test:report-atomic-value">
+
+  	<t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
+      <t:scenario label="String Containing Single Quotes">
+        <t:call function="test:report-atomic-value">
+          <t:param select="'don''t'" />
+        </t:call>
+        <t:expect label="Escaped" select="'''don''''t'''" />
+      </t:scenario>
+    </t:scenario>
+
+    <t:scenario label="xs:integer">
+      <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:integer(18446744073709551615)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'18446744073709551615'" />
+      </t:scenario>
+
+      <t:scenario label="0">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:integer(0)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'0'" />
+      </t:scenario>
+
+      <t:scenario label="-1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:integer(-1)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'-1'" />
+      </t:scenario>
+    </t:scenario>
+
+    <t:scenario label="xs:decimal">
+      <t:scenario label="1.2">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(1.2)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'1.2'" />
+      </t:scenario>
+
+      <t:scenario label="1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(1)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'1.0'" />
+      </t:scenario>
+
+      <t:scenario label="0.1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(0.1)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'0.1'" />
+      </t:scenario>
+
+      <t:scenario label="0">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(0)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'0.0'" />
+      </t:scenario>
+
+      <t:scenario label="-0.1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(-0.1)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'-0.1'" />
+      </t:scenario>
+
+      <t:scenario label="-1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(-1)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'-1.0'" />
+      </t:scenario>
+
+      <t:scenario label="-1.2">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:decimal(-1.2)" />
+        </t:call>
+        <t:expect label="Numeric literal" select="'-1.2'" />
+      </t:scenario>
+
+    </t:scenario>
+
+    <t:scenario label="xs:double">
+      <t:scenario label="1.234e56">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:double(1.234e56)" />
+        </t:call>
+        <t:expect label="Constructor" test="matches($x:result, 'xs:double\(''.+E.+''\)')" />
+      </t:scenario>
+
+      <t:scenario label="1">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:double(1)" />
+        </t:call>
+        <t:expect label="Constructor" select="'xs:double(''1'')'" />
+      </t:scenario>
+
+      <t:scenario label="NaN">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:double('NaN')" />
+        </t:call>
+        <t:expect label="Constructor" select="'xs:double(''NaN'')'" />
+      </t:scenario>
+
+      <t:scenario label="INF">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:double('INF')" />
+        </t:call>
+        <t:expect label="Constructor" select="'xs:double(''INF'')'" />
+      </t:scenario>
+
+      <t:scenario label="-INF">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:double('-INF')" />
+        </t:call>
+        <t:expect label="Constructor" select="'xs:double(''-INF'')'" />
+      </t:scenario>
+
+    </t:scenario>
+
+    <t:scenario label="xs:QName">
+      <t:scenario label="No namespace">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:QName('foo')" />
+        </t:call>
+        <t:expect label="Function" select="'QName('''', ''foo'')'" />
+      </t:scenario>
+
+      <t:scenario label="In namespace, with prefix">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:QName('x:foo')" />
+        </t:call>
+        <t:expect label="Function" select="'QName(''http://www.jenitennison.com/xslt/xspec'', ''x:foo'')'" />
+      </t:scenario>
+
+      <t:scenario label="In namespace, without prefix">
+        <t:call function="test:report-atomic-value">
+          <t:param select="QName('x-urn:test:report-atomic-value', 'foo')" />
+        </t:call>
+        <t:expect label="Function" select="'QName(''x-urn:test:report-atomic-value'', ''foo'')'" />
+      </t:scenario>
+    </t:scenario>
+
+    <t:scenario label="Other types that enters xsl:otherwise branch of the function">
+      <t:scenario label="xs:untypedAtomic">
+        <t:call function="test:report-atomic-value">
+          <t:param select="xs:untypedAtomic('foo')" />
+        </t:call>
+        <t:expect label="Constructor" select="'xs:untypedAtomic(''foo'')'" />
+      </t:scenario>
+    </t:scenario>
+
+ </t:scenario>
+
+  <!--
     Function test:atom-type
         http://www.w3.org/TR/xslt20/#built-in-types
    -->

--- a/test/xspec-50.xspec
+++ b/test/xspec-50.xspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../src/compiler/generate-tests-utils.xsl"
+	xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="test:report-value with xs:untypedAtomic">
+		<x:call template="test:report-value">
+			<x:param name="value" select="xs:untypedAtomic('0123')" />
+			<x:param name="wrapper-name" select="'x:result'" />
+			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
+		</x:call>
+		<x:expect label="Reports xs:untypedAtomic" select="'xs:untypedAtomic(''0123'')'"
+			test="string(x:result/@select)" />
+	</x:scenario>
+
+	<x:scenario label="test:report-value with xs:hexBinary">
+		<x:call template="test:report-value">
+			<x:param name="value" select="xs:hexBinary('0123')" />
+			<x:param name="wrapper-name" select="'x:expect'" />
+			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
+		</x:call>
+		<x:expect label="Reports xs:hexBinary" select="'xs:hexBinary(''0123'')'"
+			test="string(x:expect/@select)" />
+	</x:scenario>
+</x:description>

--- a/test/xspec-55.xspec
+++ b/test/xspec-55.xspec
@@ -9,7 +9,7 @@
 			<x:param name="wrapper-name" select="'x:expect'" />
 			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
 		</x:call>
-		<x:expect label="Reports as numeric litaral of decimal" select="'1.0'"
+		<x:expect label="Reports as numeric literal of decimal" select="'1.0'"
 			test="string(x:expect/@select)" />
 	</x:scenario>
 
@@ -29,7 +29,7 @@
 			<x:param name="wrapper-name" select="'x:expect'" />
 			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
 		</x:call>
-		<x:expect label="Reports as numeric litaral of integer" select="'1'"
+		<x:expect label="Reports as numeric literal of integer" select="'1'"
 			test="string(x:expect/@select)" />
 	</x:scenario>
 </x:description>

--- a/test/xspec-55.xspec
+++ b/test/xspec-55.xspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../src/compiler/generate-tests-utils.xsl"
+	xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="test:report-value with xs:decimal">
+		<x:call template="test:report-value">
+			<x:param name="value" select="xs:decimal('1')" />
+			<x:param name="wrapper-name" select="'x:expect'" />
+			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
+		</x:call>
+		<x:expect label="Reports as numeric litaral of decimal" select="'1.0'"
+			test="string(x:expect/@select)" />
+	</x:scenario>
+
+	<x:scenario label="test:report-value with xs:double">
+		<x:call template="test:report-value">
+			<x:param name="value" select="xs:double('1')" />
+			<x:param name="wrapper-name" select="'x:expect'" />
+			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
+		</x:call>
+		<x:expect label="Reports as constructor of double" select="'xs:double(''1'')'"
+			test="string(x:expect/@select)" />
+	</x:scenario>
+
+	<x:scenario label="test:report-value with xs:integer">
+		<x:call template="test:report-value">
+			<x:param name="value" select="xs:integer('1')" />
+			<x:param name="wrapper-name" select="'x:expect'" />
+			<x:param name="wrapper-ns" select="'http://www.jenitennison.com/xslt/xspec'" />
+		</x:call>
+		<x:expect label="Reports as numeric litaral of integer" select="'1'"
+			test="string(x:expect/@select)" />
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
Fixes #50 

* `test:atom-type()` now covers all the built-in types supported by every XSLT 2.0 processor.

Fixes #55 

* `test:report-atomic-value()` now returns valid expressions for decimal, double and integer.

Also added are

* Unit tests for `test:atom-type()` and `test:report-atomic-value`
* Regression tests for #50 and #55. Actually they test `test:report-value()`. I'm not sure if this is the best way.
