### PR TITLE
Add whitespace-only text node test 

### DIFF
--- a/test/xspec-space.xsl
+++ b/test/xspec-space.xsl
@@ -2,6 +2,11 @@
 <xsl:stylesheet version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xspec-space="x-urn:test:xspec-space">
 
+	<!-- Returns the context node intact -->
+	<xsl:template as="node()" name="context-mirror-template">
+		<xsl:sequence select="." />
+	</xsl:template>
+
 	<xsl:function as="xs:boolean" name="xspec-space:is-expected-text-node">
 		<xsl:param as="item()*" name="items" />
 

--- a/test/xspec-space.xsl
+++ b/test/xspec-space.xsl
@@ -7,6 +7,16 @@
 		<xsl:sequence select="." />
 	</xsl:template>
 
+	<!-- Inserts $text into <match> -->
+	<xsl:template as="element(match)" match="match">
+		<xsl:param as="text()?" name="text" />
+
+		<xsl:copy>
+			<xsl:sequence select="$text" />
+		</xsl:copy>
+	</xsl:template>
+
+	<!-- Returns true if $items is the known whitespace-only text node -->
 	<xsl:function as="xs:boolean" name="xspec-space:is-expected-text-node">
 		<xsl:param as="item()*" name="items" />
 

--- a/test/xspec-space.xsl
+++ b/test/xspec-space.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xspec-space="x-urn:test:xspec-space">
+
+	<xsl:function as="xs:boolean" name="xspec-space:is-expected-text-node">
+		<xsl:param as="item()*" name="items" />
+
+		<xsl:sequence
+			select="
+				($items instance of text())
+				and ($items eq '&#x09;&#x0A;&#x0D;&#x20;')"
+		 />
+	</xsl:function>
+
+</xsl:stylesheet>

--- a/test/xspec-space.xspec
+++ b/test/xspec-space.xspec
@@ -42,34 +42,45 @@
 	<x:scenario label="Scenario for testing whitespace-only text nodes in user elements">
 		<x:scenario label="When an element in x:param has a whitespace-only text node">
 			<x:call function="exactly-one">
-				<x:param><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
+				<x:param>
+					<p>&#x09;&#x0A;&#x0D;&#x20;</p>
+				</x:param>
 			</x:call>
-			<x:expect label="Only the whitespace-only text node should be removed"><p /></x:expect>
-			<x:expect label="x:expect with the same structure as the x:param should be Success"
-					><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+			<x:expect label="Only the whitespace-only text node should be removed">
+				<p />
+			</x:expect>
+			<x:expect label="x:expect with the same structure as the x:param should be Success">
+				<p>&#x09;&#x0A;&#x0D;&#x20;</p>
+			</x:expect>
 		</x:scenario>
 
 		<x:scenario label="When an element in x:param has @xml:space=preserve and">
 			<x:scenario label="a whitespace-only text node">
 				<x:call function="exactly-one">
-					<x:param><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
+					<x:param>
+						<p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p>
+					</x:param>
 				</x:call>
 				<x:expect
 					label="The element, @xml:space and the whitespace-only text node should be kept"
 					test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/node())" />
-				<x:expect label="x:expect with the same structure as the x:param should be Success"
-					><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+				<x:expect label="x:expect with the same structure as the x:param should be Success">
+					<p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p>
+				</x:expect>
 			</x:scenario>
 
 			<x:scenario label="an element with a whitespace-only text node">
 				<x:call function="exactly-one">
-					<x:param><p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p></x:param>
+					<x:param>
+						<p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p>
+					</x:param>
 				</x:call>
 				<x:expect
 					label="The elements, @xml:space and the whitespace-only text node should be kept"
 					test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/span/node())" />
-				<x:expect label="x:expect with the same structure as the x:param should be Success"
-					><p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p></x:expect>
+				<x:expect label="x:expect with the same structure as the x:param should be Success">
+					<p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p>
+				</x:expect>
 			</x:scenario>
 		</x:scenario>
 
@@ -77,22 +88,29 @@
 			label="When an element in x:param is specified by /x:description/@preserve-space and has">
 			<x:scenario label="a whitespace-only text node">
 				<x:call function="exactly-one">
-					<x:param><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:param>
+					<x:param>
+						<pre>&#x09;&#x0A;&#x0D;&#x20;</pre>
+					</x:param>
 				</x:call>
 				<x:expect label="The element and the whitespace-only text node should be kept"
 					test="xspec-space:is-expected-text-node(pre/node())" />
-				<x:expect label="x:expect with the same structure as the x:param should be Success"
-					><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:expect>
+				<x:expect label="x:expect with the same structure as the x:param should be Success">
+					<pre>&#x09;&#x0A;&#x0D;&#x20;</pre>
+				</x:expect>
 			</x:scenario>
 
 			<x:scenario label="an element with a whitespace-only text node">
 				<x:call function="exactly-one">
-					<x:param><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:param>
+					<x:param>
+						<pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre>
+					</x:param>
 				</x:call>
-				<x:expect label="Only the whitespace-only text node should be removed"
-					><pre><span /></pre></x:expect>
-				<x:expect label="x:expect with the same structure as the x:param should be Success"
-					><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:expect>
+				<x:expect label="Only the whitespace-only text node should be removed">
+					<pre><span /></pre>
+				</x:expect>
+				<x:expect label="x:expect with the same structure as the x:param should be Success">
+					<pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre>
+				</x:expect>
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>

--- a/test/xspec-space.xspec
+++ b/test/xspec-space.xspec
@@ -2,7 +2,7 @@
 <x:description preserve-space="pre" stylesheet="xspec-space.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xspec-space="x-urn:test:xspec-space">
 
-	<x:scenario label="Scenario for testing whitespace-only text nodes in x:* elements">
+	<x:scenario label="Scenario for testing whitespace-only text nodes in x:param and x:expect">
 		<x:scenario label="When x:param has a whitespace-only text node">
 			<x:call function="zero-or-one">
 				<x:param>&#x09;&#x0A;&#x0D;&#x20;</x:param>
@@ -23,6 +23,22 @@
 		</x:scenario>
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing whitespace-only text nodes in x:context">
+		<x:scenario label="When x:context has a whitespace-only text node">
+			<x:context>&#x09;&#x0A;&#x0D;&#x20;</x:context>
+			<x:call template="context-mirror-template" />
+			<x:expect label="The whitespace-only text node should be removed"
+				test="empty($x:result)" />
+		</x:scenario>
+
+		<x:scenario label="When x:context with @xml:space=preserve has a whitespace-only text node">
+			<x:context xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</x:context>
+			<x:call template="context-mirror-template" />
+			<x:expect label="The whitespace-only text node should be kept"
+				test="xspec-space:is-expected-text-node(node())" />
+		</x:scenario>
+	</x:scenario>
+
 	<x:scenario label="Scenario for testing whitespace-only text nodes in user elements">
 		<x:scenario label="When an element in x:param has a whitespace-only text node">
 			<x:call function="exactly-one">
@@ -34,27 +50,52 @@
 					><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
 		</x:scenario>
 
-		<x:scenario
-			label="When an element in x:param has @xml:space=preserve and a whitespace-only text node">
-			<x:call function="exactly-one">
-				<x:param><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
-			</x:call>
-			<x:expect
-				label="The element, @xml:space and the whitespace-only text node should be kept"
-				test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/node())" />
-			<x:expect label="x:expect with the same structure as the x:param should be Success"
-				><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+		<x:scenario label="When an element in x:param has @xml:space=preserve and">
+			<x:scenario label="a whitespace-only text node">
+				<x:call function="exactly-one">
+					<x:param><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
+				</x:call>
+				<x:expect
+					label="The element, @xml:space and the whitespace-only text node should be kept"
+					test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/node())" />
+				<x:expect label="x:expect with the same structure as the x:param should be Success"
+					><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+			</x:scenario>
+
+			<x:scenario label="an element with a whitespace-only text node">
+				<x:call function="exactly-one">
+					<x:param><p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p></x:param>
+				</x:call>
+				<x:expect
+					label="The elements, @xml:space and the whitespace-only text node should be kept"
+					test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/span/node())" />
+				<x:expect label="x:expect with the same structure as the x:param should be Success"
+					><p xml:space="preserve"><span>&#x09;&#x0A;&#x0D;&#x20;</span></p></x:expect>
+			</x:scenario>
 		</x:scenario>
 
 		<x:scenario
-			label="When an element in x:param is specified by /x:description/@preserve-space and has a whitespace-only text node">
-			<x:call function="exactly-one">
-				<x:param><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:param>
-			</x:call>
-			<x:expect label="The element and the whitespace-only text node should be kept"
-				test="xspec-space:is-expected-text-node(pre/node())" />
-			<x:expect label="x:expect with the same structure as the x:param should be Success"
-				><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:expect>
+			label="When an element in x:param is specified by /x:description/@preserve-space and has">
+			<x:scenario label="a whitespace-only text node">
+				<x:call function="exactly-one">
+					<x:param><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:param>
+				</x:call>
+				<x:expect label="The element and the whitespace-only text node should be kept"
+					test="xspec-space:is-expected-text-node(pre/node())" />
+				<x:expect label="x:expect with the same structure as the x:param should be Success"
+					><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:expect>
+			</x:scenario>
+
+			<x:scenario label="an element with a whitespace-only text node">
+				<x:call function="exactly-one">
+					<x:param><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:param>
+				</x:call>
+				<x:expect label="The elements should be kept" test="exists(pre/span)" />
+				<x:expect label="The whitespace-only text node should be removed"
+					test="empty(pre/span/node())" />
+				<x:expect label="x:expect with the same structure as the x:param should be Success"
+					><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:expect>
+			</x:scenario>
 		</x:scenario>
 	</x:scenario>
 </x:description>

--- a/test/xspec-space.xspec
+++ b/test/xspec-space.xspec
@@ -2,7 +2,8 @@
 <x:description preserve-space="pre" stylesheet="xspec-space.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xspec-space="x-urn:test:xspec-space">
 
-	<x:scenario label="Scenario for testing whitespace-only text nodes in x:param and x:expect">
+	<x:scenario
+		label="Scenario for testing whitespace-only text nodes in x:call/x:param and x:expect">
 		<x:scenario label="When x:param has a whitespace-only text node">
 			<x:call function="zero-or-one">
 				<x:param>&#x09;&#x0A;&#x0D;&#x20;</x:param>
@@ -36,6 +37,28 @@
 			<x:call template="context-mirror-template" />
 			<x:expect label="The whitespace-only text node should be kept"
 				test="xspec-space:is-expected-text-node(node())" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing whitespace-only text nodes in x:context/x:param">
+		<x:scenario label="When x:context/x:param has a whitespace-only text node">
+			<x:context>
+				<x:param name="text">&#x09;&#x0A;&#x0D;&#x20;</x:param>
+				<match>$text goes here</match>
+			</x:context>
+			<x:expect label="The whitespace-only text node should be removed">
+				<match />
+			</x:expect>
+		</x:scenario>
+
+		<x:scenario
+			label="When x:context/x:param with @xml:space=preserve has a whitespace-only text node">
+			<x:context>
+				<x:param name="text" xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</x:param>
+				<match>$text goes here</match>
+			</x:context>
+			<x:expect label="The whitespace-only text node should be kept"
+				test="xspec-space:is-expected-text-node(match/node())" />
 		</x:scenario>
 	</x:scenario>
 

--- a/test/xspec-space.xspec
+++ b/test/xspec-space.xspec
@@ -44,8 +44,7 @@
 			<x:call function="exactly-one">
 				<x:param><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
 			</x:call>
-			<x:expect label="The element should be kept" test="exists(p)" />
-			<x:expect label="The whitespace-only text node should be removed" test="empty(p/node())" />
+			<x:expect label="Only the whitespace-only text node should be removed"><p /></x:expect>
 			<x:expect label="x:expect with the same structure as the x:param should be Success"
 					><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
 		</x:scenario>
@@ -90,9 +89,8 @@
 				<x:call function="exactly-one">
 					<x:param><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:param>
 				</x:call>
-				<x:expect label="The elements should be kept" test="exists(pre/span)" />
-				<x:expect label="The whitespace-only text node should be removed"
-					test="empty(pre/span/node())" />
+				<x:expect label="Only the whitespace-only text node should be removed"
+					><pre><span /></pre></x:expect>
 				<x:expect label="x:expect with the same structure as the x:param should be Success"
 					><pre><span>&#x09;&#x0A;&#x0D;&#x20;</span></pre></x:expect>
 			</x:scenario>

--- a/test/xspec-space.xspec
+++ b/test/xspec-space.xspec
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description preserve-space="pre" stylesheet="xspec-space.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xspec-space="x-urn:test:xspec-space">
+
+	<x:scenario label="Scenario for testing whitespace-only text nodes in x:* elements">
+		<x:scenario label="When x:param has a whitespace-only text node">
+			<x:call function="zero-or-one">
+				<x:param>&#x09;&#x0A;&#x0D;&#x20;</x:param>
+			</x:call>
+			<x:expect label="The whitespace-only text node should be removed"
+				test="empty($x:result)" />
+			<x:expect label="x:expect with the same structure as the x:param should be Success"
+				>&#x09;&#x0A;&#x0D;&#x20;</x:expect>
+		</x:scenario>
+
+		<x:scenario label="When x:param with @xml:space=preserve has a whitespace-only text node">
+			<x:call function="exactly-one">
+				<x:param xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</x:param>
+			</x:call>
+			<x:expect label="The whitespace-only text node should be kept"
+				test="xspec-space:is-expected-text-node(node())" />
+			<x:expect label="x:expect with the same structure as the x:param should be Success" xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</x:expect>
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing whitespace-only text nodes in user elements">
+		<x:scenario label="When an element in x:param has a whitespace-only text node">
+			<x:call function="exactly-one">
+				<x:param><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
+			</x:call>
+			<x:expect label="The element should be kept" test="exists(p)" />
+			<x:expect label="The whitespace-only text node should be removed" test="empty(p/node())" />
+			<x:expect label="x:expect with the same structure as the x:param should be Success"
+					><p>&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+		</x:scenario>
+
+		<x:scenario
+			label="When an element in x:param has @xml:space=preserve and a whitespace-only text node">
+			<x:call function="exactly-one">
+				<x:param><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:param>
+			</x:call>
+			<x:expect
+				label="The element, @xml:space and the whitespace-only text node should be kept"
+				test="xspec-space:is-expected-text-node(p[@xml:space = 'preserve']/node())" />
+			<x:expect label="x:expect with the same structure as the x:param should be Success"
+				><p xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</p></x:expect>
+		</x:scenario>
+
+		<x:scenario
+			label="When an element in x:param is specified by /x:description/@preserve-space and has a whitespace-only text node">
+			<x:call function="exactly-one">
+				<x:param><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:param>
+			</x:call>
+			<x:expect label="The element and the whitespace-only text node should be kept"
+				test="xspec-space:is-expected-text-node(pre/node())" />
+			<x:expect label="x:expect with the same structure as the x:param should be Success"
+				><pre>&#x09;&#x0A;&#x0D;&#x20;</pre></x:expect>
+		</x:scenario>
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
This PR just adds some tests for the feature to handle whitespace-only text nodes.
No code change involved.

### Further work
The current [wiki](https://github.com/xspec/xspec/wiki/Writing-Scenarios) does not mention how whitespace-only text nodes are handled. We might want to add a brief description to the wiki based on this pull request.