### PR TITLE
Separate common tests (for XSLT and XQuery) from generate-tests-utils.xspec (only for XSLT) 

### DIFF
--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -1,77 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ===================================================================== -->
-<!--  File:       test/generate-tests-utils.xspec                          -->
-<!--  Author:     Florent Georges                                          -->
-<!--  Tags:                                                                -->
-<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" query="http://www.jenitennison.com/xslt/unit-test" query-at="../src/compiler/generate-query-utils.xql" stylesheet="../src/compiler/generate-tests-utils.xsl">
+<t:description xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" stylesheet="../src/compiler/generate-tests-utils.xsl">
   <!--
-	   Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
+	   Test the source file generate-tests-utils.xsl.
    -->
-  <!--
-	   Function test:deep-equal($seq1, $seq2).
-   -->
-  <t:scenario label="test:deep-equal($seq1, $seq2)">
-    <t:scenario label="Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 2"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
-    <t:scenario label="Non-Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="Sequences with Same Items in Different Orders">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="2, 1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="Empty Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
-    <t:scenario label="One empty sequence">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
-    <t:scenario label="A text node and several text nodes">
-      <t:variable name="elems" as="element()+">
-        <e>foo</e>
-        <e>bar</e>
-      </t:variable>
-      <t:call function="test:deep-equal">
-        <t:param as="text()">foobar</t:param>
-        <t:param select="$elems/text()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
-  </t:scenario>
   <!--
 	   Function test:node-deep-equal($seq1, $seq2).
    -->
   <t:scenario label="test:node-deep-equal($seq1, $seq2)">
-    <t:scenario label="Identical Element Sequences">
-      <t:call function="test:node-deep-equal">
-        <t:param name="node1">foobar</t:param>
-        <t:param name="node2">foobar</t:param>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
     <t:scenario label="Identical Attribute Sequences">
+      <!-- TODO: This scenario does not run on XQuery: xspec/xspec#82 -->
       <t:call function="test:node-deep-equal">
         <t:param name="node1" select="/node/@attribute" as="node()">
           <node attribute="foobar"/>
@@ -89,14 +26,8 @@
   -->
   <t:scenario label="test:report-atomic-value">
 
-  	<t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
-      <t:scenario label="String Containing Single Quotes">
-        <t:call function="test:report-atomic-value">
-          <t:param select="'don''t'" />
-        </t:call>
-        <t:expect label="Escaped" select="'''don''''t'''" />
-      </t:scenario>
-    </t:scenario>
+    <!-- TODO: Many of these scenarios fail on XQuery
+        xspec/xspec#58 has not been implemented for XQuery -->
 
     <t:scenario label="xs:integer">
       <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
@@ -250,6 +181,9 @@
         http://www.w3.org/TR/xslt20/#built-in-types
    -->
   <t:scenario label="test:atom-type">
+
+    <!-- TODO: Most of these scenarios fail on XQuery
+        xspec/xspec#58 has not been implemented for XQuery -->
 
     <t:scenario label="All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION">
 
@@ -425,30 +359,3 @@
 
   </t:scenario>
 </t:description>
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
-<!--                                                                       -->
-<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
-<!--                                                                       -->
-<!-- The contents of this file are subject to the MIT License (see the URI -->
-<!-- http://www.opensource.org/licenses/mit-license.php for details).      -->
-<!--                                                                       -->
-<!-- Permission is hereby granted, free of charge, to any person obtaining -->
-<!-- a copy of this software and associated documentation files (the       -->
-<!-- "Software"), to deal in the Software without restriction, including   -->
-<!-- without limitation the rights to use, copy, modify, merge, publish,   -->
-<!-- distribute, sublicense, and/or sell copies of the Software, and to    -->
-<!-- permit persons to whom the Software is furnished to do so, subject to -->
-<!-- the following conditions:                                             -->
-<!--                                                                       -->
-<!-- The above copyright notice and this permission notice shall be        -->
-<!-- included in all copies or substantial portions of the Software.       -->
-<!--                                                                       -->
-<!-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       -->
-<!-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    -->
-<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.-->
-<!-- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  -->
-<!-- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  -->
-<!-- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     -->
-<!-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                -->
-<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/test/generate-x-utils.xspec
+++ b/test/generate-x-utils.xspec
@@ -12,73 +12,74 @@
                query-at="../src/compiler/generate-query-utils.xql"
                stylesheet="../src/compiler/generate-tests-utils.xsl">
 
-  <!--
-	   Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
+   <!--
+       Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
    -->
 
-  <!--
-	   Function test:deep-equal($seq1, $seq2).
+   <!--
+       Function test:deep-equal($seq1, $seq2).
    -->
-  <t:scenario label="test:deep-equal($seq1, $seq2)">
+   <t:scenario label="test:deep-equal($seq1, $seq2)">
 
-    <t:scenario label="Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 2"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
+      <t:scenario label="Identical Sequences">
+         <t:call function="test:deep-equal">
+            <t:param select="1, 2"/>
+            <t:param select="1, 2"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq true()"/>
+      </t:scenario>
 
-    <t:scenario label="Non-Identical Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="1, 3"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
+      <t:scenario label="Non-Identical Sequences">
+         <t:call function="test:deep-equal">
+            <t:param select="1, 2"/>
+            <t:param select="1, 3"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq false()"/>
+      </t:scenario>
 
-    <t:scenario label="Sequences with Same Items in Different Orders">
-      <t:call function="test:deep-equal">
-        <t:param select="1, 2"/>
-        <t:param select="2, 1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
+      <t:scenario label="Sequences with Same Items in Different Orders">
+         <t:call function="test:deep-equal">
+            <t:param select="1, 2"/>
+            <t:param select="2, 1"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq false()"/>
+      </t:scenario>
 
-    <t:scenario label="Empty Sequences">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
+      <t:scenario label="Empty Sequences">
+         <t:call function="test:deep-equal">
+            <t:param select="()"/>
+            <t:param select="()"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq true()"/>
+      </t:scenario>
 
-    <t:scenario label="One empty sequence">
-      <t:call function="test:deep-equal">
-        <t:param select="()"/>
-        <t:param select="1"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq false()"/>
-    </t:scenario>
+      <t:scenario label="One empty sequence">
+         <t:call function="test:deep-equal">
+            <t:param select="()"/>
+            <t:param select="1"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq false()"/>
+      </t:scenario>
 
-    <t:scenario label="A text node and several text nodes">
-      <t:variable name="elems" as="element()+">
-        <e>foo</e>
-        <e>bar</e>
-      </t:variable>
-      <t:call function="test:deep-equal">
-        <t:param as="text()">foobar</t:param>
-        <t:param select="$elems/text()"/>
-      </t:call>
-      <t:expect label="the result" test="$x:result eq true()"/>
-    </t:scenario>
+      <t:scenario label="A text node and several text nodes">
+         <t:variable name="elems" as="element()+">
+            <e>foo</e>
+            <e>bar</e>
+         </t:variable>
+         <t:call function="test:deep-equal">
+            <t:param as="text()">foobar</t:param>
+            <t:param select="$elems/text()"/>
+         </t:call>
+         <t:expect label="the result" test="$x:result eq true()"/>
+      </t:scenario>
 
-  </t:scenario>
+   </t:scenario>
 
   <!--
-	   Function test:node-deep-equal($seq1, $seq2).
+    Function test:node-deep-equal($seq1, $seq2).
    -->
   <t:scenario label="test:node-deep-equal($seq1, $seq2)">
+
     <t:scenario label="Identical Element Sequences">
       <t:call function="test:node-deep-equal">
         <t:param name="node1">foobar</t:param>
@@ -86,12 +87,14 @@
       </t:call>
       <t:expect label="the result" test="$x:result eq true()"/>
     </t:scenario>
+
   </t:scenario>
 
   <!--
     Function test:report-atomic-value
   -->
   <t:scenario label="test:report-atomic-value">
+
     <t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
       <t:scenario label="String Containing Single Quotes">
         <t:call function="test:report-atomic-value">
@@ -100,7 +103,8 @@
         <t:expect label="Escaped" select="'''don''''t'''" />
       </t:scenario>
     </t:scenario>
- </t:scenario>
+
+  </t:scenario>
 
 </t:description>
 

--- a/test/generate-x-utils.xspec
+++ b/test/generate-x-utils.xspec
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ===================================================================== -->
+<!--  File:       test/generate-x-utils.xspec                              -->
+<!--  Author:     Florent Georges                                          -->
+<!--  Tags:                                                                -->
+<!--    Copyright (c) 2010 Jeni Tennsion (see end of file.)                -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<t:description xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+               query="http://www.jenitennison.com/xslt/unit-test"
+               query-at="../src/compiler/generate-query-utils.xql"
+               stylesheet="../src/compiler/generate-tests-utils.xsl">
+
+  <!--
+	   Test the source files generate-tests-utils.xsl and generate-query-utils.xql.
+   -->
+
+  <!--
+	   Function test:deep-equal($seq1, $seq2).
+   -->
+  <t:scenario label="test:deep-equal($seq1, $seq2)">
+
+    <t:scenario label="Identical Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="1, 2"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+
+    <t:scenario label="Non-Identical Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="1, 3"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+    </t:scenario>
+
+    <t:scenario label="Sequences with Same Items in Different Orders">
+      <t:call function="test:deep-equal">
+        <t:param select="1, 2"/>
+        <t:param select="2, 1"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+    </t:scenario>
+
+    <t:scenario label="Empty Sequences">
+      <t:call function="test:deep-equal">
+        <t:param select="()"/>
+        <t:param select="()"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+
+    <t:scenario label="One empty sequence">
+      <t:call function="test:deep-equal">
+        <t:param select="()"/>
+        <t:param select="1"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq false()"/>
+    </t:scenario>
+
+    <t:scenario label="A text node and several text nodes">
+      <t:variable name="elems" as="element()+">
+        <e>foo</e>
+        <e>bar</e>
+      </t:variable>
+      <t:call function="test:deep-equal">
+        <t:param as="text()">foobar</t:param>
+        <t:param select="$elems/text()"/>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+
+  </t:scenario>
+
+  <!--
+	   Function test:node-deep-equal($seq1, $seq2).
+   -->
+  <t:scenario label="test:node-deep-equal($seq1, $seq2)">
+    <t:scenario label="Identical Element Sequences">
+      <t:call function="test:node-deep-equal">
+        <t:param name="node1">foobar</t:param>
+        <t:param name="node2">foobar</t:param>
+      </t:call>
+      <t:expect label="the result" test="$x:result eq true()"/>
+    </t:scenario>
+  </t:scenario>
+
+  <!--
+    Function test:report-atomic-value
+  -->
+  <t:scenario label="test:report-atomic-value">
+    <t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
+      <t:scenario label="String Containing Single Quotes">
+        <t:call function="test:report-atomic-value">
+          <t:param select="'don''t'" />
+        </t:call>
+        <t:expect label="Escaped" select="'''don''''t'''" />
+      </t:scenario>
+    </t:scenario>
+ </t:scenario>
+
+</t:description>
+
+
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
+<!--                                                                       -->
+<!-- Copyright (c) 2010 Jeni Tennsion                                      -->
+<!--                                                                       -->
+<!-- The contents of this file are subject to the MIT License (see the URI -->
+<!-- http://www.opensource.org/licenses/mit-license.php for details).      -->
+<!--                                                                       -->
+<!-- Permission is hereby granted, free of charge, to any person obtaining -->
+<!-- a copy of this software and associated documentation files (the       -->
+<!-- "Software"), to deal in the Software without restriction, including   -->
+<!-- without limitation the rights to use, copy, modify, merge, publish,   -->
+<!-- distribute, sublicense, and/or sell copies of the Software, and to    -->
+<!-- permit persons to whom the Software is furnished to do so, subject to -->
+<!-- the following conditions:                                             -->
+<!--                                                                       -->
+<!-- The above copyright notice and this permission notice shall be        -->
+<!-- included in all copies or substantial portions of the Software.       -->
+<!--                                                                       -->
+<!-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       -->
+<!-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.-->
+<!-- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  -->
+<!-- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  -->
+<!-- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     -->
+<!-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->


### PR DESCRIPTION
Currently `test/generate-tests-utils.xspec`, despite its filename, has scenarios both for XSLT (`src/compiler/generate-tests-utils.xsl`) and XQuery (`src/compiler/generate-query-utils.xql`). So three kinds of scenarios coexist in `test/generate-tests-utils.xspec`:

* (a) Scenarios which should be Success both on XSLT and XQuery
* (b) Scenarios which should be Success on XSLT and Failure on XQuery (Some features/fixes not implemented yet in `src/compiler/generate-query-utils.xql`)
* (c) Scenarios which do work on XSLT but somehow do not work on XQuery (#82)

This pull request does two things:

* Moves (a) to a new file `test/generate-x-utils.xspec`
* Adds TODO comments to `test/generate-tests-utils.xspec`

In consequence,

* #82 is resolved tentatively. (We can run `test/generate-x-utils.xspec` for XQuery. All its scenarios should be Success.)
* `test/generate-x-utils.xspec` resembles [one of the previous snapshots of `test/generate-tests-utils.xspec`](https://github.com/xspec/xspec/blob/7303f0dce788fd8d0e091705b261d4aa284e75d2/test/generate-tests-utils.xspec).
* From TODO comments, we can find the scenarios where XQuery implementation is behind XSLT's progress.
