### PR TITLE
Harden echo in xspec-bat.cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
         # Ant version used in oXygen
         - ANT_VERSION=1.9.8
         # full path to XML Resolver jar
-        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/xml-resolver-1.2.jar
+        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/resolver.jar
     matrix:
         # latest Saxon 9.8 version and full path to Jing jar
         - SAXON_VERSION=9.8.0-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ before_install:
 
 before_script:
     # install Saxon
-    - curl -fsSL --create-dirs -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+    - curl -fsSL --create-dirs --retry 5 -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
     # install XML Calabash
     - if [ -z ${XMLCALABASH_VERSION} ]; then
         echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
       else
-        curl -fsSL --create-dirs -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
+        curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
         unzip /tmp/xspec/xmlcalabash/xmlcalabash.zip -d /tmp/xspec/xmlcalabash;
         export XMLCALABASH_CP=/tmp/xspec/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
       fi
@@ -37,19 +37,19 @@ before_script:
         echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
       else
         export BASEX_CP=/tmp/xspec/basex/basex.jar;
-        curl -fsSL --create-dirs -o ${BASEX_CP} http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
+        curl -fsSL --create-dirs --retry 5 -o ${BASEX_CP} http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
       fi
     # install Ant
-    - curl -fsSL --create-dirs -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+    - curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
     - tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
     - export PATH=/tmp/xspec/ant/apache-ant-${ANT_VERSION}/bin:{$PATH}
     # install XML Resolver
-    - curl -fsSL --create-dirs -o ${XML_RESOLVER_CP} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
+    - curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_CP} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
     # install Jing
     - if [ -z ${JING_CP} ]; then
         echo "Jing will not be installed";
       else
-        curl -fsSL --create-dirs -o ${JING_CP} http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar;
+        curl -fsSL --create-dirs --retry 5 -o ${JING_CP} http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar;
       fi
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 - ps: >-
     # install Saxon
 
-    curl.exe -fsSL --create-dirs -o "${env:SAXON_CP}" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar"
+    curl.exe -fsSL --create-dirs --retry 5 -o "${env:SAXON_CP}" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar"
 
 
     # install XML Calabash
@@ -31,7 +31,7 @@ install:
     }
 
     else {
-        curl.exe -fsSL --create-dirs -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
         7z x "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" -o"${env:TEMP}\xspec\xmlcalabash"
         ${env:XMLCALABASH_CP} = "${env:TEMP}\xspec\xmlcalabash\xmlcalabash-${env:XMLCALABASH_VERSION}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
     }
@@ -45,7 +45,7 @@ install:
 
     else {
         ${env:BASEX_CP} = "${env:TEMP}\xspec\basex\basex.jar"
-        curl.exe -fsSL --create-dirs -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
     }
 
 
@@ -56,7 +56,7 @@ install:
 
     # install XML Resolver
 
-    curl.exe -fsSL --create-dirs -o "${env:XML_RESOLVER_CP}" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+    curl.exe -fsSL --create-dirs --retry 5 -o "${env:XML_RESOLVER_CP}" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
 
 
     # install Jing
@@ -66,7 +66,7 @@ install:
     }
 
     else {
-        curl.exe -fsSL --create-dirs -o "${env:JING_CP}" "http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:JING_CP}" "http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar"
     }
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-21
       XMLCALABASH_VERSION: 1.1.16-97
+      BASEX_VERSION: 8.6.4
     # Saxon version used in oXygen
     - SAXON_VERSION: 9.7.0-19
 
@@ -33,6 +34,18 @@ install:
         curl.exe -fsSL --create-dirs -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
         7z x "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" -o"${env:TEMP}\xspec\xmlcalabash"
         ${env:XMLCALABASH_CP} = "${env:TEMP}\xspec\xmlcalabash\xmlcalabash-${env:XMLCALABASH_VERSION}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
+    }
+
+
+    # install BaseX
+
+    if( -Not( Test-Path -Path env:\BASEX_VERSION ) ) {
+        echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
+    }
+
+    else {
+        ${env:BASEX_CP} = "${env:TEMP}\xspec\basex\basex.jar"
+        curl.exe -fsSL --create-dirs -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
     }
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # Ant version used in oXygen
     ANT_VERSION: 1.9.8
     # full path to XML Resolver jar
-    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\xml-resolver-1.2.jar'
+    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\resolver.jar'
   matrix:
     # latest Saxon 9.8 version and full path to Jing jar
     - SAXON_VERSION: 9.8.0-7

--- a/test/html-charset.xsl
+++ b/test/html-charset.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xpath-default-namespace="http://www.w3.org/1999/xhtml">
+	<xsl:output method="text" />
+	<xsl:template as="text()" match="/">
+		<xsl:value-of>
+			<xsl:value-of
+				select="/html/head/meta[@http-equiv = 'Content-Type']/@content = 'text/html; charset=UTF-8'" />
+			<xsl:text>&#x0A;</xsl:text>
+		</xsl:value-of>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/html-css.xsl
+++ b/test/html-css.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xpath-default-namespace="http://www.w3.org/1999/xhtml">
+	<xsl:output method="text" />
+	<xsl:template as="text()" match="/">
+		<xsl:value-of>
+			<xsl:value-of
+				select="/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:')" />
+			<xsl:text>&#x0A;</xsl:text>
+		</xsl:value-of>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/schematron.properties
+++ b/test/schematron.properties
@@ -1,0 +1,1 @@
+test.type=s

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -58,7 +58,7 @@ for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 echo === START TEST CASES ================================================
 
 setlocal
-    call :setup "invoking xspec without arguments prints usage"
+    call :setup "invoking xspec without arguments prints usage & exit 1"
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -178,6 +178,8 @@ setlocal
     call :setup "invoking xspec generates XML report file"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+
+    rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     call :teardown
@@ -187,6 +189,8 @@ setlocal
     call :setup "invoking xspec generates HTML report file"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+
+    rem HTML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
 
     call :teardown
@@ -230,6 +234,8 @@ setlocal
     call :setup "invoking xspec with -j option generates XML report file"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+
+    rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     call :teardown
@@ -239,6 +245,8 @@ setlocal
     call :setup "invoking xspec with -j option generates JUnit report file"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+
+    rem JUnit report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml
 
     call :teardown
@@ -373,7 +381,11 @@ setlocal
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
+
+    rem Cleanup removes compiled .xspec
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
+
+    rem Cleanup removes temporary files in TEST_DIR
     call :run dir /on ..\tutorial\schematron\xspec
     call :verify_line 9 r ".*3 File.*"
     call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
@@ -761,6 +773,7 @@ rem
 :teardown
     rem
     rem Remove the XSpec output directories
+    rem    Keep "..\test\" to minimize accident
     rem
     call :rmdir ..\test\xspec
     call :rmdir ..\tutorial\xspec
@@ -818,6 +831,7 @@ rem
 
     rem
     rem Run
+    rem    Launch a child process in order to localize various environment changes
     rem
     "%COMSPEC%" /c %* > "%OUTPUT_RAW%" 2>&1
     set RETVAL=%ERRORLEVEL%

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -501,12 +501,8 @@ setlocal
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
-        rem Verify default clean.output.dir is false
+        rem Verify that the default clean.output.dir is false and leaves temp files. Delete the left files at the same time.
         call :verify_exist ..\tutorial\schematron\xspec\
-        call :verify_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
-        call :verify_exist ..\tutorial\schematron\demo-03.sch-compiled.xsl
-
-        rem Delete temp file
         call :del          ..\tutorial\schematron\demo-03.xspec-compiled.xspec
         call :del          ..\tutorial\schematron\demo-03.sch-compiled.xsl
     ) else (
@@ -560,13 +556,9 @@ setlocal
         rem Verify the build fails before cleanup
         call :verify_exist catalog\xspec\
         
-        rem Verify the build fails after Schematron setup
-        call :verify_exist catalog\xspec-160_schematron.xspec-compiled.xspec
-        call :verify_exist ..\tutorial\schematron\demo-04.sch-compiled.xsl
-
-        rem Delete temp file
-        call :del          catalog\xspec-160_schematron.xspec-compiled.xspec
-        call :del          ..\tutorial\schematron\demo-04.sch-compiled.xsl
+        rem Verify that the build fails after Schematron setup and leaves temp files. Delete them at the same time.
+        call :del catalog\xspec-160_schematron.xspec-compiled.xspec
+        call :del ..\tutorial\schematron\demo-04.sch-compiled.xsl
     ) else (
         call :skip "test for Schematron Ant with catalog and default xspec.fail skipped"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -278,7 +278,7 @@ setlocal
 
     if defined XMLCALABASH_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform -s:xspec\xspec-72-result.html -xsl:html-charset.xsl
         call :verify_line 1 x "true"
     ) else (
         call :skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -58,7 +58,7 @@ for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 echo === START TEST CASES ================================================
 
 setlocal
-    call :setup "invoking xspec without arguments prints usage & exit 1"
+    call :setup "invoking xspec without arguments prints usage"
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -771,10 +771,10 @@ rem
     rem
     rem Create the XSpec output directories
     rem
-    call :mkdir ..\test\xspec
-    call :mkdir ..\tutorial\xspec
-    call :mkdir ..\tutorial\schematron\xspec
     call :mkdir ..\test\catalog\xspec
+    call :mkdir ..\test\xspec
+    call :mkdir ..\tutorial\schematron\xspec
+    call :mkdir ..\tutorial\xspec
 
     goto :EOF
 
@@ -783,10 +783,10 @@ rem
     rem Remove the XSpec output directories
     rem    Keep "..\test\" to minimize accident
     rem
-    call :rmdir ..\test\xspec
-    call :rmdir ..\tutorial\xspec
-    call :rmdir ..\tutorial\schematron\xspec
     call :rmdir ..\test\catalog\xspec
+    call :rmdir ..\test\xspec
+    call :rmdir ..\tutorial\schematron\xspec
+    call :rmdir ..\tutorial\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -183,9 +183,11 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec generates XML and HTML report files"
+    call :setup "invoking xspec generates message with default report location and creates report files"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :verify_retval 0
+    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
@@ -256,16 +258,6 @@ setlocal
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat without TEST_DIR generates files in default location"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 0
-    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -183,20 +183,12 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec generates XML report file"
+    call :setup "invoking xspec generates XML and HTML report files"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
 
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec generates HTML report file"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
 
     rem HTML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -550,7 +550,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -419,7 +419,7 @@ setlocal
     call :setup "executing the XProc harness for BaseX generates a report"
 
     if defined BASEX_CP (
-        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -38,6 +38,14 @@ rem
 set "THIS_FILE_NX=%~nx0"
 
 rem
+rem Availability of Ant
+rem
+if not defined ANT_VERSION (
+    where ant > NUL
+    if not errorlevel 1 set ANT_VERSION=1
+)
+
+rem
 rem Go to the directory where this script resides
 rem
 pushd "%~dp0"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -15,7 +15,7 @@ if errorlevel 1 (
 rem
 rem Results log file
 rem
-set RESULTS_FILE=%TEMP%\%~n0_results.log
+set "RESULTS_FILE=%TEMP%\%~n0_results.log"
 call :del "%RESULTS_FILE%"
 
 rem
@@ -23,19 +23,19 @@ rem Work directory
 rem  - Created at :setup
 rem  - Removed recursively at :teardown
 rem
-set WORK_DIR=%TEMP%\%~n0_work
+set "WORK_DIR=%TEMP%\%~n0_work"
 
 rem
 rem Output log files for :run
 rem
-set OUTPUT_RAW=%WORK_DIR%\run_raw.log
+set "OUTPUT_RAW=%WORK_DIR%\run_raw.log"
 set "OUTPUT_FILTERED=%WORK_DIR%\run_filtered.log"
-set OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log
+set "OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log"
 
 rem
 rem Name and extension of this file
 rem
-set THIS_FILE_NX=%~nx0
+set "THIS_FILE_NX=%~nx0"
 
 rem
 rem Go to the directory where this script resides
@@ -45,7 +45,7 @@ pushd "%~dp0"
 rem
 rem Full path to the parent directory
 rem
-for %%I in (..) do set PARENT_DIR_ABS=%%~fI
+for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 
 echo === START TEST CASES ================================================
 
@@ -259,7 +259,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with TEST_DIR already set externally generates files inside TEST_DIR"
 
-    set TEST_DIR=%WORK_DIR%
+    set "TEST_DIR=%WORK_DIR%"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
@@ -305,11 +305,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for parentheses dir generates HTML report file #84"
 
-    set PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)
+    set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
     call :mkdir "%PARENTHESES_DIR%"
     copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%" > NUL
 
-    set EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html
+    set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
 
     call :run ..\bin\xspec.bat "%PARENTHESES_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
@@ -322,7 +322,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
 
-    set APOSTROPHE_DIR=%WORK_DIR%\some'path
+    set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
     call :mkdir "%APOSTROPHE_DIR%"
     copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%" > NUL
 
@@ -465,7 +465,7 @@ endlocal
 setlocal
     call :setup "Ant for Schematron with various properties except catalog"
 
-    set BUILD_XML=%WORK_DIR%\build.xml
+    set "BUILD_XML=%WORK_DIR%\build.xml"
 
     if defined ANT_VERSION (
         rem Remove a temp dir created by setup
@@ -537,7 +537,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -548,7 +548,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
     call :verify_retval 0
     call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -559,7 +559,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set XML_CATALOG=catalog\catalog-01-catalog.xml
     call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
     call :verify_retval 0
@@ -571,11 +571,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
 
-    set SPACE_DIR=%WORK_DIR%\cat a log
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
     copy catalog\catalog-01* "%SPACE_DIR%"
     
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -586,11 +586,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
 
-    set SPACE_DIR=%WORK_DIR%\cat a log
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
     copy catalog\catalog-01* "%SPACE_DIR%"
     
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
@@ -603,9 +603,9 @@ setlocal
     call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
-    call :mkdir %SAXON_HOME%
-    copy %SAXON_CP% %SAXON_HOME%
-    copy %XML_RESOLVER_CP% %SAXON_HOME%
+    call :mkdir "%SAXON_HOME%"
+    copy "%SAXON_CP%"        "%SAXON_HOME%"
+    copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
@@ -658,7 +658,7 @@ if not defined EXIT_CODE (
     set EXIT_CODE=1
 )
 if %EXIT_CODE% NEQ 0 (
-    echo ---------- %RESULTS_FILE%
+    echo ---------- "%RESULTS_FILE%"
     type "%RESULTS_FILE%"
     echo ----------
 )
@@ -709,10 +709,10 @@ rem
     rem
     rem Report 'Running'
     rem
-    set CASE_NAME=%~1
+    set "CASE_NAME=%~1"
     call :appveyor AddTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Running
     echo CASE: %CASE_NAME%
-    (echo # %CASE_NAME%) >> "%RESULTS_FILE%"
+    (echo # "%CASE_NAME%") >> "%RESULTS_FILE%"
 
     rem
     rem Create the work directory
@@ -812,7 +812,7 @@ rem
         call :verified "Return value: %RETVAL%"
     ) else (
         call :failed "Return value is %RETVAL%. Expected %~1."
-        echo ---------- %OUTPUT_RAW%
+        echo ---------- "%OUTPUT_RAW%"
         type "%OUTPUT_RAW%"
         echo ----------
     )
@@ -863,7 +863,7 @@ rem
     )
     if errorlevel 1 (
         call :failed "Line %LINE_NUMBER% does not match the expected string"
-        echo ---------- %OUTPUT_LINENUM%
+        echo ---------- "%OUTPUT_LINENUM%"
         type "%OUTPUT_LINENUM%"
         echo ----------
     ) else (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -288,26 +288,9 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat for parentheses dir generates HTML report file #84"
+    call :setup "invoking xspec.bat with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file"
 
-    set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
-    call :mkdir "%PARENTHESES_DIR%"
-    call :copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%"
-
-    set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
-
-    call :run ..\bin\xspec.bat "%PARENTHESES_DIR%\escape-for-regex.xspec"
-    call :verify_retval 0
-    call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
-    call :verify_exist "%EXPECTED_REPORT%"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
-
-    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path"
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84)"
     call :mkdir "%SPECIAL_CHARS_DIR%"
     call :copy ..\tutorial\escape-for-regex.* "%SPECIAL_CHARS_DIR%"
 
@@ -316,6 +299,7 @@ setlocal
     call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
     call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
+    call :verify_exist "%EXPECTED_REPORT%"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -394,11 +394,11 @@ setlocal
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
 
     rem Cleanup removes temporary files in TEST_DIR
-    call :run dir /on ..\tutorial\schematron\xspec
-    call :verify_line 9 r ".*3 File.*"
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.xml
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03.xsl
+    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :verify_line_count 3
+    call :verify_line 1 x demo-03.xsl
+    call :verify_line 2 x demo-03-result.html
+    call :verify_line 3 x demo-03-result.xml
 
     call :teardown
 endlocal
@@ -919,6 +919,18 @@ rem
         echo ----------
     ) else (
         call :verified "Line %LINE_NUMBER%"
+    )
+    goto :EOF
+
+:verify_line_count
+    for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set LINE_COUNT=%%I
+    if %LINE_COUNT% EQU %~1 (
+        call :verified "Line count: %~1"
+    ) else (
+        call :failed "Line count %LINE_COUNT% does not match the expected count %~1"
+        echo ---------- "%OUTPUT_LINENUM%"
+        type "%OUTPUT_LINENUM%"
+        echo ----------
     )
     goto :EOF
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -297,7 +297,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat that passes a non xs:boolean does not raise a warning #46"
 
-    call :run ..\bin\xspec.bat ..\test\xspec-46.xspec
+    call :run ..\bin\xspec.bat xspec-46.xspec
     call :verify_retval 0
     call :verify_line 4 r "Testing with"
 
@@ -352,7 +352,7 @@ endlocal
 setlocal
     call :setup "Schematron phase/parameters are passed to Schematron compile"
 
-    call :run ..\bin\xspec.bat -s ..\test\schematron-param-001.xspec
+    call :run ..\bin\xspec.bat -s schematron-param-001.xspec
     call :verify_retval 0
     call :verify_line 3 x "Paramaters: phase=P1 ?selected=codepoints-to-string((80,49))"
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -466,6 +466,7 @@ setlocal
     call :setup "Ant for Schematron with various properties except catalog"
 
     set "BUILD_XML=%WORK_DIR%\build.xml"
+    set "ANT_TEST_DIR=%WORK_DIR%\ant-temp"
 
     if defined ANT_VERSION (
         rem Remove a temp dir created by setup
@@ -474,7 +475,7 @@ setlocal
         rem For testing -Dxspec.project.dir
         call :copy ..\build.xml "%BUILD_XML%"
 
-        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
+        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
         call :verify_retval 0
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -483,7 +484,7 @@ setlocal
         call :verify_not_exist ..\tutorial\schematron\xspec\
 
         rem Verify clean.output.dir=true
-        call :verify_not_exist xspec-temp\
+        call :verify_not_exist "%ANT_TEST_DIR%"
         call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
         call :verify_not_exist ..\tutorial\schematron\demo-03.sch-compiled.xsl
     ) else (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -542,19 +542,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver"
-
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    set XML_CATALOG=catalog\catalog-01-catalog.xml
-    call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -373,6 +373,10 @@ setlocal
     call :verify_line 6 x "Schematron XSLT expand"
     call :verify_line 7 x "Schematron XSLT compile"
 
+    rem With the provided dummy XSLTs, XSpec leaves temp files. Delete them.
+    call :del ..\tutorial\schematron\demo-01.sch-compiled.xsl
+    call :del ..\tutorial\schematron\demo-01.xspec-compiled.xspec
+
     call :teardown
 endlocal
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -29,6 +29,7 @@ rem
 rem Output log files for :run
 rem
 set OUTPUT_RAW=%WORK_DIR%\run_raw.log
+set "OUTPUT_FILTERED=%WORK_DIR%\run_filtered.log"
 set OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log
 
 rem
@@ -398,6 +399,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_CP%"
         call :verify_retval 1
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -4 x "BUILD FAILED"
     ) else (
         call :skip "test for XSLT Ant with default properties skipped"
@@ -412,6 +414,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_CP%" -Dxspec.fail=false
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for XSLT Ant with xspec.fail=false skipped"
@@ -426,6 +429,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_xslt.xspec" -lib "%SAXON_CP%" -Dxspec.fail=false -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%"
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for XSLT Ant with catalog skipped"
@@ -440,6 +444,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
         rem Verify default clean.output.dir is false
@@ -471,6 +476,7 @@ setlocal
 
         call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
         rem Verify that -Dxspec-dir was honered and the default dir was not created
@@ -493,6 +499,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_schematron.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%"
         call :verify_retval 1
+        call :verify_line  * x "     [xslt] passed: 6 / pending: 0 / failed: 1 / total: 7"
         call :verify_line -4 x "BUILD FAILED"
 
         rem Verify the build fails before cleanup
@@ -518,6 +525,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_schematron.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%" -Dxspec.fail=false
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 6 / pending: 0 / failed: 1 / total: 7"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for Schematron Ant with catalog and xspec.fail=false skipped"
@@ -786,11 +794,16 @@ rem
     set RETVAL=%ERRORLEVEL%
 
     rem
+    rem Normalize CR LF.
     rem Remove the JAVA_TOOL_OPTIONS output, to keep the line numbers predictable.
     rem Remove the empty lines, to be compatible with Bats $lines.
+    rem
+    type "%OUTPUT_RAW%" | find /v "" | findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" | findstr /r /v /c:"^$" > "%OUTPUT_FILTERED%"
+
+    rem
     rem Prefix each line with its line number.
     rem
-    findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" "%OUTPUT_RAW%" | findstr /r /v /c:"^$" | find /v /n "" > "%OUTPUT_LINENUM%"
+    type "%OUTPUT_FILTERED%" | find /v /n "" > "%OUTPUT_LINENUM%"
 
     goto :EOF
 
@@ -814,11 +827,12 @@ rem
         echo 3: %3
     )
     rem
-    rem Checks to see if the specified line of the output log file matches exactly the specified string
+    rem Checks to see if the specified line of the output log file matches the specified string
     rem
     rem Parameters:
     rem    1: Line number. Starts with 1, unlike Bats $lines which starts with 0.
-    rem        Negative values indicate the reverse order. -1 is the last line. -2 is the line before the last line, and so on.
+    rem        Negative value : Indicates the reverse order. -1 is the last line. -2 is the line before the last line, and so on.
+    rem        * : Don't care. Any line.
     rem    2: Operator
     rem        x : Exact match ("=" on Bats)
     rem        r : Compare with regular expression ("=~" on Bats)
@@ -827,15 +841,22 @@ rem
     rem
 
     set LINE_NUMBER=%~1
-    if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set /a LINE_NUMBER+=%%I+1
+    if not %LINE_NUMBER%==* if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set /a LINE_NUMBER+=%%I+1
+
+                        set "FIND_STRING=[%LINE_NUMBER%]%~3"
+    if /i "%~2"=="r"    set "FIND_STRING=\[%LINE_NUMBER%\]%~3"
+    if %LINE_NUMBER%==* set "FIND_STRING=%~3"
+
+                        set "FIND_FILE=%OUTPUT_LINENUM%"
+    if %LINE_NUMBER%==* set "FIND_FILE=%OUTPUT_FILTERED%"
 
     rem
-    rem Search the line-numbered output log file
+    rem Search the output log file
     rem
     if        /i "%~2"=="x" (
-        findstr /l /x /c:"[%LINE_NUMBER%]%~3" "%OUTPUT_LINENUM%" > NUL
+        findstr /l /x /c:"%FIND_STRING%" "%FIND_FILE%" > NUL
     ) else if /i "%~2"=="r" (
-        findstr /b /r /c:"\[%LINE_NUMBER%\]%~3" "%OUTPUT_LINENUM%" > NUL
+        findstr /b /r /c:"%FIND_STRING%" "%FIND_FILE%" > NUL
     ) else (
         call :failed "Bad operator: %~2"
         goto :EOF

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -516,18 +516,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
-
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -421,6 +421,9 @@ setlocal
     if defined BASEX_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+        rem Default compiled-file
+        call :verify_exist \tmp\xspec-basex-compiled-suite.xq
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -418,12 +418,14 @@ endlocal
 setlocal
     call :setup "executing the XProc harness for BaseX generates a report"
 
+    set "COMPILED_FILE=%WORK_DIR%\compiled.xq"
+
     if defined BASEX_CP (
-        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -p compiled-file="file:/%COMPILED_FILE:\=/%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
 
-        rem Default compiled-file
-        call :verify_exist \tmp\xspec-basex-compiled-suite.xq
+        rem compiled-file
+        call :verify_exist "%COMPILED_FILE%"
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -527,6 +527,21 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
+
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
+    call :mkdir "%SPACE_DIR%\xspec"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
+    
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
+    call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
 
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
@@ -543,21 +558,6 @@ setlocal
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set XML_CATALOG=catalog\catalog-01-catalog.xml
     call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
-
-    set "SPACE_DIR=%WORK_DIR%\cat a log"
-    call :mkdir "%SPACE_DIR%\xspec"
-    call :copy catalog\catalog-01* "%SPACE_DIR%"
-    
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -350,20 +350,11 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131"
+    call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131 and removes temporary files"
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
     call :verify_line 5 x "Compiling the Schematron tests..."
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "Cleanup removes temporary files"
-
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
-    call :verify_retval 0
 
     rem Cleanup removes compiled .xspec
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -338,13 +338,15 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
 
-    set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
-    call :mkdir "%APOSTROPHE_DIR%"
-    call :copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%"
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path"
+    call :mkdir "%SPECIAL_CHARS_DIR%"
+    call :copy ..\tutorial\escape-for-regex.* "%SPECIAL_CHARS_DIR%"
 
-    call :run ..\bin\xspec.bat "%APOSTROPHE_DIR%\escape-for-regex.xspec"
+    set "EXPECTED_REPORT=%SPECIAL_CHARS_DIR%\xspec\escape-for-regex-result.html"
+
+    call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
-    call :verify_line 20 x "Report available at %APOSTROPHE_DIR%\xspec\escape-for-regex-result.html"
+    call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -605,7 +605,7 @@ setlocal
     set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir "%SAXON_HOME%"
     call :copy "%SAXON_CP%"        "%SAXON_HOME%"
-    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
+    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%\xml-resolver-1.2.jar"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -525,7 +525,7 @@ setlocal
         rem For testing -Dxspec.project.dir
         call :copy ..\build.xml "%BUILD_XML%"
 
-        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
+        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dxspec.properties="%CD%\schematron.properties" -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
         call :verify_retval 0
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -16,7 +16,7 @@ rem
 rem Results log file
 rem
 set "RESULTS_FILE=%TEMP%\%~n0_results.log"
-call :del "%RESULTS_FILE%"
+if exist "%RESULTS_FILE%" call :del "%RESULTS_FILE%"
 
 rem
 rem Work directory
@@ -732,8 +732,11 @@ rem
 
 :del
     if exist %1 (
-        del /q %1
-        if errorlevel 1 call :failed "Failed to del: %~1"
+        rem DEL returns 0 as long as the parameter is valid
+        del %1
+        if exist %1 call :failed "Failed to del: %~1"
+    ) else (
+        call :failed "File not found for del: %~1"
     )
     goto :EOF
 
@@ -744,16 +747,26 @@ rem
 
 :rmdir
     if exist %1 (
-        call :del "%~1\*"
+        rem DEL and RMDIR return 0 as long as the parameter is valid
+        del /q "%~1\*"
         rmdir %1
-        if errorlevel 1 call :failed "Failed to rmdir: %~1"
+        if exist %1 call :failed "Failed to rmdir: %~1"
+    ) else (
+        call :failed "Dir not found for rmdir: %~1"
     )
+    goto :EOF
+
+:rmdir-if-exist
+    if exist %1 call :rmdir %1
     goto :EOF
 
 :rmdir-s
     if exist %1 (
+        rem RMDIR returns 0 as long as the parameter is valid
         rmdir /s /q %1
-        if errorlevel 1 call :failed "Failed to rmdir /s: %~1"
+        if exist %1 call :failed "Failed to rmdir /s: %~1"
+    ) else (
+        call :failed "Dir not found for rmdir /s: %~1"
     )
     goto :EOF
 
@@ -790,10 +803,10 @@ rem
     rem Remove the XSpec output directories
     rem    Keep "..\test\" to minimize accident
     rem
-    call :rmdir ..\test\catalog\xspec
-    call :rmdir ..\test\xspec
-    call :rmdir ..\tutorial\schematron\xspec
-    call :rmdir ..\tutorial\xspec
+    call :rmdir-if-exist ..\test\catalog\xspec
+    call :rmdir          ..\test\xspec
+    call :rmdir-if-exist ..\tutorial\schematron\xspec
+    call :rmdir          ..\tutorial\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -307,7 +307,7 @@ setlocal
 
     set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
     call :mkdir "%PARENTHESES_DIR%"
-    copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%" > NUL
+    call :copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%"
 
     set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
 
@@ -324,7 +324,7 @@ setlocal
 
     set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
     call :mkdir "%APOSTROPHE_DIR%"
-    copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%" > NUL
+    call :copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%"
 
     call :run ..\bin\xspec.bat "%APOSTROPHE_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
@@ -472,7 +472,7 @@ setlocal
         call :rmdir ..\tutorial\schematron\xspec
 
         rem For testing -Dxspec.project.dir
-        copy ..\build.xml "%BUILD_XML%" > NUL
+        call :copy ..\build.xml "%BUILD_XML%"
 
         call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
         call :verify_retval 0
@@ -573,7 +573,7 @@ setlocal
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
-    copy catalog\catalog-01* "%SPACE_DIR%"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
     
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
@@ -588,7 +588,7 @@ setlocal
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
-    copy catalog\catalog-01* "%SPACE_DIR%"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
     
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
@@ -604,8 +604,8 @@ setlocal
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir "%SAXON_HOME%"
-    copy "%SAXON_CP%"        "%SAXON_HOME%"
-    copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
+    call :copy "%SAXON_CP%"        "%SAXON_HOME%"
+    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
@@ -673,6 +673,11 @@ exit /b %EXIT_CODE%
 rem
 rem Subroutines
 rem
+
+:copy
+    copy %1 %2 > NUL
+    if errorlevel 1 call :failed "Failed to copy: %~1 to %~2"
+    goto :EOF
 
 :del
     if exist %1 (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -632,6 +632,15 @@ rem
 rem Subroutines
 rem
 
+:echo
+    rem
+    rem Prints a message removing its surrounding quotes (")
+    rem
+    set "ECHO_LINE=%~1"
+    setlocal enabledelayedexpansion
+    echo !ECHO_LINE!
+    goto :EOF
+
 :copy
     copy %1 %2 > NUL
     if errorlevel 1 call :failed "Failed to copy: %~1 to %~2"
@@ -687,7 +696,7 @@ rem
     rem
     set "CASE_NAME=%~1"
     call :appveyor AddTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Running
-    echo CASE: %CASE_NAME%
+    call :echo "CASE: %CASE_NAME%"
     (echo # "%CASE_NAME%") >> "%RESULTS_FILE%"
 
     rem
@@ -731,21 +740,21 @@ rem
     goto :EOF
 
 :verified
-    echo ...Verified: %~1
+    call :echo "...Verified: %~1"
     if not defined CASE_RESULT set CASE_RESULT=0
     goto :EOF
 
 :failed
-    echo ...FAIL: %~1
+    call :echo "...FAIL: %~1"
     set CASE_RESULT=1
     (echo %CASE_RESULT%) >> "%RESULTS_FILE%"
     if defined CASE_NAME call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Failed -Duration 0 -ErrorMessage %1
     goto :EOF
 
 :skip
-    echo ...SKIP: %~1
+    call :echo "...SKIP: %~1"
     set CASE_RESULT=2
-    (echo # %~1) >> "%RESULTS_FILE%"
+    (echo # %1) >> "%RESULTS_FILE%"
     call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Skipped -Duration 0
     goto :EOF
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -384,6 +384,29 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec.bat with -q option runs XSpec test for XQuery"
+
+    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :verify_retval 0
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "executing the XProc harness for BaseX generates a report"
+
+    if defined BASEX_CP (
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+    ) else (
+        call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
+    )
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "HTML report contains CSS inline and not as an external file #135"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -352,7 +352,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131"
 
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
     call :verify_line 5 x "Compiling the Schematron tests..."
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -229,30 +229,14 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec with -j option generates message with JUnit report location"
+    call :setup "invoking xspec with -j option generates message with JUnit report location and creates report files"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
 
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec with -j option generates XML report file"
-
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
-
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec with -j option generates JUnit report file"
-
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
 
     rem JUnit report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -193,7 +193,7 @@ setlocal
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     rem HTML report file is created and contains CSS inline #135
-    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
     call :verify_line 1 x "true"
 
     call :teardown

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -189,11 +189,12 @@ setlocal
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
-    rem XML report file
+    rem XML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
-    rem HTML report file is created
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
+    rem HTML report file is created and contains CSS inline #135
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
+    call :verify_line 1 x "true"
 
     call :teardown
 endlocal
@@ -401,16 +402,6 @@ setlocal
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "HTML report contains CSS inline and not as an external file #135"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
-    call :verify_line 1 x "true"
 
     call :teardown
 endlocal

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -335,6 +335,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP}
 	echo $output
     [ "$status" -eq 1 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
 }
 
@@ -343,6 +344,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP} -Dxspec.fail=false
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 
@@ -351,6 +353,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_xslt.xspec -lib ${SAXON_CP} -Dxspec.fail=false -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 
@@ -359,6 +362,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 
     # Verify default clean.output.dir is false
@@ -382,6 +386,7 @@ teardown() {
     run ant -buildfile /tmp/build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir=${PWD}/xspec-temp -Dclean.output.dir=true
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 
     # Verify that -Dxspec-dir was honered and the default dir was not created
@@ -400,6 +405,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
 	echo $output
     [ "$status" -eq 1 ]
+    [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
 
     # Verify the build fails before cleanup
@@ -419,6 +425,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP} -Dxspec.fail=false
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -213,9 +213,7 @@ teardown() {
     else
         run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home=file:${PWD}/../ -oresult=xspec/xspec-72-result.html ../src/harnesses/saxon/saxon-xslt-harness.xproc
 
-    	query="declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')";
-
-        run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"$query" !method=text
+        run java -cp ${SAXON_CP} net.sf.saxon.Transform -s:xspec/xspec-72-result.html -xsl:html-charset.xsl
     fi
 
     echo "$output"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -136,9 +136,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # XML report file
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 }
 
 
@@ -146,9 +144,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # HTML report file is created
-    run stat ../tutorial/xspec/escape-for-regex-result.html
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
 }
 
 
@@ -182,9 +178,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # XML report file
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 }
 
 
@@ -192,9 +186,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # JUnit report file
-    run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -483,7 +483,7 @@ teardown() {
     export SAXON_HOME="${PWD}/saxon"
     mkdir $SAXON_HOME
     cp $SAXON_CP $SAXON_HOME
-    cp $XML_RESOLVER_CP $SAXON_HOME
+    cp $XML_RESOLVER_CP $SAXON_HOME/xml-resolver-1.2.jar
     export SAXON_CP=
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo "$output"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -142,8 +142,9 @@ teardown() {
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 
     # HTML report file is created and contains CSS inline #135
-	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
-	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
+    run java -cp ${SAXON_CP} net.sf.saxon.Transform -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
+    echo "$output"
+    [ "${lines[0]}" = "true" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -338,6 +338,9 @@ teardown() {
 
     echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+
+    # Default compiled-file
+    [ -f "/tmp/xspec-basex-compiled-suite.xq" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -292,6 +292,10 @@ teardown() {
     [ "${lines[4]}" = "Schematron XSLT include" ]
     [ "${lines[5]}" = "Schematron XSLT expand" ]
     [ "${lines[6]}" = "Schematron XSLT compile" ]
+
+    # With the provided dummy XSLTs, XSpec leaves temp files. Delete them.
+    rm ../tutorial/schematron/demo-01.sch-compiled.xsl
+    rm ../tutorial/schematron/demo-01.xspec-compiled.xspec
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -333,14 +333,15 @@ teardown() {
     if [[ -z ${XMLCALABASH_CP} && -z ${BASEX_CP} ]]; then
         skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon";
     else
-        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        compiled_file="${work_dir}/compiled.xq"
+        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -p compiled-file="file:${compiled_file}" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     fi
 
     echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 
-    # Default compiled-file
-    [ -f "/tmp/xspec-basex-compiled-suite.xq" ]
+    # compiled-file
+    [ -f "${compiled_file}" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -132,16 +132,11 @@ teardown() {
 }
 
 
-@test "invoking xspec generates XML report file" {
+@test "invoking xspec generates XML and HTML report files" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
-}
-
-
-@test "invoking xspec generates HTML report file" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # HTML report file is created
     [ -f "../tutorial/xspec/escape-for-regex-result.html" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -407,7 +407,7 @@ teardown() {
     # For testing -Dxspec.project.dir
     cp ../build.xml "${build_xml}"
 
-    run ant -buildfile "${build_xml}" -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir="${ant_test_dir}" -Dclean.output.dir=true
+    run ant -buildfile "${build_xml}" -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dxspec.properties=${PWD}/schematron.properties -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir="${ant_test_dir}" -Dclean.output.dir=true
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -416,6 +416,18 @@ teardown() {
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
+@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
+    space_dir="${work_dir}/cat a log"
+    mkdir -p "${space_dir}/xspec"
+    cp catalog/catalog-01* "${space_dir}"
+    
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+	run ../bin/xspec.sh -catalog "${space_dir}/catalog-01-catalog.xml" "${space_dir}/catalog-01-xslt.xspec"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+}
+
 @test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
@@ -428,18 +440,6 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=catalog/catalog-01-catalog.xml
 	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
-    space_dir="${work_dir}/cat a log"
-    mkdir -p "${space_dir}/xspec"
-    cp catalog/catalog-01* "${space_dir}"
-    
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog "${space_dir}/catalog-01-catalog.xml" "${space_dir}/catalog-01-xslt.xspec"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -428,16 +428,7 @@ teardown() {
 	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
-@test "invoking xspec.sh with XML_CATALOG set uses XML Catalog resolver" {
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-    export XML_CATALOG=catalog/catalog-01-catalog.xml
-	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh using XML_CATALOG with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -20,19 +20,19 @@
 setup() {
 	work_dir="${BATS_TMPDIR}/xspec/bats_work"
 	mkdir -p "${work_dir}"
-	mkdir ../tutorial/xspec
+	mkdir ../test/catalog/xspec
 	mkdir ../test/xspec
 	mkdir ../tutorial/schematron/xspec
-	mkdir ../test/catalog/xspec
+	mkdir ../tutorial/xspec
 }
 
 
 teardown() {
 	rm -rf "${work_dir}"
-	rm -rf ../tutorial/xspec
+	rm -rf ../test/catalog/xspec
 	rm -rf ../test/xspec
 	rm -rf ../tutorial/schematron/xspec
-	rm -rf ../test/catalog/xspec
+	rm -rf ../tutorial/xspec
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -134,6 +134,8 @@ teardown() {
 
 @test "invoking xspec generates XML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+
+    # XML report file
     run stat ../tutorial/xspec/escape-for-regex-result.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -142,6 +144,8 @@ teardown() {
 
 @test "invoking xspec generates HTML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+
+    # HTML report file is created
     run stat ../tutorial/xspec/escape-for-regex-result.html
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -176,6 +180,8 @@ teardown() {
 
 @test "invoking xspec with -j option generates XML report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+
+    # XML report file
     run stat ../tutorial/xspec/escape-for-regex-result.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -184,6 +190,8 @@ teardown() {
 
 @test "invoking xspec with -j option generates JUnit report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+
+    # JUnit report file
     run stat ../tutorial/xspec/escape-for-regex-junit.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -299,7 +307,11 @@ teardown() {
 @test "Cleanup removes temporary files" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
     [ "$status" -eq 0 ]
+
+    # Cleanup removes compiled .xspec
     [ ! -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
+
+    # Cleanup removes temporary files in TEST_DIR
     run ls ../tutorial/schematron/xspec
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "demo-03-result.html" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -138,11 +138,12 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 
-    # XML report file
+    # XML report file is created
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 
-    # HTML report file is created
-    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
+    # HTML report file is created and contains CSS inline #135
+	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
+	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
 }
 
 
@@ -318,13 +319,6 @@ teardown() {
 
     # compiled-file
     [ -f "${compiled_file}" ]
-}
-
-
-@test "HTML report contains CSS inline and not as an external file #135" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
-	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -225,7 +225,7 @@ teardown() {
 
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
-    run ../bin/xspec.sh ../test/xspec-46.xspec
+    run ../bin/xspec.sh xspec-46.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${lines[3]}" =~ "Testing with" ]]
@@ -275,7 +275,7 @@ teardown() {
 
 
 @test "Schematron phase/parameters are passed to Schematron compile" {
-    run ../bin/xspec.sh -s ../test/schematron-param-001.xspec
+    run ../bin/xspec.sh -s schematron-param-001.xspec
 	echo "${lines[2]}"
     [ "$status" -eq 0 ]
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -390,14 +390,10 @@ teardown() {
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
-    # Verify default clean.output.dir is false
+    # Verify that the default clean.output.dir is false and leaves temp files. Delete the left files at the same time.
     [  -d "../tutorial/schematron/xspec/" ]
-    [  -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
-    [  -f "../tutorial/schematron/demo-03.sch-compiled.xsl" ]
-
-    # Delete temp file
-    rm -f "../tutorial/schematron/demo-03.xspec-compiled.xspec"
-    rm -f "../tutorial/schematron/demo-03.sch-compiled.xsl"
+    rm    "../tutorial/schematron/demo-03.xspec-compiled.xspec"
+    rm    "../tutorial/schematron/demo-03.sch-compiled.xsl"
 }
 
 
@@ -437,13 +433,9 @@ teardown() {
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
 
-    # Verify the build fails after Schematron setup
-    [  -f "catalog/xspec-160_schematron.xspec-compiled.xspec" ]
-    [  -f "../tutorial/schematron/demo-04.sch-compiled.xsl" ]
-
-    # Delete temp file
-    rm -f "catalog/xspec-160_schematron.xspec-compiled.xspec"
-    rm -f "../tutorial/schematron/demo-04.sch-compiled.xsl"
+    # Verify that the build fails after Schematron setup and leaves temp files. Delete them at the same time.
+    rm "catalog/xspec-160_schematron.xspec-compiled.xspec"
+    rm "../tutorial/schematron/demo-04.sch-compiled.xsl"
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -353,7 +353,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD FAILED" ]]
+    [[ "${output}" =~ "BUILD FAILED" ]]
 }
 
 
@@ -362,7 +362,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 
@@ -371,7 +371,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 
@@ -380,7 +380,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
     # Verify default clean.output.dir is false
     [  -d "../tutorial/schematron/xspec/" ]
@@ -407,7 +407,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
     # Verify that -Dxspec-dir was honered and the default dir was not created
     [ ! -d "../tutorial/schematron/xspec/" ]
@@ -424,7 +424,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
-    [[ "${output}" =~  "BUILD FAILED" ]]
+    [[ "${output}" =~ "BUILD FAILED" ]]
 
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
@@ -444,7 +444,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 @test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -273,7 +273,7 @@ teardown() {
 
 
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -132,8 +132,11 @@ teardown() {
 }
 
 
-@test "invoking xspec generates XML and HTML report files" {
+@test "invoking xspec generates message with default report location and creates report files" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
@@ -190,14 +193,6 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
-}
-
-
-@test "invoking xspec.sh without TEST_DIR generates files in default location" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo "$output"
-    [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -222,8 +222,8 @@ teardown() {
 }
 
 
-@test "invoking xspec.sh with path containing an apostrophe runs successfully #119" {
-	special_chars_dir="${work_dir}/some'path"
+@test "invoking xspec.sh with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file" {
+	special_chars_dir="${work_dir}/some'path (84)"
 	mkdir "${special_chars_dir}"
 	cp ../tutorial/escape-for-regex.* "${special_chars_dir}"
 
@@ -233,6 +233,7 @@ teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[19]}" = "Report available at ${expected_report}" ]
+	[ -f "${expected_report}" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -166,24 +166,14 @@ teardown() {
 }
 
 
-@test "invoking xspec with -j option generates message with JUnit report location" {
+@test "invoking xspec with -j option generates message with JUnit report location and creates report files" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
-}
-
-
-@test "invoking xspec with -j option generates XML report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
-}
-
-
-@test "invoking xspec with -j option generates JUnit report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # JUnit report file
     [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -408,15 +408,7 @@ teardown() {
     [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
-@test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -35,7 +35,7 @@ teardown() {
 
 @test "invoking xspec without arguments prints usage" {
     run ../bin/xspec.sh
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
 }
@@ -43,7 +43,7 @@ teardown() {
 
 @test "invoking xspec with -s and -t prints error message" {
     run ../bin/xspec.sh -s -t
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-s and -t are mutually exclusive" ]
 }
@@ -51,7 +51,7 @@ teardown() {
 
 @test "invoking xspec with -s and -q prints error message" {
     run ../bin/xspec.sh -s -q
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-s and -q are mutually exclusive" ]
 }
@@ -59,7 +59,7 @@ teardown() {
 
 @test "invoking xspec with -t and -q prints error message" {
     run ../bin/xspec.sh -t -q
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-t and -q are mutually exclusive" ]
 }
@@ -68,7 +68,7 @@ teardown() {
 @test "invoking code coverage with Saxon9HE returns error message" {
     export SAXON_CP=/path/to/saxon9he.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -77,7 +77,7 @@ teardown() {
 @test "invoking code coverage with Saxon9SA returns error message" {
     export SAXON_CP=/path/to/saxon9sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -86,7 +86,7 @@ teardown() {
 @test "invoking code coverage with Saxon9 returns error message" {
     export SAXON_CP=/path/to/saxon9.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -95,7 +95,7 @@ teardown() {
 @test "invoking code coverage with Saxon8SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -104,7 +104,7 @@ teardown() {
 @test "invoking code coverage with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -114,7 +114,7 @@ teardown() {
     # Append non-Saxon jar to see if SAXON_CP is parsed correctly
     export SAXON_CP="/path/to/saxon9ee.jar:$XML_RESOLVER_CP"
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-  	echo $output
+  	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -123,7 +123,7 @@ teardown() {
 @test "invoking code coverage with Saxon9PE creates test stylesheet" {
     export SAXON_CP=/path/to/saxon9pe.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -132,7 +132,7 @@ teardown() {
 @test "invoking xspec generates XML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -140,7 +140,7 @@ teardown() {
 @test "invoking xspec generates HTML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.html
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -148,7 +148,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -157,7 +157,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8-SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -165,7 +165,7 @@ teardown() {
 
 @test "invoking xspec with -j option generates message with JUnit report location" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
@@ -174,7 +174,7 @@ teardown() {
 @test "invoking xspec with -j option generates XML report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -182,7 +182,7 @@ teardown() {
 @test "invoking xspec with -j option generates JUnit report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -190,7 +190,7 @@ teardown() {
 @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 1 ]
   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -199,7 +199,7 @@ teardown() {
 @test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
     export TEST_DIR=/tmp
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
 }
@@ -207,7 +207,7 @@ teardown() {
 
 @test "invoking xspec.sh without TEST_DIR generates files in default location" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
@@ -215,7 +215,7 @@ teardown() {
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
     run ../bin/xspec.sh ../test/xspec-46.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${lines[3]}" =~ "Testing with" ]]
 }
@@ -233,7 +233,7 @@ teardown() {
         run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"$query" !method=text
     fi
 
-    echo $output
+    echo "$output"
     [ "${lines[0]}" = "true" ]
 }
 
@@ -242,7 +242,7 @@ teardown() {
 	mkdir some\'path
 	cp ../tutorial/escape-for-regex.* some\'path 
 	run ../bin/xspec.sh some\'path/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
 	rm -rf some\'path
@@ -254,7 +254,7 @@ teardown() {
 	chmod +x /tmp/saxon
 	export PATH=$PATH:/tmp
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[0]}" = "Saxon script found, use it." ]
 	rm /tmp/saxon
@@ -275,7 +275,7 @@ teardown() {
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt-compile.xsl
     
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
-	echo $output
+	echo "$output"
     [ "${lines[4]}" = "Schematron XSLT include" ]
     [ "${lines[5]}" = "Schematron XSLT expand" ]
     [ "${lines[6]}" = "Schematron XSLT compile" ]
@@ -285,7 +285,7 @@ teardown() {
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
 	echo "${lines[4]}"
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]
 }
@@ -319,7 +319,7 @@ teardown() {
         run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     fi
 
-    echo $output
+    echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 }
 
@@ -333,7 +333,7 @@ teardown() {
 
 @test "Ant for XSLT with default properties fails on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
@@ -342,7 +342,7 @@ teardown() {
 
 @test "Ant for XSLT with xspec.fail=false continues on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP} -Dxspec.fail=false
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -351,7 +351,7 @@ teardown() {
 
 @test "Ant for XSLT with catalog resolves URI" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_xslt.xspec -lib ${SAXON_CP} -Dxspec.fail=false -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -360,7 +360,7 @@ teardown() {
 
 @test "Ant for Schematron with minimum properties #168" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -384,7 +384,7 @@ teardown() {
     cp ../build.xml /tmp/
 
     run ant -buildfile /tmp/build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir=${PWD}/xspec-temp -Dclean.output.dir=true
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -403,7 +403,7 @@ teardown() {
 
 @test "Ant for Schematron with catalog and default xspec.fail fails on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
@@ -423,7 +423,7 @@ teardown() {
 
 @test "Ant for Schematron with catalog and xspec.fail=false continues on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP} -Dxspec.fail=false
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -432,7 +432,7 @@ teardown() {
 @test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -440,7 +440,7 @@ teardown() {
 @test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -449,7 +449,7 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=catalog/catalog-01-catalog.xml
 	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -460,7 +460,7 @@ teardown() {
     cp catalog/catalog-01* cat\ a\ log
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog cat\ a\ log/catalog-01-catalog.xml cat\ a\ log/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf cat\ a\ log
@@ -473,7 +473,7 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=cat\ a\ log/catalog-01-catalog.xml
 	run ../bin/xspec.sh cat\ a\ log/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf cat\ a\ log
@@ -486,7 +486,7 @@ teardown() {
     cp $XML_RESOLVER_CP $SAXON_HOME
     export SAXON_CP=
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf $SAXON_HOME

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -272,23 +272,18 @@ teardown() {
 }
 
 
-@test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
+@test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131 and removes temporary files" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]
-}
-
-
-@test "Cleanup removes temporary files" {
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
-    [ "$status" -eq 0 ]
 
     # Cleanup removes compiled .xspec
     [ ! -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
 
     # Cleanup removes temporary files in TEST_DIR
     run ls ../tutorial/schematron/xspec
+	echo "$output"
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "demo-03-result.html" ]
     [ "${lines[1]}" = "demo-03-result.xml" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -433,7 +433,7 @@ teardown() {
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
-@test "invoking xspec.sh using -catalog with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -274,7 +274,6 @@ teardown() {
 
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
-	echo "${lines[4]}"
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]


### PR DESCRIPTION
(This pull request obsoletes #163.)

`xspec-bat.cmd` (a test script for Windows) fails if it tries to print some special characters. Demonstrated on [AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/build/498-harden-test-echo) using a temporary commit (484f6178489d9f7825f083310975909aa4e8975f).

This pull request fixes it.

No code change in XSpec core.

---

This pull request derives from #263. So needs to be handled after that.
