### PR TITLE
Add explicit content encoding for the generated HTML report

### DIFF
--- a/src/harnesses/saxon/saxon-xquery-harness.xproc
+++ b/src/harnesses/saxon/saxon-xquery-harness.xproc
@@ -14,7 +14,7 @@
     <p>The dir where you unzipped the XSpec archive on your filesystem is passed
         in the option 'xspec-home'.</p>
   </p:documentation>
-  <p:serialization port="result" indent="true"/>
+  <p:serialization port="result" indent="true" method="xhtml" encoding="UTF-8" include-content-type="true" />
   <p:import href="../harness-lib.xpl"/>
   <t:parameters name="params"/>
   <p:group>

--- a/src/harnesses/saxon/saxon-xslt-harness.xproc
+++ b/src/harnesses/saxon/saxon-xslt-harness.xproc
@@ -12,7 +12,7 @@
     <p><b>Primary input:</b> A XSpec test suite document.</p>
     <p><b>Primary output:</b> A formatted HTML XSpec report.</p>
   </p:documentation>
-  <p:serialization port="result" indent="true"/>
+  <p:serialization port="result" indent="true" method="xhtml" encoding="UTF-8" include-content-type="true" />
   <p:import href="../harness-lib.xpl"/>
   <!-- TODO: Does not work yet... -->
   <!--t:ensure-input/-->


### PR DESCRIPTION
The Saxon harnesses generated UTF-8-encoded HTML reports without specifying the encoding in the HTML file. If the report is opened from a local file, the browser has no proper way of guessing the encoding, potentially scrambling non-ASCII-characters. I only checked the Saxon harnesses, so this might be useful in other XProc harnesses as well.