### PR TITLE
Do not copy unused namespaces from format utils to output

### DIFF
--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -14,7 +14,7 @@
                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:pkg="http://expath.org/ns/pkg"
-                exclude-result-prefixes="test xs">
+                exclude-result-prefixes="test xs x pkg">
 
 <xsl:import href="../compiler/generate-tests-utils.xsl" />
 


### PR DESCRIPTION
Fixes #90.

Before and after committing this change, I created `*.html` files using the following commands.

```winbatch
set TEST_DIR=
bin\xspec.bat tutorial\escape-for-regex.xspec
test\run-xspec-tests.cmd

set TEST_DIR=tutorial\xspec-c
bin\xspec.bat -c tutorial\escape-for-regex.xspec

set TEST_DIR=tutorial\xspec-j
bin\xspec.bat -j tutorial\escape-for-regex.xspec

set TEST_DIR=test\xspeq-q
for %I in ( focus-1 focus-2 function import pending variable ) do bin\xspec.bat -q test\xspec-%I.xspec

set TEST_DIR=
```

By comparing the `*.html` files, I verified that the commit did the followings:

* Fixed #90
* Did not change the HTML structure unrelated to #90
