### PR TITLE
Add xslt-version tests

### DIFF
--- a/test/end-to-end/cases/expected/xspec-xslt2-result-norm.html
+++ b/test/end-to-end/cases/expected/xspec-xslt2-result-norm.html
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-xslt1.xsl (passed: 2 / pending: 0 / failed: 4 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="xspec-xslt1.xsl">xspec-xslt1.xsl</a></p>
+      <p>XSpec: <a href="xspec-xslt2.xspec">xspec-xslt2.xspec</a></p>
+      <p>Tested: ONCE-UPON-A-TIME</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="75%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 2</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 4</th>
+               <th class="totals">total: 6</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#ELEM-33">With 2 text nodes</a></th>
+               <th class="totals">2</th>
+               <th class="totals">0</th>
+               <th class="totals">4</th>
+               <th class="totals">6</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-33">
+         <h2 class="successful">With 2 text nodes<span class="scenario-totals">passed: 2 / pending: 0 / failed: 4 / total: 6</span></h2>
+         <table class="xspec" id="ELEM-35">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="successful">
+                  <th>With 2 text nodes</th>
+                  <th>passed: 2 / pending: 0 / failed: 4 / total: 6</th>
+               </tr>
+               <tr class="successful">
+                  <td>Result should be text nodes</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <td>Result count should be 2</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-68">All of these tests should be Success on xslt-version=1.0 and Failure on 2.0: Comparing
+                        the text nodes with</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-69">string</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-84">double</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-99">decimal</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-114">integer</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 id="ELEM-68">With 2 text nodes All of these tests should be Success on xslt-version=1.0 and Failure
+            on 2.0: Comparing the text nodes with
+         </h3>
+         <h4 id="ELEM-69">string</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                     <p>XPath <code>/node()</code> from:
+                     </p><pre><span class="diff">12</span></pre></td>
+                  <td><pre>'12'</pre></td>
+               </tr>
+            </tbody>
+         </table>
+         <h4 id="ELEM-84">double</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                     <p>XPath <code>/node()</code> from:
+                     </p><pre><span class="diff">12</span></pre></td>
+                  <td><pre>xs:double('12')</pre></td>
+               </tr>
+            </tbody>
+         </table>
+         <h4 id="ELEM-99">decimal</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                     <p>XPath <code>/node()</code> from:
+                     </p><pre><span class="diff">12</span></pre></td>
+                  <td><pre>12.0</pre></td>
+               </tr>
+            </tbody>
+         </table>
+         <h4 id="ELEM-114">integer</h4>
+         <table class="xspecResult">
+            <thead>
+               <tr>
+                  <th>Result</th>
+                  <th>Expected Result</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                     <p>XPath <code>/node()</code> from:
+                     </p><pre><span class="diff">12</span></pre></td>
+                  <td><pre>12</pre></td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/xspec-xslt2.xspec
+++ b/test/end-to-end/cases/xspec-xslt2.xspec
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../../xspec-xslt1.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xslt-version="2.0">
+	<x:import href="../../xspec-xslt1.xspec" />
+</x:description>

--- a/test/xspec-xslt1.xsl
+++ b/test/xspec-xslt1.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template name="text-nodes">
+		<xsl:text>1</xsl:text>
+		<xsl:text>2</xsl:text>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/xspec-xslt1.xspec
+++ b/test/xspec-xslt1.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="xspec-xslt1.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xslt-version="1.0">
+	<x:scenario label="With 2 text nodes">
+		<x:call template="text-nodes" />
+		<x:expect label="Result should be text nodes" test="$x:result instance of text()+" />
+		<x:expect label="Result count should be 2" select="2" test="count($x:result)" />
+		<x:scenario
+			label="All of these tests should be Success on xslt-version=1.0 and Failure on 2.0: Comparing the text nodes with">
+			<x:expect label="string" select="'12'" />
+			<x:expect label="double" select="xs:double('12')" />
+			<x:expect label="decimal" select="xs:decimal('12')" />
+			<x:expect label="integer" select="xs:integer('12')" />
+		</x:scenario>
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
This PR just adds some tests for `/x:description/@xslt-version`.
No code change involved.

---
FWIW, `test/xspec-xslt3.xspec` has `xslt-version="3.0"` but it no longer influences the test result.
The test is successful even when there is no `xslt-version` or when there is `xslt-version="1.0"`.
I guess it's because of [this](http://www.saxonica.com/documentation/index.html#!conformance/xslt30):
> Saxon (from release 9.8) acts as an XSLT 3.0 processor whether this is explicitly requested or not. Specifying version="1.0" or version="2.0" does not prevent the use of 3.0 features

