### PR TITLE
Remove JAVA_OPTIONS message from output in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
         # Saxon version used in oXygen
         - SAXON_VERSION=9.7.0-15
 
+before_install:
+    - unset _JAVA_OPTIONS
+
 before_script:
     # install bats
     - git clone https://github.com/sstephenson/bats.git /tmp/bats


### PR DESCRIPTION
## Summary

This pull request unset the `_JAVA_OPTIONS` environment variable from Travis builds so that the message `Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m` is not displayed in bats tests.

## Why
[Build #404](https://travis-ci.org/xspec/xspec/jobs/281928612) failed in Travis because some bats tests added the message `Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m` in their output thus messing up the line to be checked and making the test fail. 

This seems to be due to a recent change in Travis that explicitly sets this option in Java (see https://github.com/travis-ci/travis-ci/issues/8408 and [Travis release 2017-09-06](https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/)). Unsetting `_JAVA_OPTIONS` as suggested [here](https://github.com/rspec/rspec-dev/pull/185/commits/f4cca9294777cf6dca891991671d36a484bf37b6) removes this output message and should fix the tests (I have no way to test it locally as this is a Travis configuration issue).     