### PR TITLE
Highlight the link target in report HTML

### DIFF
--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -408,6 +408,10 @@ th { text-align: left; }
 
 span.scenario-totals {float: right; width: 22.5%; text-align: left}
 
+/* highlight the link target */
+*:target {
+	box-shadow: -0.5rem 0 0 0 #FC511D;
+}
 
 /* ------------------------------------------------------------------------ */
 /*  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.               */


### PR DESCRIPTION
A trivial change to show a ruddy vertical bar.

To see the effect, run `bin/xspec.sh tutorial/escape-for-regex.xspec` or whatever to generate a report HTML. Open the report HTML file (such as `tutorial/xspec/escape-for-regex.html`) in a web browser and click any in-page link.
