### PR TITLE
Stop using functx namespace in unrelated func

### DIFF
--- a/test/xspec-result-naming-collision.xslt
+++ b/test/xspec-result-naming-collision.xslt
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:functx="http://www.functx.com"  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xspec-17="https://github.com/xspec/xspec/pull/17"  xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="xs" version="2.0">
 
-	<xsl:function name="functx:read-document" as="document-node()?">
+	<xsl:function name="xspec-17:read-document" as="document-node()?">
 	  <xsl:sequence select="doc('xspec-result-naming-collision.xml')"/>
 	</xsl:function>
 

--- a/test/xspec-result-naming-collision.xspec
+++ b/test/xspec-result-naming-collision.xspec
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:functx="http://www.functx.com" stylesheet="xspec-result-naming-collision.xslt">
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xspec-17="https://github.com/xspec/xspec/pull/17" stylesheet="xspec-result-naming-collision.xslt">
   <!-- https://github.com/expath/xspec/issues/67
        test result naming collision when a function which reads a document containing more than 1000 node -->
   <x:scenario label="scenario 1">
-    <x:call function="functx:read-document"/>
+    <x:call function="xspec-17:read-document"/>
     <x:expect>...</x:expect>
   </x:scenario>
   <x:scenario label="scenario 2">
-    <x:call function="functx:read-document"/>
+    <x:call function="xspec-17:read-document"/>
     <x:expect>...</x:expect>
   </x:scenario>
 </x:description>


### PR DESCRIPTION
Fixes #95.

* For the namespace URI, I simply took the original pull request's URL. Any other suggestion is welcomed.
* I searched the `test` directory for the string `functx` and confirmed that no other `functx` string existed there.
* Before and after making this change, I ran `xspec-result-naming-collision.xspec` and confirmed that the generated report HTML did not change (except for the timestamp).
