### PR TITLE
Balisage improvements to Schematron support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
         # Saxon version used in oXygen
         - SAXON_VERSION=9.7.0-15
 
+before_install:
+    - unset _JAVA_OPTIONS
+
 before_script:
     # install bats
     - git clone https://github.com/sstephenson/bats.git /tmp/bats

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -161,7 +161,7 @@ rem ##
     if not defined SCHEMATRON_XSLT_COMPILE set SCHEMATRON_XSLT_COMPILE="%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl"
     
     rem # get URI to Schematron file and phase/parameters from the XSpec file
-    call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(concat(replace(document-uri(/), '(.*)/.*$', '$1'), '/', /*[local-name() = 'description']/@schematron))" ^
+    call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; replace(iri-to-uri(concat(replace(document-uri(/), '(.*)/.*$', '$1'), '/', /*[local-name() = 'description']/@schematron)), concat(codepoints-to-string(94), 'file:/'), '')" ^
         -s:"%XSPEC%" >"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" ^
         || ( call :die "Error getting Schematron location" & goto :win_main_error_exit )
     set /P SCH=<"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt"
@@ -172,8 +172,7 @@ rem ##
     set /P SCH_PARAMS=<"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt"
     echo Paramaters: %SCH_PARAMS%
     set SCHUT=%XSPEC%-compiled.xspec
-    set SCH_COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%-sch-compiled.xsl
-    set SCH_COMPILED=%SCH_COMPILED:\=/%
+    set SCH_COMPILED=%SCH%-compiled.xsl
     
     echo:
     echo Compiling the Schematron...
@@ -189,10 +188,12 @@ rem ##
         || ( call :die "Error compiling the Schematron on step 3" & goto :win_main_error_exit )
     
     rem use XQuery to get full URI to compiled Schematron
-    call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(document-uri(/))" ^
-        -s:"%SCH_COMPILED%" >"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" ^
-        || ( call :die "Error getting compiled Schematron location" & goto :win_main_error_exit )
-    set /P SCH_COMPILED=<"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt"
+    rem echo SCH_COMPILED %SCH_COMPILED%
+    rem call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; replace(iri-to-uri(document-uri(/)), concat(codepoints-to-string(94), 'file:/'), '')" ^
+    rem     -s:"%SCH_COMPILED%" >"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" ^
+    rem     || ( call :die "Error getting compiled Schematron location" & goto :win_main_error_exit )
+    rem set /P SCH_COMPILED=<"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt"
+    rem echo SCH_COMPILED %SCH_COMPILED%
     
     echo:
     echo Compiling the Schematron tests...
@@ -213,7 +214,7 @@ rem ##
 		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-var.txt" 2>nul
 		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp1.xml" 2>nul
 		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-temp2.xml" 2>nul
-		del /q "%TEST_DIR%\%TARGET_FILE_NAME%-sch-compiled.xsl" 2>nul
+		del /q "%SCH_COMPILED:/=\%" 2>nul
 	)
 	goto :EOF
 

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -294,7 +294,7 @@ if test -n "$SCHEMATRON"; then
     SCH_PARAMS=`cat "$TEST_DIR/$TARGET_FILE_NAME-var.txt"`
     echo Parameters: $SCH_PARAMS
     SCHUT=$XSPEC-compiled.xspec
-    SCH_COMPILED=$TEST_DIR/$TARGET_FILE_NAME-sch-compiled.xsl
+    SCH_COMPILED=$SCH-compiled.xsl
     
     echo
     echo "Compiling the Schematron..."
@@ -303,8 +303,8 @@ if test -n "$SCHEMATRON"; then
     xslt -o:"$SCH_COMPILED" -s:"$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml" -xsl:"$SCHEMATRON_XSLT_COMPILE" -versionmsg:off $SCH_PARAMS || die "Error compiling the Schematron on step 3"
     
     # use XQuery to get full URI to compiled Schematron
-    xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; iri-to-uri(document-uri(/))" -s:"$SCH_COMPILED" >"$TEST_DIR/$TARGET_FILE_NAME-var.txt" || die "Error getting compiled Schematron location"
-    SCH_COMPILED=`cat "$TEST_DIR/$TARGET_FILE_NAME-var.txt"`
+    # xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; replace(iri-to-uri(document-uri(/)), concat(codepoints-to-string(94), 'file:/'), '')" -s:"$SCH_COMPILED" >"$TEST_DIR/$TARGET_FILE_NAME-var.txt" || die "Error getting compiled Schematron location"
+    # SCH_COMPILED=`cat "$TEST_DIR/$TARGET_FILE_NAME-var.txt"`
     
     echo 
     echo "Compiling the Schematron tests..."
@@ -396,7 +396,7 @@ if test -n "$SCHEMATRON"; then
     rm -f "$TEST_DIR/$TARGET_FILE_NAME-var.txt"
     rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-temp1.xml"
     rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-temp2.xml"
-    rm -f "$TEST_DIR/$TARGET_FILE_NAME-sch-compiled.xsl"
+    rm -f "$SCH_COMPILED"
 fi
 
 echo "Done."

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -294,7 +294,7 @@ if test -n "$SCHEMATRON"; then
     SCH_PARAMS=`cat "$TEST_DIR/$TARGET_FILE_NAME-var.txt"`
     echo Parameters: $SCH_PARAMS
     SCHUT=$XSPEC-compiled.xspec
-    SCH_COMPILED=$SCH-compiled.xsl
+    SCH_COMPILED=$(echo "$SCH" | sed 's:^file\:::')-compiled.xsl
     
     echo
     echo "Compiling the Schematron..."

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -242,7 +242,8 @@ expect-assert =
     ## The attributes id, role, and location can be used in combination to 
     ## identify a specific <assert>. 
     element expect-assert {
-    schematron-common-expect
+    schematron-common-expect,
+    schematron-count-expect
 }
 expect-report = 
     ## In a Schematron test, verify that a <report> is thrown.
@@ -250,7 +251,8 @@ expect-report =
     ## The attributes id, role, and location can be used in combination to 
     ## identify a specific <report>. 
     element expect-report {
-    schematron-common-expect
+    schematron-common-expect,
+    schematron-count-expect
 }
 
 expect-not-assert = 
@@ -282,3 +284,7 @@ schematron-common-expect =
     ## is expected to find. Namespace prefixes that are defined in Schematron 
     ## using ns elements can be used.
     attribute location { xpath }?
+
+schematron-count-expect = 
+    ## Number of times an <assert> or <report> is expected to be thrown.
+    attribute count { xs:nonNegativeInteger }?

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -217,7 +217,7 @@ any-element = element * { attribute * { text }*, any-content }
 
 schematron-scenario = context?,
                     like*,
-                    (pending | schematron-assertion)*, 
+                    (pending | schematron-assertion | assertion)*, 
                     (pending | 
                      element scenario { common-scenario-attributes, 
                                         label, schematron-scenario })*
@@ -273,6 +273,8 @@ expect-not-report =
 }
 
 schematron-common-expect = 
+    ## Optional label to include a description of the expectation.
+    attribute label { text }?,
     ## Identify a specific <assert> or <report> using its id attribute or 
     ## the id attribute of the parent <rule>.
     attribute id { xs:NCName }?,

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -225,7 +225,7 @@ schematron-scenario = context?,
 schematron-assertion =  
     expect-assert | expect-not-assert | 
     expect-report | expect-not-report | 
-    expect-valid 
+    expect-valid | expect-rule
 
 expect-valid =
     ## In a Schematron test, verify that the Schematron is executed and the XML 
@@ -272,8 +272,20 @@ expect-not-report =
     schematron-common-expect
 }
 
+expect-rule = 
+    ## In a Schematron test, verify that a <rule> is fired.
+    element expect-rule {
+    ## Optional label to describe the expectation.
+    attribute label { text }?,
+    ## Identify a specific <rule> using its id attribute.
+    attribute id { xs:NCName }?,
+    ## Match a specific context attribute value of a <rule>.
+    attribute context { text }?,
+    schematron-count-expect
+}
+
 schematron-common-expect = 
-    ## Optional label to include a description of the expectation.
+    ## Optional label to describe the expectation.
     attribute label { text }?,
     ## Identify a specific <assert> or <report> using its id attribute or 
     ## the id attribute of the parent <rule>.

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -138,6 +138,11 @@
             ')[1] = ', codepoints-to-string(39), ., codepoints-to-string(39), ']')"/>
     </xsl:template>
     
+    <xsl:template match="@id[parent::x:expect-rule] | @context[parent::x:expect-rule]" mode="make-predicate">
+        <xsl:sequence select="concat('[@', local-name(.), 
+            ' = ', codepoints-to-string(39), ., codepoints-to-string(39), ']')"/>
+    </xsl:template>
+    
     <xsl:template match="@count | @label" mode="make-predicate"/>
     
     <xsl:template name="make-label">
@@ -154,6 +159,19 @@
                 string-join(for $e in $error return concat(codepoints-to-string(39), $e, codepoints-to-string(39)), ','),
                 ')]))'
                 )"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <xsl:template match="x:expect-rule">
+        <xsl:element name="x:expect">
+            <xsl:call-template name="make-label"/>
+            <xsl:attribute name="test">
+                <xsl:sequence select="if (@count) then 'count' else 'exists'"/>
+                <xsl:sequence select="'(svrl:schematron-output/svrl:fired-rule'"/>
+                <xsl:apply-templates select="@*" mode="make-predicate"/>
+                <xsl:sequence select="')'"/>
+                <xsl:sequence select="current()[@count]/concat(' eq ', @count)"/>
+            </xsl:attribute>
         </xsl:element>
     </xsl:template>
     

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -84,7 +84,7 @@
                 <xsl:sequence select="'(svrl:schematron-output/svrl:failed-assert'"/>
                 <xsl:apply-templates select="@*" mode="make-predicate"/>
                 <xsl:sequence select="')'"/>
-                <xsl:sequence select="if (@count) then concat(' = ', @count) else ()"/>
+                <xsl:sequence select="current()[@count]/concat(' eq ', @count)"/>
             </xsl:attribute>
         </xsl:element>
     </xsl:template>
@@ -108,7 +108,7 @@
                 <xsl:sequence select="'(svrl:schematron-output/svrl:successful-report'"/>
                 <xsl:apply-templates select="@*" mode="make-predicate"/>
                 <xsl:sequence select="')'"/>
-                <xsl:sequence select="if (@count) then concat(' = ', @count) else ()"/>
+                <xsl:sequence select="current()[@count]/concat(' eq ', @count)"/>
             </xsl:attribute>
         </xsl:element>
     </xsl:template>
@@ -141,7 +141,7 @@
     <xsl:template match="@count" mode="make-predicate"/>
     
     <xsl:template name="make-label">
-        <xsl:attribute name="label" select="string-join((tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location), ' ')"/>
+        <xsl:attribute name="label" select="string-join((tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location, current()[@count]/string('count:'), @count), ' ')"/>
     </xsl:template>
 
     <xsl:template match="x:expect-valid">

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -135,6 +135,7 @@
     <xsl:template match="@id | @role" mode="make-predicate">
         <xsl:sequence select="concat('[(@', local-name(.), 
             ', preceding-sibling::svrl:fired-rule[1]/@',local-name(.), 
+            ', preceding-sibling::svrl:active-pattern[1]/@',local-name(.), 
             ')[1] = ', codepoints-to-string(39), ., codepoints-to-string(39), ']')"/>
     </xsl:template>
     

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -138,10 +138,10 @@
             ')[1] = ', codepoints-to-string(39), ., codepoints-to-string(39), ']')"/>
     </xsl:template>
     
-    <xsl:template match="@count" mode="make-predicate"/>
+    <xsl:template match="@count | @label" mode="make-predicate"/>
     
     <xsl:template name="make-label">
-        <xsl:attribute name="label" select="string-join((tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location, current()[@count]/string('count:'), @count), ' ')"/>
+        <xsl:attribute name="label" select="string-join((@label, tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location, current()[@count]/string('count:'), @count), ' ')"/>
     </xsl:template>
 
     <xsl:template match="x:expect-valid">

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -146,7 +146,7 @@
     <xsl:template match="@count | @label" mode="make-predicate"/>
     
     <xsl:template name="make-label">
-        <xsl:attribute name="label" select="string-join((@label, tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location, current()[@count]/string('count:'), @count), ' ')"/>
+        <xsl:attribute name="label" select="string-join((@label, tokenize(local-name(),'-')[.=('report','assert','not','rule')], @id, @role, @location, @context, current()[@count]/string('count:'), @count), ' ')"/>
     </xsl:template>
 
     <xsl:template match="x:expect-valid">

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -80,9 +80,11 @@
         <xsl:element name="x:expect">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
-                <xsl:sequence select="'exists(svrl:schematron-output/svrl:failed-assert'"/>
+                <xsl:sequence select="if (@count) then 'count' else 'exists'"/>
+                <xsl:sequence select="'(svrl:schematron-output/svrl:failed-assert'"/>
                 <xsl:apply-templates select="@*" mode="make-predicate"/>
                 <xsl:sequence select="')'"/>
+                <xsl:sequence select="if (@count) then concat(' = ', @count) else ()"/>
             </xsl:attribute>
         </xsl:element>
     </xsl:template>
@@ -102,9 +104,11 @@
         <xsl:element name="x:expect">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
-                <xsl:sequence select="'exists(svrl:schematron-output/svrl:successful-report'"/>
+                <xsl:sequence select="if (@count) then 'count' else 'exists'"/>
+                <xsl:sequence select="'(svrl:schematron-output/svrl:successful-report'"/>
                 <xsl:apply-templates select="@*" mode="make-predicate"/>
                 <xsl:sequence select="')'"/>
+                <xsl:sequence select="if (@count) then concat(' = ', @count) else ()"/>
             </xsl:attribute>
         </xsl:element>
     </xsl:template>
@@ -133,6 +137,8 @@
             ', preceding-sibling::svrl:fired-rule[1]/@',local-name(.), 
             ')[1] = ', codepoints-to-string(39), ., codepoints-to-string(39), ']')"/>
     </xsl:template>
+    
+    <xsl:template match="@count" mode="make-predicate"/>
     
     <xsl:template name="make-label">
         <xsl:attribute name="label" select="string-join((tokenize(local-name(),'-')[.=('report','assert','not')], @id, @role, @location), ' ')"/>

--- a/test/schematron-012.xspec
+++ b/test/schematron-012.xspec
@@ -74,4 +74,10 @@
             <x:expect-report id="ru3" role="warn" location="/article[1]"/>
         </x:scenario>
     </x:scenario>
+    <x:scenario label="inherrit from pattern">
+        <x:scenario label="id from pattern">
+            <x:context href="schematron/schut-to-xspec-012-02.xml"/>
+            <x:expect-assert id="pattern3"/>
+        </x:scenario>
+    </x:scenario>
 </x:description>

--- a/test/schematron-016.sch
+++ b/test/schematron-016.sch
@@ -8,6 +8,12 @@
         <sch:rule context="do-report">
             <sch:report test="true()" id="t2"><sch:name/></sch:report>
         </sch:rule>
+        <sch:rule context="do-assert-warn">
+            <sch:assert test="false()" id="t3" role="warn"><sch:name/></sch:assert>
+        </sch:rule>
+        <sch:rule context="do-report-warn">
+            <sch:report test="true()" id="t4" role="warn"><sch:name/></sch:report>
+        </sch:rule>
     </sch:pattern>
 
 </sch:schema>

--- a/test/schematron-016.sch
+++ b/test/schematron-016.sch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+
+    <sch:pattern>
+        <sch:rule context="do-assert">
+            <sch:assert test="false()" id="t1"><sch:name/></sch:assert>
+        </sch:rule>
+        <sch:rule context="do-report">
+            <sch:report test="true()" id="t2"><sch:name/></sch:report>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/test/schematron-016.xspec
+++ b/test/schematron-016.xspec
@@ -132,6 +132,40 @@
                 <x:expect-report id="t2" count="2"/>
             </x:scenario>
         </x:scenario>
+        <x:scenario label="role and totals">
+            <x:context>
+                <root>
+                    <do-assert/>
+                    <do-report/>
+                    <do-assert-warn/>
+                    <do-assert-warn/>
+                    <do-report-warn/>
+                    <do-report-warn/>
+                </root>
+            </x:context>
+            <x:expect-assert role="warn" count="2"/>
+            <x:expect-assert count="3"/>
+            <x:expect-report role="warn" count="2"/>
+            <x:expect-report count="3"/>
+        </x:scenario>
+        <x:scenario label="id, role, location, count">
+            <x:context>
+                <root>
+                    <do-assert/>
+                    <do-assert-warn/>
+                    <do-assert-warn/>
+                    <do-report/>
+                    <do-report-warn/>
+                    <do-report-warn/>
+                </root>
+            </x:context>
+            <x:expect-assert location="/root/do-assert-warn[1]" role="warn" id="t3" count="1" />
+            <x:expect-assert location="/root/do-assert-warn[2]" role="warn" id="t3" count="1" />
+            <x:expect-report location="/root/do-report-warn[1]" role="warn" id="t4" count="1"/>
+            <x:expect-report location="/root/do-report-warn[2]" role="warn" id="t4" count="1"/>
+            <x:expect-assert count="3"/>
+            <x:expect-report count="3"/>
+        </x:scenario>
     </x:scenario>
 
 </x:description>

--- a/test/schematron-016.xspec
+++ b/test/schematron-016.xspec
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="schematron-016.sch">
+
+    <x:scenario label="count">
+        <x:scenario label="0">
+            <x:scenario label="assert">
+                <x:context>
+                    <root/>
+                </x:context>
+                <x:expect-assert count="0"/>
+            </x:scenario>
+            <x:scenario label="report">
+                <x:context>
+                    <root/>
+                </x:context>
+                <x:expect-report count="0"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="1">
+            <x:scenario label="assert">
+                <x:context>
+                    <root>
+                        <do-assert/>
+                    </root>
+                </x:context>
+                <x:expect-assert count="1"/>
+            </x:scenario>
+            <x:scenario label="report">
+                <x:context>
+                    <root>
+                        <do-report/>
+                    </root>
+                </x:context>
+                <x:expect-report count="1"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="2">
+            <x:scenario label="assert">
+                <x:context>
+                    <root>
+                        <do-assert/>
+                        <do-assert/>
+                    </root>
+                </x:context>
+                <x:expect-assert count="2"/>
+            </x:scenario>
+            <x:scenario label="report">
+                <x:context>
+                    <root>
+                        <do-report/>
+                        <do-report/>
+                    </root>
+                </x:context>
+                <x:expect-report count="2"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="15">
+            <x:scenario label="assert">
+                <x:context>
+                    <root>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                        <do-assert/>
+                    </root>
+                </x:context>
+                <x:expect-assert count="15"/>
+            </x:scenario>
+            <x:scenario label="report">
+                <x:context>
+                    <root>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                        <do-report/>
+                    </root>
+                </x:context>
+                <x:expect-report count="15"/>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="check specific and count totals">
+        <x:scenario label="location and totals">
+            <x:scenario label="assert">
+                <x:context>
+                    <root>
+                        <do-assert/>
+                        <do-report/>
+                        <do-assert/>
+                    </root>
+                </x:context>
+                <x:expect-assert location="/root/do-assert[2]"/>
+                <x:expect-assert count="2"/>
+                <x:expect-report count="1"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="id and totals">
+            <x:scenario label="assert">
+                <x:context>
+                    <root>
+                        <do-assert/>
+                        <do-report/>
+                        <do-assert/>
+                        <do-report/>
+                    </root>
+                </x:context>
+                <x:expect-assert id="t1" count="2"/>
+                <x:expect-report id="t2" count="2"/>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+
+</x:description>

--- a/test/schematron-017.xspec
+++ b/test/schematron-017.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-017.sch">
+    
+    <x:scenario label="Schematron with dependency using relative path">
+        <x:scenario label="item in list">
+            <x:context>
+                <example>
+                    <standard>XML</standard>
+                </example>
+            </x:context>
+            <x:expect-not-assert id="t1"/>
+        </x:scenario>
+        <x:scenario label="item not in list">
+            <x:context>
+                <example>
+                    <standard>Markdown</standard>
+                </example>
+            </x:context>
+            <x:expect-assert id="t1"/>
+        </x:scenario>
+    </x:scenario>
+    
+    
+</x:description>

--- a/test/schematron-018.xspec
+++ b/test/schematron-018.xspec
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-018.sch">
+
+    <x:scenario label="expect-rule">
+        <x:scenario label="no attributes">
+            <x:scenario label="fired-rule">
+                <x:context>
+                    <para/>
+                </x:context>
+                <x:expect-rule/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="id">
+            <x:scenario label="r1">
+                <x:context>
+                    <para/>
+                </x:context>
+                <x:expect-rule id="r1"/>
+            </x:scenario>
+            <x:scenario label="r2">
+                <x:context>
+                    <section/>
+                </x:context>
+                <x:expect-rule id="r2"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="context">
+            <x:scenario label="element">
+                <x:context>
+                    <para/>
+                </x:context>
+                <x:expect-rule context="para"/>
+            </x:scenario>
+            <x:scenario label="element with predicate">
+                <x:context>
+                    <section>
+                        <title/>
+                        <para/>
+                        <title/>
+                    </section>
+                </x:context>
+                <x:expect-rule context="title[position() gt 1]"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="count">
+            <x:scenario label="0">
+                <x:context>
+                    <article/>
+                </x:context>
+                <x:expect-rule label="verify that a rule does not fire" count="0"/>
+            </x:scenario>
+            <x:scenario label="1">
+                <x:context>
+                    <section/>
+                </x:context>
+                <x:expect-rule count="1"/>
+            </x:scenario>
+            <x:scenario label="2">
+                <x:context>
+                    <article>
+                        <section/>
+                        <section/>
+                    </article>
+                </x:context>
+                <x:expect-rule count="2"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="id and context">
+            <x:context>
+                <article>
+                    <title/>
+                </article>
+            </x:context>
+            <x:expect-rule context="title[position() eq 1]" id="r3"/>
+        </x:scenario>
+        <x:scenario label="id and count">
+            <x:context>
+                <article>
+                    <para/>
+                    <para/>
+                    <para/>
+                </article>
+            </x:context>
+            <x:expect-rule id="r1" count="3"/>
+        </x:scenario>
+        <x:scenario label="context and count">
+            <x:context>
+                <article>
+                    <para/>
+                    <para/>
+                    <para/>
+                    <para/>
+                </article>
+            </x:context>
+            <x:expect-rule context="para" count="4"/>
+        </x:scenario>
+        <x:scenario label="id, context, and count">
+            <x:context>
+                <article>
+                    <para/>
+                    <para/>
+                    <para/>
+                    <para/>
+                    <para/>
+                </article>
+            </x:context>
+            <x:expect-rule id="r1" context="para" count="5"/>
+        </x:scenario>
+        <x:scenario label="specific rules fire or do not fire">
+            <x:context>
+                <section/>
+            </x:context>
+            <x:expect-rule label="verify that a specific rule does not fire" id="r1" count="0"/>
+            <x:expect-rule label="verify that a specific rule does fire" id="r2" count="1"/>
+        </x:scenario>
+    </x:scenario>
+
+</x:description>

--- a/test/schematron-019.xspec
+++ b/test/schematron-019.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-019.sch">
+    
+    <x:scenario label="XSLT Function in Schematrion">
+        <x:scenario label="XSLT function test">
+            <x:call function="e:add" xmlns:e="example">
+                <x:param name="a" select="5" as="xs:integer"/>
+                <x:param name="b" select="2" as="xs:integer"/>
+            </x:call>
+            <x:expect label="add 5 + 2" select="xs:integer(7)"/>
+        </x:scenario>        
+    </x:scenario>
+    
+</x:description>

--- a/test/schematron-020.xspec
+++ b/test/schematron-020.xspec
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-020.sch">
+    
+    <x:scenario label="match id attribute">
+        <x:context>
+            <para/>
+        </x:context>
+        
+        <x:scenario label="in schema">
+            <x:scenario label="on assertion">
+                <x:expect-assert id="assert1"/>
+            </x:scenario>
+            <x:scenario label="on rule">
+                <x:expect-assert id="rule2"/>
+            </x:scenario>
+            <x:scenario label="on pattern">
+                <x:expect-assert id="pattern3"/>
+            </x:scenario>
+        </x:scenario>
+        
+        <x:scenario label="in imported pattern">
+            <x:scenario label="on assertion">
+                <x:expect-assert id="include1-assert1"/>
+            </x:scenario>
+            <x:scenario label="on rule">
+                <x:expect-assert id="include1-rule2"/>
+            </x:scenario>
+            <x:scenario label="on pattern">
+                <x:expect-assert id="include1-pattern3"/>
+            </x:scenario>
+        </x:scenario>
+        
+        <x:scenario label="in imported rule">
+            <x:scenario label="on assertion">
+                <x:expect-assert id="include1-assert4"/>
+            </x:scenario>
+            <x:scenario label="on rule">
+                <x:expect-assert id="include1-rule5"/>
+            </x:scenario>
+        </x:scenario>
+        
+        <x:scenario label="in imported assertion">
+            <x:scenario label="on assertion">
+                <x:expect-assert id="include1-assert6"/>
+            </x:scenario>
+        </x:scenario>
+        
+    </x:scenario>
+
+    
+</x:description>

--- a/test/schematron-021.xspec
+++ b/test/schematron-021.xspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-021.sch">
+    
+    <x:scenario label="abstract pattern">
+        <x:scenario label="implementation 1">
+            <x:context>
+                <div/>
+            </x:context>
+            <x:expect-assert id="rule1"/>
+        </x:scenario>
+        <x:scenario label="implementation 2">
+            <x:context>
+                <para/>
+            </x:context>
+            <x:expect-assert id="rule1"/>
+        </x:scenario>
+        <x:scenario label="id on pattern">
+            <x:context>
+                <figure/>
+            </x:context>
+            <x:expect-assert id="pattern5"/>
+        </x:scenario>
+    </x:scenario>
+    
+</x:description>

--- a/test/schematron-022.xspec
+++ b/test/schematron-022.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-022.sch">
+    
+    <x:scenario label="abstract rule">
+        <x:context>
+            <body/>
+        </x:context>
+        <x:expect-assert id="assert1"/>
+        <x:expect-assert id="rule3"/>
+        <x:expect-assert id="assert3"/>
+    </x:scenario>
+    
+</x:description>

--- a/test/schematron/data/standards.xml
+++ b/test/schematron/data/standards.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list>
+    <item>XML</item>
+    <item>XSLT</item>
+    <item>XQuery</item>
+    <item>Schematron</item>
+</list>

--- a/test/schematron/schematron-017.sch
+++ b/test/schematron/schematron-017.sch
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:pattern>
+        <sch:let name="list" value="doc('data/standards.xml')/list/item/text()"/>
+        <sch:rule context="standard">
+            <sch:assert test="text() = $list" id="t1">"<sch:value-of select="text()"/> is not in the list of standards.</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/test/schematron/schematron-018.sch
+++ b/test/schematron/schematron-018.sch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:pattern>
+        <sch:rule context="para" id="r1">
+            <sch:assert test="true()"/>
+        </sch:rule>
+        <sch:rule context="section" id="r2">
+            <sch:assert test="true()"/>
+        </sch:rule>
+        <sch:rule context="title[position() eq 1]" id="r3">
+            <sch:assert test="true()"/>
+        </sch:rule>
+        <sch:rule context="title[position() gt 1]" id="r4">
+            <sch:assert test="true()"/>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/test/schematron/schematron-019.sch
+++ b/test/schematron/schematron-019.sch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    
+    <sch:ns uri="example" prefix="e"/>
+    
+    <xsl:function name="e:add" as="xs:integer">
+        <xsl:param name="a" as="xs:integer"/>
+        <xsl:param name="b" as="xs:integer"/>
+        <xsl:value-of select="$a + $b"/>
+    </xsl:function>
+    
+</sch:schema>

--- a/test/schematron/schematron-020-01.sch
+++ b/test/schematron/schematron-020-01.sch
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:pattern id="include1-pattern1">
+        <sch:rule context="para" id="include1-rule1">
+            <sch:assert test="false()" id="include1-assert1"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="include1-pattern2">
+        <sch:rule context="para" id="include1-rule2">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="include1-pattern3">
+        <sch:rule context="para">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    <!-- *********************************** -->
+    <sch:pattern id="include1-pattern4">
+        <sch:rule context="para" id="include1-rule4">
+            <sch:assert test="false()" id="include1-assert4"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="include1-pattern5">
+        <sch:rule context="para" id="include1-rule5">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    <!-- *********************************** -->
+    <sch:pattern id="include1-pattern6">
+        <sch:rule context="para" id="include1-rule6">
+            <sch:assert test="false()" id="include1-assert6"/>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/test/schematron/schematron-020.sch
+++ b/test/schematron/schematron-020.sch
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:pattern id="pattern1">
+        <sch:rule context="para" id="rule1">
+            <sch:assert test="false()" id="assert1"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="pattern2">
+        <sch:rule context="para" id="rule2">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="pattern3">
+        <sch:rule context="para">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    <sch:include href="schematron-020-01.sch#include1-pattern1"/>
+    <sch:include href="schematron-020-01.sch#include1-pattern2"/>
+    <sch:include href="schematron-020-01.sch#include1-pattern3"/>
+    <sch:pattern id="pattern4">
+        <sch:include href="schematron-020-01.sch#include1-rule4"/>
+    </sch:pattern>
+    <sch:pattern id="pattern5">
+        <sch:include href="schematron-020-01.sch#include1-rule5"/>
+    </sch:pattern>
+    <sch:pattern id="pattern6">
+        <sch:rule context="para">
+            <sch:include href="schematron-020-01.sch#include1-assert6"/>
+        </sch:rule>
+    </sch:pattern>
+</sch:schema>

--- a/test/schematron/schematron-021.sch
+++ b/test/schematron/schematron-021.sch
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    
+    <sch:pattern id="pattern1" abstract="true">
+        <sch:rule context="$element" id="rule1">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:pattern id="pattern2" is-a="pattern1">
+        <sch:param name="element" value="div"/>
+    </sch:pattern>
+    
+    <sch:pattern id="pattern3" is-a="pattern1">
+        <sch:param name="element" value="para"/>
+    </sch:pattern>
+    
+    <sch:pattern id="pattern4" abstract="true">
+        <sch:rule context="$element">
+            <sch:assert test="false()"/>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:pattern id="pattern5" is-a="pattern4">
+        <sch:param name="element" value="figure"/>
+    </sch:pattern>
+    
+</sch:schema>

--- a/test/schematron/schematron-022.sch
+++ b/test/schematron/schematron-022.sch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    
+    <sch:pattern id="pattern1">
+        <sch:rule id="rule1" abstract="true">
+            <sch:assert test="false()" id="assert1"/>
+        </sch:rule>
+        <sch:rule id="rule2" abstract="true">
+            <sch:assert test="false()"/>
+        </sch:rule>
+        <sch:rule id="rule3" context="body">
+            <sch:extends rule="rule1"/>
+            <sch:extends rule="rule2"/>
+            <sch:assert test="false()" id="assert3"/>
+        </sch:rule>
+    </sch:pattern>
+    
+</sch:schema>

--- a/test/schematron/schut-to-xspec-012-out.xspec
+++ b/test/schematron/schut-to-xspec-012-out.xspec
@@ -18,17 +18,17 @@
         </x:scenario>
         <x:scenario label="with id">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert a1" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a1'])"/>
-            <x:expect label="not assert a2" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a2'])"/>
-            <x:expect label="report r1" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r1'])"/>
-            <x:expect label="not report r2" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r2'])"/>
+            <x:expect label="assert a1" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a1'])"/>
+            <x:expect label="not assert a2" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a2'])"/>
+            <x:expect label="report r1" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r1'])"/>
+            <x:expect label="not report r2" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r2'])"/>
         </x:scenario>
         <x:scenario label="with role">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert warn" test="exists(svrl:schematron-output/svrl:failed-assert[(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'])"/>
-            <x:expect label="not assert fatal" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'fatal'])"/>
-            <x:expect label="report warn" test="exists(svrl:schematron-output/svrl:successful-report[(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'])"/>
-            <x:expect label="not report info" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'info'])"/>
+            <x:expect label="assert warn" test="exists(svrl:schematron-output/svrl:failed-assert[(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'])"/>
+            <x:expect label="not assert fatal" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'fatal'])"/>
+            <x:expect label="report warn" test="exists(svrl:schematron-output/svrl:successful-report[(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'])"/>
+            <x:expect label="not report info" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'info'])"/>
         </x:scenario>
         <x:scenario label="with location">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
@@ -39,37 +39,43 @@
         </x:scenario>
         <x:scenario label="with id, location">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert a1 /article[1]/div[1]" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a1'][x:schematron-location-compare('/article[1]/div[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="not assert a2 /article[1]/div[2]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a2'][x:schematron-location-compare('/article[1]/div[2]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="report r1 /article[1]/div[3]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r1'][x:schematron-location-compare('/article[1]/div[3]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="not report r2 /article[1]/div[4]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r2'][x:schematron-location-compare('/article[1]/div[4]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="assert a1 /article[1]/div[1]" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a1'][x:schematron-location-compare('/article[1]/div[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="not assert a2 /article[1]/div[2]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a2'][x:schematron-location-compare('/article[1]/div[2]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="report r1 /article[1]/div[3]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r1'][x:schematron-location-compare('/article[1]/div[3]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="not report r2 /article[1]/div[4]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r2'][x:schematron-location-compare('/article[1]/div[4]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
         </x:scenario>
         <x:scenario label="with id, role, location">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert a1 warn /article[1]/div[1]" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]/div[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="not assert a2 error /article[1]/div[2]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'a2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'error'][x:schematron-location-compare('/article[1]/div[2]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="report r1 warn /article[1]/div[3]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]/div[3]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
-            <x:expect label="not report r2 info /article[1]/div[4]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'r2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'info'][x:schematron-location-compare('/article[1]/div[4]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="assert a1 warn /article[1]/div[1]" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]/div[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="not assert a2 error /article[1]/div[2]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'a2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'error'][x:schematron-location-compare('/article[1]/div[2]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="report r1 warn /article[1]/div[3]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]/div[3]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="not report r2 info /article[1]/div[4]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'info'][x:schematron-location-compare('/article[1]/div[4]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
         </x:scenario>
     </x:scenario>
     <x:scenario label="inherrit from rule">
         <x:scenario label="id and role from rule">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert ru1 error" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'error'])"/>
+            <x:expect label="assert ru1 error" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'error'])"/>
         </x:scenario>
         <x:scenario label="id from rule and role from assertion">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert ru1 warn" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'])"/>
+            <x:expect label="assert ru1 warn" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'])"/>
         </x:scenario>
         <x:scenario label="role from rule and id from assertion">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="assert ru2 error" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'error'])"/>
+            <x:expect label="assert ru2 error" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'error'])"/>
         </x:scenario>
         <x:scenario label="match only current rule">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
-            <x:expect label="not assert ru3" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru3'])"/>
-            <x:expect label="not assert ru3 warn" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru3'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'])"/>
-            <x:expect label="report ru3 warn /article[1]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id)[1] = 'ru3'][(@role, preceding-sibling::svrl:fired-rule[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+            <x:expect label="not assert ru3" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru3'])"/>
+            <x:expect label="not assert ru3 warn" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru3'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'])"/>
+            <x:expect label="report ru3 warn /article[1]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru3'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
+        </x:scenario>
+    </x:scenario>
+    <x:scenario label="inherrit from pattern">
+        <x:scenario label="id from pattern">
+            <x:context href="schematron/schut-to-xspec-012-02.xml"/>
+            <x:expect label="assert pattern3" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'pattern3'])"/>
         </x:scenario>
     </x:scenario>
 </x:description>

--- a/test/schut-to-xspec-012.sch
+++ b/test/schut-to-xspec-012.sch
@@ -19,4 +19,9 @@
             <sch:report test="div[2]">article has more than 1 div</sch:report>
         </sch:rule>
     </sch:pattern>
+    <sch:pattern id="pattern3">
+        <sch:rule context="section">
+            <sch:assert test="title">section should have a title</sch:assert>
+        </sch:rule>
+    </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
Pull request for issue #140. 

Improvements to Schematron support:

* Added new element `<x:expect-rule>` to test that a rule is fired/thrown.
* Added new attribute `@count` to test that an assert, report, or rule is thrown a specific number of times.
* Changed the RelaxNG grammar to allow `<x:expect>` in scenarios that have Schematron-specific expect elements.
* Changed the location of the compiled Schematron XSLT to the same folder as the Schematron so that relative file paths that are used within the Schematron will work. 
* Extended the `@id` attribute matching to include the `@id` attribute on the Schematron pattern element.