### PR TITLE
Add checks for saxon script + test

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -59,7 +59,7 @@ die() {
 # configured it, so there is no point to duplicate the logic here.
 # Just use it.
 
-if which saxon > /dev/null 2>&1; then
+if which saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev/null 2>&1; then
     echo Saxon script found, use it.
     echo
     xslt() {

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -218,3 +218,15 @@ teardown() {
 	[ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
 	rm -rf some\'path
 }
+
+
+@test "invoking xspec.sh with saxon script uses the saxon script #121 #122" {
+	echo "echo 'Saxon script with EXPath Packaging System'" > /tmp/saxon
+	chmod +x /tmp/saxon
+	export PATH=$PATH:/tmp
+	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "Saxon script found, use it." ]
+	rm /tmp/saxon
+}


### PR DESCRIPTION
Following discussions with @hanshuebner, @fgeorges, and @AirQuick in #121 and #122, I submit this pull request which hopefully sums up and includes your previous pull requests and comments on the saxon script being properly checked. I also added a test for the shell script that simulates the use of the saxon script. 

I [previously wrote](https://github.com/xspec/xspec/pull/122#discussion_r111888470) that the ```which``` command was not necessary in the condition. I was actually wrong as without it the shell script returns an error message ```command not found``` instead of evaluating to ```false```. The other conditions can be piped together without side effects as the passing test shows.

If you agree with these changes, just add a thumb up or approve it and I will merge into ```master``` and close the other pull requests. If you suggest changes, feel free to comment in this pull request.