### PR TITLE
Include path to the original XSpec test in all output report formats

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -19,6 +19,10 @@
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/generate-common-tests.xsl</pkg:import-uri>
 
    <xsl:preserve-space elements="x:space"/>
+   
+   <!-- Fix 'file:C:/...' (https://issues.apache.org/jira/browse/XMLCOMMONS-24) -->
+   <xsl:variable name="base-uri" as="xs:string" select="replace(base-uri(), '^(file:)([^/])', '$1/$2')"/>
+   
 
    <!--
        Drive the overall compilation of a suite.  Apply template on

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -113,6 +113,7 @@
          <xsl:if test="exists($query-at)">
             <xsl:attribute name="query-at" select="$query-at"/>
          </xsl:if>
+         <xsl:attribute name="xspec-original-location" select="$base-uri"/>
          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
          <xsl:call-template name="x:call-scenarios"/>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -113,7 +113,7 @@
          <xsl:if test="exists($query-at)">
             <xsl:attribute name="query-at" select="$query-at"/>
          </xsl:if>
-         <xsl:attribute name="xspec-original-location" select="$base-uri"/>
+         <xsl:attribute name="xspec" select="$base-uri"/>
          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
          <xsl:call-template name="x:call-scenarios"/>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -81,6 +81,8 @@
 	        test stylesheet, which can then be picked up by stylesheets that
 	        process *that* to generate a coverage report -->
 	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}">
+	        <xsl:attribute name="xspec-original-location" select="(@xspec-original-location, $base-uri)[1]"/>
+	        <xsl:copy-of select="@schematron"/>
                  <!-- Generate calls to the compiled top-level scenarios. -->
                  <xsl:call-template name="x:call-scenarios"/>
 	      </x:report>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -81,7 +81,7 @@
 	        test stylesheet, which can then be picked up by stylesheets that
 	        process *that* to generate a coverage report -->
 	      <x:report stylesheet="{{$x:stylesheet-uri}}" date="{{current-dateTime()}}">
-	        <xsl:attribute name="xspec-original-location" select="(@xspec-original-location, $base-uri)[1]"/>
+	        <xsl:attribute name="xspec" select="(@xspec-original-location, $base-uri)[1]"/>
 	        <xsl:copy-of select="@schematron"/>
                  <!-- Generate calls to the compiled top-level scenarios. -->
                  <xsl:call-template name="x:call-scenarios"/>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -128,7 +128,7 @@
     <head>
       <title>
          <xsl:text>Test Report for </xsl:text>
-         <xsl:value-of select="x:report/test:format-URI(@stylesheet|@query)"/>
+         <xsl:value-of select="x:report/test:format-URI((@schematron,@stylesheet,@query)[1])"/>
          <xsl:text> (</xsl:text>
          <xsl:call-template name="x:totals">
             <xsl:with-param name="tests" select="//x:scenario/x:test"/>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -166,8 +166,8 @@
   </p>
   <p>
     <xsl:text>XSpec: </xsl:text>
-    <a href="{@xspec-original-location}">
-      <xsl:value-of select="test:format-URI(@xspec-original-location)"/>
+    <a href="{@xspec}">
+      <xsl:value-of select="test:format-URI(@xspec)"/>
     </a>
   </p>
   <p>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -159,10 +159,16 @@
 
 <xsl:template match="x:report" mode="x:html-report">
   <p>
-     <xsl:value-of select="if ( exists(@query) ) then 'Query: ' else 'Stylesheet: '"/>
-     <a href="{ @stylesheet|@query }">
-        <xsl:value-of select="test:format-URI(@stylesheet|@query)"/>
+     <xsl:value-of select="if ( exists(@schematron) ) then 'Schematron: ' else if ( exists(@query) ) then 'Query: ' else 'Stylesheet: '"/>
+     <a href="{ (@schematron, @stylesheet, @query)[1] }">
+       <xsl:value-of select="test:format-URI((@schematron, @stylesheet, @query)[1])"/>
      </a>
+  </p>
+  <p>
+    <xsl:text>XSpec: </xsl:text>
+    <a href="{@xspec-original-location}">
+      <xsl:value-of select="test:format-URI(@xspec-original-location)"/>
+    </a>
   </p>
   <p>
     <xsl:text>Tested: </xsl:text>

--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -29,6 +29,7 @@
 
     <xsl:template match="x:report">
         <testsuites>
+            <xsl:attribute name="name" select="@xspec-original-location"/>
             <xsl:apply-templates select="x:scenario"/>
         </testsuites>
     </xsl:template>

--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -29,7 +29,7 @@
 
     <xsl:template match="x:report">
         <testsuites>
-            <xsl:attribute name="name" select="@xspec-original-location"/>
+            <xsl:attribute name="name" select="@xspec"/>
             <xsl:apply-templates select="x:scenario"/>
         </testsuites>
     </xsl:template>

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -39,6 +39,8 @@
     </xsl:template>
 
     <xsl:template match="@schematron">
+        <xsl:copy/>
+        <xsl:attribute name="xspec-original-location" select="base-uri(.)"/>
         <xsl:attribute name="stylesheet" select="$stylesheet"/>
         <xsl:variable name="path" select="resolve-uri(string(), base-uri())"/>
         <xsl:for-each select="doc($path)/sch:schema/sch:ns" xmlns:sch="http://purl.oclc.org/dsdl/schematron">

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -13,6 +13,9 @@
     <xsl:variable name="warn" select="('warn', 'warning')"/>
     <xsl:variable name="info" select="('info', 'information')"/>
 
+    <!-- Fix 'file:C:/...' (https://issues.apache.org/jira/browse/XMLCOMMONS-24) -->
+    <xsl:variable name="base-uri" as="xs:string" select="replace(base-uri(), '^(file:)([^/])', '$1/$2')"/>
+
 
     <xsl:template match="@* | node()" priority="-2">
         <xsl:copy>
@@ -40,7 +43,7 @@
 
     <xsl:template match="@schematron">
         <xsl:copy/>
-        <xsl:attribute name="xspec-original-location" select="base-uri(.)"/>
+        <xsl:attribute name="xspec-original-location" select="$base-uri"/>
         <xsl:attribute name="stylesheet" select="$stylesheet"/>
         <xsl:variable name="path" select="resolve-uri(string(), base-uri())"/>
         <xsl:for-each select="doc($path)/sch:schema/sch:ns" xmlns:sch="http://purl.oclc.org/dsdl/schematron">

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -27,25 +27,15 @@
         <xsl:element name="x:description">
             <xsl:namespace name="svrl" select="'http://purl.oclc.org/dsdl/svrl'"/>
             <xsl:apply-templates select="@*[not(name() = ('stylesheet'))]"/>
-            <xsl:element name="x:scenario">
-                <xsl:attribute name="label">
-                    <xsl:text>Schematron: "</xsl:text>
-                    <xsl:value-of select="@schematron"/>
-                    <xsl:text>"</xsl:text>
-                    <xsl:if test="x:param[@name='phase']">
-                        <xsl:value-of select="concat(' phase: ', x:param[@name='phase'][1]/(@select,string())[1])"/>
-                    </xsl:if>
-                </xsl:attribute>
-            </xsl:element>
             <xsl:apply-templates select="node()"/>
         </xsl:element>
     </xsl:template>
 
     <xsl:template match="@schematron">
-        <xsl:copy/>
         <xsl:attribute name="xspec-original-location" select="$base-uri"/>
         <xsl:attribute name="stylesheet" select="$stylesheet"/>
         <xsl:variable name="path" select="resolve-uri(string(), base-uri())"/>
+        <xsl:attribute name="schematron" select="$path"/>
         <xsl:for-each select="doc($path)/sch:schema/sch:ns" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
             <xsl:namespace name="{./@prefix}" select="./@uri"/>
         </xsl:for-each>

--- a/test/end-to-end/cases/expected/.gitignore
+++ b/test/end-to-end/cases/expected/.gitignore
@@ -1,3 +1,4 @@
 /*-result.html
 /*.xml
 /*.xsl
+/*.xq

--- a/test/end-to-end/cases/expected/schematron-01-result-norm.html
+++ b/test/end-to-end/cases/expected/schematron-01-result-norm.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for schematron-01.sch-compiled.xsl (passed: 3 / pending: 0 / failed: 0
-         / total: 3)
-      </title>
+      <title>Test Report for schematron-01.sch (passed: 3 / pending: 0 / failed: 0 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron-01-result-norm.html
+++ b/test/end-to-end/cases/expected/schematron-01-result-norm.html
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for schematron-01.sch-compiled.xsl (passed: 3 / pending: 0 / failed: 0
+         / total: 3)
+      </title>
+      <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Schematron: <a href="schematron-01.sch">schematron-01.sch</a></p>
+      <p>XSpec: <a href="schematron-01.xspec">schematron-01.xspec</a></p>
+      <p>Tested: ONCE-UPON-A-TIME</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="75%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 3</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 3</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#ELEM-33">schematron-01</a></th>
+               <th class="totals">3</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">3</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-33">
+         <h2 class="successful">schematron-01<span class="scenario-totals">passed: 3 / pending: 0 / failed: 0 / total: 3</span></h2>
+         <table class="xspec" id="ELEM-35">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>schematron-01</th>
+                  <th>passed: 3 / pending: 0 / failed: 0 / total: 3</th>
+               </tr>
+               <tr class="successful">
+                  <th>article should have a title</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>not assert a001</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>section should have a title</th>
+                  <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>assert a002 /article[1]/section[2]</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <td>assert a002 /article[1]/section[3]</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/xquery-tutorial-result-norm.html
+++ b/test/end-to-end/cases/expected/xquery-tutorial-result-norm.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for www.functx.com (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: <a href="www.functx.com">www.functx.com</a></p>
+      <p>XSpec: <a href="xquery-tutorial.xspec">xquery-tutorial.xspec</a></p>
+      <p>Tested: ONCE-UPON-A-TIME</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="75%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#ELEM-33">Calling function capitalize-first</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-33">
+         <h2 class="successful">Calling function capitalize-first<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="ELEM-35">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>Calling function capitalize-first</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>should capitalize the first character of the string</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/xspec-50-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-50-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-50.xsl">xspec-50.xsl</a></p>
+      <p>XSpec: <a href="xspec-50.xspec">xspec-50.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,7 +27,7 @@
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-31">Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</a></th>
+               <th><a href="#ELEM-33">Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -34,9 +35,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-31">
+      <div id="ELEM-33">
          <h2 class="failed">Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-33">
+         <table class="xspec" id="ELEM-35">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -45,14 +46,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-45">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
+                  <td><a href="#ELEM-47">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
                         and [Expected Result] = "xs:hexBinary('0123')"</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-31">Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</h3>
-         <h4 id="ELEM-45">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
+         <h3 id="ELEM-33">Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</h3>
+         <h4 id="ELEM-47">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
             and [Expected Result] = "xs:hexBinary('0123')"
          </h4>
          <table class="xspecResult">

--- a/test/end-to-end/cases/expected/xspec-55-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-55-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-55.xsl">xspec-55.xsl</a></p>
+      <p>XSpec: <a href="xspec-55.xspec">xspec-55.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,7 +27,7 @@
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-31">In a failure report HTML</a></th>
+               <th><a href="#ELEM-33">In a failure report HTML</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">3</th>
@@ -34,9 +35,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-31">
+      <div id="ELEM-33">
          <h2 class="failed">In a failure report HTML<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
-         <table class="xspec" id="ELEM-33">
+         <table class="xspec" id="ELEM-35">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -45,22 +46,22 @@
                   <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-53">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</a></td>
+                  <td><a href="#ELEM-55">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-65">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
+                  <td><a href="#ELEM-67">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
                         double)</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-77">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</a></td>
+                  <td><a href="#ELEM-79">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-31">In a failure report HTML</h3>
-         <h4 id="ELEM-53">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</h4>
+         <h3 id="ELEM-33">In a failure report HTML</h3>
+         <h4 id="ELEM-55">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -75,7 +76,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-65">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
+         <h4 id="ELEM-67">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
             double)
          </h4>
          <table class="xspecResult">
@@ -92,7 +93,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-77">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</h4>
+         <h4 id="ELEM-79">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-focus-1-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-focus-1-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-focus-1.xspec">xspec-focus-1.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,28 +27,28 @@
          </thead>
          <tbody>
             <tr class="pending">
-               <th>(<strong>testing @focus</strong>) <a href="#PENDING_ELEM-23">an unfocused correct scenario must be Pending</a></th>
+               <th>(<strong>testing @focus</strong>) <a href="#PENDING_ELEM-25">an unfocused correct scenario must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>testing @focus</strong>) <a href="#PENDING_ELEM-31">an unfocused incorrect scenario must be Pending</a></th>
+               <th>(<strong>testing @focus</strong>) <a href="#PENDING_ELEM-33">an unfocused incorrect scenario must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="successful">
-               <th><a href="#ELEM-54">a focused correct scenario</a></th>
+               <th><a href="#ELEM-56">a focused correct scenario</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-67">a focused incorrect scenario</a></th>
+               <th><a href="#ELEM-69">a focused incorrect scenario</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -55,9 +56,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-54">
+      <div id="ELEM-56">
          <h2 class="successful">a focused correct scenario<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-56">
+         <table class="xspec" id="ELEM-58">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -72,9 +73,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-67">
+      <div id="ELEM-69">
          <h2 class="failed">a focused incorrect scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-69">
+         <table class="xspec" id="ELEM-71">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -83,13 +84,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-81">must execute the test and return Failure</a></td>
+                  <td><a href="#ELEM-83">must execute the test and return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-67">a focused incorrect scenario</h3>
-         <h4 id="ELEM-81">must execute the test and return Failure</h4>
+         <h3 id="ELEM-69">a focused incorrect scenario</h3>
+         <h4 id="ELEM-83">must execute the test and return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-function-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-function-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-function.xspec">xspec-function.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,14 +27,14 @@
          </thead>
          <tbody>
             <tr class="successful">
-               <th><a href="#ELEM-38">when calling a function and expecting correctly</a></th>
+               <th><a href="#ELEM-40">when calling a function and expecting correctly</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-54">when calling a function and expecting incorrectly</a></th>
+               <th><a href="#ELEM-56">when calling a function and expecting incorrectly</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
@@ -41,9 +42,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-38">
+      <div id="ELEM-40">
          <h2 class="successful">when calling a function and expecting correctly<span class="scenario-totals">passed: 2 / pending: 0 / failed: 0 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-40">
+         <table class="xspec" id="ELEM-42">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -62,9 +63,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-54">
+      <div id="ELEM-56">
          <h2 class="failed">when calling a function and expecting incorrectly<span class="scenario-totals">passed: 0 / pending: 0 / failed: 2 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-56">
+         <table class="xspec" id="ELEM-58">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -73,17 +74,17 @@
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-72">expecting an incorrect value must return Failure</a></td>
+                  <td><a href="#ELEM-74">expecting an incorrect value must return Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-84">expecting an incorrect type must return Failure</a></td>
+                  <td><a href="#ELEM-86">expecting an incorrect type must return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-54">when calling a function and expecting incorrectly</h3>
-         <h4 id="ELEM-72">expecting an incorrect value must return Failure</h4>
+         <h3 id="ELEM-56">when calling a function and expecting incorrectly</h3>
+         <h4 id="ELEM-74">expecting an incorrect value must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -98,7 +99,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-84">expecting an incorrect type must return Failure</h4>
+         <h4 id="ELEM-86">expecting an incorrect type must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-import-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-import-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-import.xspec">xspec-import.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,28 +27,28 @@
          </thead>
          <tbody>
             <tr class="successful">
-               <th><a href="#ELEM-52">when testing a correct scenario in an importing file</a></th>
+               <th><a href="#ELEM-54">when testing a correct scenario in an importing file</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-68">when testing an incorrect scenario in an importing file</a></th>
+               <th><a href="#ELEM-70">when testing an incorrect scenario in an importing file</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="successful">
-               <th><a href="#ELEM-95">a correct scenario in an imported file</a></th>
+               <th><a href="#ELEM-97">a correct scenario in an imported file</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-108">an incorrect scenario in an imported file</a></th>
+               <th><a href="#ELEM-110">an incorrect scenario in an imported file</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -55,9 +56,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-52">
+      <div id="ELEM-54">
          <h2 class="successful">when testing a correct scenario in an importing file<span class="scenario-totals">passed: 2 / pending: 0 / failed: 0 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-54">
+         <table class="xspec" id="ELEM-56">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -76,9 +77,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-68">
+      <div id="ELEM-70">
          <h2 class="failed">when testing an incorrect scenario in an importing file<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-70">
+         <table class="xspec" id="ELEM-72">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -87,13 +88,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-82">it must return Failure</a></td>
+                  <td><a href="#ELEM-84">it must return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-68">when testing an incorrect scenario in an importing file</h3>
-         <h4 id="ELEM-82">it must return Failure</h4>
+         <h3 id="ELEM-70">when testing an incorrect scenario in an importing file</h3>
+         <h4 id="ELEM-84">it must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -109,9 +110,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-95">
+      <div id="ELEM-97">
          <h2 class="successful">a correct scenario in an imported file<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-97">
+         <table class="xspec" id="ELEM-99">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -126,9 +127,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-108">
+      <div id="ELEM-110">
          <h2 class="failed">an incorrect scenario in an imported file<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-110">
+         <table class="xspec" id="ELEM-112">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -137,13 +138,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-122">must return Failure</a></td>
+                  <td><a href="#ELEM-124">must return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-108">an incorrect scenario in an imported file</h3>
-         <h4 id="ELEM-122">must return Failure</h4>
+         <h3 id="ELEM-110">an incorrect scenario in an imported file</h3>
+         <h4 id="ELEM-124">must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-imported-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-imported-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-imported.xspec">xspec-imported.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,14 +27,14 @@
          </thead>
          <tbody>
             <tr class="successful">
-               <th><a href="#ELEM-38">a correct scenario in an imported file</a></th>
+               <th><a href="#ELEM-40">a correct scenario in an imported file</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-51">an incorrect scenario in an imported file</a></th>
+               <th><a href="#ELEM-53">an incorrect scenario in an imported file</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -41,9 +42,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-38">
+      <div id="ELEM-40">
          <h2 class="successful">a correct scenario in an imported file<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-40">
+         <table class="xspec" id="ELEM-42">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -58,9 +59,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-51">
+      <div id="ELEM-53">
          <h2 class="failed">an incorrect scenario in an imported file<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-53">
+         <table class="xspec" id="ELEM-55">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -69,13 +70,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-65">must return Failure</a></td>
+                  <td><a href="#ELEM-67">must return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-51">an incorrect scenario in an imported file</h3>
-         <h4 id="ELEM-65">must return Failure</h4>
+         <h3 id="ELEM-53">an incorrect scenario in an imported file</h3>
+         <h4 id="ELEM-67">must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-pending-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-pending-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-pending.xspec">xspec-pending.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,42 +27,42 @@
          </thead>
          <tbody>
             <tr class="pending">
-               <th>(<strong>testing x:pending</strong>) <a href="#PENDING_ELEM-23">a correct scenario in x:pending must be Pending</a></th>
+               <th>(<strong>testing x:pending</strong>) <a href="#PENDING_ELEM-25">a correct scenario in x:pending must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>testing x:pending</strong>) <a href="#PENDING_ELEM-31">an incorrect scenario in x:pending must be Pending</a></th>
+               <th>(<strong>testing x:pending</strong>) <a href="#PENDING_ELEM-33">an incorrect scenario in x:pending must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="successful">
-               <th><a href="#ELEM-70">a non-pending correct scenario alongside a pending scenario</a></th>
+               <th><a href="#ELEM-72">a non-pending correct scenario alongside a pending scenario</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-83">a non-pending incorrect scenario alongside a pending scenario</a></th>
+               <th><a href="#ELEM-85">a non-pending incorrect scenario alongside a pending scenario</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>testing @pending</strong>) <a href="#PENDING_ELEM-53">a correct scenario with @pending must be Pending</a></th>
+               <th>(<strong>testing @pending</strong>) <a href="#PENDING_ELEM-55">a correct scenario with @pending must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>testing @pending</strong>) <a href="#PENDING_ELEM-61">an incorrect scenario with @pending must be Pending</a></th>
+               <th>(<strong>testing @pending</strong>) <a href="#PENDING_ELEM-63">an incorrect scenario with @pending must be Pending</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
@@ -69,9 +70,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-70">
+      <div id="ELEM-72">
          <h2 class="successful">a non-pending correct scenario alongside a pending scenario<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-72">
+         <table class="xspec" id="ELEM-74">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -86,9 +87,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-83">
+      <div id="ELEM-85">
          <h2 class="failed">a non-pending incorrect scenario alongside a pending scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-85">
+         <table class="xspec" id="ELEM-87">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -97,13 +98,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-97">must execute the test and return Failure</a></td>
+                  <td><a href="#ELEM-99">must execute the test and return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-83">a non-pending incorrect scenario alongside a pending scenario</h3>
-         <h4 id="ELEM-97">must execute the test and return Failure</h4>
+         <h3 id="ELEM-85">a non-pending incorrect scenario alongside a pending scenario</h3>
+         <h4 id="ELEM-99">must execute the test and return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-rule-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-rule-result-norm.html
@@ -7,6 +7,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="xspec-rule.xspec">xspec-rule.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -26,28 +27,28 @@
          </thead>
          <tbody>
             <tr class="successful">
-               <th><a href="#ELEM-54">x:context with correct x:expect</a></th>
+               <th><a href="#ELEM-56">x:context with correct x:expect</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-67">x:context with incorrect x:expect</a></th>
+               <th><a href="#ELEM-69">x:context with incorrect x:expect</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>not implemented yet</strong>) <a href="#PENDING_ELEM-37">x:apply with correct x:expect</a></th>
+               <th>(<strong>not implemented yet</strong>) <a href="#PENDING_ELEM-39">x:apply with correct x:expect</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
             <tr class="pending">
-               <th>(<strong>not implemented yet</strong>) <a href="#PENDING_ELEM-45">x:apply with incorrect x:expect</a></th>
+               <th>(<strong>not implemented yet</strong>) <a href="#PENDING_ELEM-47">x:apply with incorrect x:expect</a></th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">0</th>
@@ -55,9 +56,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-54">
+      <div id="ELEM-56">
          <h2 class="successful">x:context with correct x:expect<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-56">
+         <table class="xspec" id="ELEM-58">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -72,9 +73,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-67">
+      <div id="ELEM-69">
          <h2 class="failed">x:context with incorrect x:expect<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-69">
+         <table class="xspec" id="ELEM-71">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -83,13 +84,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-81">must return Failure</a></td>
+                  <td><a href="#ELEM-83">must return Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-67">x:context with incorrect x:expect</h3>
-         <h4 id="ELEM-81">must return Failure</h4>
+         <h3 id="ELEM-69">x:context with incorrect x:expect</h3>
+         <h4 id="ELEM-83">must return Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/expected/xspec-three-dots-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-three-dots-result-norm.html
@@ -9,6 +9,7 @@
    <body>
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="xspec-three-dots.xsl">xspec-three-dots.xsl</a></p>
+      <p>XSpec: <a href="xspec-three-dots.xspec">xspec-three-dots.xspec</a></p>
       <p>Tested: ONCE-UPON-A-TIME</p>
       <h2>Contents</h2>
       <table class="xspec">
@@ -28,91 +29,91 @@
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-115">For resultant element (simple)</a></th>
+               <th><a href="#ELEM-117">For resultant element (simple)</a></th>
                <th class="totals">5</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-192">For resultant element (with attribute)</a></th>
+               <th><a href="#ELEM-194">For resultant element (with attribute)</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">3</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-233">For resultant element (with mixed content)</a></th>
+               <th><a href="#ELEM-235">For resultant element (with mixed content)</a></th>
                <th class="totals">4</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">5</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-284">For resultant attribute</a></th>
+               <th><a href="#ELEM-286">For resultant attribute</a></th>
                <th class="totals">5</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-344">For resultant text node</a></th>
+               <th><a href="#ELEM-346">For resultant text node</a></th>
                <th class="totals">4</th>
                <th class="totals">0</th>
                <th class="totals">5</th>
                <th class="totals">9</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-490">For resultant comment</a></th>
+               <th><a href="#ELEM-492">For resultant comment</a></th>
                <th class="totals">5</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-548">For resultant processing instruction</a></th>
+               <th><a href="#ELEM-550">For resultant processing instruction</a></th>
                <th class="totals">5</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-606">For resultant document node</a></th>
+               <th><a href="#ELEM-608">For resultant document node</a></th>
                <th class="totals">5</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-685">For resultant namespace node (TODO: xspec/xspec#67)</a></th>
+               <th><a href="#ELEM-687">For resultant namespace node (TODO: xspec/xspec#67)</a></th>
                <th class="totals">3</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-783">For resultant sequence of multiple nodes</a></th>
+               <th><a href="#ELEM-785">For resultant sequence of multiple nodes</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">3</th>
                <th class="totals">5</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-867">When result is empty sequence</a></th>
+               <th><a href="#ELEM-869">When result is empty sequence</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-897">For resultant atomic value</a></th>
+               <th><a href="#ELEM-899">For resultant atomic value</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-993">For any resultant item</a></th>
+               <th><a href="#ELEM-995">For any resultant item</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
@@ -120,9 +121,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-115">
+      <div id="ELEM-117">
          <h2 class="successful">For resultant element (simple)<span class="scenario-totals">passed: 5 / pending: 0 / failed: 2 / total: 7</span></h2>
-         <table class="xspec" id="ELEM-117">
+         <table class="xspec" id="ELEM-119">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -143,7 +144,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-158">When result is &lt;elem /&gt; </a></th>
+                  <th><a href="#ELEM-160">When result is &lt;elem /&gt; </a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -151,11 +152,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-159">expecting &lt;elem attrib="..." /&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-161">expecting &lt;elem attrib="..." /&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-174">When result is &lt;elem&gt;...&lt;/elem&gt; </a></th>
+                  <th><a href="#ELEM-176">When result is &lt;elem&gt;...&lt;/elem&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -167,13 +168,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-175">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-177">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-158">For resultant element (simple) When result is &lt;elem /&gt; </h3>
-         <h4 id="ELEM-159">expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
+         <h3 id="ELEM-160">For resultant element (simple) When result is &lt;elem /&gt; </h3>
+         <h4 id="ELEM-161">expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -188,8 +189,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-174">For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt; </h3>
-         <h4 id="ELEM-175">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
+         <h3 id="ELEM-176">For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt; </h3>
+         <h4 id="ELEM-177">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -205,9 +206,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-192">
+      <div id="ELEM-194">
          <h2 class="successful">For resultant element (with attribute)<span class="scenario-totals">passed: 2 / pending: 0 / failed: 1 / total: 3</span></h2>
-         <table class="xspec" id="ELEM-194">
+         <table class="xspec" id="ELEM-196">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -216,7 +217,7 @@
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-215">When result is &lt;elem attrib="val" /&gt; </a></th>
+                  <th><a href="#ELEM-217">When result is &lt;elem attrib="val" /&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -228,13 +229,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-216">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-218">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-215">For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt; </h3>
-         <h4 id="ELEM-216">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
+         <h3 id="ELEM-217">For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt; </h3>
+         <h4 id="ELEM-218">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -250,9 +251,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-233">
+      <div id="ELEM-235">
          <h2 class="successful">For resultant element (with mixed content)<span class="scenario-totals">passed: 4 / pending: 0 / failed: 1 / total: 5</span></h2>
-         <table class="xspec" id="ELEM-235">
+         <table class="xspec" id="ELEM-237">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -277,7 +278,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-265">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt; </a></th>
+                  <th><a href="#ELEM-267">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt; </a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -285,15 +286,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-266">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-268">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-265">For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
+         <h3 id="ELEM-267">For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
             
          </h3>
-         <h4 id="ELEM-266">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
+         <h4 id="ELEM-268">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -312,9 +313,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-284">
+      <div id="ELEM-286">
          <h2 class="successful">For resultant attribute<span class="scenario-totals">passed: 5 / pending: 0 / failed: 1 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-286">
+         <table class="xspec" id="ELEM-288">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -343,7 +344,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-322">When result is @attrib="..." </a></th>
+                  <th><a href="#ELEM-324">When result is @attrib="..." </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -355,13 +356,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-323">expecting @attrib="val" should be Failure</a></td>
+                  <td><a href="#ELEM-325">expecting @attrib="val" should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-322">For resultant attribute When result is @attrib="..." </h3>
-         <h4 id="ELEM-323">expecting @attrib="val" should be Failure</h4>
+         <h3 id="ELEM-324">For resultant attribute When result is @attrib="..." </h3>
+         <h4 id="ELEM-325">expecting @attrib="val" should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -381,9 +382,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-344">
+      <div id="ELEM-346">
          <h2 class="successful">For resultant text node<span class="scenario-totals">passed: 4 / pending: 0 / failed: 5 / total: 9</span></h2>
-         <table class="xspec" id="ELEM-346">
+         <table class="xspec" id="ELEM-348">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -392,7 +393,7 @@
                   <th>passed: 4 / pending: 0 / failed: 5 / total: 9</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-401">When result is usual text node</a></th>
+                  <th><a href="#ELEM-403">When result is usual text node</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -400,11 +401,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-402">expecting '...' should be Failure</a></td>
+                  <td><a href="#ELEM-404">expecting '...' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-417">When result is whitespace-only text node</a></th>
+                  <th><a href="#ELEM-419">When result is whitespace-only text node</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -412,11 +413,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-418">expecting usual text node should be Failure</a></td>
+                  <td><a href="#ELEM-420">expecting usual text node should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-436">When result is zero-length text node</a></th>
+                  <th><a href="#ELEM-438">When result is zero-length text node</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -424,11 +425,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-437">expecting usual text node should be Failure</a></td>
+                  <td><a href="#ELEM-439">expecting usual text node should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-455">When result is three-dot text node</a></th>
+                  <th><a href="#ELEM-457">When result is three-dot text node</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -436,17 +437,17 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-456">expecting usual text node should be Failure</a></td>
+                  <td><a href="#ELEM-458">expecting usual text node should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-474">expecting '...' should be Failure</a></td>
+                  <td><a href="#ELEM-476">expecting '...' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-401">For resultant text node When result is usual text node</h3>
-         <h4 id="ELEM-402">expecting '...' should be Failure</h4>
+         <h3 id="ELEM-403">For resultant text node When result is usual text node</h3>
+         <h4 id="ELEM-404">expecting '...' should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -463,8 +464,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-417">For resultant text node When result is whitespace-only text node</h3>
-         <h4 id="ELEM-418">expecting usual text node should be Failure</h4>
+         <h3 id="ELEM-419">For resultant text node When result is whitespace-only text node</h3>
+         <h4 id="ELEM-420">expecting usual text node should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -483,8 +484,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-436">For resultant text node When result is zero-length text node</h3>
-         <h4 id="ELEM-437">expecting usual text node should be Failure</h4>
+         <h3 id="ELEM-438">For resultant text node When result is zero-length text node</h3>
+         <h4 id="ELEM-439">expecting usual text node should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -503,8 +504,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-455">For resultant text node When result is three-dot text node</h3>
-         <h4 id="ELEM-456">expecting usual text node should be Failure</h4>
+         <h3 id="ELEM-457">For resultant text node When result is three-dot text node</h3>
+         <h4 id="ELEM-458">expecting usual text node should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -523,7 +524,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-474">expecting '...' should be Failure</h4>
+         <h4 id="ELEM-476">expecting '...' should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -541,9 +542,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-490">
+      <div id="ELEM-492">
          <h2 class="successful">For resultant comment<span class="scenario-totals">passed: 5 / pending: 0 / failed: 1 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-492">
+         <table class="xspec" id="ELEM-494">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -572,7 +573,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-528">When result is &lt;!--...--&gt; </a></th>
+                  <th><a href="#ELEM-530">When result is &lt;!--...--&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -584,13 +585,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-529">expecting &lt;!--comment--&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-531">expecting &lt;!--comment--&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-528">For resultant comment When result is &lt;!--...--&gt; </h3>
-         <h4 id="ELEM-529">expecting &lt;!--comment--&gt; should be Failure</h4>
+         <h3 id="ELEM-530">For resultant comment When result is &lt;!--...--&gt; </h3>
+         <h4 id="ELEM-531">expecting &lt;!--comment--&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -610,9 +611,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-548">
+      <div id="ELEM-550">
          <h2 class="successful">For resultant processing instruction<span class="scenario-totals">passed: 5 / pending: 0 / failed: 1 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-550">
+         <table class="xspec" id="ELEM-552">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -641,7 +642,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-586">When result is &lt;?pi ...?&gt; </a></th>
+                  <th><a href="#ELEM-588">When result is &lt;?pi ...?&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -653,13 +654,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-587">expecting &lt;?pi data?&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-589">expecting &lt;?pi data?&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-586">For resultant processing instruction When result is &lt;?pi ...?&gt; </h3>
-         <h4 id="ELEM-587">expecting &lt;?pi data?&gt; should be Failure</h4>
+         <h3 id="ELEM-588">For resultant processing instruction When result is &lt;?pi ...?&gt; </h3>
+         <h4 id="ELEM-589">expecting &lt;?pi data?&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -679,9 +680,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-606">
+      <div id="ELEM-608">
          <h2 class="successful">For resultant document node<span class="scenario-totals">passed: 5 / pending: 0 / failed: 2 / total: 7</span></h2>
-         <table class="xspec" id="ELEM-608">
+         <table class="xspec" id="ELEM-610">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -702,7 +703,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-649">When result is &lt;xsl:document /&gt; </a></th>
+                  <th><a href="#ELEM-651">When result is &lt;xsl:document /&gt; </a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -710,11 +711,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-650">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-652">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-665">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#ELEM-667">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -726,13 +727,13 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-666">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-668">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-649">For resultant document node When result is &lt;xsl:document /&gt; </h3>
-         <h4 id="ELEM-650">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
+         <h3 id="ELEM-651">For resultant document node When result is &lt;xsl:document /&gt; </h3>
+         <h4 id="ELEM-652">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -749,8 +750,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-665">For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
-         <h4 id="ELEM-666">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
+         <h3 id="ELEM-667">For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
+         <h4 id="ELEM-668">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -770,9 +771,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-685">
+      <div id="ELEM-687">
          <h2 class="successful">For resultant namespace node (TODO: xspec/xspec#67)<span class="scenario-totals">passed: 3 / pending: 0 / failed: 4 / total: 7</span></h2>
-         <table class="xspec" id="ELEM-687">
+         <table class="xspec" id="ELEM-689">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -781,11 +782,11 @@
                   <th>passed: 3 / pending: 0 / failed: 4 / total: 7</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-731">When result is xmlns:prefix="namespace-uri" </a></th>
+                  <th><a href="#ELEM-733">When result is xmlns:prefix="namespace-uri" </a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-732">expecting xmlns:prefix="..." should be Success</a></td>
+                  <td><a href="#ELEM-734">expecting xmlns:prefix="..." should be Success</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -793,11 +794,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-744">When result is xmlns="namespace-uri" </a></th>
+                  <th><a href="#ELEM-746">When result is xmlns="namespace-uri" </a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-745">expecting xmlns="..." should be Success</a></td>
+                  <td><a href="#ELEM-747">expecting xmlns="..." should be Success</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -805,11 +806,11 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-757">When result is xmlns:prefix="..." </a></th>
+                  <th><a href="#ELEM-759">When result is xmlns:prefix="..." </a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-758">expecting xmlns:prefix="..." should be Success</a></td>
+                  <td><a href="#ELEM-760">expecting xmlns:prefix="..." should be Success</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -817,15 +818,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-770">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
+                  <td><a href="#ELEM-772">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-731">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns:prefix="namespace-uri"
+         <h3 id="ELEM-733">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns:prefix="namespace-uri"
             
          </h3>
-         <h4 id="ELEM-732">expecting xmlns:prefix="..." should be Success</h4>
+         <h4 id="ELEM-734">expecting xmlns:prefix="..." should be Success</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -840,10 +841,10 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-744">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns="namespace-uri"
+         <h3 id="ELEM-746">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns="namespace-uri"
             
          </h3>
-         <h4 id="ELEM-745">expecting xmlns="..." should be Success</h4>
+         <h4 id="ELEM-747">expecting xmlns="..." should be Success</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -858,10 +859,10 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-757">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns:prefix="..."
+         <h3 id="ELEM-759">For resultant namespace node (TODO: xspec/xspec#67) When result is xmlns:prefix="..."
             
          </h3>
-         <h4 id="ELEM-758">expecting xmlns:prefix="..." should be Success</h4>
+         <h4 id="ELEM-760">expecting xmlns:prefix="..." should be Success</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -876,7 +877,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-770">expecting xmlns:prefix="namespace-uri" should be Failure</h4>
+         <h4 id="ELEM-772">expecting xmlns:prefix="namespace-uri" should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -892,9 +893,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-783">
+      <div id="ELEM-785">
          <h2 class="successful">For resultant sequence of multiple nodes<span class="scenario-totals">passed: 2 / pending: 0 / failed: 3 / total: 5</span></h2>
-         <table class="xspec" id="ELEM-785">
+         <table class="xspec" id="ELEM-787">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -903,7 +904,7 @@
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-814">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
+                  <th><a href="#ELEM-816">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="successful">
@@ -915,23 +916,23 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-815">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-817">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-832">expecting ...... should be Failure</a></td>
+                  <td><a href="#ELEM-834">expecting ...... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-849">expecting sequence of three ... should be Failure</a></td>
+                  <td><a href="#ELEM-851">expecting sequence of three ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-814">For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
+         <h3 id="ELEM-816">For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
             /&gt; 
          </h3>
-         <h4 id="ELEM-815">expecting ... should be Failure</h4>
+         <h4 id="ELEM-817">expecting ... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -948,7 +949,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-832">expecting ...... should be Failure</h4>
+         <h4 id="ELEM-834">expecting ...... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -965,7 +966,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-849">expecting sequence of three ... should be Failure</h4>
+         <h4 id="ELEM-851">expecting sequence of three ... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -983,9 +984,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-867">
+      <div id="ELEM-869">
          <h2 class="failed">When result is empty sequence<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-869">
+         <table class="xspec" id="ELEM-871">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -994,13 +995,13 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-881">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-883">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-867">When result is empty sequence</h3>
-         <h4 id="ELEM-881">expecting ... should be Failure</h4>
+         <h3 id="ELEM-869">When result is empty sequence</h3>
+         <h4 id="ELEM-883">expecting ... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1018,9 +1019,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-897">
+      <div id="ELEM-899">
          <h2 class="successful">For resultant atomic value<span class="scenario-totals">passed: 2 / pending: 0 / failed: 4 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-899">
+         <table class="xspec" id="ELEM-901">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -1029,7 +1030,7 @@
                   <th>passed: 2 / pending: 0 / failed: 4 / total: 6</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-936">When result is 'string'</a></th>
+                  <th><a href="#ELEM-938">When result is 'string'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1037,15 +1038,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-937">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-939">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-952">expecting '...' should be Failure</a></td>
+                  <td><a href="#ELEM-954">expecting '...' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-964">When result is '...'</a></th>
+                  <th><a href="#ELEM-966">When result is '...'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1053,17 +1054,17 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-965">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-967">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-980">expecting 'string' should be Failure</a></td>
+                  <td><a href="#ELEM-982">expecting 'string' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-936">For resultant atomic value When result is 'string'</h3>
-         <h4 id="ELEM-937">expecting ... should be Failure</h4>
+         <h3 id="ELEM-938">For resultant atomic value When result is 'string'</h3>
+         <h4 id="ELEM-939">expecting ... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1080,7 +1081,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-952">expecting '...' should be Failure</h4>
+         <h4 id="ELEM-954">expecting '...' should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1095,8 +1096,8 @@
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-964">For resultant atomic value When result is '...'</h3>
-         <h4 id="ELEM-965">expecting ... should be Failure</h4>
+         <h3 id="ELEM-966">For resultant atomic value When result is '...'</h3>
+         <h4 id="ELEM-967">expecting ... should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1113,7 +1114,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-980">expecting 'string' should be Failure</h4>
+         <h4 id="ELEM-982">expecting 'string' should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1129,9 +1130,9 @@
             </tbody>
          </table>
       </div>
-      <div id="ELEM-993">
+      <div id="ELEM-995">
          <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 4 / total: 4</span></h2>
-         <table class="xspec" id="ELEM-995">
+         <table class="xspec" id="ELEM-997">
             <col width="75%" />
             <col width="25%" />
             <tbody>
@@ -1140,25 +1141,25 @@
                   <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1019">expecting .... (four dots) should be Failure</a></td>
+                  <td><a href="#ELEM-1021">expecting .... (four dots) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1037">expecting ...x (three dots with extra character) should be Failure</a></td>
+                  <td><a href="#ELEM-1039">expecting ...x (three dots with extra character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1055">expecting ... with surrounding whitespace should be Failure</a></td>
+                  <td><a href="#ELEM-1057">expecting ... with surrounding whitespace should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1073">expecting '...' (xs:string) should be Failure</a></td>
+                  <td><a href="#ELEM-1075">expecting '...' (xs:string) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <h3 id="ELEM-993">For any resultant item</h3>
-         <h4 id="ELEM-1019">expecting .... (four dots) should be Failure</h4>
+         <h3 id="ELEM-995">For any resultant item</h3>
+         <h4 id="ELEM-1021">expecting .... (four dots) should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1177,7 +1178,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-1037">expecting ...x (three dots with extra character) should be Failure</h4>
+         <h4 id="ELEM-1039">expecting ...x (three dots with extra character) should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1196,7 +1197,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-1055">expecting ... with surrounding whitespace should be Failure</h4>
+         <h4 id="ELEM-1057">expecting ... with surrounding whitespace should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>
@@ -1215,7 +1216,7 @@
                </tr>
             </tbody>
          </table>
-         <h4 id="ELEM-1073">expecting '...' (xs:string) should be Failure</h4>
+         <h4 id="ELEM-1075">expecting '...' (xs:string) should be Failure</h4>
          <table class="xspecResult">
             <thead>
                <tr>

--- a/test/end-to-end/cases/schematron-01.sch
+++ b/test/end-to-end/cases/schematron-01.sch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    
+    <sch:pattern>
+        <sch:rule context="article">
+            <sch:assert test="title" id="a001">
+                article should have a title
+            </sch:assert>
+        </sch:rule>
+        <sch:rule context="section">
+            <sch:assert test="title" id="a002">
+                section should have a title
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+</sch:schema>

--- a/test/end-to-end/cases/schematron-01.xml
+++ b/test/end-to-end/cases/schematron-01.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<article>
+    <title>Example</title>
+    <section>
+        <title>Introduction</title>
+        <p>Welcome to demo 3!</p>
+    </section>
+    <section>
+        <p>This is an example.</p>
+    </section>
+    <section>
+        <p>Scenario excpect's can specify a location in the context XML that an assert or report is expected to identify.</p>
+    </section>
+</article>

--- a/test/end-to-end/cases/schematron-01.xspec
+++ b/test/end-to-end/cases/schematron-01.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="schematron-01.sch">
+    <x:scenario label="schematron-01">
+        <x:context href="schematron-01.xml"/>
+        <x:scenario label="article should have a title">
+            <x:expect-not-assert id="a001"/>
+        </x:scenario>
+        <x:scenario label="section should have a title">
+            <x:expect-assert id="a002" location="/article[1]/section[2]"/>
+            <x:expect-assert id="a002" location="/article[1]/section[3]"/>
+        </x:scenario>
+    </x:scenario>
+</x:description>

--- a/test/end-to-end/cases/xquery-tutorial.xq
+++ b/test/end-to-end/cases/xquery-tutorial.xq
@@ -1,0 +1,8 @@
+module namespace functx = "http://www.functx.com";
+
+declare function functx:capitalize-first
+($arg as xs:string?) as xs:string? {
+    
+    concat(upper-case(substring($arg, 1, 1)),
+    substring($arg, 2))
+};

--- a/test/end-to-end/cases/xquery-tutorial.xspec
+++ b/test/end-to-end/cases/xquery-tutorial.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" 
+               xmlns:functx="http://www.functx.com"
+               query="http://www.functx.com" 
+               query-at="xquery-tutorial.xq">
+
+  <x:scenario label="Calling function capitalize-first">
+    <x:call function="functx:capitalize-first">
+      <x:param select="'hello'"/>
+    </x:call>
+
+    <x:expect label="should capitalize the first character of the string" select="'Hello'"/>
+
+  </x:scenario>
+
+</x:description>

--- a/test/end-to-end/generate-expected.cmd
+++ b/test/end-to-end/generate-expected.cmd
@@ -37,7 +37,14 @@ for %%I in ("%CASES_DIR%\*.xspec") do (
     rem
     rem Generate the report HTML
     rem
-    "%COMSPEC%" /c ..\..\bin\xspec.bat "%%~I"
+    call :check_test_type "%%~nI"
+    if errorlevel 2 (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat -s "%%~I"
+    ) else if errorlevel 1 (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat -q "%%~I"
+    ) else (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat "%%~I"
+    )
 
     rem
     rem Normalize the report HTML
@@ -49,3 +56,19 @@ rem
 rem Go back to the initial directory
 rem
 popd
+
+rem
+rem Exit as success
+rem
+exit /b 0
+
+:check_test_type
+    set var=%~1
+    if "%var:~0,6%"=="xquery" (
+        set TEST_TYPE=1
+    ) else if "%var:~0,10%"=="schematron" (
+        set TEST_TYPE=2
+    ) else (
+        set TEST_TYPE=0
+    )
+    exit /b %TEST_TYPE%

--- a/test/end-to-end/generate-expected.sh
+++ b/test/end-to-end/generate-expected.sh
@@ -16,7 +16,13 @@ do
     echo "Processing ${CASE_FILEPATH}..."
 
     # Generate the report HTML
-    ../../bin/xspec.sh ${CASE_FILEPATH}
+    if test "${CASE_FILEPATH:0:10}" = "schematron"; then
+        ../../bin/xspec.sh -s ${CASE_FILEPATH}
+    elif test "${CASE_FILEPATH:0:6}" = "xquery"; then
+        ../../bin/xspec.sh -q ${CASE_FILEPATH}
+    else
+        ../../bin/xspec.sh ${CASE_FILEPATH}
+    fi
 
     # Normalize the report HTML
     CASE_FILENAME=${CASE_FILEPATH##*/}

--- a/test/end-to-end/generate-expected.sh
+++ b/test/end-to-end/generate-expected.sh
@@ -15,17 +15,18 @@ do
     echo "----------"
     echo "Processing ${CASE_FILEPATH}..."
 
+    CASE_FILENAME=${CASE_FILEPATH##*/}
+    CASE_BASENAME=${CASE_FILENAME%.xspec}
+
     # Generate the report HTML
-    if test "${CASE_FILEPATH:0:10}" = "schematron"; then
+    if test "${CASE_FILENAME:0:10}" = "schematron"; then
         ../../bin/xspec.sh -s ${CASE_FILEPATH}
-    elif test "${CASE_FILEPATH:0:6}" = "xquery"; then
+    elif test "${CASE_FILENAME:0:6}" = "xquery"; then
         ../../bin/xspec.sh -q ${CASE_FILEPATH}
     else
         ../../bin/xspec.sh ${CASE_FILEPATH}
     fi
 
     # Normalize the report HTML
-    CASE_FILENAME=${CASE_FILEPATH##*/}
-    CASE_BASENAME=${CASE_FILENAME%.xspec}
     java -classpath ${SAXON_CP} net.sf.saxon.Transform -o:${TEST_DIR}/${CASE_BASENAME}-result-norm.html -s:${TEST_DIR}/${CASE_BASENAME}-result.html -xsl:processor/normalize.xsl
 done

--- a/test/end-to-end/processor/_normalizer.xsl
+++ b/test/end-to-end/processor/_normalizer.xsl
@@ -81,7 +81,7 @@
 				in:		<a href="file:/path/to/tested.xsl">/path/to/tested.xsl</a>
 				out:	<a href="tested.xsl">tested.xsl</a>
 	-->
-	<xsl:template as="element(a)" match="/html/body/p[1]/a" mode="local:normalize">
+	<xsl:template as="element(a)" match="/html/body/p[1 or 2]/a" mode="local:normalize">
 		<xsl:copy>
 			<xsl:apply-templates mode="#current" select="attribute()" />
 			<xsl:attribute name="href" select="util:filename-and-extension(@href)" />
@@ -96,7 +96,7 @@
 				in:		<p>Tested: 23 February 2017 at 11:18</p>
 				out:	<p>Tested: ONCE-UPON-A-TIME</p>
 	-->
-	<xsl:template as="text()" match="/html/body/p[2]/text()" mode="local:normalize">
+	<xsl:template as="text()" match="/html/body/p[3]/text()" mode="local:normalize">
 		<!-- Use analyze-string() so that the transformation will fail when nothing matches -->
 		<xsl:analyze-string regex="^(Tested:) .+$" select=".">
 			<xsl:matching-substring>

--- a/test/end-to-end/processor/_normalizer.xsl
+++ b/test/end-to-end/processor/_normalizer.xsl
@@ -81,7 +81,7 @@
 				in:		<a href="file:/path/to/tested.xsl">/path/to/tested.xsl</a>
 				out:	<a href="tested.xsl">tested.xsl</a>
 	-->
-	<xsl:template as="element(a)" match="/html/body/p[1 or 2]/a" mode="local:normalize">
+	<xsl:template as="element(a)" match="/html/body/p[position() = (1, 2)]/a" mode="local:normalize">
 		<xsl:copy>
 			<xsl:apply-templates mode="#current" select="attribute()" />
 			<xsl:attribute name="href" select="util:filename-and-extension(@href)" />

--- a/test/end-to-end/run-e2e-tests.cmd
+++ b/test/end-to-end/run-e2e-tests.cmd
@@ -35,7 +35,14 @@ for %%I in ("%CASES_DIR%\*.xspec") do (
     rem
     rem Generate the report HTML
     rem
-    "%COMSPEC%" /c ..\..\bin\xspec.bat "%%~I" > NUL 2>&1
+    call :check_test_type "%%~nI"
+    if errorlevel 2 (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat -s "%%~I" > NUL 2>&1
+    ) else if errorlevel 1 (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat -q "%%~I" > NUL 2>&1
+    ) else (
+      "%COMSPEC%" /c ..\..\bin\xspec.bat "%%~I" > NUL 2>&1
+    )
 
     rem
     rem Compare with the expected HTML
@@ -59,3 +66,15 @@ rem
 rem Exit as success
 rem
 exit /b 0
+
+:check_test_type
+    set var=%~1
+    if "%var:~0,6%"=="xquery" (
+        set TEST_TYPE=1
+    ) else if "%var:~0,10%"=="schematron" (
+        set TEST_TYPE=2
+    ) else (
+        set TEST_TYPE=0
+    )
+    exit /b %TEST_TYPE%
+

--- a/test/end-to-end/run-e2e-tests.sh
+++ b/test/end-to-end/run-e2e-tests.sh
@@ -11,18 +11,19 @@ export TEST_DIR=${CASES_DIR}/xspec
 # Run test cases
 for CASE_FILEPATH in ${CASES_DIR}/*.xspec
 do
+    CASE_FILENAME=${CASE_FILEPATH##*/}
+    CASE_BASENAME=${CASE_FILENAME%.xspec}
+
     # Generate the report HTML
-    if test "${CASE_FILEPATH:0:10}" = "schematron"; then
+    if test "${CASE_FILENAME:0:10}" = "schematron"; then
         ../../bin/xspec.sh -s ${CASE_FILEPATH} > /dev/null 2>&1
-    elif test "${CASE_FILEPATH:0:6}" = "xquery"; then
+    elif test "${CASE_FILENAME:0:6}" = "xquery"; then
         ../../bin/xspec.sh -q ${CASE_FILEPATH} > /dev/null 2>&1
     else
         ../../bin/xspec.sh ${CASE_FILEPATH} > /dev/null 2>&1
     fi
 
     # Compare with the expected HTML
-    CASE_FILENAME=${CASE_FILEPATH##*/}
-    CASE_BASENAME=${CASE_FILENAME%.xspec}
     if java -classpath ${SAXON_CP} net.sf.saxon.Transform -s:${TEST_DIR}/${CASE_BASENAME}-result.html -xsl:processor/compare.xsl | grep '^OK: Compared '
         then
             # OK, nothing to do

--- a/test/end-to-end/run-e2e-tests.sh
+++ b/test/end-to-end/run-e2e-tests.sh
@@ -12,7 +12,13 @@ export TEST_DIR=${CASES_DIR}/xspec
 for CASE_FILEPATH in ${CASES_DIR}/*.xspec
 do
     # Generate the report HTML
-    ../../bin/xspec.sh ${CASE_FILEPATH} > /dev/null 2>&1
+    if test "${CASE_FILEPATH:0:10}" = "schematron"; then
+        ../../bin/xspec.sh -s ${CASE_FILEPATH} > /dev/null 2>&1
+    elif test "${CASE_FILEPATH:0:6}" = "xquery"; then
+        ../../bin/xspec.sh -q ${CASE_FILEPATH} > /dev/null 2>&1
+    else
+        ../../bin/xspec.sh ${CASE_FILEPATH} > /dev/null 2>&1
+    fi
 
     # Compare with the expected HTML
     CASE_FILENAME=${CASE_FILEPATH##*/}

--- a/test/schematron/schut-to-xspec-001-out.xspec
+++ b/test/schematron/schut-to-xspec-001-out.xspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario"/>
 </x:description>

--- a/test/schematron/schut-to-xspec-002-out.xspec
+++ b/test/schematron/schut-to-xspec-002-out.xspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     xmlns:xlink="http://www.w3.org/1999/xlink" stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-002.sch&#34;"/>
     <x:scenario label="Schematron test scenario"/>
 </x:description>

--- a/test/schematron/schut-to-xspec-003-out.xspec
+++ b/test/schematron/schut-to-xspec-003-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario">
         <x:scenario label="nested"></x:scenario>
     </x:scenario>

--- a/test/schematron/schut-to-xspec-004-out.xspec
+++ b/test/schematron/schut-to-xspec-004-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario">
         <x:scenario label="pending via attribute" pending="test"></x:scenario>
     </x:scenario>

--- a/test/schematron/schut-to-xspec-005-out.xspec
+++ b/test/schematron/schut-to-xspec-005-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario"/>
     <x:scenario label="focused" focus="test"/>
 </x:description>

--- a/test/schematron/schut-to-xspec-006-out.xspec
+++ b/test/schematron/schut-to-xspec-006-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="s1" shared="yes">
         <x:context href="schut-to-xspec-test.sch"/>
     </x:scenario>

--- a/test/schematron/schut-to-xspec-007-out.xspec
+++ b/test/schematron/schut-to-xspec-007-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario">
         <x:context href="schut-to-xspec-007.xml"/>
     </x:scenario>

--- a/test/schematron/schut-to-xspec-008-out.xspec
+++ b/test/schematron/schut-to-xspec-008-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:scenario label="Schematron test scenario">
         <x:context href="xspec/context-d1e6.xml"/>
     </x:scenario>

--- a/test/schematron/schut-to-xspec-009-out.xspec
+++ b/test/schematron/schut-to-xspec-009-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <!--BEGIN IMPORT "schut-to-xspec-009-import-in.xspec"-->
     <x:scenario label="B"/>
     <!--END IMPORT "schut-to-xspec-009-import-in.xspec"-->

--- a/test/schematron/schut-to-xspec-010-out.xspec
+++ b/test/schematron/schut-to-xspec-010-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34;"/>
     <x:import href="schut-to-xspec-010-import.xspec"/>
     <x:scenario label="A"/>
 </x:description>

--- a/test/schematron/schut-to-xspec-011-out.xspec
+++ b/test/schematron/schut-to-xspec-011-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34; phase: P1"/>
     <x:param name="phase">P1</x:param>
     <x:scenario label="Schematron test scenario"/>
 </x:description>

--- a/test/schematron/schut-to-xspec-012-out.xspec
+++ b/test/schematron/schut-to-xspec-012-out.xspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?><x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="schut-to-xspec-test.sch.xsl"><x:scenario label="Schematron: &#34;schut-to-xspec-012.sch&#34;"/>
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?><x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="schut-to-xspec-test.sch.xsl" schematron="..." xspec-original-location="...">
     <x:scenario label="expect-valid">
         <x:context href="schematron/schut-to-xspec-012-01.xml"/>
         <x:expect label="valid" test="boolean(svrl:schematron-output[svrl:fired-rule]) and                 not(boolean((svrl:schematron-output/svrl:failed-assert union svrl:schematron-output/svrl:successful-report)[                 not(@role) or @role = ('error','fatal')]))"/>

--- a/test/schematron/schut-to-xspec-013-out.xspec
+++ b/test/schematron/schut-to-xspec-013-out.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../src/schemas/xspec.rnc" type="application/relax-ng-compact-syntax"?>
 <x:description xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="..." xspec-original-location="..."
     stylesheet="schut-to-xspec-test.sch.xsl">
-    <x:scenario label="Schematron: &#34;schut-to-xspec-test.sch&#34; phase: concat('P','1')"/>
     <x:param name="phase" select="concat('P','1')"/>
     <x:scenario label="Schematron test scenario"/>
 </x:description>

--- a/test/schut-to-xspec.xspec
+++ b/test/schut-to-xspec.xspec
@@ -21,8 +21,8 @@
                 </example>
             </x:expect>
         </x:scenario>
-    </x:scenario>    
-    <x:scenario label="description">
+    </x:scenario>
+    <x:scenario label="parameters">
         <x:scenario label="no phase">
             <x:context href="schematron/schut-to-xspec-001-in.xspec"/>
             <x:expect label="xspec description" href="schematron/schut-to-xspec-001-out.xspec"/>


### PR DESCRIPTION
This pull request adds a reference to the original XSpec file in all output report formats and is consistent for XSLT, XQuery, and Schematron tests.

The original XSpec file location is included in the XSpec XML report as attribute `x:report/@xspec-original-location`; in the JUnit report as attribute `testsuites/@name`; and in the HTML report as part of test report summary information. 

In Schematron tests the original XSpec file location is added to the temporary XSpec file as attribute `x:description/@xspec-original-location`.

This pull request also improves the HTML report summary information for Schematron tests by including the path to the Schematron being tested in a way consistent with XSLT and XQuery test reports, and removed the generated scenario with Schematron information in a label.

The end-to-end tests have also been extended to include XQuery and Schematron tests.

This pull request closes issue #176, issue #180, and pull request #181 .