### PR TITLE
Resolve native file path to URI in coverage-report.xsl

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -532,64 +532,12 @@ call :xslt -o:"%HTML%" ^
     inline-css=true ^
     || ( call :die "Error formatting the report" & goto :win_main_error_exit )
 
-rem
-rem Absolute path of the XSPEC env var
-rem
-for %%I in ("%XSPEC%") do set WIN_XSPEC_ABS=%%~fI
-
 if defined COVERAGE (
-    rem
-    rem For $tests and $pwd, convert the native file path to a wannabe-
-    rem URI. The peculiar implementation of Java prefers the following
-    rem forms (if it's absolute).
-    rem
-    rem    For drive: file:/c:/dir/file
-    rem    For UNC:   file:////host/share/dir/file
-    rem
-    rem Note that in terms of the native file path, coverage-report.xsl
-    rem handles $tests and $pwd differently.
-    rem
-    rem    Scheme ('file:')
-    rem
-    rem        $tests
-    rem            The XSPEC env var may be absolute or relative. If
-    rem            relative, we need to omit 'file:' from $tests.
-    rem            For simplicity, we always obtain the absolute path of
-    rem            the XSPEC env var and prefix it with 'file:'.
-    rem
-    rem        $pwd
-    rem            The CD env var is always absolute. So we always prefix
-    rem            it with 'file:'.
-    rem
-    rem    '\' character
-    rem
-    rem        $tests
-    rem            coverage-report.xsl replaces '\' with '/'. You can
-    rem            leave '\' intact here.
-    rem
-    rem        $pwd
-    rem            coverage-report.xsl does nothing. You have to replace
-    rem            '\' with '/' here.
-    rem
-    rem    UNC
-    rem
-    rem        $tests
-    rem            You have to care about UNC.
-    rem
-    rem        $pwd
-    rem            You don't have to care about UNC. By default CMD.EXE
-    rem            does not accept UNC as the current directory.
-    rem
-    rem We don't escape any characters here. Too much for this simple
-    rem batch script. Fortunately Saxon 9.7 seems to be more tolerant of
-    rem space chars than 9.6.
-    rem
     call :xslt -l:on ^
         -o:"%COVERAGE_HTML%" ^
         -s:"%COVERAGE_XML%" ^
         -xsl:"%XSPEC_HOME%\src\reporter\coverage-report.xsl" ^
-        tests="file:/%WIN_XSPEC_ABS:\\=/\\%" ^
-        pwd="file:/%CD:\=/%/" ^
+        tests="%XSPEC%" ^
         inline-css=true ^
         || ( call :die "Error formating the coverage report" & goto :win_main_error_exit )
     call :win_echo "Report available at %COVERAGE_HTML%"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -373,7 +373,6 @@ if test -n "$COVERAGE"; then
         -s:"$COVERAGE_XML" \
         -xsl:"$XSPEC_HOME/src/reporter/coverage-report.xsl" \
         "tests=$XSPEC" \
-        "pwd=file:`pwd`/" \
         inline-css=true \
         || die "Error formating the coverage report"
     echo "Report available at $COVERAGE_HTML"

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -13,13 +13,13 @@
   xmlns:test="http://www.jenitennison.com/xslt/unit-test"
   xmlns="http://www.w3.org/1999/xhtml"
   xmlns:pkg="http://expath.org/ns/pkg"
-  exclude-result-prefixes="xs">
+  xmlns:file="http://expath.org/ns/file"
+  exclude-result-prefixes="#all">
 
 <xsl:import href="format-utils.xsl" />
 
 <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/coverage-report.xsl</pkg:import-uri>
 
-<xsl:param name="pwd"   as="xs:string" required="yes"/>
 <xsl:param name="tests" as="xs:string" required="yes"/>
 
 <xsl:param name="inline-css">false</xsl:param>
@@ -29,7 +29,7 @@
 
 
 <xsl:variable name="tests-uri" as="xs:anyURI" select="
-    resolve-uri(translate($tests, '\', '/'), $pwd)"/>
+    file:path-to-uri($tests)"/>
 
 <xsl:variable name="stylesheet-uri" as="xs:anyURI"
   select="if (doc($tests-uri)/*/@stylesheet)


### PR DESCRIPTION
`coverage-report.xsl` has two half-baked parameters `tests` and `pwd`. They put a burden upon its caller: https://github.com/xspec/xspec/blob/0e21fca458505ad9b2048e3b42a06a99952a7e3e/bin/xspec.bat#L535-L586

This pull request removes `pwd` and resolves `tests` within `coverage-report.xsl`.

The change depends on [`file:path-to-uri()`](http://www.saxonica.com/documentation/index.html#!functions/expath-file/path-to-uri) which requires Saxon-PE or EE. That shouldn't be a problem, because `coverage-report.xsl` requires Saxon-PE+ in the first place.

Verified that the pull request generated the same coverage reports as the current master, using the files from #197 and these command lines:

Windows
```winbatch
bin\xspec.bat -c tutorial\coverage\demo.xspec
bin\xspec.bat -c %CD%\tutorial\coverage\demo.xspec
```

Linux
```bash
bin/xspec.sh -c tutorial/coverage/demo.xspec
bin/xspec.sh -c `pwd`/tutorial/coverage/demo.xspec 
```

No automated tests for now. It should be addressed by #195.
