### PR TITLE
TODO comments for #4

### DIFF
--- a/test/xspec-focus-1.xspec
+++ b/test/xspec-focus-1.xspec
@@ -11,9 +11,9 @@
        Test @focus.
    -->
   <!--
-       Normal scenarios (must be pending because of the @focus).
+       Normal scenarios (must be pending because of the @focus in "Focused on scenarios").
    -->
-  <t:scenario label="pending call" focus="focus">
+  <t:scenario label="pending call" focus="TODO: xspec/xspec#4: Remove this @focus">
     <t:call function="my:square">
       <t:param select="3"/>
     </t:call>
@@ -34,7 +34,7 @@
     </t:call>
     <t:expect label="the result" test="$x:result eq 9"/>
   </t:scenario>
-  <t:scenario label="focus must fail">
+  <t:scenario label="focus must fail: TODO: xspec/xspec#4: Restore @focus='focus'">
     <t:call function="my:square">
       <t:param select="2"/>
     </t:call>

--- a/test/xspec-function.xspec
+++ b/test/xspec-function.xspec
@@ -8,7 +8,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <?oxygen RNGSchema="http://xspec.googlecode.com/svn/trunk/xspec.rnc" type="compact"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <t:scenario label="call" focus="focus">
+  <t:scenario label="call" focus="TODO: xspec/xspec#4: Remove this @focus">
     <t:call function="my:square">
       <t:param select="3"/>
     </t:call>

--- a/test/xspec-imported.xspec
+++ b/test/xspec-imported.xspec
@@ -8,7 +8,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <?oxygen RNGSchema="http://xspec.googlecode.com/svn/trunk/xspec.rnc" type="compact"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <t:scenario label="call" focus="focus">
+  <t:scenario label="call" focus="TODO: xspec/xspec#4: Remove this @focus">
     <t:call function="my:square">
       <t:param select="3"/>
     </t:call>

--- a/test/xspec-pending.xspec
+++ b/test/xspec-pending.xspec
@@ -31,7 +31,7 @@
   <!--
        Non-pending scenarios.
    -->
-  <t:scenario label="call" focus="focus">
+  <t:scenario label="call" focus="TODO: xspec/xspec#4: Remove this @focus">
     <t:call function="my:square">
       <t:param select="3"/>
     </t:call>

--- a/test/xspec-rule.xspec
+++ b/test/xspec-rule.xspec
@@ -16,7 +16,7 @@
       <transformed/>
     </t:expect>
   </t:scenario>
-  <t:scenario label="context result is wrong: must fail" pending="should be rewritten">
+  <t:scenario label="context result is wrong: must fail" pending="TODO: xspec/xspec#4: Remove this @pending">
     <t:context>
       <rule/>
     </t:context>


### PR DESCRIPTION
Related to #4.

df4959b87cf8054ca4ad8b6d17b627c233dff659 added/removed `focus`/`pending` as workaround.
I understand the workaround was necessary. However, the workaround makes it hard to distinguish the genuine `focus`/`pending` from the workaround ones.

This change gives explicit TODO comments to the workaround ones.

@cirulls,
Can you please verify I have put the correct TODOs at the right places?
If ok, please consider merging this.
