### PR TITLE
Allow Schematron XSLTs to be provided externally

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -156,6 +156,10 @@ rem ##
 :schematron_compile
     echo Setting up Schematron...
     
+    if not defined SCHEMATRON_XSLT_INCLUDE set SCHEMATRON_XSLT_INCLUDE="%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl"
+    if not defined SCHEMATRON_XSLT_EXPAND set SCHEMATRON_XSLT_EXPAND="%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl"
+    if not defined SCHEMATRON_XSLT_COMPILE set SCHEMATRON_XSLT_COMPILE="%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl"
+    
     rem # get URI to Schematron file and phase/parameters from the XSpec file
     call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(concat(replace(document-uri(/), '(.*)/.*$', '$1'), '/', /*[local-name() = 'description']/@schematron))" ^
         -s:"%XSPEC%" >"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" ^
@@ -174,13 +178,13 @@ rem ##
     echo:
     echo Compiling the Schematron...
     call :xslt -o:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" -s:"%SCH%" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl" -versionmsg:off ^
+        -xsl:"%SCHEMATRON_XSLT_INCLUDE%" -versionmsg:off ^
         || ( call :die "Error compiling the Schematron on step 1" & goto :win_main_error_exit )
     call :xslt -o:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" -s:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl" -versionmsg:off ^
+        -xsl:"%SCHEMATRON_XSLT_EXPAND%" -versionmsg:off ^
         || ( call :die "Error compiling the Schematron on step 2" & goto :win_main_error_exit )
     call :xslt -o:"%SCH_COMPILED%" -s:"%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" ^
-        -xsl:"%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl" -versionmsg:off ^
+        -xsl:"%SCHEMATRON_XSLT_COMPILE%" -versionmsg:off ^
         %SCH_PARAMS% ^
         || ( call :die "Error compiling the Schematron on step 3" & goto :win_main_error_exit )
     

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -275,6 +275,16 @@ fi
 if test -n "$SCHEMATRON"; then
     echo "Setting up Schematron..."
     
+    if test -z "$SCHEMATRON_XSLT_INCLUDE"; then
+        SCHEMATRON_XSLT_INCLUDE="$XSPEC_HOME/src/schematron/iso-schematron/iso_dsdl_include.xsl";
+    fi
+    if test -z "$SCHEMATRON_XSLT_EXPAND"; then
+        SCHEMATRON_XSLT_EXPAND="$XSPEC_HOME/src/schematron/iso-schematron/iso_abstract_expand.xsl";
+    fi
+    if test -z "$SCHEMATRON_XSLT_COMPILE"; then
+        SCHEMATRON_XSLT_COMPILE="$XSPEC_HOME/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl";
+    fi
+    
     # get URI to Schematron file and phase/parameters from the XSpec file
     # Need to escape for sh in XQuery: dollar sign as \$
     xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(concat(replace(document-uri(/), '(.*)/.*\$', '\$1'), '/', /*[local-name() = 'description']/@schematron))" -s:"$XSPEC" >"$TEST_DIR/$TARGET_FILE_NAME-var.txt" || die "Error getting Schematron location"
@@ -288,9 +298,9 @@ if test -n "$SCHEMATRON"; then
     
     echo
     echo "Compiling the Schematron..."
-    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -s:"$SCH" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_dsdl_include.xsl" -versionmsg:off || die "Error compiling the Schematron on step 1"
-    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_abstract_expand.xsl" -versionmsg:off || die "Error compiling the Schematron on step 2"
-    xslt -o:"$SCH_COMPILED" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -xsl:"$XSPEC_HOME/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl" -versionmsg:off $SCH_PARAMS || die "Error compiling the Schematron on step 3"
+    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -s:"$SCH" -xsl:"$SCHEMATRON_XSLT_INCLUDE" -versionmsg:off || die "Error compiling the Schematron on step 1"
+    xslt -o:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml" -xsl:"$SCHEMATRON_XSLT_EXPAND" -versionmsg:off || die "Error compiling the Schematron on step 2"
+    xslt -o:"$SCH_COMPILED" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -xsl:"$SCHEMATRON_XSLT_COMPILE" -versionmsg:off $SCH_PARAMS || die "Error compiling the Schematron on step 3"
     
     # use XQuery to get full URI to compiled Schematron
     xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(document-uri(/))" -s:"$SCH_COMPILED" >"$TEST_DIR/$TARGET_FILE_NAME-var.txt" || die "Error getting compiled Schematron location"

--- a/test/schematron/schematron-xslt-compile.xsl
+++ b/test/schematron/schematron-xslt-compile.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+        <xsl:element name="test">
+            <xsl:message>Schematron XSLT compile</xsl:message>
+        </xsl:element>
+    </xsl:template>
+</xsl:stylesheet>

--- a/test/schematron/schematron-xslt-expand.xsl
+++ b/test/schematron/schematron-xslt-expand.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+        <xsl:element name="test">
+            <xsl:message>Schematron XSLT expand</xsl:message>
+        </xsl:element>
+    </xsl:template>
+</xsl:stylesheet>

--- a/test/schematron/schematron-xslt-include.xsl
+++ b/test/schematron/schematron-xslt-include.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+        <xsl:element name="test">
+            <xsl:message>Schematron XSLT include</xsl:message>
+        </xsl:element>
+    </xsl:template>
+</xsl:stylesheet>

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -342,6 +342,21 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs"
+    
+    set SCHEMATRON_XSLT_INCLUDE=schematron\schematron-xslt-include.xsl
+    set SCHEMATRON_XSLT_EXPAND=schematron\schematron-xslt-expand.xsl
+    set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt-compile.xsl
+    
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
+    call :verify_line 5 x "Schematron XSLT include"
+    call :verify_line 6 x "Schematron XSLT expand"
+    call :verify_line 7 x "Schematron XSLT compile"
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131"
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -342,7 +342,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs"
+    call :setup "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile"
     
     set SCHEMATRON_XSLT_INCLUDE=schematron\schematron-xslt-include.xsl
     set SCHEMATRON_XSLT_EXPAND=schematron\schematron-xslt-expand.xsl

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -265,6 +265,19 @@ teardown() {
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]
 }
 
+@test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs" {
+    
+    export SCHEMATRON_XSLT_INCLUDE=schematron/schematron-xslt-include.xsl
+    export SCHEMATRON_XSLT_EXPAND=schematron/schematron-xslt-expand.xsl
+    export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt-compile.xsl
+    
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
+	echo $output
+    [[ "${lines[5]}" =~ "Schematron XSLT include" ]]
+    [[ "${lines[6]}" =~ "Schematron XSLT expand" ]]
+    [[ "${lines[7]}" =~ "Schematron XSLT compile" ]]
+}
+
 
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -265,7 +265,7 @@ teardown() {
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]
 }
 
-@test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs" {
+@test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile" {
     
     export SCHEMATRON_XSLT_INCLUDE=schematron/schematron-xslt-include.xsl
     export SCHEMATRON_XSLT_EXPAND=schematron/schematron-xslt-expand.xsl
@@ -273,9 +273,9 @@ teardown() {
     
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
 	echo $output
-    [[ "${lines[5]}" =~ "Schematron XSLT include" ]]
-    [[ "${lines[6]}" =~ "Schematron XSLT expand" ]]
-    [[ "${lines[7]}" =~ "Schematron XSLT compile" ]]
+    [ "${lines[4]}" = "Schematron XSLT include" ]
+    [ "${lines[5]}" = "Schematron XSLT expand" ]
+    [ "${lines[6]}" = "Schematron XSLT compile" ]
 }
 
 


### PR DESCRIPTION
This change adds the ability for Schematron XSLTs to be provided externally. This will help with using XSpec to test the Schematron XSLTs (see [Schematron Issue 49](https://github.com/Schematron/schematron/issues/49)) and may help with testing customizations of the Schematron XSLTs (see http://schematron.com/front-page/the-schematron-skeleton-implementation/). To use external Schematron XSLTs set/export the following environment variables with the path to the XSLTs for XSpec to use when compiling a Schematron schema.

* SCHEMATRON_XSLT_INCLUDE - the default is iso_dsdl_include.xsl
* SCHEMATRON_XSLT_EXPAND - the default is iso_abstract_expand.xsl
* SCHEMATRON_XSLT_COMPILE - the default is iso_svrl_for_xslt2.xsl
