### PR TITLE
Keep type annotations in $impl:test-items

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -323,9 +323,14 @@
                    Have to experiment a bit to see if that really is the case.                   
                    TODO: To remove. Use directly $x:result instead.  See issue 14. -->
               <when test="$x:result instance of node()+">
-                <document>
-                  <copy-of select="$x:result" />
-                </document>
+                <!-- $impl:test-items-doc aims to create an implicit document node as described
+                     in http://www.w3.org/TR/xslt20/#temporary-trees
+                     So its "variable" element must not have @as or @select.
+                     Do not use "document" or "copy-of" element: xspec/xspec#47 -->
+                <variable name="impl:test-items-doc">
+                  <sequence select="$x:result" />
+                </variable>
+                <sequence select="$impl:test-items-doc treat as document-node()" />
               </when>
               <otherwise>
                 <sequence select="$x:result" />


### PR DESCRIPTION
Fixes #47

This change keeps the type annotations in `$impl:test-items` by creating an [implicit document node](http://www.w3.org/TR/xslt20/#temporary-trees).

Another option would be creating the document node explicitly with `validation="preserve"`. But the `validation` attribute is not available on Saxon-HE. Not a viable option.

No regression test at the moment. Reproducing the bug requires Saxon-EE.