### PR TITLE
Wrap node and atomic value in report

### DIFF
--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -319,6 +319,23 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
+      <xsl:when test="$value[. instance of node()]">
+        <!-- $value is a mixture of nodes and atomic values. Wrap each of them. -->
+        <xsl:attribute name="select">/*/(@* | node())</xsl:attribute>
+        <xsl:for-each select="$value">
+          <xsl:element name="temp" namespace="{$wrapper-ns}">
+            <xsl:choose>
+              <xsl:when test="empty(.)">()</xsl:when>
+              <xsl:when test=". instance of node()">
+                <xsl:apply-templates select="." mode="test:report-value" />
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="test:report-atomic-value(.)" />
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:element>
+        </xsl:for-each>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:attribute name="select">
           <xsl:choose>

--- a/test/end-to-end/cases/expected/xspec-151-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-151-result-norm.html
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-151.xsl (0/0/1/1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="xspec-151.xsl">xspec-151.xsl</a></p>
+      <p>Tested: ONCE-UPON-A-TIME</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="85%" />
+         <col width="15%" />
+         <thead>
+            <tr>
+               <th style="text-align: right; font-weight: normal; ">passed/pending/failed/total</th>
+               <th>0/0/1/1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#ELEM-22">When result is a mixture of element and string</a></th>
+               <th>0/0/1/1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-22">
+         <h2 class="failed">When result is a mixture of element and string<span class="scenario-totals">0/0/1/1</span></h2>
+         <table class="xspec" id="ELEM-24">
+            <col width="85%" />
+            <col width="15%" />
+            <tbody>
+               <tr class="failed">
+                  <th>When result is a mixture of element and string</th>
+                  <th>0/0/1/1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-36">[Result] in a failure report HTML must wrap element and string separately</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-22">When result is a mixture of element and string</h3>
+         <h4 id="ELEM-36">[Result] in a failure report HTML must wrap element and string separately</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                     <p>XPath <code>/*/(@* | node())</code> from:
+                     </p><pre>&lt;<span class="diff">temp</span> xmlns:test-mix="x-urn:test-mix"&gt;
+   &lt;<span class="diff">test-mix:fooElement</span>&gt;
+      &lt;<span class="diff">test-mix:barElement</span> /&gt;
+   &lt;/test-mix:fooElement&gt;
+&lt;/temp&gt;&lt;<span class="diff">temp</span> xmlns:test-mix="x-urn:test-mix"&gt;<span class="diff">'string'</span>&lt;/temp&gt;</pre></td>
+                  <td><pre>()</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/xspec-151.xsd
+++ b/test/end-to-end/cases/xspec-151.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="x-urn:test-mix"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="fooType">
+		<xs:sequence>
+			<xs:element name="barElement" />
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/test/end-to-end/cases/xspec-151.xsl
+++ b/test/end-to-end/cases/xspec-151.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0" xmlns:test-mix="x-urn:test-mix"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:import-schema namespace="x-urn:test-mix" schema-location="xspec-151.xsd"
+		use-when="system-property('xsl:is-schema-aware') eq 'yes'" />
+
+	<xsl:function as="item()+" name="test-mix:element-and-string">
+		<xsl:element name="test-mix:fooElement" type="test-mix:fooType"
+			use-when="system-property('xsl:is-schema-aware') eq 'yes'">
+			<xsl:message select="'Testing with schema-aware'" />
+			<test-mix:barElement />
+		</xsl:element>
+
+		<xsl:element name="test-mix:fooElement"
+			use-when="not(system-property('xsl:is-schema-aware') eq 'yes')">
+			<xsl:message select="'Testing without schema-aware'" />
+			<test-mix:barElement />
+		</xsl:element>
+
+		<xsl:sequence select="'string'" />
+	</xsl:function>
+</xsl:stylesheet>

--- a/test/end-to-end/cases/xspec-151.xspec
+++ b/test/end-to-end/cases/xspec-151.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="xspec-151.xsl" xmlns:test-mix="x-urn:test-mix"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="When result is a mixture of element and string">
+		<x:call function="test-mix:element-and-string" />
+		<x:expect label="[Result] in a failure report HTML must wrap element and string separately"
+			test="false()" />
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
Fixes #151

Previously, [`test:report-value`](https://github.com/xspec/xspec/blob/7205f223645addeae67781cdbd192d8082945aec/src/compiler/generate-tests-utils.xsl#L284) handled a mixed sequence of nodes and atomic values as if all its items were atomic values.
So XSpec terminated prematurely (in case of #151) or the failure report HTML did not fully depict the result.

With this PR, each item in a mixed sequence is wrapped separately.
