### PR TITLE
Add tests for CSS inline in #135

### DIFF
--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -381,6 +381,16 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "HTML report contains CSS inline and not as an external file #135"
+
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
+    call :verify_line 1 x "true"
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -319,3 +319,10 @@ teardown() {
     echo $output
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 }
+
+
+@test "HTML report contains CSS inline and not as an external file #135" {
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
+	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
+}


### PR DESCRIPTION
## Summary

This pull request adds a test to check that the HTML report contains an inline CSS. This feature was introduced in #135 and this test checks that the inline CSS is always generated. 

## What it is testing

The test does a simple search (grep) in the generated HTML report and checks that there is a line with the opening style element (`<style type="text/css">`) and with a CSS property (I chose randomly `margin-right`).

@AirQuick : would you be able to add a similar test for the batch script? Feel free to check out and commit directly to this branch so that we can merge the pull request with both tests. But it's also fine if you prefer to work on a separate branch and merge with two separate commits. Let me know the test makes sense to you and if you would like to add more checks for #135.