### PR TITLE
Run XSpec test in folder with an apostrophe in its name (#119)

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -32,8 +32,9 @@
 
 <xsl:variable name="xspec-ns" select="'http://www.jenitennison.com/xslt/xspec'"/>
 
+<xsl:variable name="apostrophe">'</xsl:variable>
 <xsl:variable name="stylesheet-uri" as="xs:anyURI" 
-  select="resolve-uri(/x:description/@stylesheet, base-uri(/x:description))" />  
+  select="resolve-uri(/x:description/@stylesheet, replace(base-uri(/x:description), $apostrophe, '%27'))" />  
 
 <xsl:variable name="stylesheet" as="document-node()" 
   select="doc($stylesheet-uri)" />

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -270,6 +270,20 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
+
+    set APOSTROPHE_DIR=%WORK_DIR%\some'path
+    call :mkdir "%APOSTROPHE_DIR%"
+    copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%" > NUL
+
+    call :run ..\bin\xspec.bat "%APOSTROPHE_DIR%\escape-for-regex.xspec"
+    call :verify_retval 0
+    call :verify_line 20 x "Report available at %APOSTROPHE_DIR%\xspec\escape-for-regex-result.html"
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -207,3 +207,14 @@ teardown() {
     echo $output
     [ "${lines[0]}" = "true" ]
 }
+
+
+@test "invoking xspec.sh with path containing an apostrophe runs successfully #119" {
+	mkdir some\'path
+	cp ../tutorial/escape-for-regex.* some\'path 
+    run ../bin/xspec.sh some\'path/escape-for-regex.xspec
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
+	rm -rf some\'path
+}

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -212,9 +212,9 @@ teardown() {
 @test "invoking xspec.sh with path containing an apostrophe runs successfully #119" {
 	mkdir some\'path
 	cp ../tutorial/escape-for-regex.* some\'path 
-    run ../bin/xspec.sh some\'path/escape-for-regex.xspec
+	run ../bin/xspec.sh some\'path/escape-for-regex.xspec
 	echo $output
-    [ "$status" -eq 0 ]
-    [ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
 	rm -rf some\'path
 }


### PR DESCRIPTION
### Summary
This pull request addresses #119 and allows to run an XSpec test stored in a folder which has an apostrophe in its name.

### What has changed
In ```generate-xspec-tests.xsl``` I replaced the apostrophe with the encoded character ```%27``` as suggested by @raducoravu in https://github.com/xspec/xspec/issues/119#issue-221183560. A similar solution was also suggested by Michael Kay (see [XSLT 2.0 book](http://p2p.wrox.com/xslt/50152-how-do-you-translate-apostrophe.html#post182183) and [Stackoverflow](http://stackoverflow.com/a/12406443)). I used ```replace()``` instead of ```translate()``` as in the original post from @raducoravu although I think both functions can achieve the same result. 

I added a test in ```bats.xspec``` that creates a folder ```some'path```, copy the tutorial example in this folder, and runs the test. At the end of the test the folder ```some'path``` is deleted. I preferred to create and delete the dummy folder inside the test instead of doing this in the ```setup()``` and ```teardown()``` as this is only relevant for this test.

### How to review it
Run the example provided by @raducoravu in https://github.com/xspec/xspec/issues/119#issuecomment-293798005, it should run successfully with the code in this pull request.

@raducoravu: could you check that this fixes #119?
@AirQuick: would it be possible to add a similar test in the batch script?