### PR TITLE
  Run XProc test on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
-    # latest Saxon 9.7 version and XML Calabash
+    # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-15
       XMLCALABASH_VERSION: 1.1.15-97
     # latest Saxon 9.6 version
@@ -27,6 +27,10 @@ install:
       ${env:XMLCALABASH_CP} = "${xmlcalabash_home}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
       Invoke-WebRequest -Uri "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip" -OutFile "${xmlcalabash_home}.zip"
       7z x "${xmlcalabash_home}.zip" -o"${xmlcalabash_home}\..\"
+    }
+
+    else {
+        echo "XMLCalabash will not be installed as it uses a higher version of Saxon"
     }
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
 environment:
   SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
-    # latest Saxon 9.7 version
+    # latest Saxon 9.7 version and XML Calabash
     - SAXON_VERSION: 9.7.0-15
+      XMLCALABASH_VERSION: 1.1.15-97
     # latest Saxon 9.6 version
     - SAXON_VERSION: 9.6.0-10
     # Saxon version used in oXygen
@@ -10,11 +11,23 @@ environment:
 
 install:
 - ps: >-
+    # install Saxon
+
     $saxon_home = Split-Path -Path "${env:SAXON_CP}" -Parent
 
     mkdir -Path $saxon_home
 
     Invoke-WebRequest -Uri "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar" -OutFile "${env:SAXON_CP}"
+
+
+    # install XML Calabash
+
+    if( Test-Path -Path env:\XMLCALABASH_VERSION ) {
+      $xmlcalabash_home = "${env:TEMP}\xspec\xmlcalabash-${env:XMLCALABASH_VERSION}"
+      ${env:XMLCALABASH_CP} = "${xmlcalabash_home}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
+      Invoke-WebRequest -Uri "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip" -OutFile "${xmlcalabash_home}.zip"
+      7z x "${xmlcalabash_home}.zip" -o"${xmlcalabash_home}\..\"
+    }
 build: off
 test_script:
 - cmd: >-

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -261,7 +261,7 @@ setlocal
 
     if defined XMLCALABASH_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
         call :verify_line 1 x "true"
     ) else (
         call :skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -264,11 +264,7 @@ setlocal
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
         call :verify_line 1 x "true"
     ) else (
-        rem
-        rem Treat as success
-        rem
-        call :run ver
-        call :verify_retval 0
+        call :skip
     )
 
     call :teardown
@@ -392,6 +388,12 @@ rem
     set CASE_RESULT=1
     (echo %CASE_RESULT%) >> "%RESULTS_FILE%"
     if defined CASE_NAME call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Failed -Duration 0 -ErrorMessage %1
+    goto :EOF
+
+:skip
+    echo ...SKIP
+    set CASE_RESULT=2
+    call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Skipped -Duration 0
     goto :EOF
 
 :run

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -269,7 +269,7 @@ setlocal
 
     if defined XMLCALABASH_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
         call :verify_line 1 x "true"
     ) else (
         rem

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -261,10 +261,10 @@ setlocal
 
     if defined XMLCALABASH_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
         call :verify_line 1 x "true"
     ) else (
-        call :skip
+        call :skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon"
     )
 
     call :teardown
@@ -391,8 +391,9 @@ rem
     goto :EOF
 
 :skip
-    echo ...SKIP
+    echo ...SKIP: %~1
     set CASE_RESULT=2
+    (echo # %~1) >> "%RESULTS_FILE%"
     call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Skipped -Duration 0
     goto :EOF
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -264,6 +264,24 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "executing the Saxon XProc harness generates a report with UTF-8 encoding"
+
+    if defined XMLCALABASH_CP (
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
+        call :verify_line 1 x "true"
+    ) else (
+        rem
+        rem Treat as success
+        rem
+        call :run ver
+        call :verify_retval 0
+    )
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -194,7 +194,7 @@ teardown() {
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding" {
 	run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home=file:${PWD}/../ -oresult=xspec/xspec-72-result.html ../src/harnesses/saxon/saxon-xslt-harness.xproc
-	run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
+	run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
 	echo $output
     [[ "${lines[0]}" = 'true' ]]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -193,8 +193,8 @@ teardown() {
 
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding" {
-	run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home=file://${TRAVIS_BUILD_DIR}/ -oresult=${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html ${TRAVIS_BUILD_DIR}/src/harnesses/saxon/saxon-xslt-harness.xproc 
-	run java -cp ${SAXON_CP} net.sf.saxon.Query -s:${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; /html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8'" !method=text
+	run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home=file:${PWD}/../ -oresult=xspec/xspec-72-result.html ../src/harnesses/saxon/saxon-xslt-harness.xproc
+	run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-7', '&#x0A;')" !method=text
 	echo $output
     [[ "${lines[0]}" = 'true' ]]
 }


### PR DESCRIPTION
Following #76, this pull request adds XProc test to the test set on AppVeyor.

* For the simulated failure, see the AppVeyor/Travis test result of 2173614 in [the commit log](https://github.com/AirQuick/xspec/commits/win_xproc). (It expects 'UTF-7' and thus failed.)
* `xspec.bats` is also modified a bit. (in order to be more platform independent)
* `'&#x0A;'` is added to XQuery. (in order to avoid conflict with the "Picked up JAVA_TOOL_OPTIONS..." stderr line which is emitted when the `JAVA_TOOL_OPTIONS` environment variable is defined)
