### PR TITLE
Proposal issue 192 (Enhance coverage-report.xsl to be able to specify css location)

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -590,6 +590,7 @@ if defined COVERAGE (
         -xsl:"%XSPEC_HOME%\src\reporter\coverage-report.xsl" ^
         tests="file:/%WIN_XSPEC_ABS:\\=/\\%" ^
         pwd="file:/%CD:\=/%/" ^
+        inline-css=true ^
         || ( call :die "Error formating the coverage report" & goto :win_main_error_exit )
     call :win_echo "Report available at %COVERAGE_HTML%"
     rem %OPEN% "%COVERAGE_HTML%"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -374,6 +374,7 @@ if test -n "$COVERAGE"; then
         -xsl:"$XSPEC_HOME/src/reporter/coverage-report.xsl" \
         "tests=$XSPEC" \
         "pwd=file:`pwd`/" \
+        inline-css=true \
         || die "Error formating the coverage report"
     echo "Report available at $COVERAGE_HTML"
     #$OPEN "$COVERAGE_HTML"

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -21,6 +21,9 @@
 
 <xsl:param name="pwd"   as="xs:string" required="yes"/>
 <xsl:param name="tests" as="xs:string" required="yes"/>
+<xsl:param name="report-css-uri" select="
+    resolve-uri('test-report.css', static-base-uri())"/>
+
 
 <xsl:variable name="tests-uri" as="xs:anyURI" select="
     resolve-uri(translate($tests, '\', '/'), $pwd)"/>
@@ -64,7 +67,7 @@
     <head>
       <title>Test Coverage Report for <xsl:value-of select="test:format-URI($stylesheet-uri)" /></title>
       <link rel="stylesheet" type="text/css" 
-        href="{resolve-uri('test-report.css', static-base-uri())}" />
+        href="{$report-css-uri}"/>
     </head>
     <body>
       <h1>Test Coverage Report</h1>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -21,6 +21,9 @@
 
 <xsl:param name="pwd"   as="xs:string" required="yes"/>
 <xsl:param name="tests" as="xs:string" required="yes"/>
+
+<xsl:param name="inline-css">false</xsl:param>
+  
 <xsl:param name="report-css-uri" select="
     resolve-uri('test-report.css', static-base-uri())"/>
 
@@ -66,8 +69,15 @@
   <html>
     <head>
       <title>Test Coverage Report for <xsl:value-of select="test:format-URI($stylesheet-uri)" /></title>
-      <link rel="stylesheet" type="text/css" 
-        href="{$report-css-uri}"/>
+      <xsl:if test="$inline-css = 'false'">
+         <link rel="stylesheet" type="text/css" 
+            href="{$report-css-uri}"/>
+      </xsl:if>
+      <xsl:if test="not($inline-css = 'false')">
+        <style type="text/css">
+          <xsl:value-of select="unparsed-text($report-css-uri)" disable-output-escaping="yes"/>
+        </style>
+      </xsl:if>
     </head>
     <body>
       <h1>Test Coverage Report</h1>


### PR DESCRIPTION
As proposed by #AirQuick, added a parameter to allow to create inlined CSS, and another one to specify CSS location.
Based on current master.