### PR TITLE
Test with Saxon 9.7.0.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
     matrix:
         # latest Saxon 9.7 version
-        - SAXON_VERSION=9.7.0-18
+        - SAXON_VERSION=9.7.0-20
           XMLCALABASH_VERSION=1.1.16-97
           BASEX_VERSION=8.6.4
         # latest Saxon 9.6 version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
     # latest Saxon 9.7 version
-    - SAXON_VERSION: 9.7.0-18
+    - SAXON_VERSION: 9.7.0-20
       XMLCALABASH_VERSION: 1.1.16-97
     # latest Saxon 9.6 version
     - SAXON_VERSION: 9.6.0-10


### PR DESCRIPTION
Just move on to the latest maintenance release of Saxon 9.7.
9.7.0.20 released on 28 July 2017
