### PR TITLE
fix failing and pending tests #4

### DIFF
--- a/test/xspec-focus-1.xspec
+++ b/test/xspec-focus-1.xspec
@@ -1,49 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ===================================================================== -->
 <!--  File:       test/xspec-pending.xspec                                 -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <!--
-       Test @focus.
-   -->
-  <!--
-       Normal scenarios (must be pending because of the @focus).
-   -->
-  <t:scenario label="pending call" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="pending must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="the type" test="$x:result instance of xs:string"/>
-  </t:scenario>
-  <!--
-       Focused on scenarios.
-   -->
-  <t:scenario label="focus call" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="focus must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="the type" test="$x:result instance of xs:string"/>
-  </t:scenario>
+
+    <t:scenario label="when testing a focused scenario" focus="testing focus">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="it must execute the focused test" test="$x:result eq 9"/>
+    </t:scenario>
+
+    <t:scenario label="when testing an unfocused and correct scenario">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="it must mark the test as pending" test="$x:result instance of xs:integer"/>
+    </t:scenario>
+
+    <t:scenario label="when testing an unfocused and incorrect scenario">
+        <t:call function="my:square">
+            <t:param select="2"/>
+        </t:call>
+        <t:expect label="it must mark the test as pending" test="$x:result instance of xs:string"/>
+    </t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-focus-2.xspec
+++ b/test/xspec-focus-2.xspec
@@ -1,67 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ===================================================================== -->
 <!--  File:       test/xspec-pending.xspec                                 -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <!--
-       Test @focus and pending toghether (both @pending and t:pending).
-   -->
-  <!--
-       Test x:pending.
-   -->
-  <t:pending label="testing pending element">
-    <t:scenario label="pending call (element)">
-      <t:call function="my:square">
-        <t:param select="3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq 9"/>
+
+    <t:pending label="when using a pending element">
+        <t:scenario label="a correct scenario without the focus attribute">
+            <t:call function="my:square">
+                <t:param select="3"/>
+            </t:call>
+            <t:expect label="must return a pending test" test="$x:result eq 9"/>
+        </t:scenario>
+        <t:scenario label="a correct scenario with a focus attribute" focus="testing focus">
+            <t:call function="my:square">
+                <t:param select="3"/>
+            </t:call>
+            <t:expect label="must execute the test and return a successful test" test="$x:result eq 9"/>
+        </t:scenario>
+    </t:pending>
+
+    <t:scenario label="when testing a non-pending scenario without focus">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="it must return a pending test" test="$x:result eq 9"/>
     </t:scenario>
-    <t:scenario label="pending call (element) + focus" focus="focus">
-      <t:call function="my:square">
-        <t:param select="3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq 9"/>
+    <t:scenario label="when testing a non-pending scenario with focus" focus="testing focus">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="it must execute the test and return a successful test" test="$x:result eq 9"/>
     </t:scenario>
-  </t:pending>
-  <!--
-       Non-pending scenarios.
-   -->
-  <t:scenario label="call">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="call + focus" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <!--
-       Test @pending.
-   -->
-  <t:scenario label="pending call (attribute)" pending="testing pending attribute">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <!-- does not make sense, really, but to see how the implem reacts -->
-  <t:scenario label="pending call (attribute) + focus" pending="testing pending attribute" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
+
+    <t:scenario label="when using a pending attribute" pending="testing pending attribute">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="it must return a pending test" test="$x:result eq 9"/>
+    </t:scenario>
+
+    <t:scenario label="when using both pending and focus attributes (not recommended as ambiguous)" pending="testing pending attribute" focus="testing focus attribute">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="the focus attribute has priority, the test is executed and return a successful test" test="$x:result eq 9"/>
+    </t:scenario>
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-function.xspec
+++ b/test/xspec-function.xspec
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/xspec-function.xspec                                -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- ====================================================================== -->
+<!--  File:        test/xspec-function.xspec                                -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <t:scenario label="call" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-    <t:expect label="the type" test="$x:result instance of xs:integer"/>
-  </t:scenario>
-  <t:scenario label="must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="wrong result" test="$x:result eq 42"/>
-  </t:scenario>
+
+	<t:scenario label="when calling a square function with a parameter">
+		<t:call function="my:square">
+			<t:param select="3"/>
+		</t:call>
+		<t:expect label="the result is correct" test="$x:result eq 9"/>
+		<t:expect label="the type is correct" test="$x:result instance of xs:integer"/>
+	</t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-import.xspec
+++ b/test/xspec-import.xspec
@@ -1,30 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/xspec-import.xspec                                  -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- ====================================================================== -->
+<!--  File:        test/xspec-import.xspec                                  -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <t:import href="xspec-imported.xspec"/>
-  <t:scenario label="call">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-    <t:expect label="the type" test="$x:result instance of xs:integer"/>
-  </t:scenario>
-  <t:scenario label="must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="the type" test="$x:result instance of xs:string"/>
-  </t:scenario>
+
+    <t:import href="xspec-imported.xspec"/>
+
+    <t:scenario label="when calling a square function with a parameter">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="the result is correct" test="$x:result eq 9"/>
+        <t:expect label="the type is correct" test="$x:result instance of xs:integer"/>
+    </t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-imported.xspec
+++ b/test/xspec-imported.xspec
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/xspec-imported.xspec                                -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- ====================================================================== -->
+<!--  File:        test/xspec-imported.xspec                                -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <t:scenario label="call" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="wrong result" test="$x:result eq 42"/>
-  </t:scenario>
+
+    <t:scenario label="when calling a square function with a parameter">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="the result is correct" test="$x:result eq 9"/>
+    </t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-pending.xspec
+++ b/test/xspec-pending.xspec
@@ -1,66 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/xspec-pending.xspec                                 -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- ====================================================================== -->
+<!--  File:        test/xspec-pending.xspec                                 -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="http://example.org/ns/my" query="http://example.org/ns/my" query-at="xspec-tested.xql" stylesheet="xspec-tested.xsl">
-  <!--
-       Test pending features (x:pending and @pending).
-   -->
-  <!--
-       Test x:pending.
-   -->
-  <t:pending label="testing pending element">
-    <t:scenario label="pending call (element)">
-      <t:call function="my:square">
-        <t:param select="3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq 9"/>
+
+    <t:pending label="when using a pending element">
+
+        <t:scenario label="a correct scenario">
+            <t:call function="my:square">
+                <t:param select="3"/>
+            </t:call>
+            <t:expect label="must return a pending test" test="$x:result eq 9"/>
+            <t:expect label="must return a pending test" test="$x:result instance of xs:integer"/>
+        </t:scenario>
+
+        <t:scenario label="an incorrect scenario">
+            <t:call function="my:square">
+                <t:param select="2"/>
+            </t:call>
+            <t:expect label="must return a pending test" test="$x:result instance of xs:string"/>
+        </t:scenario>
+    </t:pending>
+
+    <t:scenario label="when using a pending attribute with a correct scenario" pending="testing pending attribute">
+        <t:call function="my:square">
+            <t:param select="3"/>
+        </t:call>
+        <t:expect label="must return a pending test" test="$x:result eq 9"/>
     </t:scenario>
-    <t:scenario label="pending must fail (element)">
-      <t:call function="my:square">
-        <t:param select="2"/>
-      </t:call>
-      <t:expect label="the type" test="$x:result instance of xs:string"/>
+
+    <t:scenario label="when using a pending attribute with an incorrect scenario" pending="testing pending attribute">
+        <t:call function="my:square">
+            <t:param select="2"/>
+        </t:call>
+        <t:expect label="must return a pending test" test="$x:result instance of xs:string"/>
     </t:scenario>
-  </t:pending>
-  <!--
-       Non-pending scenarios.
-   -->
-  <t:scenario label="call" focus="focus">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="must fail">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="the type" test="$x:result instance of xs:string"/>
-  </t:scenario>
-  <!--
-       Test @pending.
-   -->
-  <t:scenario label="pending call (attribute)" pending="testing pending attribute">
-    <t:call function="my:square">
-      <t:param select="3"/>
-    </t:call>
-    <t:expect label="the result" test="$x:result eq 9"/>
-  </t:scenario>
-  <t:scenario label="pending must fail (attribute)" pending="testing pending attribute">
-    <t:call function="my:square">
-      <t:param select="2"/>
-    </t:call>
-    <t:expect label="the type" test="$x:result instance of xs:string"/>
-  </t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-rule.xspec
+++ b/test/xspec-rule.xspec
@@ -1,55 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/xspec-rule.xspec                                    -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- ====================================================================== -->
+<!--  File:        test/xspec-rule.xspec                                    -->
+<!--  Author:      Florent Georges                                          -->
+<!--  Contributor: Sandro Cirulli, github.com/cirulls                       -->
+<!--  Copyright (c) 2010 Jeni Tennison (see end of file.)                   -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" stylesheet="xspec-tested.xsl">
-  <t:scenario label="context">
-    <t:context>
-      <rule/>
-    </t:context>
-    <t:expect label="the result">
-      <transformed/>
-    </t:expect>
-  </t:scenario>
-  <t:scenario label="context result is wrong: must fail" pending="should be rewritten">
-    <t:context>
-      <rule/>
-    </t:context>
-    <t:expect label="wrong result">
-      <erroneous/>
-    </t:expect>
-  </t:scenario>
-  <!-- TODO: Make two different cases for the base t:apply and with param. -->
-  <t:scenario label="apply" pending="not implemented yet">
-    <t:variable name="ctxt" as="element()">
-      <rule/>
-    </t:variable>
-    <t:apply select="$ctxt">
-      <t:param name="p" select="0"/>
-    </t:apply>
-    <t:expect label="the result">
-      <transformed/>
-    </t:expect>
-  </t:scenario>
-  <t:scenario label="apply result is wrong: must fail" pending="not implemented yet">
-    <t:variable name="ctxt" as="element()">
-      <rule/>
-    </t:variable>
-    <t:apply select="$ctxt">
-      <t:param name="p" select="0"/>
-    </t:apply>
-    <t:expect label="wrong result">
-      <erroneous/>
-    </t:expect>
-  </t:scenario>
+
+    <t:scenario label="when running a scenario with a context">
+        <t:context>
+            <rule/>
+        </t:context>
+        <t:expect label="the element in the context must be converted">
+            <transformed/>
+        </t:expect>
+    </t:scenario>
+
+    <!-- TODO: Make two different cases for the base t:apply and with param. -->
+    <t:scenario label="apply" pending="not implemented yet">
+        <t:variable name="ctxt" as="element()">
+            <rule/>
+        </t:variable>
+        <t:apply select="$ctxt">
+            <t:param name="p" select="0"/>
+        </t:apply>
+        <t:expect label="the result">
+            <transformed/>
+        </t:expect>
+    </t:scenario>
+
+    <t:scenario label="apply result is wrong: must fail" pending="not implemented yet">
+        <t:variable name="ctxt" as="element()">
+            <rule/>
+        </t:variable>
+        <t:apply select="$ctxt">
+            <t:param name="p" select="0"/>
+        </t:apply>
+        <t:expect label="wrong result">
+            <erroneous/>
+        </t:expect>
+    </t:scenario>
+
 </t:description>
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!-- Copyright (c) 2010 Jeni Tennison                                      -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->


### PR DESCRIPTION
This pull request addresses #4 and should make #61 redundant. 

### Changes applied to all the files

I edited the value of attribute ```label``` in order to provide explicit description of what the test is doing. I removed comments before the test as the test should now be self-explanatory thanks to the text in label. 

I added my name as contributor to mark the tests I edited and corrected a typo related to Jeni's surname. I have not applied these cosmetic changes to other tests not committed in this pull request. 

### ```xspec-function.xspec```, ```xspec-imported.xspec``` and ```xspec-import.xspec```  

I removed the failing test checking that the wrong result is failing. This check is already covered by a previous successful test that checks that the result is correct. 

### ```xspec-pending.xspec```

I removed the test in the non-pending scenario as this test is already covered in xspec-function.xspec

This test is checking the correct behaviour of the ```x:pending``` element and ```pending``` attribute. The expected result for these tests is to generate pending tests in the report (regardless if the scenario is correct or incorrect). Therefore I believe it is fine to leave these tests as pending as the test suite will spot if a change in the implementation of the ```x:pending``` element and the ```pending``` attribute invalids these tests. 

The test suite will not check that these tests always generate a pending test in the report (if the test passes it will not break the test suit) but it will spot at least if the tests generate failing results in the report. Testing that these tests always generate pending results would require a different runner script than ```run-xspec-tests.xspec``` which I am not going to implement at this stage (maybe in the future if there are several tests similar to this one). 

### ```xspec-rule.xspec```

I removed the failing test checking that the wrong result is failing. This check is already covered by a previous successful test that checks that the result is correct. 

I left as ```pending="not implemented yet"``` tests related to ```t:apply```. This is part of the review of the ```apply``` element not currently in the RNG Schema as highlighted in #60.

### ```xspec-focus-1.xspec```

This test is checking the correct behaviour of the ```focus``` attribute. The expected result for these tests is to run only the test with the ```focus``` attribute and mark as pending all the other tests (regardless if the scenario is correct or incorrect). Therefore I removed the duplicate tests and implemented:

- a focused scenario which must run
- an unfocused scenario with correct result that must be marked as pending
- an unfocused scenario with incorrect result that must be marked as pending

As for ```xspec-pending```, the test suite will only check that there are no failing tests, there is no check that the pending tests will not become successful.
 
### ```xspec-focus-1.xspec```

This test mainly describes how the ```focus``` attribute works and how it behaves when used in conjuction with pending scenarios. I mainly edited the label text in order to describe explicitly how the implementation of ```focus``` is behaving.

### Review

@AirQuick: could you please review this pull request and confirm that it addresses #61 as well? Thanks.