### PR TITLE
Warn if expect is ambiguous (node-selection with boolean test attribute)

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -354,6 +354,13 @@
                this is an error.  See issue 5.-->
           <variable name="impl:boolean-test" as="xs:boolean"
             select="$impl:test-result instance of xs:boolean" />
+          <xsl:if test="@href or @select or (node() except x:label)">
+            <if test="$impl:boolean-test">
+              <message>
+                <text>WARNING: <xsl:value-of select="name(.)"/> has boolean @test (i.e. assertion) along with @href, @select or child node (i.e. comparison). Comparison factors will be ignored.</text>
+              </message>
+            </if>
+          </xsl:if>
           <variable name="impl:successful" as="xs:boolean"
             select="if ($impl:boolean-test) then $impl:test-result cast as xs:boolean
                     else test:deep-equal($impl:expected, $impl:test-result, {$version})" />

--- a/test/end-to-end/cases/expected/xspec-ambiguous-test-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-ambiguous-test-result-norm.html
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-ambiguous-test.xsl (passed: 5 / pending: 0 / failed: 5 / total:
+         10)
+      </title>
+      <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="xspec-ambiguous-test.xsl">xspec-ambiguous-test.xsl</a></p>
+      <p>Tested: ONCE-UPON-A-TIME</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="75%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 5</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 5</th>
+               <th class="totals">total: 10</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#ELEM-52">Scenario for verifying boolean @test precedes @href</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-89">Scenario for verifying boolean @test precedes @select</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-123">Scenario for verifying boolean @test precedes child node</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-158">Scenario for verifying boolean @test precedes empty sequence (no @href, @select or
+                     child node)</a></th>
+               <th class="totals">2</th>
+               <th class="totals">0</th>
+               <th class="totals">2</th>
+               <th class="totals">4</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-52">
+         <h2 class="successful">Scenario for verifying boolean @test precedes @href<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-54">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for verifying boolean @test precedes @href</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-72">When function returns true(),</a></th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-73">Expecting document node via @href should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <td>Expecting document node via @href along with @test=$x:result should be Success</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-72">Scenario for verifying boolean @test precedes @href When function returns true(),</h3>
+         <h4 id="ELEM-73">Expecting document node via @href should be Failure</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><pre>xs:boolean('true')</pre></td>
+                  <td>
+                     <p>XPath <code>/</code> from:
+                     </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="ELEM-89">
+         <h2 class="successful">Scenario for verifying boolean @test precedes @select<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-91">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for verifying boolean @test precedes @select</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-109">When function returns false(),</a></th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>Expecting false() via @select should be Success</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-110">Expecting false() via @select along with @test=$x:result should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-109">Scenario for verifying boolean @test precedes @select When function returns false(),</h3>
+         <h4 id="ELEM-110">Expecting false() via @select along with @test=$x:result should be Failure</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><pre>xs:boolean('false')</pre></td>
+                  <td><pre>xs:boolean('false')</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="ELEM-123">
+         <h2 class="successful">Scenario for verifying boolean @test precedes child node<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-125">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for verifying boolean @test precedes child node</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-143">When function returns true()</a></th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-144">Expecting element(foo) via child node should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <td>Expecting element(foo) via child node along with @test=$x:result should be Success</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-143">Scenario for verifying boolean @test precedes child node When function returns true()</h3>
+         <h4 id="ELEM-144">Expecting element(foo) via child node should be Failure</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><pre>xs:boolean('true')</pre></td>
+                  <td><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="ELEM-158">
+         <h2 class="successful">Scenario for verifying boolean @test precedes empty sequence (no @href, @select or
+            child node)<span class="scenario-totals">passed: 2 / pending: 0 / failed: 2 / total: 4</span></h2>
+         <table class="xspec" id="ELEM-160">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Scenario for verifying boolean @test precedes empty sequence (no @href, @select or
+                     child node)
+                  </th>
+                  <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-185">When function returns true()</a></th>
+                  <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-186">Expecting empty sequence (no @href, @select or child node) should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-198">Ditto using x:label</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <td>Expecting empty sequence (no @href, @select or child node) along with @test=$x:result
+                     should be Success
+                  </td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <td>Ditto using x:label (Not actually empty: xspec/xspec#173)</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-185">Scenario for verifying boolean @test precedes empty sequence (no @href, @select or
+            child node) When function returns true()
+         </h3>
+         <h4 id="ELEM-186">Expecting empty sequence (no @href, @select or child node) should be Failure</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><pre>xs:boolean('true')</pre></td>
+                  <td><pre>()</pre></td>
+               </tr>
+            </tbody>
+         </table>
+         <h4 id="ELEM-198">Ditto using x:label</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><pre>xs:boolean('true')</pre></td>
+                  <td><pre>&lt;<span class="diff">x:label</span>&gt;<span class="diff">Ditto using x:label</span>&lt;/x:label&gt;</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/xspec-ambiguous-test.xml
+++ b/test/end-to-end/cases/xspec-ambiguous-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo />

--- a/test/end-to-end/cases/xspec-ambiguous-test.xsl
+++ b/test/end-to-end/cases/xspec-ambiguous-test.xsl
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />

--- a/test/end-to-end/cases/xspec-ambiguous-test.xspec
+++ b/test/end-to-end/cases/xspec-ambiguous-test.xspec
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="xspec-ambiguous-test.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Scenario for verifying boolean @test precedes @href">
+		<x:scenario label="When function returns true(),">
+			<x:call function="exactly-one">
+				<x:param as="xs:boolean" select="true()" />
+			</x:call>
+
+			<x:expect href="xspec-ambiguous-test.xml"
+				label="Expecting document node via @href should be Failure" />
+
+			<x:expect href="xspec-ambiguous-test.xml"
+				label="Expecting document node via @href along with @test=$x:result should be Success"
+				test="$x:result treat as xs:boolean" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for verifying boolean @test precedes @select">
+		<x:scenario label="When function returns false(),">
+			<x:call function="exactly-one">
+				<x:param as="xs:boolean" select="false()" />
+			</x:call>
+
+			<x:expect label="Expecting false() via @select should be Success" select="false()" />
+
+			<x:expect
+				label="Expecting false() via @select along with @test=$x:result should be Failure"
+				select="false()" test="$x:result treat as xs:boolean" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for verifying boolean @test precedes child node">
+		<x:scenario label="When function returns true()">
+			<x:call function="exactly-one">
+				<x:param as="xs:boolean" select="true()" />
+			</x:call>
+
+			<x:expect label="Expecting element(foo) via child node should be Failure">
+				<foo />
+			</x:expect>
+
+			<x:expect
+				label="Expecting element(foo) via child node along with @test=$x:result should be Success"
+				test="$x:result treat as xs:boolean">
+				<foo />
+			</x:expect>
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario
+		label="Scenario for verifying boolean @test precedes empty sequence (no @href, @select or child node)">
+		<x:scenario label="When function returns true()">
+			<x:call function="exactly-one">
+				<x:param as="xs:boolean" select="true()" />
+			</x:call>
+
+			<x:expect
+				label="Expecting empty sequence (no @href, @select or child node) should be Failure" />
+			<x:expect>
+				<x:label>Ditto using x:label</x:label>
+			</x:expect>
+
+			<x:expect
+				label="Expecting empty sequence (no @href, @select or child node) along with @test=$x:result should be Success"
+				test="$x:result treat as xs:boolean" />
+			<x:expect test="$x:result treat as xs:boolean">
+				<x:label>Ditto using x:label (Not actually empty: xspec/xspec#173)</x:label>
+			</x:expect>
+		</x:scenario>
+	</x:scenario>
+</x:description>

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -525,6 +525,18 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "Ambiguous @test generates warning"
+
+    call :run ..\bin\xspec.bat end-to-end\cases\xspec-ambiguous-test.xspec
+    call :verify_line 10 r "WARNING: x:expect has boolean @test"
+    call :verify_line 15 r "WARNING: x:expect has boolean @test"
+    call :verify_line 22 r "WARNING: x:expect has boolean @test"
+    call :verify_line 31 x "Formatting Report..."
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem
@@ -606,7 +618,8 @@ rem
     rem
     rem Create the XSpec output directories
     rem
-    call :mkdir ..\test\xspec
+    call :mkdir xspec
+    call :mkdir end-to-end\cases\xspec
     call :mkdir ..\tutorial\xspec
     call :mkdir ..\tutorial\schematron\xspec
 
@@ -615,8 +628,10 @@ rem
 :teardown
     rem
     rem Remove the XSpec output directories
+    rem    Keep "..\test\" to minimize accident
     rem
     call :rmdir ..\test\xspec
+    call :rmdir ..\test\end-to-end\cases\xspec
     call :rmdir ..\tutorial\xspec
     call :rmdir ..\tutorial\schematron\xspec
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -18,15 +18,17 @@
 #===============================================================================
 
 setup() {
+	mkdir xspec
+	mkdir end-to-end/cases/xspec
 	mkdir ../tutorial/xspec
-	mkdir ../test/xspec
 	mkdir ../tutorial/schematron/xspec
 }
 
 
 teardown() {
-	rm -rf ../tutorial/xspec
 	rm -rf ../test/xspec
+	rm -rf ../test/end-to-end/cases/xspec
+	rm -rf ../tutorial/xspec
 	rm -rf ../tutorial/schematron/xspec
 }
 
@@ -417,4 +419,14 @@ teardown() {
 	echo $output
     [ "$status" -eq 0 ]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+}
+
+
+@test "Ambiguous @test generates warning" {
+    run ../bin/xspec.sh end-to-end/cases/xspec-ambiguous-test.xspec
+	echo "$output"
+    [[ "${lines[9]}"  =~ "WARNING: x:expect has boolean @test" ]]
+    [[ "${lines[14]}" =~ "WARNING: x:expect has boolean @test" ]]
+    [[ "${lines[21]}" =~ "WARNING: x:expect has boolean @test" ]]
+    [  "${lines[30]}" =  "Formatting Report..." ]
 }


### PR DESCRIPTION
`@test` in `x:expect` has duality by design: https://github.com/xspec/xspec/blob/63cf95d7eade5678e5c994fae18ff69d3410ac5d/src/compiler/generate-xspec-tests.xsl#L357-L359

1. If `@test` is an xs:boolean, Success/Failure is determined only by `@test`.
2. If `@test` is not an xs:boolean, Success/Failure is determined by comparing `@test` with `@href`, `@select` and/or child node.

In the first case, having `@href`, `@select` or child node in `x:expect` is ambiguous or error-prone at best, because they are ignored at run time.

For example, in this scenario,
```xml
<x:scenario label="When function returns false()"> 
	<x:call function="exactly-one"> 
		<x:param select="false()" /> 
	</x:call> 
	<x:expect 
		label="Expecting false()?" 
		select="false()" test="$x:result" /> 
</x:scenario> 
```
the developer may intend to compare `@test` (false) with `@select` (false) and expect Success. But the actual outcome is Failure.

This PR generates a warning, if `x:expect` has `@href`, `@select` or child node at compile time *and* `@test` is boolean at run time.
