### PR TITLE
add XProc harness for BaseX standalone (review #103)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
         # latest Saxon 9.7 version
         - SAXON_VERSION=9.7.0-18
           XMLCALABASH_VERSION=1.1.16-97
+          BASEX_VERSION=8.6.4
         # latest Saxon 9.6 version
         - SAXON_VERSION=9.6.0-10
         # Saxon version used in oXygen
@@ -26,6 +27,13 @@ before_script:
         wget -O /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
         unzip /tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}.zip -d /tmp/xspec;
         export XMLCALABASH_CP=/tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
+      fi
+    # install BaseX
+    - if [ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]; then
+        echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
+      else
+        wget -O /tmp/basex/basex-${BASEX_VERSION}.jar http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
+        export BASEX_CP=/tmp/basex/basex-${BASEX_VERSION}.jar;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
     - if [ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]; then
         echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
       else
+        mkdir -p /tmp/basex
         wget -O /tmp/basex/basex-${BASEX_VERSION}.jar http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
         export BASEX_CP=/tmp/basex/basex-${BASEX_VERSION}.jar;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
         export XMLCALABASH_CP=/tmp/xspec/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
       fi
     # install BaseX
-    - if [ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]; then
+    - if [[ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]]; then
         echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
       else
         mkdir -p /tmp/basex

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
     - if [[ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]]; then
         echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
       else
-        mkdir -p /tmp/basex
+        mkdir -p /tmp/basex;
         wget -O /tmp/basex/basex-${BASEX_VERSION}.jar http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
         export BASEX_CP=/tmp/basex/basex-${BASEX_VERSION}.jar;
       fi

--- a/src/harnesses/basex/basex-standalone-xquery-harness.xproc
+++ b/src/harnesses/basex/basex-standalone-xquery-harness.xproc
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ===================================================================== -->
+<!--  File:       basex-standalone-xquery-harness.xproc                    -->
+<!--  Author:     Florent Georges                                          -->
+<!--  Date:       2011-08-30                                               -->
+<!--  URI:        http://xspec.googlecode.com/                             -->
+<!--  Tags:                                                                -->
+<!--    Copyright (c) 2011 Florent Georges (see end of file.)              -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
+   xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="http://www.jenitennison.com/xslt/xspec"
+   xmlns:pkg="http://expath.org/ns/pkg"
+   pkg:import-uri="http://www.jenitennison.com/xslt/xspec/basex/harness/standalone/xquery.xproc"
+   name="basex-standalone-xquery-harness" type="t:basex-standalone-xquery-harness" version="1.0">
+
+   <p:documentation>
+      <p>This pipeline executes an XSpec test suite with BaseX standalone.</p>
+      <p><b>Primary input:</b> A XSpec test suite document.</p>
+      <p><b>Primary output:</b> A formatted HTML XSpec report.</p>
+      <p>The dir where you unzipped the XSpec archive on your filesystem is passed in the option
+         'xspec-home'. The compiled test suite (the XQuery file to be actually evaluated) is saved
+         on the filesystem to be passed to BaseX. The name of this file is passed in the option
+         'compiled-file' (it defaults to a file in /tmp). The BaseX JAR file is passed through
+         'basex-jar'.</p>
+   </p:documentation>
+
+   <p:serialization port="result" indent="true"/>
+
+   <p:import href="../harness-lib.xpl"/>
+
+   <t:parameters name="params"/>
+
+   <p:group>
+      <p:variable name="xspec-home" select="/c:param-set/c:param[@name eq 'xspec-home']/@value">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
+      <p:variable name="basex-jar" select="/c:param-set/c:param[@name eq 'basex-jar']/@value">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
+      <!-- TODO: Use a robust way to get a tmp file name from the OS... -->
+      <p:variable name="compiled-file"
+         select="( /c:param-set/c:param[@name eq 'compiled-file']/@value,
+            'file:/tmp/xspec-basex-compiled-suite.xq' )[1]">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
+      <p:variable name="utils-library-at"
+         select="/c:param-set/c:param[@name eq 'utils-library-at']/@value">
+         <p:pipe step="params" port="parameters"/>
+      </p:variable>
+      <!-- either no at location hint, or resolved from xspec-home if packaging not supported -->
+      <p:variable name="utils-lib"
+         select="if ( $utils-library-at ) then
+            $utils-library-at
+          else if ( $xspec-home ) then
+            resolve-uri('src/compiler/generate-query-utils.xql', $xspec-home)
+          else
+            ''"/>
+
+      <!-- compile the suite into a query -->
+      <t:compile-xquery>
+         <p:with-param name="utils-library-at" select="$utils-lib"/>
+      </t:compile-xquery>
+
+      <!-- escape the query as text -->
+      <p:escape-markup name="escape"/>
+
+      <!-- store it on disk in order to pass it to BaseX -->
+      <p:store method="text" name="store">
+         <p:with-option name="href" select="$compiled-file"/>
+      </p:store>
+
+      <!-- run it on BaseX -->
+      <p:choose cx:depends-on="store">
+         <p:when test="p:value-available('basex-jar')">
+            <!-- use Java directly, rely on 'basex-jar' -->
+            <p:exec command="java">
+               <p:with-option name="args"
+                  select="
+                   string-join(
+                     ('-cp', $basex-jar, 'org.basex.BaseX', $compiled-file),
+                     ' ')"/>
+               <p:input port="source">
+                  <p:empty/>
+               </p:input>
+            </p:exec>
+         </p:when>
+         <p:otherwise>
+            <!-- rely on a script 'basex' being in the PATH -->
+            <p:exec command="basex">
+               <p:with-option name="args" select="$compiled-file"/>
+               <p:input port="source">
+                  <p:empty/>
+               </p:input>
+            </p:exec>
+         </p:otherwise>
+      </p:choose>
+
+      <!-- unwrap the exec step wrapper element -->
+      <p:unwrap match="/c:result"/>
+
+      <!-- format the report -->
+      <t:format-report/>
+   </p:group>
+
+</p:pipeline>
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+<!-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.             -->
+<!--                                                                       -->
+<!-- Copyright (c) 2011 Florent Georges                                    -->
+<!--                                                                       -->
+<!-- The contents of this file are subject to the MIT License (see the URI -->
+<!-- http://www.opensource.org/licenses/mit-license.php for details).      -->
+<!--                                                                       -->
+<!-- Permission is hereby granted, free of charge, to any person obtaining -->
+<!-- a copy of this software and associated documentation files (the       -->
+<!-- "Software"), to deal in the Software without restriction, including   -->
+<!-- without limitation the rights to use, copy, modify, merge, publish,   -->
+<!-- distribute, sublicense, and/or sell copies of the Software, and to    -->
+<!-- permit persons to whom the Software is furnished to do so, subject to -->
+<!-- the following conditions:                                             -->
+<!--                                                                       -->
+<!-- The above copyright notice and this permission notice shall be        -->
+<!-- included in all copies or substantial portions of the Software.       -->
+<!--                                                                       -->
+<!-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       -->
+<!-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.-->
+<!-- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  -->
+<!-- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  -->
+<!-- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     -->
+<!-- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -18,20 +18,20 @@
 #===============================================================================
 
 setup() {
-	  mkdir ../tutorial/xspec
-	  mkdir ../test/xspec
+    mkdir ../tutorial/xspec
+	mkdir ../test/xspec
 }
 
 
 teardown() {
-	  rm -rf ../tutorial/xspec
-	  rm -rf ../test/xspec
+    rm -rf ../tutorial/xspec
+    rm -rf ../test/xspec
 }
 
 
 @test "invoking xspec without arguments prints usage" {
     run ../bin/xspec.sh
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-h] filename [coverage]" ]
 }
@@ -64,7 +64,7 @@ teardown() {
 @test "invoking code coverage with Saxon9HE returns error message" {
     export SAXON_CP=/path/to/saxon9he.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -73,7 +73,7 @@ teardown() {
 @test "invoking code coverage with Saxon9SA returns error message" {
     export SAXON_CP=/path/to/saxon9sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -82,7 +82,7 @@ teardown() {
 @test "invoking code coverage with Saxon9 returns error message" {
     export SAXON_CP=/path/to/saxon9.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -91,7 +91,7 @@ teardown() {
 @test "invoking code coverage with Saxon8SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -100,7 +100,7 @@ teardown() {
 @test "invoking code coverage with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -118,7 +118,7 @@ teardown() {
 @test "invoking code coverage with Saxon9PE creates test stylesheet" {
     export SAXON_CP=/path/to/saxon9pe.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -127,7 +127,7 @@ teardown() {
 @test "invoking xspec generates XML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
 }
 
@@ -135,7 +135,7 @@ teardown() {
 @test "invoking xspec generates HTML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.html
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
 }
 
@@ -143,7 +143,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -152,7 +152,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8-SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -160,7 +160,7 @@ teardown() {
 
 @test "invoking xspec with -j option generates message with JUnit report location" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
@@ -169,7 +169,7 @@ teardown() {
 @test "invoking xspec with -j option generates XML report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
 }
 
@@ -177,16 +177,16 @@ teardown() {
 @test "invoking xspec with -j option generates JUnit report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
 }
 
 
 @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
-	  run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	  echo $output
-	  [ "$status" -eq 1 ]
+	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo $output
+	[ "$status" -eq 1 ]
   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
 
@@ -194,7 +194,7 @@ teardown() {
 @test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
     export TEST_DIR=/tmp
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
 }
@@ -202,7 +202,7 @@ teardown() {
 
 @test "invoking xspec.sh without TEST_DIR generates files in default location" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
@@ -210,7 +210,7 @@ teardown() {
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
     run ../bin/xspec.sh ../test/xspec-46.xspec
-	  echo $output
+	echo $output
     [ "$status" -eq 0 ]
     [[ "${lines[3]}" =~ "Testing with" ]]
 }
@@ -261,4 +261,25 @@ teardown() {
 	echo "${lines[2]}"
     [ "$status" -eq 0 ]
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]
+}
+
+
+@test "invoking xspec.sh with -q option runs XSpec test for XQuery" {
+    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+	echo "${lines[5]}"
+    [ "$status" -eq 0 ]
+    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+}
+
+
+@test "executing the XProc harness for BaseX generates a report" {
+
+    if [ -z ${XMLCALABASH_CP} && -z ${BASEX_CP} ]; then
+        skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon";
+    else
+        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+    fi
+
+    echo $output
+    [[ "${lines[0]}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -274,7 +274,7 @@ teardown() {
 
 @test "executing the XProc harness for BaseX generates a report" {
 
-    if [ -z ${XMLCALABASH_CP} && -z ${BASEX_CP} ]; then
+    if [[ -z ${XMLCALABASH_CP} && -z ${BASEX_CP} ]]; then
         skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon";
     else
         run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -281,5 +281,5 @@ teardown() {
     fi
 
     echo $output
-    [[ "${lines[0]}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 }

--- a/tutorial/xquery-tutorial.xq
+++ b/tutorial/xquery-tutorial.xq
@@ -1,0 +1,8 @@
+module namespace functx = "http://www.functx.com";
+
+declare function functx:capitalize-first
+($arg as xs:string?) as xs:string? {
+    
+    concat(upper-case(substring($arg, 1, 1)),
+    substring($arg, 2))
+};

--- a/tutorial/xquery-tutorial.xspec
+++ b/tutorial/xquery-tutorial.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" 
+               xmlns:functx="http://www.functx.com"
+               query="http://www.functx.com" 
+               query-at="xquery-tutorial.xq">
+
+  <x:scenario label="Calling function capitalize-first">
+    <x:call function="functx:capitalize-first">
+      <x:param select="'hello'"/>
+    </x:call>
+
+    <x:expect label="should capitalize the first character of the string" select="'Hello'"/>
+
+  </x:scenario>
+
+</x:description>


### PR DESCRIPTION
## Summary
This pull request integrates the XProc test harness for BaseX standalone developed by @fgeorges in #103. 

## What has changed
I took the [XProc test harness for BaseX standalone](https://github.com/xspec/xspec/blob/fix/revert-revert-reverting/src/harnesses/basex/basex-standalone-xquery-harness.xproc) from #103 as developed it by @fgeorges. I added the following files:

- Documentation on how to run the XProc harness for BaseX standalone in the [wiki](https://github.com/xspec/xspec/wiki/Running-with-BaseX)
- [Bats test](https://github.com/xspec/xspec/blob/review/103-basex/test/xspec.bats#L275-L285) for Linux/MacOS that runs the XProc harness for BaseX standalone
- XQuery tutorial files: [xquery-tutorial.xq](https://github.com/xspec/xspec/blob/review/103-basex/tutorial/xquery-tutorial.xq) and [xquery-tutorial.xspec](https://github.com/xspec/xspec/blob/review/103-basex/tutorial/xquery-tutorial.xspec)
- Documentation on how to run the XQuery tutorial files on the [wiki](https://github.com/xspec/xspec/wiki/Getting-Started-with-XSpec-and-XQuery)
- [Bats test](https://github.com/xspec/xspec/blob/review/103-basex/test/xspec.bats#L267-L272) for Linux/MacOS that runs an XSpec test for XQuery

## Why
This was the version of the XProc harness for BaseX standalone that was originally present in XSpec v0.4.0 but has been removed in ad6b041. As the XProc harness for Saxon, it makes use of the harness-lib.xpl for running all the XProc harnesses in a similar way. 

## How to test it
Follow the documentation on the [wiki](https://github.com/xspec/xspec/wiki/Running-with-BaseX).

The [Travis configuration](https://github.com/xspec/xspec/blob/review/103-basex/.travis.yml#L31-L38) and this [bats test](https://github.com/xspec/xspec/blob/review/103-basex/test/xspec.bats#L275-L285) also show how to install and run the XProc harness for BaseX standalone.