### PR TITLE
add XProc harness for Saxon from v0.4.0

### DIFF
--- a/src/harnesses/harness-lib.xpl
+++ b/src/harnesses/harness-lib.xpl
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ===================================================================== -->
+<!--  File:       harness-lib.xpl                                          -->
+<!--  Author:     Florent Georges                                          -->
+<!--  Date:       2011-11-08                                               -->
+<!--  URI:        http://xspec.googlecode.com/                             -->
+<!--  Tags:                                                                -->
+<!--    Copyright (c) 2011 Florent Georges (see end of file.)              -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+           xmlns:c="http://www.w3.org/ns/xproc-step"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+           xmlns:t="http://www.jenitennison.com/xslt/xspec"
+           xmlns:pkg="http://expath.org/ns/pkg"
+           pkg:import-uri="#none"
+           version="1.0">
+
+   <!--
+       Ensure there is exactly one document on the input port.
+       
+       If this is the case, it behaves like p:identity, if not, it throws an error.
+       
+       TODO: Does not work as is...
+   -->
+   <!--p:declare-step type="t:ensure-input">
+      <p:input  port="source" primary="true"/>
+      <p:output port="result" primary="true"/>
+      <p:choose>
+         <p:xpath-context>
+            <p:pipe step="ensure-input" port="source"/>
+         </p:xpath-context>
+         <p:when test="empty(/)">
+            <p:error code="t:ERR002"/>
+         </p:when>
+         <p:otherwise>
+            <p:identity/>
+         </p:otherwise>
+      </p:choose>
+   </p:declare-step-->
+
+   <!--
+       Short-cut for p:parameters which passes through input, with primary parameters input.
+       
+       Inspired from Geert Josten util library:
+       https://github.com/grtjn/xproc-ebook-conv/blob/master/src/nl/grtjn/xproc/util/utils.xpl
+   -->
+   <p:declare-step type="t:parameters" name="parameters">
+      <p:input port="source"        primary="true"/>
+      <p:input port="in-parameters" primary="true" kind="parameter" sequence="true"/>
+      <p:output port="result"       primary="true">
+         <p:pipe step="parameters" port="source"/>
+      </p:output>
+      <p:output port="parameters"   primary="false">
+         <p:pipe step="params" port="result"/>
+      </p:output>
+      <p:parameters name="params">
+         <p:input port="parameters">
+            <p:pipe step="parameters" port="in-parameters"/>
+         </p:input>
+      </p:parameters>
+   </p:declare-step>
+
+   <!--
+       Pass through and possibly log the input.
+       
+       If there is a parameter with the name $if-set, its value must be a URI, where
+       to log the input.  If there is not, then no log is produced.
+   -->
+   <p:declare-step type="t:log" name="log">
+      <!-- the port declarations -->
+      <p:input  port="source"     primary="true"/>
+      <p:input  port="parameters" primary="true" kind="parameter"/>
+      <p:output port="result"     primary="true"/>
+      <p:option name="if-set" required="true"/>
+      <!-- retrieve the params -->
+      <t:parameters name="params"/>
+      <p:group>
+         <p:variable name="uri" select="/c:param-set/c:param[@name eq $if-set]/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <p:choose>
+            <p:when test="$uri">
+               <p:store method="text">
+                  <p:with-option name="href" select="$uri"/>
+               </p:store>
+               <p:identity>
+                  <p:input port="source">
+                     <p:pipe step="log" port="source"/>
+                  </p:input>
+               </p:identity>
+            </p:when>
+            <p:otherwise>
+               <p:identity/>
+            </p:otherwise>
+         </p:choose>
+      </p:group>
+   </p:declare-step>
+
+   <!--
+       Compile the suite on source into a stylesheet on result.
+   -->
+   <p:declare-step type="t:compile-xslt" name="compile-xsl">
+      <!-- the port declarations -->
+      <p:input  port="source"     primary="true"/>
+      <p:input  port="parameters" primary="true" kind="parameter"/>
+      <p:output port="result"     primary="true"/>
+      <!-- retrieve the params -->
+      <t:parameters name="params"/>
+      <p:group>
+         <p:variable name="xspec-home" select="
+             /c:param-set/c:param[@name eq 'xspec-home']/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <p:variable name="compiler-uri" select="
+             /c:param-set/c:param[@name eq 'compiler-uri']/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <!-- if compiler-uri is not passed, then use xspec-home to resolve the compiler -->
+         <!-- if xspec-home is not passed, then use the packaging public URI -->
+         <p:variable name="compiler" select="
+             if ( $compiler-uri ) then
+               $compiler-uri
+             else if ( $xspec-home ) then
+               resolve-uri('src/compiler/generate-xspec-tests.xsl', $xspec-home)
+             else
+               'http://www.jenitennison.com/xslt/xspec/generate-xspec-tests.xsl'"/>
+         <!-- load the compiler -->
+         <p:load name="compiler" pkg:kind="xslt">
+            <p:with-option name="href" select="$compiler"/>
+         </p:load>
+         <!-- actually compile the suite in a stylesheet -->
+         <p:xslt>
+            <p:input port="source">
+               <p:pipe port="source" step="compile-xsl"/>
+            </p:input>
+            <p:input port="stylesheet">
+               <p:pipe port="result" step="compiler"/>
+            </p:input>
+            <p:input port="parameters">
+               <p:empty/>
+            </p:input>
+         </p:xslt>
+      </p:group>
+      <!-- log the result? -->
+      <t:log if-set="log-compilation">
+         <p:input port="parameters">
+            <p:pipe step="params" port="parameters"/>
+         </p:input>
+      </t:log>
+   </p:declare-step>
+
+   <!--
+       Compile the suite on source into a query on result.
+       
+       The query is wrapped into an element c:query.  Parameters to the XSpec
+       XQuery compiler, AKA generate-query-tests.xsl, can be passed on the
+       parameters port (e.g. utils-library-at to set the at location hint to use
+       to import the XSpec utils library module in the generated query).
+   -->
+   <p:declare-step type="t:compile-xquery" name="compile-xq">
+      <!-- the port declarations -->
+      <p:input  port="source" primary="true"/>
+      <p:input  port="parameters" kind="parameter"/>
+      <p:output port="result" primary="true"/>
+      <!-- retrieve the params -->
+      <t:parameters name="params"/>
+      <p:group>
+        <!-- param: xspec-home: the dir with the sources of XSpec if EXPath packaging
+             is not supported -->
+         <p:variable name="xspec-home" select="
+             /c:param-set/c:param[@name eq 'xspec-home']/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <!-- param: compiler-uri: the URI of the XSpec compiler to XQuery -->
+         <p:variable name="compiler-uri" select="
+             /c:param-set/c:param[@name eq 'compiler-uri']/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <!-- if compiler-uri is not passed, then use xspec-home to resolve the compiler -->
+         <!-- if xspec-home is not passed, then use the packaging public URI -->
+         <p:variable name="compiler" select="
+             if ( $compiler-uri ) then
+               $compiler-uri
+             else if ( $xspec-home ) then
+               resolve-uri('src/compiler/generate-query-tests.xsl', $xspec-home)
+             else
+               'http://www.jenitennison.com/xslt/xspec/generate-query-tests.xsl'"/>
+         <!-- wrap the generated query in a c:query element -->
+         <p:string-replace match="xsl:import/@href" name="compiler">
+            <p:with-option name="replace" select="concat('''', $compiler, '''')"/>
+            <p:input port="source">
+               <p:inline>
+                  <!-- TODO: I think this is due to a bug in Calabash, if I don't create a node
+                       using the prefix 't', then the biding is not visible to Saxon and it throws
+                       a compilation error for this stylesheet... -->
+                  <xsl:stylesheet version="2.0" t:dummy="...">
+                     <xsl:import href="..."/>
+                     <xsl:template match="/">
+                        <c:query>
+                           <xsl:call-template name="t:generate-tests"/>
+                        </c:query>
+                     </xsl:template>
+                  </xsl:stylesheet>
+               </p:inline>
+            </p:input>
+         </p:string-replace>
+         <!-- actually compile the suite in a query -->
+         <p:xslt name="do-it">
+            <p:input port="source">
+               <p:pipe step="compile-xq" port="source"/>
+            </p:input>
+            <p:input port="stylesheet">
+               <p:pipe step="compiler" port="result"/>
+            </p:input>
+         </p:xslt>
+      </p:group>
+      <!-- log the result? -->
+      <t:log if-set="log-compilation">
+         <p:input port="parameters">
+            <p:pipe step="params" port="parameters"/>
+         </p:input>
+      </t:log>
+   </p:declare-step>
+
+   <!--
+       Get the XML report on source, and give the HTML report on result.
+       
+       If xspec-home is set, it is used to resolve the XSLT that formats the
+       report.  If not, its public URI is used, to be resolved through the
+       EXPath packaging system.  If the document element is not an XSpec
+       t:report, the error t:ERR001 is thrown.
+   -->
+   <p:declare-step type="t:format-report" name="format">
+      <!-- the port declarations -->
+      <p:input  port="source"     primary="true"/>
+      <p:input  port="parameters" kind="parameter"/>
+      <p:output port="result"     primary="true"/>
+      <!-- retrieve the params -->
+      <t:parameters name="params"/>
+      <p:group>
+        <!-- param: xspec-home: the dir with the sources of XSpec if EXPath packaging
+             is not supported -->
+         <p:variable name="xspec-home" select="
+             /c:param-set/c:param[@name eq 'xspec-home']/@value">
+            <p:pipe step="params" port="parameters"/>
+         </p:variable>
+         <!-- either the public URI, or resolved from xspec-home if packaging not supported -->
+         <p:variable name="formatter" select="
+             if ( $xspec-home ) then
+               resolve-uri('src/reporter/format-xspec-report.xsl', $xspec-home)
+             else
+               'http://www.jenitennison.com/xslt/xspec/format-xspec-report.xsl'"/>
+         <!-- log the report? -->
+         <t:log if-set="log-xml-report">
+            <p:input port="parameters">
+               <p:pipe step="format" port="parameters"/>
+            </p:input>
+         </t:log>
+         <!-- if there is a report, format it, or it is an error -->
+         <p:choose>
+            <p:when test="exists(/t:report)">
+               <p:load name="formatter" pkg:kind="xslt">
+                  <p:with-option name="href" select="$formatter"/>
+               </p:load>
+               <p:xslt name="format-report">
+                  <p:input port="source">
+                     <p:pipe step="format" port="source"/>
+                  </p:input>
+                  <p:input port="stylesheet">
+                     <p:pipe step="formatter" port="result"/>
+                  </p:input>
+                  <p:input port="parameters">
+                     <p:empty/>
+                  </p:input>
+               </p:xslt>
+            </p:when>
+            <p:otherwise>
+               <p:error code="t:ERR001">
+                  <p:input port="source">
+                     <p:inline>
+                        <message>Not a t:report document</message>
+                     </p:inline>
+                  </p:input>
+               </p:error>
+            </p:otherwise>
+         </p:choose>
+      </p:group>
+      <!-- log the report? -->
+      <t:log if-set="log-report">
+         <p:input port="parameters">
+            <p:pipe step="format" port="parameters"/>
+         </p:input>
+      </t:log>
+   </p:declare-step>
+
+</p:library>
+
+
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
+<!--                                                                       -->
+<!-- Copyright (c) 2011 Florent Georges                                    -->
+<!--                                                                       -->
+<!-- The contents of this file are subject to the MIT License (see the URI -->
+<!-- http://www.opensource.org/licenses/mit-license.php for details).      -->
+<!--                                                                       -->
+<!-- Permission is hereby granted, free of charge, to any person obtaining -->
+<!-- a copy of this software and associated documentation files (the       -->
+<!-- "Software"), to deal in the Software without restriction, including   -->
+<!-- without limitation the rights to use, copy, modify, merge, publish,   -->
+<!-- distribute, sublicense, and/or sell copies of the Software, and to    -->
+<!-- permit persons to whom the Software is furnished to do so, subject to -->
+<!-- the following conditions:                                             -->
+<!--                                                                       -->
+<!-- The above copyright notice and this permission notice shall be        -->
+<!-- included in all copies or substantial portions of the Software.       -->
+<!--                                                                       -->
+<!-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       -->
+<!-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.-->
+<!-- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  -->
+<!-- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  -->
+<!-- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     -->
+<!-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/src/harnesses/saxon/saxon-xquery-harness.xproc
+++ b/src/harnesses/saxon/saxon-xquery-harness.xproc
@@ -7,91 +7,82 @@
 <!--  Tags:                                                                -->
 <!--    Copyright (c) 2011 Florent Georges (see end of file.)              -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:pkg="http://expath.org/ns/pkg" pkg:import-uri="http://www.jenitennison.com/xslt/xspec/saxon/harness/xquery.xproc" name="saxon-xquery-harness" type="t:saxon-xquery-harness" version="1.0">
-    <p:documentation>
-        <p>This pipeline executes an XSpec test suite with the Saxon embedded in Calabash.</p>
-        <p><b>Primary input:</b> A XSpec test suite document.</p>
-        <p><b>Primary output:</b> A formatted HTML XSpec report.</p>
-        <p>The dir where you unzipped the XSpec archive on your filesystem is passed
-            in the option 'xspec-home'.</p>
-    </p:documentation>
 
-    <p:serialization port="result" indent="true" method="xhtml" encoding="UTF-8" include-content-type="true"/>
 
-    <p:option name="xspec-home" required="true"/>
+<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            xmlns:t="http://www.jenitennison.com/xslt/xspec"
+            xmlns:pkg="http://expath.org/ns/pkg"
+            pkg:import-uri="http://www.jenitennison.com/xslt/xspec/saxon/harness/xquery.xproc"
+            name="saxon-xquery-harness"
+            type="t:saxon-xquery-harness"
+            version="1.0">
+	
+   <p:documentation>
+      <p>This pipeline executes an XSpec test suite with the Saxon embedded in Calabash.</p>
+      <p><b>Primary input:</b> A XSpec test suite document.</p>
+      <p><b>Primary output:</b> A formatted HTML XSpec report.</p>
+      <p>The dir where you unzipped the XSpec archive on your filesystem is passed
+        in the option 'xspec-home'.</p>
+   </p:documentation>
 
-    <!-- TODO: Use the absolute URIs through the EXPath Packaging System. -->
-    <p:variable name="compiler" select="resolve-uri('src/compiler/generate-query-tests.xsl', $xspec-home)"/>
-    <p:variable name="formatter" select="resolve-uri('src/reporter/format-xspec-report.xsl', $xspec-home)"/>
-    <p:variable name="utils-lib" select="resolve-uri('src/compiler/generate-query-utils.xql', $xspec-home)"/>
+   <p:serialization port="result" indent="true"/>
 
-    <p:string-replace match="xsl:import/@href" name="compiler">
-        <p:with-option name="replace" select="concat('''', $compiler, '''')"/>
-        <p:input port="source">
-            <p:inline>
-                <xsl:stylesheet version="2.0">
-                    <xsl:import href="..."/>
-                    <xsl:template match="/">
-                        <c:query>
-                            <xsl:call-template name="t:generate-tests"/>
-                        </c:query>
-                    </xsl:template>
-                </xsl:stylesheet>
-            </p:inline>
-        </p:input>
-    </p:string-replace>
+   <p:import href="../harness-lib.xpl"/>
 
-    <p:xslt name="compile">
-        <p:input port="source">
-            <p:pipe step="saxon-xquery-harness" port="source"/>
-        </p:input>
-        <p:input port="stylesheet">
-            <p:pipe step="compiler" port="result"/>
-        </p:input>
-        <p:with-param name="utils-library-at" select="$utils-lib"/>
-    </p:xslt>
+   <t:parameters name="params"/>
 
-    <p:escape-markup name="escape"/>
+   <p:group>
+      <p:variable name="xspec-home" select="
+          /c:param-set/c:param[@name eq 'xspec-home']/@value">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
+      <p:variable name="utils-library-at" select="
+          /c:param-set/c:param[@name eq 'utils-library-at']/@value">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
 
-    <p:xquery name="run">
-        <p:input port="source">
+      <!-- either no at location hint, or resolved from xspec-home if packaging not supported -->
+      <p:variable name="utils-lib" select="
+          if ( $utils-library-at ) then
+            $utils-library-at
+          else if ( $xspec-home ) then
+            resolve-uri('src/compiler/generate-query-utils.xql', $xspec-home)
+          else
+            ''"/>
+
+      <!-- compile the suite into a query -->
+      <t:compile-xquery>
+         <p:with-param name="utils-library-at" select="$utils-lib"/>
+      </t:compile-xquery>
+
+      <!-- escape the query as text -->
+      <p:escape-markup name="escape"/>
+
+      <!-- run it on saxon -->
+      <p:xquery name="run">
+         <p:input port="source">
             <p:empty/>
-        </p:input>
-        <p:input port="query">
+         </p:input>
+         <p:input port="query">
             <p:pipe step="escape" port="result"/>
-        </p:input>
-        <p:input port="parameters">
+         </p:input>
+         <p:input port="parameters">
             <p:empty/>
-        </p:input>
-    </p:xquery>
+         </p:input>
+      </p:xquery>
 
-    <p:choose>
-        <p:when test="exists(/t:report)">
-            <p:load name="formatter">
-                <p:with-option name="href" select="$formatter"/>
-            </p:load>
-            <p:xslt name="format-report">
-                <p:input port="source">
-                    <p:pipe step="run" port="result"/>
-                </p:input>
-                <p:input port="stylesheet">
-                    <p:pipe step="formatter" port="result"/>
-                </p:input>
-            </p:xslt>
-        </p:when>
-        <p:otherwise>
-            <p:error code="t:ERR001">
-                <p:input port="source">
-                    <p:pipe step="run" port="result"/>
-                </p:input>
-            </p:error>
-        </p:otherwise>
-    </p:choose>
+      <!-- format the report -->
+      <t:format-report/>
+   </p:group>
+
 </p:pipeline>
+
+
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2008, 2010 Jeni Tennison                                -->
+<!-- Copyright (c) 2011 Florent Georges                                    -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/src/harnesses/saxon/saxon-xslt-harness.xproc
+++ b/src/harnesses/saxon/saxon-xslt-harness.xproc
@@ -2,82 +2,64 @@
 <!-- ===================================================================== -->
 <!--  File:       saxon-xslt-harness.xproc                                 -->
 <!--  Author:     Florent Georges                                          -->
-<!--  Reviewed:   github.com/cirulls                                       -->
-<!--  Copyright (c) 2011 Florent Georges (see end of file.)                -->
+<!--  Date:       2011-08-30                                               -->
+<!--  URI:        http://xspec.googlecode.com/                             -->
+<!--  Tags:                                                                -->
+<!--    Copyright (c) 2011 Florent Georges (see end of file.)              -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="http://www.jenitennison.com/xslt/xspec" xmlns:pkg="http://expath.org/ns/pkg" pkg:import-uri="http://www.jenitennison.com/xslt/xspec/saxon/harness/xslt.xproc" name="saxon-xslt-harness" type="t:saxon-xslt-harness" version="1.0">
-	<p:documentation>
-		<p>This pipeline executes an XSpec test suite with the Saxon embedded in Calabash.</p>
-		<p><b>Primary input:</b> A XSpec test suite document.</p>
-		<p><b>Primary output:</b> A formatted HTML XSpec report.</p>
-		<p>The dir where you unzipped the XSpec archive on your filesystem is passed
-			in the option 'xspec-home'.</p>
-	</p:documentation>
 
-	<p:serialization port="result" indent="true" method="xhtml" encoding="UTF-8" include-content-type="true"/>
 
-	<p:option name="xspec-home" required="true"/>
+<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:t="http://www.jenitennison.com/xslt/xspec"
+            xmlns:pkg="http://expath.org/ns/pkg"
+            pkg:import-uri="http://www.jenitennison.com/xslt/xspec/saxon/harness/xslt.xproc"
+            name="saxon-xslt-harness"
+            type="t:saxon-xslt-harness"
+            version="1.0">
 
-	<!-- TODO: Use the absolute URIs through the EXPath Packaging System. -->
-	<p:variable name="compiler" select="resolve-uri('src/compiler/generate-xspec-tests.xsl', $xspec-home)"/>
-	<p:variable name="formatter" select="resolve-uri('src/reporter/format-xspec-report.xsl', $xspec-home)"/>
+   <p:documentation>
+      <p>This pipeline executes an XSpec test suite with the Saxon embedded in Calabash.</p>
+      <p><b>Primary input:</b> A XSpec test suite document.</p>
+      <p><b>Primary output:</b> A formatted HTML XSpec report.</p>
+   </p:documentation>
 
-	<p:load name="compiler">
-		<p:with-option name="href" select="$compiler"/>
-	</p:load>
+   <p:serialization port="result" indent="true" method="xhtml"
+                    encoding="UTF-8" include-content-type="true"/>
 
-	<p:xslt name="compile">
-		<p:input port="source">
-			<p:pipe step="saxon-xslt-harness" port="source"/>
-		</p:input>
-		<p:input port="stylesheet">
-			<p:pipe step="compiler" port="result"/>
-		</p:input>
-		<p:input port="parameters">
-			<p:empty/>
-		</p:input>
-	</p:xslt>
+   <p:import href="../harness-lib.xpl"/>
 
-	<p:xslt name="run" template-name="t:main">
-		<p:input port="source">
-			<p:empty/>
-		</p:input>
-		<p:input port="stylesheet">
-			<p:pipe step="compile" port="result"/>
-		</p:input>
-		<p:input port="parameters">
-			<p:empty/>
-		</p:input>
-	</p:xslt>
+   <!-- TODO: Does not work yet... -->
+   <!--t:ensure-input/-->
 
-	<p:choose>
-		<p:when test="exists(/t:report)">
-			<p:load name="formatter">
-				<p:with-option name="href" select="$formatter"/>
-			</p:load>
-			<p:xslt name="format-report">
-				<p:input port="source">
-					<p:pipe step="run" port="result"/>
-				</p:input>
-				<p:input port="stylesheet">
-					<p:pipe step="formatter" port="result"/>
-				</p:input>
-			</p:xslt>
-		</p:when>
-		<p:otherwise>
-			<p:error code="t:ERR001">
-				<p:input port="source">
-					<p:pipe step="run" port="result"/>
-				</p:input>
-			</p:error>
-		</p:otherwise>
-	</p:choose>
+   <!-- compile the suite into a stylesheet -->
+   <t:compile-xslt name="compile"/>
+
+   <!-- run it on saxon -->
+   <p:xslt name="run" template-name="t:main">
+      <p:input port="source">
+         <p:empty/>
+      </p:input>
+      <p:input port="stylesheet">
+         <p:pipe step="compile" port="result"/>
+      </p:input>
+      <p:input port="parameters">
+         <p:empty/>
+      </p:input>
+   </p:xslt>
+
+   <!-- format the report -->
+   <t:format-report/>
 
 </p:pipeline>
+
+
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
 <!--                                                                       -->
-<!-- Copyright (c) 2008, 2010 Jeni Tennison                                -->
+<!-- Copyright (c) 2011 Florent Georges                                    -->
 <!--                                                                       -->
 <!-- The contents of this file are subject to the MIT License (see the URI -->
 <!-- http://www.opensource.org/licenses/mit-license.php for details).      -->

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -260,7 +260,7 @@ setlocal
     call :setup "executing the Saxon XProc harness generates a report with UTF-8 encoding"
 
     if defined XMLCALABASH_CP (
-        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
         call :verify_line 1 x "true"
     ) else (

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -138,7 +138,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
 
 
@@ -172,7 +172,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]]
+    [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
 }
 
 
@@ -180,7 +180,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
 
 
@@ -205,5 +205,5 @@ teardown() {
     fi
 
     echo $output
-    [[ "${lines[0]}" = "true" ]]
+    [ "${lines[0]}" = "true" ]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -138,7 +138,8 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
+    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml"
+    || "${lines[26]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]]
 }
 
 
@@ -172,7 +173,8 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
+    [[ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html"
+    || "${lines[24]}" = "Report available at /tmp/escape-for-regex-result.html" ]]
 }
 
 
@@ -180,7 +182,8 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html"
+    || "${lines[24]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]]
 }
 
 
@@ -188,17 +191,23 @@ teardown() {
     run ../bin/xspec.sh ../test/xspec-46.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[3]}" =~ "Testing with" ]]
+    [[ "${lines[3]}" =~ "Testing with"
+    || "${lines[7]}" =~ "Testing with" ]]
 }
 
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding" {
-    if [ -z ${XMLCALABASH_CP} ]; then
-		    skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon";
-	  fi 
 
-	  run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec xspec-home=file://${TRAVIS_BUILD_DIR}/ -oresult=${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html ${TRAVIS_BUILD_DIR}/src/harnesses/saxon/saxon-xslt-harness.xproc 
-	  run java -cp ${SAXON_CP} net.sf.saxon.Query -s:${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; /html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8'" !method=text
-	  echo $output
-    [[ "${lines[0]}" = 'true' ]]
+    if [ -z ${XMLCALABASH_CP} ]; then
+        skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon";
+    else
+        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home=file://${TRAVIS_BUILD_DIR}/ -oresult=${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html ${TRAVIS_BUILD_DIR}/src/harnesses/saxon/saxon-xslt-harness.xproc
+
+    	query="declare default element namespace 'http://www.w3.org/1999/xhtml'; /html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8'";
+
+        run java -cp ${SAXON_CP} net.sf.saxon.Query -s:${TRAVIS_BUILD_DIR}/test/xspec/xspec-72-result.html -qs:"$query" !method=text
+    fi
+
+    echo $output
+    [[ "${lines[0]}" = "true" ]]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -138,8 +138,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml"
-    || "${lines[26]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]]
+    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]]
 }
 
 
@@ -173,8 +172,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html"
-    || "${lines[24]}" = "Report available at /tmp/escape-for-regex-result.html" ]]
+    [[ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]]
 }
 
 
@@ -182,8 +180,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html"
-    || "${lines[24]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]]
+    [[ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]]
 }
 
 
@@ -191,8 +188,7 @@ teardown() {
     run ../bin/xspec.sh ../test/xspec-46.xspec
 	  echo $output
     [ "$status" -eq 0 ]
-    [[ "${lines[3]}" =~ "Testing with"
-    || "${lines[7]}" =~ "Testing with" ]]
+    [[ "${lines[3]}" =~ "Testing with" ]]
 }
 
 


### PR DESCRIPTION
## Summary

This pull request is part of the code review for #103 and addresses the XProc harness for Saxon. See https://github.com/xspec/xspec/pull/103#issuecomment-286272902 for details. This pull request has been approved in https://github.com/xspec/xspec/pull/103#issuecomment-286288272.

## Why

The XProc harness was reverted to v0.3.0 in https://github.com/xspec/xspec/commit/ad6b0412afdf9f95feeb5b6c0e99804fa34d7bfc because it didn't seem to work. @fgeorges fixed this as part of #103 and provided information on how to run it so that the XProc harness implemented in v0.4.0-RC can be now used.

## What has changed
The library ```harness-lib.xpl``` is used for this XProc harness and can be re-used for other harnesses. One of the major changes from v0.3.0 is the use of the ```-p``` option in front of the parameter ```xspec-home```, this is required to run the harness correctly and needs to be added to the documentation. For more information see https://github.com/xspec/xspec/pull/103#issuecomment-286272902.