### PR TITLE
run-xspec-tests.*: Print result.log on failure

### DIFF
--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -32,7 +32,6 @@
       <t:expect label="the label message" test="$t:result/xsl:message eq 'my label'"/>
       <t:expect label="the scenario" test="exists($t:result/t:scenario)"/>
       <t:expect label="the scenario label" test="$t:result/t:scenario/t:label eq 'my label'"/>
-      <t:expect label="Fail by intention" test="false()" />
     </t:scenario>
   </t:scenario>
 </t:description>

--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -32,6 +32,7 @@
       <t:expect label="the label message" test="$t:result/xsl:message eq 'my label'"/>
       <t:expect label="the scenario" test="exists($t:result/t:scenario)"/>
       <t:expect label="the scenario label" test="$t:result/t:scenario/t:label eq 'my label'"/>
+      <t:expect label="Fail by intention" test="false()" />
     </t:scenario>
   </t:scenario>
 </t:description>

--- a/test/run-xspec-tests.cmd
+++ b/test/run-xspec-tests.cmd
@@ -47,6 +47,9 @@ for %%I in (*.xspec) do (
     ( findstr /r /c:".*failed: [1-9]" "%RESULT_FILE%" || findstr /r /c:"\*\** Error [a-z][a-z]*ing the test suite" "%RESULT_FILE%" ) > NUL
     if not errorlevel 1 (
         echo FAILED: %%~I
+        echo ---------- "%RESULT_FILE%"
+        type "%RESULT_FILE%"
+        echo ----------
         if /i "%APPVEYOR%"=="True" appveyor UpdateTest "%%~I" -Framework custom -Filename "%~nx0" -Outcome Failed -Duration 0
         exit /b 1
     ) else (

--- a/test/run-xspec-tests.cmd
+++ b/test/run-xspec-tests.cmd
@@ -44,7 +44,7 @@ for %%I in (*.xspec) do (
     rem
     rem Inspect result
     rem
-    findstr /r /c:".*failed: [1-9]" "%RESULT_FILE%" || findstr /r /c:"\*\** Error [a-z][a-z]*ing the test suite" "%RESULT_FILE%"
+    ( findstr /r /c:".*failed: [1-9]" "%RESULT_FILE%" || findstr /r /c:"\*\** Error [a-z][a-z]*ing the test suite" "%RESULT_FILE%" ) > NUL
     if not errorlevel 1 (
         echo FAILED: %%~I
         if /i "%APPVEYOR%"=="True" appveyor UpdateTest "%%~I" -Framework custom -Filename "%~nx0" -Outcome Failed -Duration 0

--- a/test/run-xspec-tests.sh
+++ b/test/run-xspec-tests.sh
@@ -26,7 +26,12 @@
 for xspectest in *.xspec; 
 do ../bin/xspec.sh $xspectest &> result.log; 
     if grep -q ".*failed:\s[1-9]" result.log || grep -q -E "\*+\sError\s(running|compiling)\sthe\stest\ssuite" result.log;
-        then echo "FAILED: $xspectest" && exit 1;
+        then
+            echo "FAILED: $xspectest";
+            echo "---------- result.log";
+            cat result.log;
+            echo "----------";
+            exit 1;
         else echo "OK: $xspectest";
     fi
 done


### PR DESCRIPTION
Fixes #109.

Just printing `result.log` would be the simplest way for now. So here it is.

What happens with this change on a test failure:
* [Travis](https://travis-ci.org/AirQuick/xspec/jobs/211437161#L218-L241)
* [AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/build/134-fix_issue-109/job/03fkwbp6dtew71hs#L140)