### PR TITLE
From pull request #129 discussion: suppress warning message and clean up temporary files

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -174,13 +174,13 @@ rem ##
     echo:
     echo Compiling the Schematron...
     call :xslt -o:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" -s:"%SCH%" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl" ^
+        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl" -versionmsg:off ^
         || ( call :die "Error compiling the Schematron on step 1" & goto :win_main_error_exit )
     call :xslt -o:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" -s:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl" ^
+        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl" -versionmsg:off ^
         || ( call :die "Error compiling the Schematron on step 2" & goto :win_main_error_exit )
     call :xslt -o:"%SCH_COMPILED%" -s:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl" ^
+        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl" -versionmsg:off ^
         %SCH_PARAMS% ^
         || ( call :die "Error compiling the Schematron on step 3" & goto :win_main_error_exit )
     
@@ -201,6 +201,17 @@ rem ##
     set XSPEC=%SCHUT%
     echo:
     goto :EOF
+
+:cleanup
+	if defined SCHEMATRON (
+		del /q "%SCHUT%" 2>nul
+		del /q "%TEST_DIR%\context-*.xml" 2>nul
+		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" 2>nul
+		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" 2>nul
+		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" 2>nul
+		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-compiled.xsl" 2>nul
+	)
+	goto :EOF
 
 :win_echo
     rem
@@ -587,7 +598,7 @@ if defined COVERAGE (
     rem %OPEN% "%HTML%"
 )
 
-if defined SCHEMATRON del "%SCHUT%"
+call :cleanup
 
 echo Done.
 exit /b

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -52,7 +52,7 @@ rem ##
     echo   filename   the XSpec document
     echo   -t         test an XSLT stylesheet (the default)
     echo   -q         test an XQuery module (mutually exclusive with -t and -s)
-    echo   -s         test a Schematron module (mutually exclusive with -t and -q)
+    echo   -s         test a Schematron schema (mutually exclusive with -t and -q)
     echo   -c         output test coverage report
     echo   -j         output JUnit report
     echo   -h         display this help message

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -288,9 +288,9 @@ if test -n "$SCHEMATRON"; then
     
     echo
     echo "Compiling the Schematron..."
-    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -s:"$SCH" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_dsdl_include.xsl" || die "Error compiling the Schematron on step 1"
-    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_abstract_expand.xsl" || die "Error compiling the Schematron on step 2"
-    xslt -o:"$SCH_COMPILED" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl" $SCH_PARAMS || die "Error compiling the Schematron on step 3"
+    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -s:"$SCH" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_dsdl_include.xsl" -versionmsg:off || die "Error compiling the Schematron on step 1"
+    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_abstract_expand.xsl" -versionmsg:off || die "Error compiling the Schematron on step 2"
+    xslt -o:"$SCH_COMPILED" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl" -versionmsg:off $SCH_PARAMS || die "Error compiling the Schematron on step 3"
     
     # use XQuery to get full URI to compiled Schematron
     xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(document-uri(/))" -s:"$SCH_COMPILED" >"$TEST_DIR/$TARGET_FILE_NAME-var.txt" || die "Error getting compiled Schematron location"
@@ -377,8 +377,16 @@ else
     #$OPEN "$HTML"
 fi
 
+##
+## cleanup
+##
 if test -n "$SCHEMATRON"; then
-    rm "$SCHUT"
+    rm -f "$SCHUT"
+    rm -f "$TEST_DIR"/context-*.xml
+    rm -f "$TEST_DIR/$TARGET_FILE_NAME-var.txt"
+    rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml"
+    rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml"
+    rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-compiled.xsl"
 fi
 
 echo "Done."

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -41,7 +41,7 @@ usage() {
     echo "  filename   the XSpec document"
     echo "  -t         test an XSLT stylesheet (the default)"
     echo "  -q         test an XQuery module (mutually exclusive with -t and -s)"
-    echo "  -s         test a Schematron module (mutually exclusive with -t and -q)"
+    echo "  -s         test a Schematron schema (mutually exclusive with -t and -q)"
     echo "  -c         output test coverage report"
     echo "  -j         output JUnit report"
     echo "  -h         display this help message"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -341,6 +341,26 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "Schematron phase/parameters are passed to Schematron compile"
+
+    call :run ..\bin\xspec.bat -s ..\test\schematron-param-001.xspec
+    call :verify_retval 0
+    call :verify_line 3 x "Paramaters: phase=P1 ?selected=codepoints-to-string((80,49))"
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131"
+
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
+    call :verify_retval 0
+    call :verify_line 5 x "Compiling the Schematron tests..."
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem
@@ -424,6 +444,7 @@ rem
     rem
     call :mkdir ..\test\xspec
     call :mkdir ..\tutorial\xspec
+    call :mkdir ..\tutorial\schematron\xspec
 
     goto :EOF
 
@@ -433,6 +454,7 @@ rem
     rem
     call :rmdir ..\test\xspec
     call :rmdir ..\tutorial\xspec
+    call :rmdir ..\tutorial\schematron\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -342,16 +342,6 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "Schematron phase/parameters are passed to Schematron compile"
-
-    call :run ..\bin\xspec.bat -s ..\test\schematron-param-001.xspec
-    call :verify_retval 0
-    call :verify_line 3 x "Paramaters: phase=P1 ?selected=codepoints-to-string((80,49))"
-
-    call :teardown
-endlocal
-
-setlocal
     call :setup "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131"
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -351,6 +351,21 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "Cleanup removes temporary files"
+
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
+    call :verify_retval 0
+    call :run dir /on ..\tutorial\schematron\xspec
+    call :verify_line 9 r ".*3 File.*"
+    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
+    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.xml
+    call :verify_exist ..\tutorial\schematron\xspec\demo-03.xsl
+    call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem
@@ -567,5 +582,13 @@ rem
         call :verified "Exist: %~1"
     ) else (
         call :failed "Not exist: %~1"
+    )
+    goto :EOF
+
+:verify_not_exist
+    if exist %1 (
+        call :failed "Exist: %~1"
+    ) else (
+        call :verified "Not exist: %~1"
     )
     goto :EOF

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -356,12 +356,12 @@ setlocal
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
+    call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
     call :run dir /on ..\tutorial\schematron\xspec
     call :verify_line 9 r ".*3 File.*"
     call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
     call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.xml
     call :verify_exist ..\tutorial\schematron\xspec\demo-03.xsl
-    call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
 
     call :teardown
 endlocal

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -18,14 +18,16 @@
 #===============================================================================
 
 setup() {
-    mkdir ../tutorial/xspec
+	mkdir ../tutorial/xspec
 	mkdir ../test/xspec
+	mkdir ../tutorial/schematron/xspec
 }
 
 
 teardown() {
-    rm -rf ../tutorial/xspec
-    rm -rf ../test/xspec
+	rm -rf ../tutorial/xspec
+	rm -rf ../test/xspec
+	rm -rf ../tutorial/schematron/xspec
 }
 
 
@@ -261,6 +263,15 @@ teardown() {
 	echo "${lines[2]}"
     [ "$status" -eq 0 ]
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]
+}
+
+
+@test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
+	echo "${lines[4]}"
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[4]}" == "Compiling the Schematron tests..." ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -275,6 +275,18 @@ teardown() {
 }
 
 
+@test "Cleanup removes temporary files" {
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
+    [ "$status" -eq 0 ]
+    [ ! -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
+    run ls ../tutorial/schematron/xspec
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "demo-03-result.html" ]
+    [ "${lines[1]}" = "demo-03-result.xml" ]
+    [ "${lines[2]}" = "demo-03.xsl" ]
+}
+
+
 @test "invoking xspec.sh with -q option runs XSpec test for XQuery" {
     run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
 	echo "${lines[5]}"


### PR DESCRIPTION
As discussed in pull request #129: suppress warning message "Running an XSLT 10 stylesheet with an XSLT 20 processor" during Schematron compilation and clean up temporary files.