### PR TITLE
Run tests with Saxon 9.7.0-15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
     matrix:
         # latest Saxon 9.7 version
-        - SAXON_VERSION=9.7.0-14
+        - SAXON_VERSION=9.7.0-15
         # latest Saxon 9.6 version
         - SAXON_VERSION=9.6.0-10
         # Saxon version used in oXygen

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
     # latest Saxon 9.7 version
-    - SAXON_VERSION: 9.7.0-14
+    - SAXON_VERSION: 9.7.0-15
     # latest Saxon 9.6 version
     - SAXON_VERSION: 9.6.0-10
     # Saxon version used in oXygen

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  SAXON_CP: '%APPVEYOR_BUILD_FOLDER%\saxon\saxon9he.jar'
+  SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
     # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-14
@@ -10,9 +10,11 @@ environment:
 
 install:
 - ps: >-
-    mkdir -Name "saxon"
+    $saxon_home = Split-Path -Path "${env:SAXON_CP}" -Parent
 
-    Invoke-WebRequest "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar" -OutFile "saxon\saxon9he.jar"
+    mkdir -Path $saxon_home
+
+    Invoke-WebRequest -Uri "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar" -OutFile "${env:SAXON_CP}"
 build: off
 test_script:
 - cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,17 @@ environment:
   SAXON_CP: '%APPVEYOR_BUILD_FOLDER%\saxon\saxon9he.jar'
   matrix:
     # latest Saxon 9.7 version
-    - SAXON_VER: 9.7.0-14
+    - SAXON_VERSION: 9.7.0-14
     # latest Saxon 9.6 version
-    - SAXON_VER: 9.6.0-10
+    - SAXON_VERSION: 9.6.0-10
     # Saxon version used in oXygen
-    - SAXON_VER: 9.6.0-7
+    - SAXON_VERSION: 9.6.0-7
 
 install:
 - ps: >-
     mkdir -Name "saxon"
 
-    Invoke-WebRequest "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VER}/Saxon-HE-${env:SAXON_VER}.jar" -OutFile "saxon\saxon9he.jar"
+    Invoke-WebRequest "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar" -OutFile "saxon\saxon9he.jar"
 build: off
 test_script:
 - cmd: >-


### PR DESCRIPTION
* 9a75af7ef08fa322e139b89ce38c082723642e4c increments the Saxon 9.7 maintenance version
* b756310088dcb95be771f007eabc45adbbaa2ca9 and 47b1d168d8060c210460e9cd2f8e919b4db58525 are not directly related to the Saxon version. They are only to align some details of `appveyor.yml` with those of `.travis.yml`.
