### PR TITLE
Inline CSS to make test report portable

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -43,6 +43,7 @@ usage() {
     echo "  -q         test an XQuery module (mutually exclusive with -t)"
     echo "  -c         output test coverage report"
     echo "  -j         output JUnit report"
+    echo "  -i         inline CSS in report HTML"
     echo "  -h         display this help message"
     echo "  coverage   deprecated, use -c instead"
 }
@@ -180,6 +181,9 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
 			    exit 1
 			fi
             JUNIT=1;;
+        # Inline CSS in HTML report
+        -i)
+                        INLINE_CSS="inline-css=true()";;
         # Help!
         -h)
             usage
@@ -303,6 +307,7 @@ echo "Formatting Report..."
 xslt -o:"$HTML" \
     -s:"$RESULT" \
     -xsl:"$XSPEC_HOME/src/reporter/format-xspec-report.xsl" \
+    $INLINE_CSS \
     || die "Error formating the report"
 if test -n "$COVERAGE"; then
     xslt -l:on \

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -23,6 +23,8 @@
 <xsl:param name="report-css-uri" select="
     resolve-uri('test-report.css', static-base-uri())"/>
 
+<xsl:param name="inline-css" select="false()"/>
+
 <xsl:function name="x:pending-callback" as="node()*">
   <!-- returns formatted output for $pending. -->
   <xsl:param name="pending" as="xs:string?"/>
@@ -130,7 +132,10 @@
          </xsl:call-template>
          <xsl:text>)</xsl:text>
       </title>
-      <link rel="stylesheet" type="text/css" href="{ $report-css-uri }"/>
+      <xsl:choose>
+        <xsl:when test="$inline-css"><style><xsl:value-of select="unparsed-text( $report-css-uri )" disable-output-escaping="yes"/></style></xsl:when>
+        <xsl:otherwise><link rel="stylesheet" type="text/css" href="{ $report-css-uri }"/></xsl:otherwise>
+      </xsl:choose>
       <xsl:call-template name="x:html-head-callback"/>
     </head>
     <body>


### PR DESCRIPTION
This change pulls the CSS styles for styling the test report into the generated HTML instead of referring to it by a computed link.  It makes the test report self-contained, so that it can be easily displayed with proper styling when it is passed around or served by a http server.