### PR TITLE
Fix coverage report parser limitation (Remove recursive call)

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -181,7 +181,8 @@
 </xsl:variable>
 
 <xsl:template name="test:output-lines" as="node()+">
-  <xsl:context-item as="element()" use="required" />
+  <!-- xsl:context-item is not implemented in Saxon 9.6 -->
+  <!--<xsl:context-item as="element()" use="required" />-->
 
   <xsl:param name="stylesheet-string" as="xs:string" required="yes" />
   <xsl:param name="number-format" as="xs:string" required="yes" />


### PR DESCRIPTION
Fixes #215

With this pull request, the test files attached in #215 produce a coverage report successfully.
![fixed](https://user-images.githubusercontent.com/8489367/41296625-4e68d3e8-6e98-11e8-86b2-623060fa28bb.png)

### Fix
This pull request just moves the things out of `xsl:matching-substring` and adjusts their details to `xsl:iterate`.
The change requires XSLT 3.0, which shouldn't be a problem as the code coverage is a rather advanced feature.

### Test
Using the files in #197, I manually verified that this pull request generated the same HTML file as the current master.
No automated tests for now. It should be addressed by #195.
