### PR TITLE
Align Travis configuration with AppVeyor in #86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
     matrix:
         # latest Saxon 9.7 version
         - SAXON_VERSION=9.7.0-15
+          XMLCALABASH_VERSION=1.1.15-97          
         # latest Saxon 9.6 version
         - SAXON_VERSION=9.6.0-10
         # Saxon version used in oXygen
@@ -19,10 +20,13 @@ before_script:
     - wget -O ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
     - chmod +x ${SAXON_CP}
     # install XML Calabash
-    - export XMLCALABASH_VERSION=1.1.15-97
-    - wget -O /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip 
-    - unzip /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip -d /tmp/xspec
-    - export XMLCALABASH_CP=/tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar
+    - if [ -z ${XMLCALABASH_VERSION} ]; then
+        echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
+      else
+        wget -O /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
+        unzip /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip -d /tmp/xspec;
+        export XMLCALABASH_CP=/tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
+      fi
 
 script:
     - cd test

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -193,7 +193,7 @@ teardown() {
 
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding" {
-	if [ -z ${XMLCALABASH_VERSION} ]; then
+	if [ -z ${XMLCALABASH_CP} ]; then
 		skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon";
 	fi 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -193,6 +193,10 @@ teardown() {
 
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding" {
+	if [ -z ${XMLCALABASH_VERSION} ]; then
+		skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon";
+	fi 
+
 	run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home=file://${TRAVIS_BUILD_DIR}/ -oresult=${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html ${TRAVIS_BUILD_DIR}/src/harnesses/saxon/saxon-xslt-harness.xproc 
 	run java -cp ${SAXON_CP} net.sf.saxon.Query -s:${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; /html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8'" !method=text
 	echo $output


### PR DESCRIPTION
## Summary
This pull request aligns the Travis configuration with the AppVeyor configuration implemented in #86.

## Why
#76 introduced a test for checking that the XProc harness is working. Running XProc requires XMLCalabash which is installed in the ```.travis.yml``` file. However, XMLCalabash currently comes bundled with Saxon 9.7.0.11 as highlighted by @AirQuick in https://github.com/xspec/xspec/pull/86#discussion_r104289634. It is therefore useless to install it and run the test for XProc when a lower version of Saxon is used. This also makes the test suite slower.    

## What has changed
In ```.travis.yml``` I added the ```XMLCALABASH_VERSION``` in the matrix as suggested by @AirQuick in https://github.com/xspec/xspec/pull/86#discussion_r104293014. This is in line with the configuration in ```appveyor.yml``` and also makes it easier to upgrade to a new version of XMLCalabash in the future.

In ```xspec.bats``` I skipped the test if the environment variable ```XMLCALABASH_VERSION``` is not set.   

## How to review
I tested that the Travis configuration works as expected in [this Travis build](https://travis-ci.org/xspec/xspec/builds/208357031) (see the job logs):

- [build 235.1](https://travis-ci.org/xspec/xspec/jobs/208357032) (Saxon 9.7.0-15) installs XMLCalabash and runs the test
- [build 235.2](https://travis-ci.org/xspec/xspec/jobs/208357033) (Saxon 9.6.0-10) doesn't install XMLCalabash and skip the test
- [build 235.3](https://travis-ci.org/xspec/xspec/jobs/208357035) (Saxon 9.6.0-7) doesn't install XMLCalabash and skip the test

@AirQuick : could you please review this pull request and see if it aligns with your pull request in #86? Once you approve this, I will merge both pull requests into master. 