### PR TITLE
Test on Saxon 9.8.0.7, 9.7.0.21 and 9.7.0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 env:
     matrix:
+        # latest Saxon 9.8 version
+        - SAXON_VERSION=9.8.0-7
         # latest Saxon 9.7 version
-        - SAXON_VERSION=9.7.0-20
+        - SAXON_VERSION=9.7.0-21
           XMLCALABASH_VERSION=1.1.16-97
           BASEX_VERSION=8.6.4
-        # latest Saxon 9.6 version
-        - SAXON_VERSION=9.6.0-10
         # Saxon version used in oXygen
-        - SAXON_VERSION=9.7.0-15
+        - SAXON_VERSION=9.7.0-19
 
 before_install:
     - unset _JAVA_OPTIONS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 environment:
   SAXON_CP: '%TEMP%\xspec\saxon\saxon9he.jar'
   matrix:
+    # latest Saxon 9.8 version
+    - SAXON_VERSION: 9.8.0-7
     # latest Saxon 9.7 version
-    - SAXON_VERSION: 9.7.0-20
+    - SAXON_VERSION: 9.7.0-21
       XMLCALABASH_VERSION: 1.1.16-97
-    # latest Saxon 9.6 version
-    - SAXON_VERSION: 9.6.0-10
     # Saxon version used in oXygen
-    - SAXON_VERSION: 9.7.0-15
+    - SAXON_VERSION: 9.7.0-19
 
 install:
 - ps: >-


### PR DESCRIPTION
Reflects the new 9.8 and the latest 9.7 maintenance releases.

This PR effectively removes 9.6 from testing. Since 9.6 is not actively maintained, I think it's ok.