### PR TITLE
Remove unused namespace declarations in HTML report

### DIFF
--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -54,6 +54,11 @@
   </xsl:variable>
   <xsl:variable name="new-namespaces" as="node()*" 
     select="namespace::*[not(. = $omit-namespaces) and ($level = 0 or not(name() = ../../namespace::*/name()))]" />
+
+  <!-- remove all unused namespaces -->
+  <xsl:variable name="new-namespaces" as="node()*"
+    select="$new-namespaces[current()/(self::*|.//(*|@*))/namespace-uri() = .]" />
+
   <xsl:if test="not(namespace::*[name() = '']) and ../namespace::*[name() = '']">
     <xsl:text> xmlns=""</xsl:text>
   </xsl:if>


### PR DESCRIPTION
In documents with many namespaces, the namespace declarations in the serialized XML fragments in the HTML report can be very distracting. This patch removes all namespace declarations from the report that are not actually used in the fragment.