### PR TITLE
Support for XML Catalogs in xspec.bat/sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
         # Ant version used in oXygen
         - ANT_VERSION=1.9.8
         # full path to XML Resolver jar
-        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/xml-resolver.jar
+        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/xml-resolver-1.2.jar
     matrix:
         # latest Saxon 9.8 version
         - SAXON_VERSION=9.8.0-7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # Ant version used in oXygen
     ANT_VERSION: 1.9.8
     # full path to XML Resolver jar
-    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\xml-resolver.jar'
+    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\xml-resolver-1.2.jar'
   matrix:
     # latest Saxon 9.8 version
     - SAXON_VERSION: 9.8.0-7

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -47,7 +47,7 @@ rem ##
         call :win_echo %1
         echo:
     )
-    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-h] filename [coverage]
+    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog:file^|-h] filename [coverage]
     echo:
     echo   filename   the XSpec document
     echo   -t         test an XSLT stylesheet (the default)
@@ -56,6 +56,7 @@ rem ##
     echo   -c         output test coverage report
     echo   -j         output JUnit report
     echo   -h         display this help message
+    echo   -catalog:file  use XML Catalog file to locate resources
     echo   coverage   deprecated, use -c instead
     goto :EOF
 
@@ -69,7 +70,7 @@ rem ##
     goto :EOF
 
 :xslt
-    java -cp "%CP%" net.sf.saxon.Transform %*
+    java -cp "%CP%" net.sf.saxon.Transform %CATALOG% %*
     goto :EOF
 
 :win_xslt_trace
@@ -86,18 +87,18 @@ rem ##
     rem Outer Redirect:
     rem    To restore the original direction, swap stdout and stderr again 
     rem
-    ( java -cp "%CP%" net.sf.saxon.Transform %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
+    ( java -cp "%CP%" net.sf.saxon.Transform %CATALOG% %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
     goto :EOF
 
 :xquery
-    java -cp "%CP%" net.sf.saxon.Query %*
+    java -cp "%CP%" net.sf.saxon.Query %CATALOG% %*
     goto :EOF
 
 :win_xquery_trace
     rem
     rem As for redirect and pipe, see :win_xslt_trace
     rem
-    ( java -cp "%CP%" net.sf.saxon.Query %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
+    ( java -cp "%CP%" net.sf.saxon.Query %CATALOG% %* 3>&2 2>&1 1>&3 | findstr /r /c:"^<..*>$" ) 3>&2 2>&1 1>&3
     goto :EOF
 
 :win_reset_options
@@ -112,6 +113,7 @@ rem ##
     set WIN_DEPRECATED_COVERAGE=
     set WIN_EXTRA_OPTION=
     set XSPEC=
+    set CATALOG=
     goto :EOF
 
 :win_get_options
@@ -131,6 +133,8 @@ rem ##
         set JUNIT=1
     ) else if "%WIN_ARGV%"=="-h" (
         set WIN_HELP=1
+    ) else if "%WIN_ARGV:~0,8%"=="-catalog" (
+        set CATALOG=%WIN_ARGV%
     ) else if "%WIN_ARGV:~0,1%"=="-" (
         set "WIN_UNKNOWN_OPTION=%WIN_ARGV%"
     ) else if defined XSPEC (

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -47,7 +47,7 @@ rem ##
         call :win_echo %1
         echo:
     )
-    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog:file^|-h] filename [coverage]
+    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog file^|-h] filename [coverage]
     echo:
     echo   filename   the XSpec document
     echo   -t         test an XSLT stylesheet (the default)
@@ -56,7 +56,7 @@ rem ##
     echo   -c         output test coverage report
     echo   -j         output JUnit report
     echo   -h         display this help message
-    echo   -catalog:file  use XML Catalog file to locate resources
+    echo   -catalog file  use XML Catalog file to locate resources
     echo   coverage   deprecated, use -c instead
     goto :EOF
 
@@ -134,7 +134,9 @@ rem ##
     ) else if "%WIN_ARGV%"=="-h" (
         set WIN_HELP=1
     ) else if "%WIN_ARGV:~0,8%"=="-catalog" (
-        set CATALOG=%WIN_ARGV%
+        set XML_CATALOG=1
+    ) else if "%XML_CATALOG%"=="1" (
+        set XML_CATALOG="%WIN_ARGV%"
     ) else if "%WIN_ARGV:~0,1%"=="-" (
         set "WIN_UNKNOWN_OPTION=%WIN_ARGV%"
     ) else if defined XSPEC (
@@ -345,6 +347,13 @@ rem Parse command line
 rem
 call :win_reset_options
 call :win_get_options %*
+
+rem
+rem # set CATALOG option for Saxon if XML_CATALOG has been set
+rem
+if defined XML_CATALOG (
+    set CATALOG="-catalog:%XML_CATALOG%"
+)
 
 rem
 rem # Schematron

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -321,6 +321,11 @@ if not defined SAXON_CP (
         call :win_echo "Saxon jar cannot be found in SAXON_HOME: %SAXON_HOME%"
     )
 )
+if defined SAXON_HOME (
+    if exist "%SAXON_HOME%\xml-resolver-1.2.jar" (
+        set SAXON_CP="%SAXON_CP%;%SAXON_HOME%\xml-resolver-1.2.jar"
+    )
+)
 
 set CP=%SAXON_CP%;%XSPEC_HOME%\java
 

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -47,17 +47,17 @@ rem ##
         call :win_echo %1
         echo:
     )
-    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog file^|-h] filename [coverage]
+    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog file^|-h] file [coverage]
     echo:
-    echo   filename   the XSpec document
-    echo   -t         test an XSLT stylesheet (the default)
-    echo   -q         test an XQuery module (mutually exclusive with -t and -s)
-    echo   -s         test a Schematron schema (mutually exclusive with -t and -q)
-    echo   -c         output test coverage report
-    echo   -j         output JUnit report
-    echo   -h         display this help message
+    echo   file           the XSpec document
+    echo   -t             test an XSLT stylesheet (the default)
+    echo   -q             test an XQuery module (mutually exclusive with -t and -s)
+    echo   -s             test a Schematron schema (mutually exclusive with -t and -q)
+    echo   -c             output test coverage report
+    echo   -j             output JUnit report
     echo   -catalog file  use XML Catalog file to locate resources
-    echo   coverage   deprecated, use -c instead
+    echo   -h             display this help message
+    echo   coverage       deprecated, use -c instead
     goto :EOF
 
 :die

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -133,10 +133,9 @@ rem ##
         set JUNIT=1
     ) else if "%WIN_ARGV%"=="-h" (
         set WIN_HELP=1
-    ) else if "%WIN_ARGV:~0,8%"=="-catalog" (
-        set XML_CATALOG=1
-    ) else if "%XML_CATALOG%"=="1" (
-        set XML_CATALOG="%WIN_ARGV%"
+    ) else if "%WIN_ARGV%"=="-catalog" (
+        set "XML_CATALOG=%~2"
+        shift
     ) else if "%WIN_ARGV:~0,1%"=="-" (
         set "WIN_UNKNOWN_OPTION=%WIN_ARGV%"
     ) else if defined XSPEC (
@@ -162,9 +161,9 @@ rem ##
 :schematron_compile
     echo Setting up Schematron...
     
-    if not defined SCHEMATRON_XSLT_INCLUDE set SCHEMATRON_XSLT_INCLUDE="%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl"
-    if not defined SCHEMATRON_XSLT_EXPAND set SCHEMATRON_XSLT_EXPAND="%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl"
-    if not defined SCHEMATRON_XSLT_COMPILE set SCHEMATRON_XSLT_COMPILE="%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl"
+    if not defined SCHEMATRON_XSLT_INCLUDE set "SCHEMATRON_XSLT_INCLUDE=%XSPEC_HOME%\src\schematron\iso-schematron\iso_dsdl_include.xsl"
+    if not defined SCHEMATRON_XSLT_EXPAND set "SCHEMATRON_XSLT_EXPAND=%XSPEC_HOME%\src\schematron\iso-schematron\iso_abstract_expand.xsl"
+    if not defined SCHEMATRON_XSLT_COMPILE set "SCHEMATRON_XSLT_COMPILE=%XSPEC_HOME%\src\schematron\iso-schematron\iso_svrl_for_xslt2.xsl"
     
     rem # get URI to Schematron file and phase/parameters from the XSpec file
     call :xquery -qs:"declare namespace output = 'http://www.w3.org/2010/xslt-xquery-serialization'; declare option output:method 'text'; replace(iri-to-uri(concat(replace(document-uri(/), '(.*)/.*$', '$1'), '/', /*[local-name() = 'description']/@schematron)), concat(codepoints-to-string(94), 'file:/'), '')" ^
@@ -325,7 +324,7 @@ if not defined SAXON_CP (
 )
 if defined SAXON_HOME (
     if exist "%SAXON_HOME%\xml-resolver-1.2.jar" (
-        set SAXON_CP="%SAXON_CP%;%SAXON_HOME%\xml-resolver-1.2.jar"
+        set "SAXON_CP=%SAXON_CP%;%SAXON_HOME%\xml-resolver-1.2.jar"
     )
 )
 
@@ -352,7 +351,7 @@ rem
 rem # set CATALOG option for Saxon if XML_CATALOG has been set
 rem
 if defined XML_CATALOG (
-    set CATALOG="-catalog:%XML_CATALOG%"
+    set CATALOG=-catalog:"%XML_CATALOG%"
 )
 
 rem

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -337,9 +337,9 @@ rem ##
 rem
 
 rem
-rem JAR filename
+rem Saxon jar filename
 rem
-for %%I in ("%SAXON_CP%") do set WIN_SAXON_CP_N=%%~nI
+for %%I in ("%SAXON_CP:;=";"%") do if /i "%%~xI"==".jar" if /i "%%~nI" GEQ "saxon8" if /i "%%~nI" LSS "saxonb9a" set WIN_SAXON_JAR_N=%%~nI
 
 rem
 rem Parse command line
@@ -385,7 +385,7 @@ rem
 rem # Coverage
 rem
 if defined COVERAGE (
-    if /i not "%WIN_SAXON_CP_N%"=="saxon9pe" if /i not "%WIN_SAXON_CP_N%"=="saxon9ee" (
+    if /i not "%WIN_SAXON_JAR_N%"=="saxon9pe" if /i not "%WIN_SAXON_JAR_N%"=="saxon9ee" (
         echo Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE.
         exit /b 1
     )
@@ -395,7 +395,7 @@ rem
 rem # JUnit report
 rem
 if defined JUNIT (
-    if /i "%WIN_SAXON_CP_N:~0,6%"=="saxon8" (
+    if /i "%WIN_SAXON_JAR_N:~0,6%"=="saxon8" (
         echo Saxon8 detected. JUnit report requires Saxon9.
         exit /b 1
     )
@@ -440,7 +440,7 @@ rem Deprecated 'coverage' option
 rem
 if defined WIN_DEPRECATED_COVERAGE (
     echo Long-form option 'coverage' deprecated, use '-c' instead.
-    if /i not "%WIN_SAXON_CP_N%"=="saxon9pe" if /i not "%WIN_SAXON_CP_N%"=="saxon9ee" (
+    if /i not "%WIN_SAXON_JAR_N%"=="saxon9pe" if /i not "%WIN_SAXON_JAR_N%"=="saxon9ee" (
         echo Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE.
         exit /b 1
     )
@@ -450,7 +450,7 @@ if defined WIN_DEPRECATED_COVERAGE (
 rem
 rem Env var no longer necessary
 rem
-set WIN_SAXON_CP_N=
+set WIN_SAXON_JAR_N=
 
 rem
 rem ##

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -36,17 +36,17 @@ usage() {
         echo "$1"
         echo;
     fi
-    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]"
+    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]"
     echo
-    echo "  filename   the XSpec document"
-    echo "  -t         test an XSLT stylesheet (the default)"
-    echo "  -q         test an XQuery module (mutually exclusive with -t and -s)"
-    echo "  -s         test a Schematron schema (mutually exclusive with -t and -q)"
-    echo "  -c         output test coverage report"
-    echo "  -j         output JUnit report"
-    echo "  -h         display this help message"
+    echo "  file           the XSpec document"
+    echo "  -t             test an XSLT stylesheet (the default)"
+    echo "  -q             test an XQuery module (mutually exclusive with -t and -s)"
+    echo "  -s             test a Schematron schema (mutually exclusive with -t and -q)"
+    echo "  -c             output test coverage report"
+    echo "  -j             output JUnit report"
     echo "  -catalog file  use XML Catalog file to locate resources"
-    echo "  coverage   deprecated, use -c instead"
+    echo "  -h             display this help message"
+    echo "  coverage       deprecated, use -c instead"
 }
 
 die() {

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -144,6 +144,9 @@ if test -z "$SAXON_CP"; then
     	echo "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
 #        die "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
     fi
+    if test -f "${SAXON_HOME}/xml-resolver-1.2.jar"; then
+	   SAXON_CP="${SAXON_CP}${CP_DELIM}${SAXON_HOME}/xml-resolver-1.2.jar";
+	fi
 fi
 
 CP="${SAXON_CP}${CP_DELIM}${XSPEC_HOME}/java/"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -65,19 +65,19 @@ if which saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev
     echo Saxon script found, use it.
     echo
     xslt() {
-        saxon --add-cp "${XSPEC_HOME}/java/" $CATALOG --xsl "$@"
+        saxon --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xsl "$@"
     }
     xquery() {
-        saxon --add-cp "${XSPEC_HOME}/java/" $CATALOG --xq "$@"
+        saxon --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xq "$@"
     }
 else
     echo Saxon script not found, invoking JVM directly instead.
     echo
     xslt() {
-        java -cp "$CP" net.sf.saxon.Transform $CATALOG "$@"
+        java -cp "$CP" net.sf.saxon.Transform ${CATALOG:+"$CATALOG"} "$@"
     }
     xquery() {
-        java -cp "$CP" net.sf.saxon.Query $CATALOG "$@"
+        java -cp "$CP" net.sf.saxon.Query ${CATALOG:+"$CATALOG"} "$@"
     }
 fi
 
@@ -222,7 +222,7 @@ done
 
 # set CATALOG option for Saxon if XML_CATALOG has been set
 if test -n "$XML_CATALOG"; then
-    CATALOG="-catalog:${XML_CATALOG// /%20}"
+    CATALOG="-catalog:$XML_CATALOG"
 else
     CATALOG=
 fi

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -222,7 +222,7 @@ done
 
 # set CATALOG option for Saxon if XML_CATALOG has been set
 if test -n "$XML_CATALOG"; then
-    CATALOG="-catalog:$XML_CATALOG"
+    CATALOG="-catalog:${XML_CATALOG// /%20}"
 else
     CATALOG=
 fi

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -36,7 +36,7 @@ usage() {
         echo "$1"
         echo;
     fi
-    echo "Usage: xspec [-t|-q|-s|-c|-j|-h] filename [coverage]"
+    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]"
     echo
     echo "  filename   the XSpec document"
     echo "  -t         test an XSLT stylesheet (the default)"
@@ -45,6 +45,7 @@ usage() {
     echo "  -c         output test coverage report"
     echo "  -j         output JUnit report"
     echo "  -h         display this help message"
+    echo "  -catalog:file  use XML Catalog file to locate resources"
     echo "  coverage   deprecated, use -c instead"
 }
 
@@ -64,19 +65,19 @@ if which saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev
     echo Saxon script found, use it.
     echo
     xslt() {
-        saxon --add-cp "${XSPEC_HOME}/java/" --xsl "$@"
+        saxon --add-cp "${XSPEC_HOME}/java/" $CATALOG --xsl "$@"
     }
     xquery() {
-        saxon --add-cp "${XSPEC_HOME}/java/" --xq "$@"
+        saxon --add-cp "${XSPEC_HOME}/java/" $CATALOG --xq "$@"
     }
 else
     echo Saxon script not found, invoking JVM directly instead.
     echo
     xslt() {
-        java -cp "$CP" net.sf.saxon.Transform "$@"
+        java -cp "$CP" net.sf.saxon.Transform $CATALOG "$@"
     }
     xquery() {
-        java -cp "$CP" net.sf.saxon.Query "$@"
+        java -cp "$CP" net.sf.saxon.Query $CATALOG "$@"
     }
 fi
 
@@ -151,6 +152,7 @@ CP="${SAXON_CP}${CP_DELIM}${XSPEC_HOME}/java/"
 ## options ###################################################################
 ##
 
+CATALOG=
 while echo "$1" | grep -- ^- >/dev/null 2>&1; do
     case "$1" in
         # XSLT
@@ -200,6 +202,9 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
 			    exit 1
 			fi
             JUNIT=1;;
+        # Catalog
+        -catalog*)
+            CATALOG="$1";;
         # Help!
         -h)
             usage

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -36,7 +36,7 @@ usage() {
         echo "$1"
         echo;
     fi
-    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]"
+    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]"
     echo
     echo "  filename   the XSpec document"
     echo "  -t         test an XSLT stylesheet (the default)"
@@ -45,7 +45,7 @@ usage() {
     echo "  -c         output test coverage report"
     echo "  -j         output JUnit report"
     echo "  -h         display this help message"
-    echo "  -catalog:file  use XML Catalog file to locate resources"
+    echo "  -catalog file  use XML Catalog file to locate resources"
     echo "  coverage   deprecated, use -c instead"
 }
 
@@ -155,7 +155,6 @@ CP="${SAXON_CP}${CP_DELIM}${XSPEC_HOME}/java/"
 ## options ###################################################################
 ##
 
-CATALOG=
 while echo "$1" | grep -- ^- >/dev/null 2>&1; do
     case "$1" in
         # XSLT
@@ -206,8 +205,9 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
 			fi
             JUNIT=1;;
         # Catalog
-        -catalog*)
-            CATALOG="$1";;
+        -catalog)
+            shift
+            XML_CATALOG="$1";;
         # Help!
         -h)
             usage
@@ -219,6 +219,13 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
     esac
     shift;
 done
+
+# set CATALOG option for Saxon if XML_CATALOG has been set
+if test -n "$XML_CATALOG"; then
+    CATALOG="-catalog:$XML_CATALOG"
+else
+    CATALOG=
+fi
 
 # set XSLT if XQuery has not been set (that's the default)
 if test -z "$XQUERY"; then

--- a/test/catalog/catalog-01-catalog.xml
+++ b/test/catalog/catalog-01-catalog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    
+    <public publicId="-//example//EN" uri="catalog-01.dtd"/>
+    
+</catalog>

--- a/test/catalog/catalog-01-doc.xml
+++ b/test/catalog/catalog-01-doc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root PUBLIC "-//example//EN" "unreachable-uri.dtd">
+<root>
+    <title>Test catalog</title>
+</root>

--- a/test/catalog/catalog-01-xquery.xspec
+++ b/test/catalog/catalog-01-xquery.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" query-at="catalog-01.xquery" query="catalog/test" xmlns:t="catalog/test">
+    <x:scenario label="catalog test">
+        <x:call function="t:test">
+            <x:param href="catalog-01-doc.xml"/>
+        </x:call>
+        <x:expect label="fixed attribute is set" select="'1.0'"/>
+    </x:scenario>
+</x:description>

--- a/test/catalog/catalog-01-xslt.xspec
+++ b/test/catalog/catalog-01-xslt.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="catalog-01.xslt">
+    <x:scenario label="catalog test">
+        <x:context href="catalog-01-doc.xml"/>
+        <x:expect label="fixed attribute is set" test="root/@dtd-version = '1.0'"/>
+    </x:scenario>
+</x:description>

--- a/test/catalog/catalog-01.dtd
+++ b/test/catalog/catalog-01.dtd
@@ -1,0 +1,5 @@
+
+<!ELEMENT title ( #PCDATA ) >
+
+<!ELEMENT root ( title )>
+<!ATTLIST root dtd-version CDATA #FIXED "1.0" >

--- a/test/catalog/catalog-01.xquery
+++ b/test/catalog/catalog-01.xquery
@@ -1,0 +1,4 @@
+module namespace t = "catalog/test";
+declare function t:test($doc as item()) as xs:string? {
+    $doc/root/@dtd-version
+};

--- a/test/catalog/catalog-01.xslt
+++ b/test/catalog/catalog-01.xslt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -53,7 +53,7 @@ setlocal
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-h] filename [coverage]"
+    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -559,6 +559,39 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
+
+    call :mkdir "cat a log"
+    call :mkdir "cat a log\xspec"
+    copy catalog\catalog-01* "cat a log"
+    
+    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    call :run ..\bin\xspec.bat -catalog "cat a log\catalog-01-catalog.xml" "cat a log\catalog-01-xslt.xspec"
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :rmdir-s "cat a log"
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
+
+    call :mkdir "cat a log"
+    call :mkdir "cat a log\xspec"
+    copy catalog\catalog-01* "cat a log"
+    
+    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "XML_CATALOG=cat a log\catalog-01-catalog.xml"
+    call :run ..\bin\xspec.bat "cat a log\catalog-01-xslt.xspec"
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :rmdir-s "cat a log"
+    call :teardown
+endlocal
+
 
 echo === END TEST CASES ==================================================
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -53,7 +53,7 @@ setlocal
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]"
+    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]"
 
     call :teardown
 endlocal
@@ -529,7 +529,7 @@ setlocal
     call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
 
     set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
-    call :run ..\bin\xspec.bat -catalog:catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
+    call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 
@@ -540,9 +540,21 @@ setlocal
     call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
 
     set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
-    call :run ..\bin\xspec.bat -catalog:catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
+    call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
     call :verify_retval 0
     call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver"
+
+    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set XML_CATALOG=catalog\catalog-01-catalog.xml
+    call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -592,6 +592,22 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
+
+    set SAXON_HOME=%WORK_DIR%\saxon
+    call :mkdir %SAXON_HOME%
+    copy %SAXON_CP% %SAXON_HOME%
+    copy %XML_RESOLVER_CP% %SAXON_HOME%
+    set SAXON_CP=
+    
+    call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
 
 echo === END TEST CASES ==================================================
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -525,6 +525,29 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
+
+    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    call :run ..\bin\xspec.bat -catalog:catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
+
+    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    call :run ..\bin\xspec.bat -catalog:catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
+    call :verify_retval 0
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+
 echo === END TEST CASES ==================================================
 
 rem
@@ -609,6 +632,7 @@ rem
     call :mkdir ..\test\xspec
     call :mkdir ..\tutorial\xspec
     call :mkdir ..\tutorial\schematron\xspec
+    call :mkdir ..\test\catalog\xspec
 
     goto :EOF
 
@@ -619,6 +643,7 @@ rem
     call :rmdir ..\test\xspec
     call :rmdir ..\tutorial\xspec
     call :rmdir ..\tutorial\schematron\xspec
+    call :rmdir ..\test\catalog\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -596,9 +596,13 @@ setlocal
     call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
+    echo SAXON_HOME: %SAXON_HOME%
+    echo SAXON_CP: %SAXON_CP%
+    echo XML_RESOLVER_CP: %XML_RESOLVER_CP%
     call :mkdir %SAXON_HOME%
     copy %SAXON_CP% %SAXON_HOME%
     copy %XML_RESOLVER_CP% %SAXON_HOME%
+    dir %SAXON_HOME%
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -594,13 +594,9 @@ setlocal
     call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
-    echo SAXON_HOME: %SAXON_HOME%
-    echo SAXON_CP: %SAXON_CP%
-    echo XML_RESOLVER_CP: %XML_RESOLVER_CP%
     call :mkdir %SAXON_HOME%
     copy %SAXON_CP% %SAXON_HOME%
     copy %XML_RESOLVER_CP% %SAXON_HOME%
-    dir %SAXON_HOME%
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -595,7 +595,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
 
-    set SAXON_HOME=%WORK_DIR%\saxon
+    set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir %SAXON_HOME%
     copy %SAXON_CP% %SAXON_HOME%
     copy %XML_RESOLVER_CP% %SAXON_HOME%

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -562,33 +562,31 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
 
-    call :mkdir "cat a log"
-    call :mkdir "cat a log\xspec"
-    copy catalog\catalog-01* "cat a log"
+    set SPACE_DIR=%WORK_DIR%\cat a log
+    call :mkdir "%SPACE_DIR%\xspec"
+    copy catalog\catalog-01* "%SPACE_DIR%"
     
     set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
-    call :run ..\bin\xspec.bat -catalog "cat a log\catalog-01-catalog.xml" "cat a log\catalog-01-xslt.xspec"
+    call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 
-    call :rmdir-s "cat a log"
     call :teardown
 endlocal
 
 setlocal
     call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
 
-    call :mkdir "cat a log"
-    call :mkdir "cat a log\xspec"
-    copy catalog\catalog-01* "cat a log"
+    set SPACE_DIR=%WORK_DIR%\cat a log
+    call :mkdir "%SPACE_DIR%\xspec"
+    copy catalog\catalog-01* "%SPACE_DIR%"
     
     set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
-    set "XML_CATALOG=cat a log\catalog-01-catalog.xml"
-    call :run ..\bin\xspec.bat "cat a log\catalog-01-xslt.xspec"
+    set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
+    call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 
-    call :rmdir-s "cat a log"
     call :teardown
 endlocal
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -53,7 +53,7 @@ setlocal
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]"
+    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -151,7 +151,8 @@ endlocal
 setlocal
     call :setup "invoking code coverage with Saxon9EE creates test stylesheet"
 
-    set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9ee.jar
+    rem Append non-Saxon jar to see if SAXON_CP is parsed correctly
+    set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9ee.jar;%XML_RESOLVER_CP%
 
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -473,14 +473,10 @@ teardown() {
 
 @test "invoking xspec.sh using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
     export SAXON_HOME="${PWD}/saxon"
-    echo SAXON_HOME: $SAXON_HOME
-    echo SAXON_CP: $SAXON_CP
-    echo XML_RESOLVER_CP: $XML_RESOLVER_CP
     mkdir $SAXON_HOME
     cp $SAXON_CP $SAXON_HOME
     cp $XML_RESOLVER_CP $SAXON_HOME
     export SAXON_CP=
-    ls $SAXON_HOME
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo $output
 	[ "$status" -eq 0 ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -445,3 +445,28 @@ teardown() {
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
+
+@test "invoking xspec.sh using -catalog with spaces in file path uses XML Catalog resolver" {
+    mkdir cat\ a\ log
+    mkdir cat\ a\ log/xspec
+    cp catalog/catalog-01* cat\ a\ log
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+	run ../bin/xspec.sh -catalog cat\ a\ log/catalog-01-catalog.xml cat\ a\ log/catalog-01-xslt.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+	rm -rf cat\ a\ log
+}
+
+@test "invoking xspec.sh using XML_CATALOG with spaces in file path uses XML Catalog resolver" {
+    mkdir cat\ a\ log
+    mkdir cat\ a\ log/xspec
+    cp catalog/catalog-01* cat\ a\ log
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+    export XML_CATALOG=cat\ a\ log/catalog-01-catalog.xml
+	run ../bin/xspec.sh cat\ a\ log/catalog-01-xslt.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+	rm -rf cat\ a\ log
+}

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -473,10 +473,14 @@ teardown() {
 
 @test "invoking xspec.sh using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
     export SAXON_HOME="${PWD}/saxon"
+    echo SAXON_HOME: $SAXON_HOME
+    echo SAXON_CP: $SAXON_CP
+    echo XML_RESOLVER_CP: $XML_RESOLVER_CP
     mkdir $SAXON_HOME
     cp $SAXON_CP $SAXON_HOME
     cp $XML_RESOLVER_CP $SAXON_HOME
     export SAXON_CP=
+    ls $SAXON_HOME
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo $output
 	[ "$status" -eq 0 ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -35,7 +35,7 @@ teardown() {
     run ../bin/xspec.sh
 	echo $output
     [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-h] filename [coverage]" ]
+    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -37,7 +37,7 @@ teardown() {
     run ../bin/xspec.sh
 	echo $output
     [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]" ]
+    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -470,3 +470,16 @@ teardown() {
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf cat\ a\ log
 }
+
+@test "invoking xspec.sh using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
+    mkdir saxon
+    cp $SAXON_CP saxon
+    cp $XML_RESOLVER_CP saxon
+    export SAXON_HOME=saxon
+    export SAXON_CP=
+	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+	rm -rf saxon
+}

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -472,14 +472,14 @@ teardown() {
 }
 
 @test "invoking xspec.sh using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
-    mkdir saxon
-    cp $SAXON_CP saxon
-    cp $XML_RESOLVER_CP saxon
-    export SAXON_HOME=saxon
+    export SAXON_HOME="${PWD}/saxon"
+    mkdir $SAXON_HOME
+    cp $SAXON_CP $SAXON_HOME
+    cp $XML_RESOLVER_CP $SAXON_HOME
     export SAXON_CP=
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo $output
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-	rm -rf saxon
+	rm -rf $SAXON_HOME
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -111,7 +111,8 @@ teardown() {
 
 
 @test "invoking code coverage with Saxon9EE creates test stylesheet" {
-    export SAXON_CP=/path/to/saxon9ee.jar
+    # Append non-Saxon jar to see if SAXON_CP is parsed correctly
+    export SAXON_CP="/path/to/saxon9ee.jar:$XML_RESOLVER_CP"
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
   	echo $output
     [ "$status" -eq 1 ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -37,7 +37,7 @@ teardown() {
     run ../bin/xspec.sh
 	echo $output
     [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog:file|-h] filename [coverage]" ]
+    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] filename [coverage]" ]
 }
 
 
@@ -423,7 +423,7 @@ teardown() {
 
 @test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog:catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
+	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo $output
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
@@ -431,8 +431,17 @@ teardown() {
 
 @test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog:catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
+	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
 	echo $output
 	[ "$status" -eq 0 ]
 	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+}
+
+@test "invoking xspec.sh with XML_CATALOG set uses XML Catalog resolver" {
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+    export XML_CATALOG=catalog/catalog-01-catalog.xml
+	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -21,6 +21,7 @@ setup() {
 	mkdir ../tutorial/xspec
 	mkdir ../test/xspec
 	mkdir ../tutorial/schematron/xspec
+	mkdir ../test/catalog/xspec
 }
 
 
@@ -28,6 +29,7 @@ teardown() {
 	rm -rf ../tutorial/xspec
 	rm -rf ../test/xspec
 	rm -rf ../tutorial/schematron/xspec
+	rm -rf ../test/catalog/xspec
 }
 
 
@@ -417,4 +419,20 @@ teardown() {
 	echo $output
     [ "$status" -eq 0 ]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+}
+
+@test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+	run ../bin/xspec.sh -catalog:catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+}
+
+@test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+	run ../bin/xspec.sh -catalog:catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }


### PR DESCRIPTION
This pull request is to add support for OASIS XML Catalogs to `xspec.bat` and `xspec.sh` as requested in issue #167. 

Here are suggestions for changes to the wiki documentation to describe this feature:

* Create a new page about XML Catalog support using the information in [this comment](https://github.com/xspec/xspec/issues/167#issuecomment-367173274).
* Add a link to the XML Catalog page from the pages for [Installation on Windows](https://github.com/xspec/xspec/wiki/Installation-on-Windows) and [Installation on Max and Linux](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux) for optional additional installation steps to enable catalog support.
* Update the [Environment Variables](https://github.com/xspec/xspec/wiki/Environment-Variables) page to add the new environment variable XML_CATALOG
* Also on the [Environment Variables](https://github.com/xspec/xspec/wiki/Environment-Variables) page, edit the description of SAXON_CP and SAXON_HOME (or add another footnote) to mention that a catalog resolver xml-resolver-1.2.jar can be included to enable catalog support..
