### PR TITLE
Schematron Ant: Do not set bogus phase parameter when phase is undefined

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
 
-<project name="xspec" default="xspec" xmlns:if="ant:if">
+<project name="xspec" default="xspec" xmlns:if="ant:if" xmlns:unless="ant:unless">
   <description>XSpec is a Behavior Driven Development (BDD) framework for XSLT and XQuery.
     
     Usage (command-line):
@@ -166,7 +166,7 @@
   
   <target name="getSchematronPhase" if="${test.schematron}" unless="xspec.phase">
     <xml-to-properties in="${xspec.xml}" style="get-schematron-phase.xsl"/>
-    <echo message="Schematron phase set in XSpec: '${xspec.phase}'" if:set="xspec.phase"/>
+    <echo message="Schematron phase set in XSpec: '${xspec.phase}'" unless:blank="${xspec.phase}"/>
   </target>
   
   
@@ -202,7 +202,7 @@
     </xslt>
     
     <echo message="   STEP 3: Convert Schematron to XSL"/>
-    <echo message="           phase=${xspec.phase}" if:set="xspec.phase"/>
+    <echo message="           phase=${xspec.phase}" unless:blank="${xspec.phase}"/>
     <xslt 
       in="${xspec.dir}/${xspec.base}.sch"
       out="${xspec.compiled.xsl}" 
@@ -211,7 +211,7 @@
       >
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
       <param name="allow-foreign" expression="true"/>
-      <param name="phase" expression="${xspec.phase}" if:set="xspec.phase"/>
+      <param name="phase" expression="${xspec.phase}" unless:blank="${xspec.phase}"/>
       <xmlcatalog if:set="catalog">
         <catalogpath>
           <pathelement location="${catalog}"/>

--- a/build.xml
+++ b/build.xml
@@ -210,6 +210,7 @@
       force="true"
       >
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <!-- TODO: Parameters should be gathered from .xspec file -->
       <param name="allow-foreign" expression="true"/>
       <param name="phase" expression="${xspec.phase}" unless:blank="${xspec.phase}"/>
       <xmlcatalog if:set="catalog">

--- a/src/ant/get-schematron-phase.xsl
+++ b/src/ant/get-schematron-phase.xsl
@@ -10,6 +10,7 @@
 	<xsl:template as="element(xspec)" match="document-node()">
 		<xspec>
 			<phase>
+				<!-- TODO: @href and @select should be taken into account -->
 				<xsl:value-of select="/x:description/x:param[@name = 'phase'][1]" />
 			</phase>
 		</xspec>

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -434,21 +434,21 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "Ant for Schematron with minimum properties"
+    call :setup "Ant for Schematron with minimum properties #168"
 
     if defined ANT_VERSION (
-        call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-02-PhaseA.xspec" -lib "%SAXON_CP%" -Dtest.type=s
+        call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s
         call :verify_retval 0
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
         rem Verify default clean.output.dir is false
         call :verify_exist ..\tutorial\schematron\xspec\
-        call :verify_exist ..\tutorial\schematron\demo-02-PhaseA.xspec-compiled.xspec
-        call :verify_exist ..\tutorial\schematron\demo-02.sch-compiled.xsl
+        call :verify_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
+        call :verify_exist ..\tutorial\schematron\demo-03.sch-compiled.xsl
 
         rem Delete temp file
-        call :del          ..\tutorial\schematron\demo-02-PhaseA.xspec-compiled.xspec
-        call :del          ..\tutorial\schematron\demo-02.sch-compiled.xsl
+        call :del          ..\tutorial\schematron\demo-03.xspec-compiled.xspec
+        call :del          ..\tutorial\schematron\demo-03.sch-compiled.xsl
     ) else (
         call :skip "test for Schematron Ant with minimum properties skipped"
     )

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -352,20 +352,20 @@ teardown() {
 }
 
 
-@test "Ant for Schematron with minimum properties" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-02-PhaseA.xspec -lib ${SAXON_CP} -Dtest.type=s
+@test "Ant for Schematron with minimum properties #168" {
+    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
 	echo $output
     [ "$status" -eq 0 ]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 
     # Verify default clean.output.dir is false
     [  -d "../tutorial/schematron/xspec/" ]
-    [  -f "../tutorial/schematron/demo-02-PhaseA.xspec-compiled.xspec" ]
-    [  -f "../tutorial/schematron/demo-02.sch-compiled.xsl" ]
+    [  -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
+    [  -f "../tutorial/schematron/demo-03.sch-compiled.xsl" ]
 
     # Delete temp file
-    rm -f "../tutorial/schematron/demo-02-PhaseA.xspec-compiled.xspec"
-    rm -f "../tutorial/schematron/demo-02.sch-compiled.xsl"
+    rm -f "../tutorial/schematron/demo-03.xspec-compiled.xspec"
+    rm -f "../tutorial/schematron/demo-03.sch-compiled.xsl"
 }
 
 


### PR DESCRIPTION
Fixes #168

If the user sets no `xspec.phase` property and the .xspec file defines no phase in Schematron testing, `build.xml` sets a bogus phase parameter at STEP 3.
So the user has to set `xspec.phase` explicitly, when testing `demo-03.xspec`. Though that's how the original PR #160 was designed, the design is not aligned with `xspec.bat/sh` which works more friendly.

With this PR, the user no longer has to set `xspec.phase` when testing `demo-03.xspec` and the like.