### PR TITLE
Issue 180 (Add x:original-xspec-location in junit report)

### DIFF
--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -113,6 +113,7 @@
          <xsl:if test="exists($query-at)">
             <xsl:attribute name="query-at" select="$query-at"/>
          </xsl:if>
+         <attribute name="original-xspec-location" select="{base-uri()}"/>
          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
          <xsl:call-template name="x:call-scenarios"/>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -50,6 +50,7 @@
        /x:description/@query-at/resolve-uri(., base-uri(..))"/>
    <!--xsl:param name="query-at" as="xs:string?" select="
        /x:description/@query-at"/-->
+   <xsl:variable name="document-source-uri" as="xs:anyURI" select="document-uri(root(/))"/>
 
    <xsl:template match="/">
       <xsl:call-template name="x:generate-tests"/>
@@ -113,8 +114,8 @@
          <xsl:if test="exists($query-at)">
             <xsl:attribute name="query-at" select="$query-at"/>
          </xsl:if>
-         <attribute name="original-xspec-location" select="{base-uri()}"/>
-         <xsl:text> {&#10;</xsl:text>
+	 <xsl:attribute name="original-xspec-location" select="$document-source-uri"/>
+          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
          <xsl:call-template name="x:call-scenarios"/>
          <xsl:text>&#10;}&#10;</xsl:text>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -80,7 +80,7 @@
 	        that the URI appears in the trace report generated from running the
 	        test stylesheet, which can then be picked up by stylesheets that
 	        process *that* to generate a coverage report -->
-	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}">
+	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}" original-xspec-location="{{(/x:description/@original-location,base-uri())[1]}}">
                  <!-- Generate calls to the compiled top-level scenarios. -->
                  <xsl:call-template name="x:call-scenarios"/>
 	      </x:report>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -37,7 +37,9 @@
   select="resolve-uri(/x:description/@stylesheet, replace(base-uri(/x:description), $apostrophe, '%27'))" />  
 
 <xsl:variable name="stylesheet" as="document-node()" 
-  select="doc($stylesheet-uri)" />
+	select="doc($stylesheet-uri)" />
+
+<xsl:variable name="document-source-uri" as="xs:anyURI" select="document-uri(root(/))"/>
 
 <xsl:template match="/">
    <xsl:call-template name="x:generate-tests"/>
@@ -80,7 +82,7 @@
 	        that the URI appears in the trace report generated from running the
 	        test stylesheet, which can then be picked up by stylesheets that
 	        process *that* to generate a coverage report -->
-	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}" original-xspec-location="{{(/x:description/@original-location,base-uri())[1]}}">
+	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}" original-xspec-location="{$document-source-uri}">
                  <!-- Generate calls to the compiled top-level scenarios. -->
                  <xsl:call-template name="x:call-scenarios"/>
 	      </x:report>

--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -28,11 +28,11 @@
     <xsl:output name="escaped" method="xml" omit-xml-declaration="yes" indent="yes"/>
 
     <xsl:template match="x:report">
-        <testsuites>
-            <xsl:apply-templates select="x:scenario"/>
+       <testsuites x:original-xspec-location="{@original-xspec-location}">
+           <xsl:apply-templates select="x:scenario"/>
         </testsuites>
     </xsl:template>
-    
+
     <xsl:template match="x:scenario">
         <testsuite>
             <xsl:attribute name="name" select="x:label"/>


### PR DESCRIPTION
Here is a proposal for [issue 80](https://github.com/xspec/xspec/issues/180).
It adds a @x:original-xspec-location in junit report, which is not allowed by [JUnit report Schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd), but as it is in a different namespace, it should not be a problem.