### PR TITLE
Files for code coverage tutorial

### DIFF
--- a/tutorial/coverage/demo-imported.xsl
+++ b/tutorial/coverage/demo-imported.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--
+		Identity template
+	-->
+	<xsl:template as="node()" match="@* | node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@* | node()" />
+		</xsl:copy>
+	</xsl:template>
+
+	<!--
+		Makes <iron> into <sword>
+			This template will be overridden.
+	-->
+	<xsl:template as="element(sword)" match="iron">
+		<sword>
+			<xsl:apply-templates select="@* | node()" />
+		</sword>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/tutorial/coverage/demo.xsl
+++ b/tutorial/coverage/demo.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:import href="demo-imported.xsl" />
+
+	<!--
+		Makes <iron> into <shield>
+			This template overrides an imported template.
+	-->
+	<xsl:template as="element(shield)" match="iron">
+		<shield>
+			<xsl:apply-templates select="@* | node()" />
+		</shield>
+	</xsl:template>
+
+	<!--
+		Makes <iron> into <gold>
+			Only in alchemy mode.
+	-->
+	<xsl:template as="element(gold)" match="iron" mode="alchemy">
+		<gold>
+			<xsl:apply-templates select="@* | node()" />
+		</gold>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/tutorial/coverage/demo.xspec
+++ b/tutorial/coverage/demo.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="demo.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="'iron' element">
+		<x:context>
+			<iron weight="1" />
+		</x:context>
+		<x:expect label="is transformed to 'shield' element">
+			<shield weight="1" />
+		</x:expect>
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
Fixes #196 

If this pull request is ok and gets merged, I'll replace [the tutorial section of wiki](https://github.com/xspec/xspec/wiki/Code-Coverage#tutorial) with this excerpt

```shell
$ bin/xspec.sh -c tutorial/coverage/demo.xspec
Saxon script not found, invoking JVM directly instead.

Creating Test Stylesheet...

Running Tests...
Collecting test coverage data; suppressing progress report...
****************************************
controller=net.sf.saxon.Controller@d29f28

Formatting Report...
passed: 1 / pending: 0 / failed: 0 / total: 1
Report available at tutorial/coverage/xspec/demo-coverage.html
Done.
```
and this picture

![demo](https://user-images.githubusercontent.com/8489367/38677875-7a6ffa8a-3e9a-11e8-8c3c-57f121746e78.png)
