### PR TITLE
xspec.sh: Filter out unexpected lines from coverage xml

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -334,9 +334,9 @@ if test -n "$XSLT"; then
     # for XSLT
     if test -n "$COVERAGE"; then
         echo "Collecting test coverage data; suppressing progress report..."
-        xslt -T:$COVERAGE_CLASS \
+        ((xslt -T:$COVERAGE_CLASS \
             -o:"$RESULT" -s:"$XSPEC" -xsl:"$COMPILED" \
-            -it:{http://www.jenitennison.com/xslt/xspec}main 2> "$COVERAGE_XML" \
+            -it:{http://www.jenitennison.com/xslt/xspec}main 3>&2 2>&1 1>&3 | grep "^<..*>$") 3>&2 2>&1 1>&3) 2> "$COVERAGE_XML" \
             || die "Error collecting test coverage data"
     else
         xslt -o:"$RESULT" -s:"$XSPEC" -xsl:"$COMPILED" \
@@ -347,8 +347,8 @@ else
     # for XQuery
     if test -n "$COVERAGE"; then
         echo "Collecting test coverage data; suppressing progress report..."
-        xquery -T:$COVERAGE_CLASS \
-            -o:"$RESULT" -s:"$XSPEC" "$COMPILED" 2> "$COVERAGE_XML" \
+        ((xquery -T:$COVERAGE_CLASS \
+            -o:"$RESULT" -s:"$XSPEC" "$COMPILED" 3>&2 2>&1 1>&3 | grep "^<..*>$") 3>&2 2>&1 1>&3) 2> "$COVERAGE_XML" \
             || die "Error collecting test coverage data"
     else
         xquery -o:"$RESULT" -s:"$XSPEC" "$COMPILED" \


### PR DESCRIPTION
Fixes #204

This pull request implements the same workaround as Windows `xspec.bat`: https://github.com/xspec/xspec/blob/0e21fca458505ad9b2048e3b42a06a99952a7e3e/bin/xspec.bat#L76-L89

I tested this pull request on Ubuntu 14 and

* Verified that the coverage report was generated successfully both in Case 1 and Case 2 written in #204.

* Compared `xspec/escape-for-regex-coverage.xml` (Case 1) and `xspec/xquery-tutorial-coverage.xml` (Case 2) with the ones generated by the current master, and verified that only the garbage lines were removed and no XML lines were lost.

No automated tests for now. It should be addressed by #195.
