### PR TITLE
Add test:deep-equal($seq1, $seq2, $version) tests

### DIFF
--- a/test/generate-x-utils.xspec
+++ b/test/generate-x-utils.xspec
@@ -80,7 +80,7 @@
    -->
    <t:scenario label="test:deep-equal($seq1, $seq2, $version)">
       <t:scenario label="In version 1.0">
-         <t:scenario label="comparing analogous text nodes with">
+         <t:scenario label="comparing text nodes with analogous">
             <t:scenario label="string">
                <t:call function="test:deep-equal">
                   <t:param select="'12'"/>
@@ -149,8 +149,8 @@
          </t:scenario>
       </t:scenario>
 
-      <t:scenario label="In version 2.0, comparing analogous text nodes with">
-         <t:scenario label="comparing analogous text nodes with">
+      <t:scenario label="In version 2.0">
+         <t:scenario label="comparing text nodes with analogous">
             <t:scenario label="string">
                <t:call function="test:deep-equal">
                   <t:param select="'12'"/>


### PR DESCRIPTION
This PR just adds some tests for `test:deep-equal($seq1, $seq2, $version)`.
No code change involved.

The added tests are compatible both with XSLT and XQuery.
Once #187 gets merged, the tests will run automatically on Travis/AppVeyor in XQuery.