### PR TITLE
Test Ant saxon.custom.options property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
         # Ant version used in oXygen
         - ANT_VERSION=1.9.8
         # full path to XML Resolver jar
-        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/xml-resolver-1.2.jar
+        - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/resolver.jar
     matrix:
         # latest Saxon 9.8 version and full path to Jing jar
         - SAXON_VERSION=9.8.0-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ before_install:
 
 before_script:
     # install Saxon
-    - curl -fsSL --create-dirs -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+    - curl -fsSL --create-dirs --retry 5 -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
     # install XML Calabash
     - if [ -z ${XMLCALABASH_VERSION} ]; then
         echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
       else
-        curl -fsSL --create-dirs -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
+        curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
         unzip /tmp/xspec/xmlcalabash/xmlcalabash.zip -d /tmp/xspec/xmlcalabash;
         export XMLCALABASH_CP=/tmp/xspec/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
       fi
@@ -37,19 +37,19 @@ before_script:
         echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
       else
         export BASEX_CP=/tmp/xspec/basex/basex.jar;
-        curl -fsSL --create-dirs -o ${BASEX_CP} http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
+        curl -fsSL --create-dirs --retry 5 -o ${BASEX_CP} http://files.basex.org/maven/org/basex/basex/${BASEX_VERSION}/basex-${BASEX_VERSION}.jar;
       fi
     # install Ant
-    - curl -fsSL --create-dirs -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+    - curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
     - tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
     - export PATH=/tmp/xspec/ant/apache-ant-${ANT_VERSION}/bin:{$PATH}
     # install XML Resolver
-    - curl -fsSL --create-dirs -o ${XML_RESOLVER_CP} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
+    - curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_CP} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
     # install Jing
     - if [ -z ${JING_CP} ]; then
         echo "Jing will not be installed";
       else
-        curl -fsSL --create-dirs -o ${JING_CP} http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar;
+        curl -fsSL --create-dirs --retry 5 -o ${JING_CP} http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar;
       fi
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 - ps: >-
     # install Saxon
 
-    curl.exe -fsSL --create-dirs -o "${env:SAXON_CP}" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar"
+    curl.exe -fsSL --create-dirs --retry 5 -o "${env:SAXON_CP}" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${env:SAXON_VERSION}/Saxon-HE-${env:SAXON_VERSION}.jar"
 
 
     # install XML Calabash
@@ -31,7 +31,7 @@ install:
     }
 
     else {
-        curl.exe -fsSL --create-dirs -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
         7z x "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" -o"${env:TEMP}\xspec\xmlcalabash"
         ${env:XMLCALABASH_CP} = "${env:TEMP}\xspec\xmlcalabash\xmlcalabash-${env:XMLCALABASH_VERSION}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
     }
@@ -45,7 +45,7 @@ install:
 
     else {
         ${env:BASEX_CP} = "${env:TEMP}\xspec\basex\basex.jar"
-        curl.exe -fsSL --create-dirs -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
     }
 
 
@@ -56,7 +56,7 @@ install:
 
     # install XML Resolver
 
-    curl.exe -fsSL --create-dirs -o "${env:XML_RESOLVER_CP}" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+    curl.exe -fsSL --create-dirs --retry 5 -o "${env:XML_RESOLVER_CP}" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
 
 
     # install Jing
@@ -66,7 +66,7 @@ install:
     }
 
     else {
-        curl.exe -fsSL --create-dirs -o "${env:JING_CP}" "http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar"
+        curl.exe -fsSL --create-dirs --retry 5 -o "${env:JING_CP}" "http://central.maven.org/maven2/com/thaiopensource/jing/20091111/jing-20091111.jar"
     }
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-21
       XMLCALABASH_VERSION: 1.1.16-97
+      BASEX_VERSION: 8.6.4
     # Saxon version used in oXygen
     - SAXON_VERSION: 9.7.0-19
 
@@ -33,6 +34,18 @@ install:
         curl.exe -fsSL --create-dirs -o "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/${env:XMLCALABASH_VERSION}/xmlcalabash-${env:XMLCALABASH_VERSION}.zip"
         7z x "${env:TEMP}\xspec\xmlcalabash\xmlcalabash.zip" -o"${env:TEMP}\xspec\xmlcalabash"
         ${env:XMLCALABASH_CP} = "${env:TEMP}\xspec\xmlcalabash\xmlcalabash-${env:XMLCALABASH_VERSION}\xmlcalabash-${env:XMLCALABASH_VERSION}.jar"
+    }
+
+
+    # install BaseX
+
+    if( -Not( Test-Path -Path env:\BASEX_VERSION ) ) {
+        echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
+    }
+
+    else {
+        ${env:BASEX_CP} = "${env:TEMP}\xspec\basex\basex.jar"
+        curl.exe -fsSL --create-dirs -o "${env:BASEX_CP}" "http://files.basex.org/maven/org/basex/basex/${env:BASEX_VERSION}/basex-${env:BASEX_VERSION}.jar"
     }
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # Ant version used in oXygen
     ANT_VERSION: 1.9.8
     # full path to XML Resolver jar
-    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\xml-resolver-1.2.jar'
+    XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\resolver.jar'
   matrix:
     # latest Saxon 9.8 version and full path to Jing jar
     - SAXON_VERSION: 9.8.0-7

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -117,7 +117,7 @@ rem ##
     goto :EOF
 
 :win_get_options
-    set WIN_ARGV=%~1
+    set "WIN_ARGV=%~1"
 
     if not defined WIN_ARGV (
         goto :EOF
@@ -176,8 +176,8 @@ rem ##
         || ( call :die "Error getting Schematron phase and parameters" & goto :win_main_error_exit )
     set /P SCH_PARAMS=<"%TEST_DIR%\%TARGET_FILE_NAME%-var.txt"
     echo Paramaters: %SCH_PARAMS%
-    set SCHUT=%XSPEC%-compiled.xspec
-    set SCH_COMPILED=%SCH%-compiled.xsl
+    set "SCHUT=%XSPEC%-compiled.xspec"
+    set "SCH_COMPILED=%SCH%-compiled.xsl"
     
     echo:
     echo Compiling the Schematron...
@@ -202,13 +202,13 @@ rem ##
     
     echo:
     echo Compiling the Schematron tests...
-    set TEST_DIR_URI=file:///%TEST_DIR:\=/%
+    set "TEST_DIR_URI=file:///%TEST_DIR:\=/%"
     call :xslt -o:"%SCHUT%" -s:"%XSPEC%" ^
         -xsl:"%XSPEC_HOME%\src\schematron\schut-to-xspec.xsl" ^
         stylesheet="%SCH_COMPILED%" ^
         test_dir="%TEST_DIR_URI%" ^
         || ( call :die "Error compiling the Schematron tests" & goto :win_main_error_exit )
-    set XSPEC=%SCHUT%
+    set "XSPEC=%SCHUT%"
     echo:
     goto :EOF
 
@@ -227,7 +227,9 @@ rem ##
     rem
     rem Prints a message removing its surrounding quotes (")
     rem
-    echo %~1
+    set "WIN_ECHO_LINE=%~1"
+    setlocal enabledelayedexpansion
+    echo !WIN_ECHO_LINE!
     goto :EOF
 
 rem
@@ -271,7 +273,7 @@ rem
 rem # set XSPEC_HOME if it has not been set by the user (set it to the
 rem # parent dir of this script)
 rem
-if not defined XSPEC_HOME set XSPEC_HOME=%~dp0..
+if not defined XSPEC_HOME set "XSPEC_HOME=%~dp0.."
 
 rem
 rem # safety checks
@@ -328,7 +330,7 @@ if defined SAXON_HOME (
     )
 )
 
-set CP=%SAXON_CP%;%XSPEC_HOME%\java
+set "CP=%SAXON_CP%;%XSPEC_HOME%\java"
 
 rem
 rem ##
@@ -339,7 +341,7 @@ rem
 rem
 rem Saxon jar filename
 rem
-for %%I in ("%SAXON_CP:;=";"%") do if /i "%%~xI"==".jar" if /i "%%~nI" GEQ "saxon8" if /i "%%~nI" LSS "saxonb9a" set WIN_SAXON_JAR_N=%%~nI
+for %%I in ("%SAXON_CP:;=";"%") do if /i "%%~xI"==".jar" if /i "%%~nI" GEQ "saxon8" if /i "%%~nI" LSS "saxonb9a" set "WIN_SAXON_JAR_N=%%~nI"
 
 rem
 rem Parse command line
@@ -458,19 +460,19 @@ rem ## files and dirs ##########################################################
 rem ##
 rem
 
-if not defined TEST_DIR for %%I in ("%XSPEC%") do set TEST_DIR=%%~dpIxspec
-for %%I in ("%XSPEC%") do set TARGET_FILE_NAME=%%~nI
+if not defined TEST_DIR for %%I in ("%XSPEC%") do set "TEST_DIR=%%~dpIxspec"
+for %%I in ("%XSPEC%") do set "TARGET_FILE_NAME=%%~nI"
 
 if defined XSLT (
     set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xsl"
 ) else (
     set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xq"
 )
-set COVERAGE_XML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.xml
-set COVERAGE_HTML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.html
-set RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-result.xml
-set HTML=%TEST_DIR%\%TARGET_FILE_NAME%-result.html
-set JUNIT_RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-junit.xml
+set "COVERAGE_XML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.xml"
+set "COVERAGE_HTML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.html"
+set "RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-result.xml"
+set "HTML=%TEST_DIR%\%TARGET_FILE_NAME%-result.html"
+set "JUNIT_RESULT=%TEST_DIR%\%TARGET_FILE_NAME%-junit.xml"
 set COVERAGE_CLASS=com.jenitennison.xslt.tests.XSLTCoverageTraceListener
 
 if not exist "%TEST_DIR%" (

--- a/build.xml
+++ b/build.xml
@@ -8,336 +8,407 @@
 
 
 <project name="xspec" default="xspec" xmlns:if="ant:if" xmlns:unless="ant:unless">
-  <description>XSpec is a Behavior Driven Development (BDD) framework for XSLT and XQuery.
-    
+  <description><![CDATA[
     Usage (command-line):
     
-    ant -Dxspec.xml=/path/to/xspec/file
-    -Dtest.type=t|s
-    -Dxspec.project.dir=/path/to/folder/where/xspec/is/installed
-    -Dxspec.phase=#ALL
-    -lib /path/to/saxon.jar 
-    -lib /path/to/xml-resolver.jar 
-    -Dclean.output.dir=true|false
-    -Dxspec.fail=true|false
-
-    where:
-    
-    xspec.xml                  XSpec test file
-    test.type                  Value "t" if XSpec describes an XSLT file, "s" if XSpec describes a Schematron file
-                               [Optional; the default value is "t"]
-    xspec.project.dir          Folder in which XSpec is installed
-                               [Optional; the default is the folder containing this build file]
-    xspec.phase                Schematron phase. Used only for testing Schematron. Can be "#ALL".
-                               [Optional; the default is taken from "phase" parameter in XSpec file]
-    lib                        Additional jar libraries (saxon, xml-resolver)
-                               or folder where they are located
-    clean.output.dir           Value true to delete temporary files, value false to keep them
-                               [Optional; the default is false]
-    xspec.fail                 Value true makes the build fail when one or more tests failed
-                               [Optional; the default is true]
+      See https://github.com/xspec/xspec/wiki/Running-with-Ant
     
     ---
     
     Usage (Oxygen XSLT transformation scenario):
     
-    This file is an updated copy of Oxygen's ${frameworksDir}/xspec/build.xml 
+      This file can be used in place of Oxygen's ${frameworksDir}/xspec/build.xml 
     
-    Setup:
+      Setup:
     
-    - Duplicate Oxygen's default XSpec scenario
-    - Under Options tab:
-      - Build file: [this file]
-    - Under Parameters tab:
-      - New parameters if required (See the usage above):
-        - test.type
-        - xspec.phase
-        - xspec.fail
-      - Parameter xspec.project.dir value C:\Git\xspec
-      - If parameter catalog uses ${pdu}, replace it with ${pd}
+        - Duplicate Oxygen's default XSpec scenario
     
-  </description>
-  
-  <dirname property="xspec.project.dir" file="${ant.file.xspec}"/>
-  
-  <!-- File of properties determining or describing local
-       configuration. -->
-  <property name="xspec.properties" location="${xspec.project.dir}/xspec.properties"/>
-  <property file="${xspec.properties}"/>
-  
+        - Under Options tab:
+          - Build file: [this file]
     
-  <dirname property="xspec.base.dir" file="${xspec.xml}" />
-  <basename property="xspec.xml.base" file="${xspec.xml}" suffix=".xml" />
-  <basename property="xspec.base" file="${xspec.xml.base}" suffix=".xspec" />
-  
-  <property name="xspec.dir"
-    value="${xspec.base.dir}/xspec" />
-  
-  <property name="xspec.xsl"
-    value="${xspec.dir}/${xspec.base}.xsl" />
-  <property name="xspec.result.xml"
-    value="${xspec.dir}/${xspec.base}-result.xml" />
-  <property name="xspec.result.html"
-    value="${xspec.dir}/${xspec.base}-result.html" />
-  
-  <!-- property needed to create a custom Saxon, for example  -warnings:recover -strip:none -opt:10 -dtd:off -l:off -versionmsg:off -expand:on -outval:fatal -val:lax -->
-  <property name="saxon.custom.options" value=""/>
-  
-  <!-- property needed to control the cleanup of all intermediate files -->
-  <property name="clean.output.dir" value="false"/>
-  
-  <!-- property needed to customize the HTML result. -->
-  <property name="format.xspec.report" value="${xspec.project.dir}/src/reporter/format-xspec-report.xsl"/>
-  
-  <!-- property needed to control the cleanup of all intermediate files -->  
-  <condition property="can.delete">
-    <and>
-      <equals arg1="${clean.output.dir}" arg2="true"/>
-    </and>
-  </condition>
-  
-  
-  <property name="test.type" value="t"/>
-  <condition property="test.xslt">
-    <equals arg1="${test.type}" arg2="t"/>
-  </condition>
-  <condition property="test.schematron">
-    <equals arg1="${test.type}" arg2="s"/>
-  </condition>
-  
-  <property name="xspec.fail" value="true"/>
+        - Under Parameters tab:
+          - "xspec.project.dir" parameter value: "C:\Git\xspec" for example
+          - If "catalog" parameter uses ${pdu}, replace it with ${pd}
+          - New parameters if required (See https://github.com/xspec/xspec/wiki/Running-with-Ant):
+            - test.type
+            - xspec.phase
+            - xspec.fail
+  ]]></description>
 
-  <!-- .xspec file.
-    If testing Schematron, it is created at "STEP 4" and deleted by cleanup. -->
-  <condition property="xspec.compiled.xml" value="${xspec.xml}-compiled.xspec" else="${xspec.xml}">
-    <istrue value="${test.schematron}"/>
+  <!-- "xspec.project.dir" property: Documented in Wiki. DO NOT RENAME.
+    Directory where XSpec repository is cloned. -->
+  <dirname property="xspec.project.dir" file="${ant.file.xspec}" />
+
+  <!-- "xspec.properties" property: Documented. DO NOT RENAME.
+    Absolute or relative path of Ant properties file -->
+  <property name="xspec.properties" location="${xspec.project.dir}/xspec.properties" />
+  <property file="${xspec.properties}" />
+
+  <!-- "xspec.xml" property: Documented in Wiki. DO NOT RENAME.
+    No default value. This property is always provided by the user.
+    This property name is vague. Use the alias property "xspec.xspecfile.original" for internal use. -->
+
+  <!-- "saxon.custom.options" property: Used by Oxygen default transformation. DO NOT RENAME.
+    Optional command-line arguments passed to Saxon when running the tests.
+    For example, -warnings:recover -strip:none -opt:10 -dtd:off -l:off -versionmsg:off -expand:on
+    -outval:fatal -val:lax
+    No default value. This property is occasionally provided by the user. -->
+
+  <!-- "catalog" property: Documented in Wiki. DO NOT RENAME.
+    File path (not URL) of XML catalog file -->
+
+  <!-- File path of the original XSpec file specified by the user -->
+  <property name="xspec.xspecfile.original" value="${xspec.xml}" />
+
+  <!-- Directory of the original XSpec file -->
+  <dirname property="xspec.xspecfile.dir" file="${xspec.xspecfile.original}" />
+
+  <!-- File name (with extension) of the original XSpec file -->
+  <basename property="xspec.xspecfile.name" file="${xspec.xspecfile.original}" />
+
+  <!-- File name (without extension) of the original XSpec file -->
+  <basename property="xspec.xspecfile.name.without.xml"
+            file="${xspec.xspecfile.name}"
+            suffix=".xml" />
+  <basename property="xspec.xspecfile.name.without.ext"
+            file="${xspec.xspecfile.name.without.xml}"
+            suffix=".xspec" />
+
+  <!-- "xspec.dir" property: Documented in Wiki. DO NOT RENAME.
+    This property name is vague. Use the alias property "xspec.output.dir" for internal use. -->
+  <property name="xspec.dir" value="${xspec.xspecfile.dir}/xspec" />
+
+  <!-- Directory where various output files are created -->
+  <property name="xspec.output.dir" value="${xspec.dir}" />
+
+  <!-- File path of the XML report file -->
+  <property name="xspec.result.xml"
+            value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-result.xml" />
+
+  <!-- "xspec.result.html" property: Used by Oxygen default transformation. DO NOT RENAME.
+    File path of the HTML report file -->
+  <property name="xspec.result.html"
+            value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-result.html" />
+
+  <!-- "clean.output.dir" property: Documented in Wiki. DO NOT RENAME.
+    Controls whether to delete the output files -->
+  <property name="clean.output.dir" value="false" />
+
+  <!-- File path of XSLT file for formatting the HTML report file. -->
+  <property name="xspec.reporter.xsl"
+            value="${xspec.project.dir}/src/reporter/format-xspec-report.xsl" />
+
+  <!-- "test.type" property: Documented in Wiki. DO NOT RENAME.
+    Specifies XSLT, XQuery or Schematron -->
+  <property name="test.type" value="t" />
+
+  <!-- Properties indicating whether the test type is a specific type -->
+  <condition property="xspec.is.schematron" else="false">
+    <equals arg1="${test.type}" arg2="s" />
   </condition>
-  
-  <!-- Catalog URL
+  <condition property="xspec.is.xquery" else="false">
+    <equals arg1="${test.type}" arg2="q" />
+  </condition>
+  <condition property="xspec.is.xslt" else="false">
+    <equals arg1="${test.type}" arg2="t" />
+  </condition>
+
+  <!-- "xspec.fail" property: Documented in Wiki. DO NOT RENAME.
+    Controls whether to make the build fail when one or more tests failed -->
+  <property name="xspec.fail" value="true" />
+
+  <!-- File path of the XSpec file after preprocessing.
+    XSLT and XQuery: This property is just the alias of the original XSpec file.
+    Schematron: This file is created while preprocessing at "STEP 4" and deleted by cleanup. -->
+  <condition property="xspec.xspecfile.preprocessed"
+             value="${xspec.xspecfile.original}-compiled.xspec"
+             else="${xspec.xspecfile.original}">
+    <istrue value="${xspec.is.schematron}" />
+  </condition>
+
+  <!-- Catalog URL.
     To work around a Saxon bug, it must be URL: https://saxonica.plan.io/issues/3025#note-8
     To debug catalog resolution, -Dsaxon.custom.options=-t would help.
-    oXygen 19 default transformation scenario sets catalog even when file does not exist. Hence validate=false. -->
-  <makeurl property="catalog.url" file="${catalog}" validate="false" if:set="catalog"/>
+    Oxygen 20 default transformation scenario sets catalog even when file does not exist. Hence
+    validate=false. -->
+  <makeurl property="xspec.catalog.url" file="${catalog}" validate="false" if:set="catalog" />
 
+  <!-- File path of the compiled XSLT/XQuery file that finally runs the tests -->
+  <property name="xspec.compiled.runner.without.ext" 
+            value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}" />
+  <condition property="xspec.compiled.runner"
+             value="${xspec.compiled.runner.without.ext}.xq"
+             else="${xspec.compiled.runner.without.ext}.xsl">
+    <istrue value="${xspec.is.xquery}" />
+  </condition>
+
+  <!-- Converts URL to file path -->
   <scriptdef name="makepath" language="javascript" src="${xspec.project.dir}/src/ant/make-path.js">
-    <attribute name="url"/>
-    <attribute name="property"/>
+    <attribute name="url" />
+    <attribute name="property" />
   </scriptdef>
 
-  <!-- Transforms input xml and loads output xml as properties -->
+  <!-- Performs XSLT using Saxon with common parameters including catalog -->
+  <macrodef name="saxon-xslt">
+    <attribute name="in" />
+    <attribute name="out" />
+    <attribute name="style" />
+
+    <element name="factory-elements" optional="true" />
+    <element name="xslt-elements" optional="true" />
+
+    <sequential>
+      <xslt in="@{in}" out="@{out}" style="@{style}" force="true">
+        <factory name="net.sf.saxon.TransformerFactoryImpl">
+          <factory-elements />
+
+          <!-- For debugging -->
+          <!--<attribute name="http://saxon.sf.net/feature/timing"
+                     value="true"/>-->
+        </factory>
+
+        <xmlcatalog if:set="catalog">
+          <catalogpath>
+            <pathelement location="${catalog}" />
+          </catalogpath>
+        </xmlcatalog>
+
+        <xslt-elements />
+      </xslt>
+    </sequential>
+  </macrodef>
+
+  <!-- Transforms the input XML using the given XSLT and loads the output XML as Ant properties -->
   <macrodef name="xml-to-properties">
-    <attribute name="in"/>
-    <attribute name="style"/>
+    <attribute name="in" />
+    <attribute name="style" />
 
     <sequential>
       <!-- <tempfile deleteonexit=false> accumulates temp files. <tempfile deleteonexit=true> makes
         debugging a bit harder. Hence a fixed path. -->
-      <property name="xspec.xml-to-properties.temp" value="${xspec.dir}/${xspec.base}_xml-to-properties.xml"/>
+      <property name="xspec.xml-to-properties.temp"
+                value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}_xml-to-properties.xml" />
 
-      <xslt in="@{in}"
-        out="${xspec.xml-to-properties.temp}"
-        style="${xspec.project.dir}/src/ant/@{style}"
-        force="true"
-        >
-        <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-        <xmlcatalog if:set="catalog">
-          <catalogpath>
-            <pathelement location="${catalog}"/>
-          </catalogpath>
-        </xmlcatalog>
-      </xslt>
+      <saxon-xslt in="@{in}"
+                  out="${xspec.xml-to-properties.temp}"
+                  style="${xspec.project.dir}/src/ant/@{style}" />
 
-      <xmlproperty file="${xspec.xml-to-properties.temp}"/>
+      <xmlproperty file="${xspec.xml-to-properties.temp}" />
     </sequential>
   </macrodef>
 
-  <target name="locateSchematron" if="${test.schematron}">
-    <xml-to-properties in="${xspec.xml}" style="locate-schematron.xsl"/>
+  <!-- Prepares the environment before compilation -->
+  <target name="init">
+    <echo message="Testing ${xspec.xspecfile.name} [${test.type}]" />
 
-    <makepath url="${xspec.schematron.uri}" property="xspec.schematron.path"/>
-    <echo message="Path of Schematron file to compile: ${xspec.schematron.path}"/> 
+    <!-- Verify "test.type" -->
+    <fail message="Invalid test.type: '${test.type}'">
+      <condition>
+        <and>
+          <isfalse value="${xspec.is.schematron}" />
+          <isfalse value="${xspec.is.xquery}" />
+          <isfalse value="${xspec.is.xslt}" />
+        </and>
+      </condition>
+    </fail>
 
-    <!-- Location of compiled Schematron XSL file 
-      Since original Schematron may reference helper files at relative paths, the compiled XSL file
-      needs to go in the same folder as the original Schematron
-     -->
-    <property name="xspec.compiled.xsl" value="${xspec.schematron.path}-compiled.xsl"/>
+    <!-- Verify .xspec file existence, to avoid creating a useless output directory -->
+    <available property="xspec.xspecfile.is.available"
+               file="${xspec.xspecfile.original}" type="file" />
+    <fail message="XSpec file not found: '${xspec.xspecfile.original}'"
+          unless="xspec.xspecfile.is.available" />
+
+    <!-- Create the output directory.
+      Need to retry, for the creation may fail temporarily while running the build repeatedly
+      with clean.output.dir=true. -->
+    <retry retrycount="2" retrydelay="1000">
+      <mkdir dir="${xspec.output.dir}" />
+    </retry>
   </target>
-  
-  <target name="getSchematronPhase" if="${test.schematron}" unless="xspec.phase">
-    <xml-to-properties in="${xspec.xml}" style="get-schematron-phase.xsl"/>
-    <echo message="Schematron phase set in XSpec: '${xspec.phase}'" unless:blank="${xspec.phase}"/>
+
+  <!-- Gets the file path (not URL) of the Schematron file -->
+  <target name="locate-schematron-file" if="${xspec.is.schematron}">
+    <xml-to-properties in="${xspec.xspecfile.original}" style="locate-schematron.xsl" />
+    <makepath property="xspec.schematron.file" url="${xspec.schematron.uri}" />
+    <echo message="Path of Schematron file: ${xspec.schematron.file}"
+          level="info" />
   </target>
-  
-  
-  <target name="compileSchematron" depends="locateSchematron,getSchematronPhase" if="${test.schematron}">
-    <echo message="START COMPILING SCHEMATRON FILE '${xspec.schematron.path}'"/>
-    
-    <echo message="   STEP 1: Including modules"/>
-    <xslt in="${xspec.schematron.path}"
-      out="${xspec.dir}/${xspec.base}_dsdl_included.sch"
-      style="${xspec.project.dir}/src/schematron/iso-schematron/iso_dsdl_include.xsl"
-      force="true"
-      >
-      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
-    </xslt>
-    
-    <echo message="   STEP 2: Expanding abstracts"/>
-    <xslt in="${xspec.dir}/${xspec.base}_dsdl_included.sch" 
-      out="${xspec.dir}/${xspec.base}.sch" 
-      style="${xspec.project.dir}/src/schematron/iso-schematron/iso_abstract_expand.xsl" 
-      force="true"
-      >
-      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
-    </xslt>
-    
-    <echo message="   STEP 3: Convert Schematron to XSL"/>
-    <echo message="           phase=${xspec.phase}" unless:blank="${xspec.phase}"/>
-    <xslt 
-      in="${xspec.dir}/${xspec.base}.sch"
-      out="${xspec.compiled.xsl}" 
-      style="${xspec.project.dir}/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl" 
-      force="true"
-      >
-      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <!-- TODO: Parameters should be gathered from .xspec file -->
-      <param name="allow-foreign" expression="true"/>
-      <param name="phase" expression="${xspec.phase}" unless:blank="${xspec.phase}"/>
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
-    </xslt>
-    
-    <makeurl property="xspec.compiled.xsl.url" file="${xspec.compiled.xsl}"/>
-    <makeurl property="xspec.dir.url" file="${xspec.dir}"/>
 
-    <echo message="   STEP 4: Convert XSpec (into a format that references the XSL generated from the Schematron)"/>    
-    <xslt 
-      in="${xspec.xml}"
-      out="${xspec.compiled.xml}" 
-      style="${xspec.project.dir}/src/schematron/schut-to-xspec.xsl" 
-      force="true"
-      >
-      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <param name="stylesheet" expression="${xspec.compiled.xsl.url}"/>
-      <param name="test_dir" expression="${xspec.dir.url}"/>
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
-    </xslt>
+  <!-- Gets the Schematron phase defined in the XSpec file, if no phase was specified by the user.
+    Gets a zero-length string when the phase is not defined in the XSpec file. -->
+  <target name="get-schematron-phase" if="${xspec.is.schematron}" unless="xspec.phase">
+    <xml-to-properties in="${xspec.xspecfile.original}" style="get-schematron-phase.xsl" />
+    <echo message="Schematron phase set in XSpec: '${xspec.phase}'"
+          level="info"
+          unless:blank="${xspec.phase}" />
+  </target>
 
-    <echo message="COMPILATION COMPLETE"/>
-    
-   </target>
-  
-   
+  <!-- Preprocesses the XSpec file for Schematron -->
+  <target name="preprocess-schematron"
+          depends="locate-schematron-file, get-schematron-phase"
+          if="${xspec.is.schematron}">
+    <!-- Location of the temporary files -->
+    <property name="xspec.schematron.preprocessed.step1"
+              value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-sch-temp1.xml" />
+    <property name="xspec.schematron.preprocessed.step2"
+              value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-sch-temp2.xml" />
 
-  
-  <target name="xspec"
-    description="Runs the XSpec unit tests in ${xspec.compiled.xml}" depends="compileSchematron">
-    
-    <echo message="Creating Test Stylesheet..."/>
-    <xslt in="${xspec.compiled.xml}" 
-      out="${xspec.xsl}"
-      style="${xspec.project.dir}/src/compiler/generate-xspec-tests.xsl"
-      force="true"
-      >     
-      <factory name="net.sf.saxon.TransformerFactoryImpl" />     
+    <!-- Location of the preprocessed Schematron XSL file.
+      Since the original Schematron file may reference other files at relative paths,
+      the preprocessed XSL file needs to go in the same folder as the original Schematron file.
+      This file is created at "STEP 3" and deleted by cleanup. -->
+    <property name="xspec.schematron.preprocessed.xsl.file"
+              value="${xspec.schematron.file}-compiled.xsl" />
 
-	  <!-- Pass a catalog to Saxon -->
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
+    <echo message="STEP 1: Include modules"
+          level="info" />
+    <saxon-xslt in="${xspec.schematron.file}"
+                out="${xspec.schematron.preprocessed.step1}"
+                style="${xspec.project.dir}/src/schematron/iso-schematron/iso_dsdl_include.xsl" />
 
-    </xslt>
-    
-    <echo message="Running Tests..."/>
-    
+    <echo message="STEP 2: Expand abstracts"
+          level="info" />
+    <saxon-xslt in="${xspec.schematron.preprocessed.step1}"
+                out="${xspec.schematron.preprocessed.step2}"
+                style="${xspec.project.dir}/src/schematron/iso-schematron/iso_abstract_expand.xsl" />
+
+    <echo message="STEP 3: Convert Schematron to XSLT"
+          level="info" />
+    <echo message="phase=${xspec.phase}"
+          level="info"
+          unless:blank="${xspec.phase}" />
+    <saxon-xslt in="${xspec.schematron.preprocessed.step2}"
+                out="${xspec.schematron.preprocessed.xsl.file}"
+                style="${xspec.project.dir}/src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl">
+      <xslt-elements>
+        <!-- TODO: Parameters should be gathered from .xspec file -->
+        <param name="allow-foreign" expression="true" />
+        <param name="phase" expression="${xspec.phase}" unless:blank="${xspec.phase}" />
+      </xslt-elements>
+    </saxon-xslt>
+
+    <makeurl property="xspec.schematron.preprocessed.xsl.url"
+             file="${xspec.schematron.preprocessed.xsl.file}" />
+    <makeurl property="xspec.output.dir.url"
+             file="${xspec.output.dir}" />
+
+    <echo message="STEP 4: Convert XSpec into another XSpec that references the generated XSLT"
+          level="info" />
+    <saxon-xslt in="${xspec.xspecfile.original}"
+                out="${xspec.xspecfile.preprocessed}"
+                style="${xspec.project.dir}/src/schematron/schut-to-xspec.xsl">
+      <xslt-elements>
+        <param name="stylesheet" expression="${xspec.schematron.preprocessed.xsl.url}" />
+        <param name="test_dir" expression="${xspec.output.dir.url}" />
+      </xslt-elements>
+    </saxon-xslt>
+  </target>
+
+  <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
+  <target name="compile" depends="init, preprocess-schematron">
+    <condition property="xspec.compiler.xsl"
+               value="generate-query-tests.xsl"
+               else="generate-xspec-tests.xsl">
+      <istrue value="${xspec.is.xquery}" />
+    </condition>
+
+    <echo message="Compiling Tests..."
+          level="info" />
+    <saxon-xslt in="${xspec.xspecfile.preprocessed}"
+                out="${xspec.compiled.runner}"
+                style="${xspec.project.dir}/src/compiler/${xspec.compiler.xsl}" />
+  </target>
+
+  <!-- Runs the compiled XSpec for XQuery -->
+  <target name="run-xquery-test" depends="compile" if="${xspec.is.xquery}">
+    <echo message="Running XQuery Tests..."
+          level="info" />
+
     <!-- Can't specify saxon.custom.options with <xslt> task so have to
-		     fall back to running Saxon as Java app. -->
-    <java classname="net.sf.saxon.Transform"
-      fork="true">
+      fall back to running Saxon as Java app. -->
+    <java classname="net.sf.saxon.Query" fork="true" failonerror="true">
       <!-- Saxon should be included in the classpath -->
       <classpath>
-        <pathelement path="${java.class.path}"/>
+        <pathelement path="${java.class.path}" />
       </classpath>
-      
-      <arg value="-catalog:${catalog.url}" if:set="catalog"/>
-      
-      <!-- Pass custom options to Saxon, for example  -warnings:recover -strip:none -opt:10 -dtd:off -l:off -versionmsg:off -expand:on -outval:fatal -val:lax -->
-      <arg line="${saxon.custom.options}"/>
-      
-      <arg value="-ext:on" />
-      <arg value="-s:${xspec.compiled.xml}" />
+
+      <arg line="${saxon.custom.options}" if:set="saxon.custom.options" />
+      <arg value="-catalog:${xspec.catalog.url}" if:set="catalog" />
       <arg value="-o:${xspec.result.xml}" />
-      <arg value="-xsl:${xspec.xsl}" />
-      <arg value="-it:{http://www.jenitennison.com/xslt/xspec}main" />
+      <arg value="-s:${xspec.xspecfile.preprocessed}" />
+      <arg value="-q:${xspec.compiled.runner}" />
     </java>
-
-
-    <xslt in="${xspec.result.xml}"
-      out="${xspec.result.html}"
-      style="${format.xspec.report}">    
-      <factory name="net.sf.saxon.TransformerFactoryImpl">
-        <attribute
-          name="http://saxon.sf.net/feature/allow-external-functions" 
-          value="true"/>
-      </factory>
-
-      <xmlcatalog if:set="catalog">
-        <catalogpath>
-          <pathelement location="${catalog}"/>
-        </catalogpath>
-      </xmlcatalog>
-    </xslt>
-    <antcall target="fail"/>
-    <antcall target="cleanup"/>
   </target>
-  
+
+  <!-- Runs the compiled XSpec for XSLT -->
+  <target name="run-xslt-test" depends="compile" unless="${xspec.is.xquery}">
+    <echo message="Running XSLT Tests..."
+          level="info" />
+
+    <!-- Can't specify saxon.custom.options with <xslt> task so have to
+      fall back to running Saxon as Java app. -->
+    <java classname="net.sf.saxon.Transform" fork="true" failonerror="true">
+      <!-- Saxon should be included in the classpath -->
+      <classpath>
+        <pathelement path="${java.class.path}" />
+      </classpath>
+
+      <arg line="${saxon.custom.options}" if:set="saxon.custom.options" />
+      <arg value="-catalog:${xspec.catalog.url}" if:set="catalog" />
+      <arg value="-it:{http://www.jenitennison.com/xslt/xspec}main" />
+      <arg value="-ext:on" />
+      <arg value="-o:${xspec.result.xml}" />
+      <arg value="-s:${xspec.xspecfile.preprocessed}" />
+      <arg value="-xsl:${xspec.compiled.runner}" />
+    </java>
+  </target>
+
+  <!-- Main target -->
+  <target name="xspec"
+          description="Generates the result of XSpec tests"
+          depends="run-xquery-test, run-xslt-test">
+    <saxon-xslt in="${xspec.result.xml}"
+                out="${xspec.result.html}"
+                style="${xspec.reporter.xsl}">
+      <factory-elements>
+        <attribute name="http://saxon.sf.net/feature/allow-external-functions"
+                   value="true"/>
+      </factory-elements>
+      <xslt-elements>
+        <param name="inline-css" expression="true" />
+      </xslt-elements>
+    </saxon-xslt>
+
+    <antcall target="fail" />
+    <antcall target="cleanup" />
+  </target>
+
+  <!-- Makes the build fail, unless otherwise specified -->
   <target name="fail" if="${xspec.fail}">
-    <xml-to-properties in="${xspec.result.xml}" style="find-test-failure.xsl"/>
-    <fail message="XSpec tests failed. See ${xspec.result.html} for a report">
+    <xml-to-properties in="${xspec.result.xml}" style="find-test-failure.xsl" />
+    <fail message="XSpec tests failed. See ${xspec.result.html} for a report.">
       <condition>
         <not>
-          <istrue value="${xspec.passed}"/>
+          <istrue value="${xspec.passed}" />
         </not>
       </condition>
     </fail>
   </target>
-  
-  <target name="echoproperties">
-    <echoproperties />
-  </target>
-  
-  <!-- clean up if required.-->
-  <target name="cleanup" if="can.delete">
-    <echo>Clean up</echo>
-    
+
+  <!-- Cleans up the output files, if required-->
+  <target name="cleanup" if="${clean.output.dir}">
+    <echo message="Clean up"
+          level="info" />
+
     <!-- Need to retry, for someone may still hold a file, which tends to happen on AppVeyor. -->
     <retry retrycount="1" retrydelay="1000">
-      <delete dir="${xspec.dir}"/>
+      <delete dir="${xspec.output.dir}" />
     </retry>
-    
-    <delete file="${xspec.compiled.xml}" if:true="${test.schematron}"/>
-    <delete file="${xspec.compiled.xsl}"/>
+
+    <delete file="${xspec.xspecfile.preprocessed}" if:true="${xspec.is.schematron}" />
+    <delete file="${xspec.schematron.preprocessed.xsl.file}" />
   </target>
-  
+
 </project>
 
 

--- a/test/do-nothing.xquery
+++ b/test/do-nothing.xquery
@@ -1,0 +1,1 @@
+module namespace do-nothing = "x-urn:test:do-nothing";

--- a/test/do-nothing.xsl
+++ b/test/do-nothing.xsl
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />

--- a/test/html-charset.xsl
+++ b/test/html-charset.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xpath-default-namespace="http://www.w3.org/1999/xhtml">
+	<xsl:output method="text" />
+	<xsl:template as="text()" match="/">
+		<xsl:value-of>
+			<xsl:value-of
+				select="/html/head/meta[@http-equiv = 'Content-Type']/@content = 'text/html; charset=UTF-8'" />
+			<xsl:text>&#x0A;</xsl:text>
+		</xsl:value-of>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/html-css.xsl
+++ b/test/html-css.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xpath-default-namespace="http://www.w3.org/1999/xhtml">
+	<xsl:output method="text" />
+	<xsl:template as="text()" match="/">
+		<xsl:value-of>
+			<xsl:value-of
+				select="/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:')" />
+			<xsl:text>&#x0A;</xsl:text>
+		</xsl:value-of>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/saxon-custom-options/config.xml
+++ b/test/saxon-custom-options/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration edition="HE" xmlns="http://saxon.sf.net/ns/configuration">
+	<collations>
+		<collation ignore-case="yes" lang="en" uri="x-urn:test:saxon-custon-options:collation" />
+	</collations>
+</configuration>

--- a/test/saxon-custom-options/test.xspec
+++ b/test/saxon-custom-options/test.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xquery"
+	stylesheet="../do-nothing.xsl" xmlns:do-nothing="x-urn:test:do-nothing"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Compare 'a' and 'A' using custom collation">
+		<x:call function="compare">
+			<x:param select="'a'" />
+			<x:param select="'A'" />
+			<x:param select="'x-urn:test:saxon-custon-options:collation'" />
+		</x:call>
+		<x:expect label="Equal" select="0" />
+	</x:scenario>
+</x:description>

--- a/test/schematron.properties
+++ b/test/schematron.properties
@@ -1,0 +1,1 @@
+test.type=s

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -427,6 +427,21 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "Ant for XQuery with default properties"
+
+    if defined ANT_VERSION (
+        call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec" -lib "%SAXON_CP%" -Dtest.type=q
+        call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+        call :verify_line -2 x "BUILD SUCCESSFUL"
+    ) else (
+        call :skip "test for XQuery Ant with default properties skipped"
+    )
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "Ant for Schematron with minimum properties #168"
 
     if defined ANT_VERSION (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -58,7 +58,7 @@ for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 echo === START TEST CASES ================================================
 
 setlocal
-    call :setup "invoking xspec without arguments prints usage"
+    call :setup "invoking xspec without arguments prints usage & exit 1"
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -178,6 +178,8 @@ setlocal
     call :setup "invoking xspec generates XML report file"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+
+    rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     call :teardown
@@ -187,6 +189,8 @@ setlocal
     call :setup "invoking xspec generates HTML report file"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+
+    rem HTML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
 
     call :teardown
@@ -230,6 +234,8 @@ setlocal
     call :setup "invoking xspec with -j option generates XML report file"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+
+    rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     call :teardown
@@ -239,6 +245,8 @@ setlocal
     call :setup "invoking xspec with -j option generates JUnit report file"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
+
+    rem JUnit report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml
 
     call :teardown
@@ -373,7 +381,11 @@ setlocal
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
+
+    rem Cleanup removes compiled .xspec
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
+
+    rem Cleanup removes temporary files in TEST_DIR
     call :run dir /on ..\tutorial\schematron\xspec
     call :verify_line 9 r ".*3 File.*"
     call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
@@ -761,6 +773,7 @@ rem
 :teardown
     rem
     rem Remove the XSpec output directories
+    rem    Keep "..\test\" to minimize accident
     rem
     call :rmdir ..\test\xspec
     call :rmdir ..\tutorial\xspec
@@ -818,6 +831,7 @@ rem
 
     rem
     rem Run
+    rem    Launch a child process in order to localize various environment changes
     rem
     "%COMSPEC%" /c %* > "%OUTPUT_RAW%" 2>&1
     set RETVAL=%ERRORLEVEL%

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -501,12 +501,8 @@ setlocal
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
-        rem Verify default clean.output.dir is false
+        rem Verify that the default clean.output.dir is false and leaves temp files. Delete the left files at the same time.
         call :verify_exist ..\tutorial\schematron\xspec\
-        call :verify_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
-        call :verify_exist ..\tutorial\schematron\demo-03.sch-compiled.xsl
-
-        rem Delete temp file
         call :del          ..\tutorial\schematron\demo-03.xspec-compiled.xspec
         call :del          ..\tutorial\schematron\demo-03.sch-compiled.xsl
     ) else (
@@ -560,13 +556,9 @@ setlocal
         rem Verify the build fails before cleanup
         call :verify_exist catalog\xspec\
         
-        rem Verify the build fails after Schematron setup
-        call :verify_exist catalog\xspec-160_schematron.xspec-compiled.xspec
-        call :verify_exist ..\tutorial\schematron\demo-04.sch-compiled.xsl
-
-        rem Delete temp file
-        call :del          catalog\xspec-160_schematron.xspec-compiled.xspec
-        call :del          ..\tutorial\schematron\demo-04.sch-compiled.xsl
+        rem Verify that the build fails after Schematron setup and leaves temp files. Delete them at the same time.
+        call :del catalog\xspec-160_schematron.xspec-compiled.xspec
+        call :del ..\tutorial\schematron\demo-04.sch-compiled.xsl
     ) else (
         call :skip "test for Schematron Ant with catalog and default xspec.fail skipped"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -278,7 +278,7 @@ setlocal
 
     if defined XMLCALABASH_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -oresult=xspec/xspec-72-result.html ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-        call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:xspec\xspec-72-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')" !method=text
+        call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform -s:xspec\xspec-72-result.html -xsl:html-charset.xsl
         call :verify_line 1 x "true"
     ) else (
         call :skip "test for XProc skipped as XMLCalabash uses a higher version of Saxon"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -58,7 +58,7 @@ for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 echo === START TEST CASES ================================================
 
 setlocal
-    call :setup "invoking xspec without arguments prints usage & exit 1"
+    call :setup "invoking xspec without arguments prints usage"
 
     call :run ..\bin\xspec.bat
     call :verify_retval 1

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -771,10 +771,10 @@ rem
     rem
     rem Create the XSpec output directories
     rem
-    call :mkdir ..\test\xspec
-    call :mkdir ..\tutorial\xspec
-    call :mkdir ..\tutorial\schematron\xspec
     call :mkdir ..\test\catalog\xspec
+    call :mkdir ..\test\xspec
+    call :mkdir ..\tutorial\schematron\xspec
+    call :mkdir ..\tutorial\xspec
 
     goto :EOF
 
@@ -783,10 +783,10 @@ rem
     rem Remove the XSpec output directories
     rem    Keep "..\test\" to minimize accident
     rem
-    call :rmdir ..\test\xspec
-    call :rmdir ..\tutorial\xspec
-    call :rmdir ..\tutorial\schematron\xspec
     call :rmdir ..\test\catalog\xspec
+    call :rmdir ..\test\xspec
+    call :rmdir ..\tutorial\schematron\xspec
+    call :rmdir ..\tutorial\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -183,9 +183,11 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec generates XML and HTML report files"
+    call :setup "invoking xspec generates message with default report location and creates report files"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :verify_retval 0
+    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
@@ -256,16 +258,6 @@ setlocal
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat without TEST_DIR generates files in default location"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 0
-    call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -183,20 +183,12 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec generates XML report file"
+    call :setup "invoking xspec generates XML and HTML report files"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
 
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec generates HTML report file"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
 
     rem HTML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -550,7 +550,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -614,6 +614,52 @@ setlocal
     call :teardown
 endlocal
 
+setlocal
+    call :setup "Ant for XSLT with saxon.custom.options"
+
+    rem Test with a space in file name
+    set "SAXON_CONFIG=%WORK_DIR%\saxon config.xml"
+
+    if defined ANT_VERSION (
+        call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
+        
+        call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\saxon-custom-options\test.xspec" -lib "%SAXON_CP%" -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t"
+        call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+        call :verify_line -2 x "BUILD SUCCESSFUL"
+
+        rem Verify '-t'
+        call :verify_line  * r "     \[java\] Memory used:"
+    ) else (
+        call :skip "test for XSLT Ant with saxon.custom.options skipped"
+    )
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "Ant for XQuery with saxon.custom.options"
+
+    rem Test with a space in file name
+    set "SAXON_CONFIG=%WORK_DIR%\saxon config.xml"
+
+    if defined ANT_VERSION (
+        call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
+        
+        call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\saxon-custom-options\test.xspec" -lib "%SAXON_CP%" -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" -Dtest.type=q
+        call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+        call :verify_line -2 x "BUILD SUCCESSFUL"
+
+        rem Verify '-t'
+        call :verify_line  * r "     \[java\] Memory used:"
+    ) else (
+        call :skip "test for XQuery Ant with saxon.custom.options skipped"
+    )
+
+    call :teardown
+endlocal
+
 echo === END TEST CASES ==================================================
 
 rem

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -419,7 +419,7 @@ setlocal
     call :setup "executing the XProc harness for BaseX generates a report"
 
     if defined BASEX_CP (
-        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -38,6 +38,14 @@ rem
 set "THIS_FILE_NX=%~nx0"
 
 rem
+rem Availability of Ant
+rem
+if not defined ANT_VERSION (
+    where ant > NUL
+    if not errorlevel 1 set ANT_VERSION=1
+)
+
+rem
 rem Go to the directory where this script resides
 rem
 pushd "%~dp0"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -15,7 +15,7 @@ if errorlevel 1 (
 rem
 rem Results log file
 rem
-set RESULTS_FILE=%TEMP%\%~n0_results.log
+set "RESULTS_FILE=%TEMP%\%~n0_results.log"
 call :del "%RESULTS_FILE%"
 
 rem
@@ -23,19 +23,19 @@ rem Work directory
 rem  - Created at :setup
 rem  - Removed recursively at :teardown
 rem
-set WORK_DIR=%TEMP%\%~n0_work
+set "WORK_DIR=%TEMP%\%~n0_work"
 
 rem
 rem Output log files for :run
 rem
-set OUTPUT_RAW=%WORK_DIR%\run_raw.log
+set "OUTPUT_RAW=%WORK_DIR%\run_raw.log"
 set "OUTPUT_FILTERED=%WORK_DIR%\run_filtered.log"
-set OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log
+set "OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log"
 
 rem
 rem Name and extension of this file
 rem
-set THIS_FILE_NX=%~nx0
+set "THIS_FILE_NX=%~nx0"
 
 rem
 rem Go to the directory where this script resides
@@ -45,7 +45,7 @@ pushd "%~dp0"
 rem
 rem Full path to the parent directory
 rem
-for %%I in (..) do set PARENT_DIR_ABS=%%~fI
+for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
 
 echo === START TEST CASES ================================================
 
@@ -259,7 +259,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with TEST_DIR already set externally generates files inside TEST_DIR"
 
-    set TEST_DIR=%WORK_DIR%
+    set "TEST_DIR=%WORK_DIR%"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
@@ -305,11 +305,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for parentheses dir generates HTML report file #84"
 
-    set PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)
+    set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
     call :mkdir "%PARENTHESES_DIR%"
     copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%" > NUL
 
-    set EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html
+    set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
 
     call :run ..\bin\xspec.bat "%PARENTHESES_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
@@ -322,7 +322,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
 
-    set APOSTROPHE_DIR=%WORK_DIR%\some'path
+    set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
     call :mkdir "%APOSTROPHE_DIR%"
     copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%" > NUL
 
@@ -465,7 +465,7 @@ endlocal
 setlocal
     call :setup "Ant for Schematron with various properties except catalog"
 
-    set BUILD_XML=%WORK_DIR%\build.xml
+    set "BUILD_XML=%WORK_DIR%\build.xml"
 
     if defined ANT_VERSION (
         rem Remove a temp dir created by setup
@@ -537,7 +537,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -548,7 +548,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
     call :verify_retval 0
     call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -559,7 +559,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver"
 
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set XML_CATALOG=catalog\catalog-01-catalog.xml
     call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
     call :verify_retval 0
@@ -571,11 +571,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using -catalog with spaces in file path uses XML Catalog resolver"
 
-    set SPACE_DIR=%WORK_DIR%\cat a log
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
     copy catalog\catalog-01* "%SPACE_DIR%"
     
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -586,11 +586,11 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
 
-    set SPACE_DIR=%WORK_DIR%\cat a log
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
     copy catalog\catalog-01* "%SPACE_DIR%"
     
-    set SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
@@ -603,9 +603,9 @@ setlocal
     call :setup "invoking xspec.bat using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar"
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
-    call :mkdir %SAXON_HOME%
-    copy %SAXON_CP% %SAXON_HOME%
-    copy %XML_RESOLVER_CP% %SAXON_HOME%
+    call :mkdir "%SAXON_HOME%"
+    copy "%SAXON_CP%"        "%SAXON_HOME%"
+    copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
@@ -658,7 +658,7 @@ if not defined EXIT_CODE (
     set EXIT_CODE=1
 )
 if %EXIT_CODE% NEQ 0 (
-    echo ---------- %RESULTS_FILE%
+    echo ---------- "%RESULTS_FILE%"
     type "%RESULTS_FILE%"
     echo ----------
 )
@@ -709,10 +709,10 @@ rem
     rem
     rem Report 'Running'
     rem
-    set CASE_NAME=%~1
+    set "CASE_NAME=%~1"
     call :appveyor AddTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Running
     echo CASE: %CASE_NAME%
-    (echo # %CASE_NAME%) >> "%RESULTS_FILE%"
+    (echo # "%CASE_NAME%") >> "%RESULTS_FILE%"
 
     rem
     rem Create the work directory
@@ -812,7 +812,7 @@ rem
         call :verified "Return value: %RETVAL%"
     ) else (
         call :failed "Return value is %RETVAL%. Expected %~1."
-        echo ---------- %OUTPUT_RAW%
+        echo ---------- "%OUTPUT_RAW%"
         type "%OUTPUT_RAW%"
         echo ----------
     )
@@ -863,7 +863,7 @@ rem
     )
     if errorlevel 1 (
         call :failed "Line %LINE_NUMBER% does not match the expected string"
-        echo ---------- %OUTPUT_LINENUM%
+        echo ---------- "%OUTPUT_LINENUM%"
         type "%OUTPUT_LINENUM%"
         echo ----------
     ) else (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -288,9 +288,9 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file"
+    call :setup "invoking xspec.bat with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs successfully and generates HTML report file"
 
-    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84)"
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84) here & there"
     call :mkdir "%SPECIAL_CHARS_DIR%"
     call :copy ..\tutorial\escape-for-regex.* "%SPECIAL_CHARS_DIR%"
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -288,26 +288,9 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat for parentheses dir generates HTML report file #84"
+    call :setup "invoking xspec.bat with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file"
 
-    set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
-    call :mkdir "%PARENTHESES_DIR%"
-    call :copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%"
-
-    set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
-
-    call :run ..\bin\xspec.bat "%PARENTHESES_DIR%\escape-for-regex.xspec"
-    call :verify_retval 0
-    call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
-    call :verify_exist "%EXPECTED_REPORT%"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
-
-    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path"
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84)"
     call :mkdir "%SPECIAL_CHARS_DIR%"
     call :copy ..\tutorial\escape-for-regex.* "%SPECIAL_CHARS_DIR%"
 
@@ -316,6 +299,7 @@ setlocal
     call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
     call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
+    call :verify_exist "%EXPECTED_REPORT%"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -394,11 +394,11 @@ setlocal
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
 
     rem Cleanup removes temporary files in TEST_DIR
-    call :run dir /on ..\tutorial\schematron\xspec
-    call :verify_line 9 r ".*3 File.*"
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.html
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03-result.xml
-    call :verify_exist ..\tutorial\schematron\xspec\demo-03.xsl
+    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :verify_line_count 3
+    call :verify_line 1 x demo-03.xsl
+    call :verify_line 2 x demo-03-result.html
+    call :verify_line 3 x demo-03-result.xml
 
     call :teardown
 endlocal
@@ -919,6 +919,18 @@ rem
         echo ----------
     ) else (
         call :verified "Line %LINE_NUMBER%"
+    )
+    goto :EOF
+
+:verify_line_count
+    for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set LINE_COUNT=%%I
+    if %LINE_COUNT% EQU %~1 (
+        call :verified "Line count: %~1"
+    ) else (
+        call :failed "Line count %LINE_COUNT% does not match the expected count %~1"
+        echo ---------- "%OUTPUT_LINENUM%"
+        type "%OUTPUT_LINENUM%"
+        echo ----------
     )
     goto :EOF
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -297,7 +297,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat that passes a non xs:boolean does not raise a warning #46"
 
-    call :run ..\bin\xspec.bat ..\test\xspec-46.xspec
+    call :run ..\bin\xspec.bat xspec-46.xspec
     call :verify_retval 0
     call :verify_line 4 r "Testing with"
 
@@ -352,7 +352,7 @@ endlocal
 setlocal
     call :setup "Schematron phase/parameters are passed to Schematron compile"
 
-    call :run ..\bin\xspec.bat -s ..\test\schematron-param-001.xspec
+    call :run ..\bin\xspec.bat -s schematron-param-001.xspec
     call :verify_retval 0
     call :verify_line 3 x "Paramaters: phase=P1 ?selected=codepoints-to-string((80,49))"
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -466,6 +466,7 @@ setlocal
     call :setup "Ant for Schematron with various properties except catalog"
 
     set "BUILD_XML=%WORK_DIR%\build.xml"
+    set "ANT_TEST_DIR=%WORK_DIR%\ant-temp"
 
     if defined ANT_VERSION (
         rem Remove a temp dir created by setup
@@ -474,7 +475,7 @@ setlocal
         rem For testing -Dxspec.project.dir
         call :copy ..\build.xml "%BUILD_XML%"
 
-        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
+        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
         call :verify_retval 0
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -483,7 +484,7 @@ setlocal
         call :verify_not_exist ..\tutorial\schematron\xspec\
 
         rem Verify clean.output.dir=true
-        call :verify_not_exist xspec-temp\
+        call :verify_not_exist "%ANT_TEST_DIR%"
         call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec
         call :verify_not_exist ..\tutorial\schematron\demo-03.sch-compiled.xsl
     ) else (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -542,19 +542,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver"
-
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    set XML_CATALOG=catalog\catalog-01-catalog.xml
-    call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat using XML_CATALOG with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -373,6 +373,10 @@ setlocal
     call :verify_line 6 x "Schematron XSLT expand"
     call :verify_line 7 x "Schematron XSLT compile"
 
+    rem With the provided dummy XSLTs, XSpec leaves temp files. Delete them.
+    call :del ..\tutorial\schematron\demo-01.sch-compiled.xsl
+    call :del ..\tutorial\schematron\demo-01.xspec-compiled.xspec
+
     call :teardown
 endlocal
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -29,6 +29,7 @@ rem
 rem Output log files for :run
 rem
 set OUTPUT_RAW=%WORK_DIR%\run_raw.log
+set "OUTPUT_FILTERED=%WORK_DIR%\run_filtered.log"
 set OUTPUT_LINENUM=%WORK_DIR%\run_linenum.log
 
 rem
@@ -398,6 +399,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_CP%"
         call :verify_retval 1
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -4 x "BUILD FAILED"
     ) else (
         call :skip "test for XSLT Ant with default properties skipped"
@@ -412,6 +414,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_CP%" -Dxspec.fail=false
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for XSLT Ant with xspec.fail=false skipped"
@@ -426,6 +429,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_xslt.xspec" -lib "%SAXON_CP%" -Dxspec.fail=false -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%"
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for XSLT Ant with catalog skipped"
@@ -440,6 +444,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
         rem Verify default clean.output.dir is false
@@ -471,6 +476,7 @@ setlocal
 
         call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"
 
         rem Verify that -Dxspec-dir was honered and the default dir was not created
@@ -493,6 +499,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_schematron.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%"
         call :verify_retval 1
+        call :verify_line  * x "     [xslt] passed: 6 / pending: 0 / failed: 1 / total: 7"
         call :verify_line -4 x "BUILD FAILED"
 
         rem Verify the build fails before cleanup
@@ -518,6 +525,7 @@ setlocal
     if defined ANT_VERSION (
         call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\catalog\xspec-160_schematron.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog="%CD%\catalog\xspec-160_catalog.xml" -lib "%XML_RESOLVER_CP%" -Dxspec.fail=false
         call :verify_retval 0
+        call :verify_line  * x "     [xslt] passed: 6 / pending: 0 / failed: 1 / total: 7"
         call :verify_line -2 x "BUILD SUCCESSFUL"
     ) else (
         call :skip "test for Schematron Ant with catalog and xspec.fail=false skipped"
@@ -786,11 +794,16 @@ rem
     set RETVAL=%ERRORLEVEL%
 
     rem
+    rem Normalize CR LF.
     rem Remove the JAVA_TOOL_OPTIONS output, to keep the line numbers predictable.
     rem Remove the empty lines, to be compatible with Bats $lines.
+    rem
+    type "%OUTPUT_RAW%" | find /v "" | findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" | findstr /r /v /c:"^$" > "%OUTPUT_FILTERED%"
+
+    rem
     rem Prefix each line with its line number.
     rem
-    findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" "%OUTPUT_RAW%" | findstr /r /v /c:"^$" | find /v /n "" > "%OUTPUT_LINENUM%"
+    type "%OUTPUT_FILTERED%" | find /v /n "" > "%OUTPUT_LINENUM%"
 
     goto :EOF
 
@@ -814,11 +827,12 @@ rem
         echo 3: %3
     )
     rem
-    rem Checks to see if the specified line of the output log file matches exactly the specified string
+    rem Checks to see if the specified line of the output log file matches the specified string
     rem
     rem Parameters:
     rem    1: Line number. Starts with 1, unlike Bats $lines which starts with 0.
-    rem        Negative values indicate the reverse order. -1 is the last line. -2 is the line before the last line, and so on.
+    rem        Negative value : Indicates the reverse order. -1 is the last line. -2 is the line before the last line, and so on.
+    rem        * : Don't care. Any line.
     rem    2: Operator
     rem        x : Exact match ("=" on Bats)
     rem        r : Compare with regular expression ("=~" on Bats)
@@ -827,15 +841,22 @@ rem
     rem
 
     set LINE_NUMBER=%~1
-    if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set /a LINE_NUMBER+=%%I+1
+    if not %LINE_NUMBER%==* if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set /a LINE_NUMBER+=%%I+1
+
+                        set "FIND_STRING=[%LINE_NUMBER%]%~3"
+    if /i "%~2"=="r"    set "FIND_STRING=\[%LINE_NUMBER%\]%~3"
+    if %LINE_NUMBER%==* set "FIND_STRING=%~3"
+
+                        set "FIND_FILE=%OUTPUT_LINENUM%"
+    if %LINE_NUMBER%==* set "FIND_FILE=%OUTPUT_FILTERED%"
 
     rem
-    rem Search the line-numbered output log file
+    rem Search the output log file
     rem
     if        /i "%~2"=="x" (
-        findstr /l /x /c:"[%LINE_NUMBER%]%~3" "%OUTPUT_LINENUM%" > NUL
+        findstr /l /x /c:"%FIND_STRING%" "%FIND_FILE%" > NUL
     ) else if /i "%~2"=="r" (
-        findstr /b /r /c:"\[%LINE_NUMBER%\]%~3" "%OUTPUT_LINENUM%" > NUL
+        findstr /b /r /c:"%FIND_STRING%" "%FIND_FILE%" > NUL
     ) else (
         call :failed "Bad operator: %~2"
         goto :EOF

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -516,18 +516,7 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver"
-
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
+    call :setup "invoking xspec.bat for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path"
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -421,6 +421,9 @@ setlocal
     if defined BASEX_CP (
         call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+        rem Default compiled-file
+        call :verify_exist \tmp\xspec-basex-compiled-suite.xq
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -418,12 +418,14 @@ endlocal
 setlocal
     call :setup "executing the XProc harness for BaseX generates a report"
 
+    set "COMPILED_FILE=%WORK_DIR%\compiled.xq"
+
     if defined BASEX_CP (
-        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -p compiled-file="file:/%COMPILED_FILE:\=/%" -o result=xspec/xquery-tutorial-result.html ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
         call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
 
-        rem Default compiled-file
-        call :verify_exist \tmp\xspec-basex-compiled-suite.xq
+        rem compiled-file
+        call :verify_exist "%COMPILED_FILE%"
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -527,6 +527,21 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
+
+    set "SPACE_DIR=%WORK_DIR%\cat a log"
+    call :mkdir "%SPACE_DIR%\xspec"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
+    
+    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
+    call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
+    call :verify_retval 0
+    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "invoking xspec.bat for XQuery with -catalog uses XML Catalog resolver"
 
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
@@ -543,21 +558,6 @@ setlocal
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set XML_CATALOG=catalog\catalog-01-catalog.xml
     call :run ..\bin\xspec.bat catalog\catalog-01-xslt.xspec
-    call :verify_retval 0
-    call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec.bat for XSLT using -catalog with spaces in file path uses XML Catalog resolver"
-
-    set "SPACE_DIR=%WORK_DIR%\cat a log"
-    call :mkdir "%SPACE_DIR%\xspec"
-    call :copy catalog\catalog-01* "%SPACE_DIR%"
-    
-    set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
-    call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
     call :verify_line 8 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -350,20 +350,11 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131"
+    call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131 and removes temporary files"
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
     call :verify_line 5 x "Compiling the Schematron tests..."
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "Cleanup removes temporary files"
-
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
-    call :verify_retval 0
 
     rem Cleanup removes compiled .xspec
     call :verify_not_exist ..\tutorial\schematron\demo-03.xspec-compiled.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -338,13 +338,15 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with path containing an apostrophe runs successfully #119"
 
-    set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
-    call :mkdir "%APOSTROPHE_DIR%"
-    call :copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%"
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path"
+    call :mkdir "%SPECIAL_CHARS_DIR%"
+    call :copy ..\tutorial\escape-for-regex.* "%SPECIAL_CHARS_DIR%"
 
-    call :run ..\bin\xspec.bat "%APOSTROPHE_DIR%\escape-for-regex.xspec"
+    set "EXPECTED_REPORT=%SPECIAL_CHARS_DIR%\xspec\escape-for-regex-result.html"
+
+    call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
-    call :verify_line 20 x "Report available at %APOSTROPHE_DIR%\xspec\escape-for-regex-result.html"
+    call :verify_line 20 x "Report available at %EXPECTED_REPORT%"
 
     call :teardown
 endlocal

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -605,7 +605,7 @@ setlocal
     set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir "%SAXON_HOME%"
     call :copy "%SAXON_CP%"        "%SAXON_HOME%"
-    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
+    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%\xml-resolver-1.2.jar"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -525,7 +525,7 @@ setlocal
         rem For testing -Dxspec.project.dir
         call :copy ..\build.xml "%BUILD_XML%"
 
-        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
+        call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dxspec.properties="%CD%\schematron.properties" -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
         call :verify_retval 0
         call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
         call :verify_line -2 x "BUILD SUCCESSFUL"

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -16,7 +16,7 @@ rem
 rem Results log file
 rem
 set "RESULTS_FILE=%TEMP%\%~n0_results.log"
-call :del "%RESULTS_FILE%"
+if exist "%RESULTS_FILE%" call :del "%RESULTS_FILE%"
 
 rem
 rem Work directory
@@ -732,8 +732,11 @@ rem
 
 :del
     if exist %1 (
-        del /q %1
-        if errorlevel 1 call :failed "Failed to del: %~1"
+        rem DEL returns 0 as long as the parameter is valid
+        del %1
+        if exist %1 call :failed "Failed to del: %~1"
+    ) else (
+        call :failed "File not found for del: %~1"
     )
     goto :EOF
 
@@ -744,16 +747,26 @@ rem
 
 :rmdir
     if exist %1 (
-        call :del "%~1\*"
+        rem DEL and RMDIR return 0 as long as the parameter is valid
+        del /q "%~1\*"
         rmdir %1
-        if errorlevel 1 call :failed "Failed to rmdir: %~1"
+        if exist %1 call :failed "Failed to rmdir: %~1"
+    ) else (
+        call :failed "Dir not found for rmdir: %~1"
     )
+    goto :EOF
+
+:rmdir-if-exist
+    if exist %1 call :rmdir %1
     goto :EOF
 
 :rmdir-s
     if exist %1 (
+        rem RMDIR returns 0 as long as the parameter is valid
         rmdir /s /q %1
-        if errorlevel 1 call :failed "Failed to rmdir /s: %~1"
+        if exist %1 call :failed "Failed to rmdir /s: %~1"
+    ) else (
+        call :failed "Dir not found for rmdir /s: %~1"
     )
     goto :EOF
 
@@ -790,10 +803,10 @@ rem
     rem Remove the XSpec output directories
     rem    Keep "..\test\" to minimize accident
     rem
-    call :rmdir ..\test\catalog\xspec
-    call :rmdir ..\test\xspec
-    call :rmdir ..\tutorial\schematron\xspec
-    call :rmdir ..\tutorial\xspec
+    call :rmdir-if-exist ..\test\catalog\xspec
+    call :rmdir          ..\test\xspec
+    call :rmdir-if-exist ..\tutorial\schematron\xspec
+    call :rmdir          ..\tutorial\xspec
 
     rem
     rem Remove the work directory

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -307,7 +307,7 @@ setlocal
 
     set "PARENTHESES_DIR=%WORK_DIR%\%~n0 (84)"
     call :mkdir "%PARENTHESES_DIR%"
-    copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%" > NUL
+    call :copy ..\tutorial\escape-for-regex.* "%PARENTHESES_DIR%"
 
     set "EXPECTED_REPORT=%PARENTHESES_DIR%\xspec\escape-for-regex-result.html"
 
@@ -324,7 +324,7 @@ setlocal
 
     set "APOSTROPHE_DIR=%WORK_DIR%\some'path"
     call :mkdir "%APOSTROPHE_DIR%"
-    copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%" > NUL
+    call :copy ..\tutorial\escape-for-regex.* "%APOSTROPHE_DIR%"
 
     call :run ..\bin\xspec.bat "%APOSTROPHE_DIR%\escape-for-regex.xspec"
     call :verify_retval 0
@@ -472,7 +472,7 @@ setlocal
         call :rmdir ..\tutorial\schematron\xspec
 
         rem For testing -Dxspec.project.dir
-        copy ..\build.xml "%BUILD_XML%" > NUL
+        call :copy ..\build.xml "%BUILD_XML%"
 
         call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_CP%" -Dtest.type=s -Dxspec.project.dir="%CD%\.." -Dxspec.phase=#ALL -Dxspec.dir="%CD%\xspec-temp" -Dclean.output.dir=true
         call :verify_retval 0
@@ -573,7 +573,7 @@ setlocal
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
-    copy catalog\catalog-01* "%SPACE_DIR%"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
     
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
@@ -588,7 +588,7 @@ setlocal
 
     set "SPACE_DIR=%WORK_DIR%\cat a log"
     call :mkdir "%SPACE_DIR%\xspec"
-    copy catalog\catalog-01* "%SPACE_DIR%"
+    call :copy catalog\catalog-01* "%SPACE_DIR%"
     
     set "SAXON_CP=%SAXON_CP%;%XML_RESOLVER_CP%"
     set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
@@ -604,8 +604,8 @@ setlocal
 
     set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir "%SAXON_HOME%"
-    copy "%SAXON_CP%"        "%SAXON_HOME%"
-    copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
+    call :copy "%SAXON_CP%"        "%SAXON_HOME%"
+    call :copy "%XML_RESOLVER_CP%" "%SAXON_HOME%"
     set SAXON_CP=
     
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
@@ -673,6 +673,11 @@ exit /b %EXIT_CODE%
 rem
 rem Subroutines
 rem
+
+:copy
+    copy %1 %2 > NUL
+    if errorlevel 1 call :failed "Failed to copy: %~1 to %~2"
+    goto :EOF
 
 :del
     if exist %1 (

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -632,6 +632,15 @@ rem
 rem Subroutines
 rem
 
+:echo
+    rem
+    rem Prints a message removing its surrounding quotes (")
+    rem
+    set "ECHO_LINE=%~1"
+    setlocal enabledelayedexpansion
+    echo !ECHO_LINE!
+    goto :EOF
+
 :copy
     copy %1 %2 > NUL
     if errorlevel 1 call :failed "Failed to copy: %~1 to %~2"
@@ -687,7 +696,7 @@ rem
     rem
     set "CASE_NAME=%~1"
     call :appveyor AddTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Running
-    echo CASE: %CASE_NAME%
+    call :echo "CASE: %CASE_NAME%"
     (echo # "%CASE_NAME%") >> "%RESULTS_FILE%"
 
     rem
@@ -731,21 +740,21 @@ rem
     goto :EOF
 
 :verified
-    echo ...Verified: %~1
+    call :echo "...Verified: %~1"
     if not defined CASE_RESULT set CASE_RESULT=0
     goto :EOF
 
 :failed
-    echo ...FAIL: %~1
+    call :echo "...FAIL: %~1"
     set CASE_RESULT=1
     (echo %CASE_RESULT%) >> "%RESULTS_FILE%"
     if defined CASE_NAME call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Failed -Duration 0 -ErrorMessage %1
     goto :EOF
 
 :skip
-    echo ...SKIP: %~1
+    call :echo "...SKIP: %~1"
     set CASE_RESULT=2
-    (echo # %~1) >> "%RESULTS_FILE%"
+    (echo # %1) >> "%RESULTS_FILE%"
     call :appveyor UpdateTest "%CASE_NAME%" -Framework custom -Filename "%THIS_FILE_NX%" -Outcome Skipped -Duration 0
     goto :EOF
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -384,6 +384,29 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec.bat with -q option runs XSpec test for XQuery"
+
+    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :verify_retval 0
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+
+    call :teardown
+endlocal
+
+setlocal
+    call :setup "executing the XProc harness for BaseX generates a report"
+
+    if defined BASEX_CP (
+        call :run java -Xmx1024m -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" -p basex-jar="%BASEX_CP%" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+    ) else (
+        call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
+    )
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "HTML report contains CSS inline and not as an external file #135"
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -352,7 +352,7 @@ endlocal
 setlocal
     call :setup "invoking xspec.bat with the -s option does not display Schematron warnings #129 #131"
 
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
     call :verify_retval 0
     call :verify_line 5 x "Compiling the Schematron tests..."
 

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -229,30 +229,14 @@ setlocal
 endlocal
 
 setlocal
-    call :setup "invoking xspec with -j option generates message with JUnit report location"
+    call :setup "invoking xspec with -j option generates message with JUnit report location and creates report files"
 
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
 
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec with -j option generates XML report file"
-
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
-
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "invoking xspec with -j option generates JUnit report file"
-
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
 
     rem JUnit report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -193,7 +193,7 @@ setlocal
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
     rem HTML report file is created and contains CSS inline #135
-    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
     call :verify_line 1 x "true"
 
     call :teardown

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -189,11 +189,12 @@ setlocal
     call :verify_retval 0
     call :verify_line 19 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
-    rem XML report file
+    rem XML report file is created
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
 
-    rem HTML report file is created
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
+    rem HTML report file is created and contains CSS inline #135
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
+    call :verify_line 1 x "true"
 
     call :teardown
 endlocal
@@ -401,16 +402,6 @@ setlocal
     ) else (
         call :skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon"
     )
-
-    call :teardown
-endlocal
-
-setlocal
-    call :setup "HTML report contains CSS inline and not as an external file #135"
-
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :run java -cp "%SAXON_CP%" net.sf.saxon.Query -s:..\tutorial\xspec\escape-for-regex-result.html -qs:"declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head[not(link[@type = 'text/css'])]/style[@type = 'text/css']/contains(., 'margin-right:'), '&#x0A;')" !method=text
-    call :verify_line 1 x "true"
 
     call :teardown
 endlocal

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -335,6 +335,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP}
 	echo $output
     [ "$status" -eq 1 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
 }
 
@@ -343,6 +344,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP} -Dxspec.fail=false
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 
@@ -351,6 +353,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_xslt.xspec -lib ${SAXON_CP} -Dxspec.fail=false -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 
@@ -359,6 +362,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 
     # Verify default clean.output.dir is false
@@ -382,6 +386,7 @@ teardown() {
     run ant -buildfile /tmp/build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir=${PWD}/xspec-temp -Dclean.output.dir=true
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 
     # Verify that -Dxspec-dir was honered and the default dir was not created
@@ -400,6 +405,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
 	echo $output
     [ "$status" -eq 1 ]
+    [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
 
     # Verify the build fails before cleanup
@@ -419,6 +425,7 @@ teardown() {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP} -Dxspec.fail=false
 	echo $output
     [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
 }
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -213,9 +213,7 @@ teardown() {
     else
         run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -isource=xspec-72.xspec -p xspec-home=file:${PWD}/../ -oresult=xspec/xspec-72-result.html ../src/harnesses/saxon/saxon-xslt-harness.xproc
 
-    	query="declare default element namespace 'http://www.w3.org/1999/xhtml'; concat(/html/head/meta[@http-equiv eq 'Content-Type']/@content = 'text/html; charset=UTF-8', '&#x0A;')";
-
-        run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"$query" !method=text
+        run java -cp ${SAXON_CP} net.sf.saxon.Transform -s:xspec/xspec-72-result.html -xsl:html-charset.xsl
     fi
 
     echo "$output"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -136,9 +136,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # XML report file
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 }
 
 
@@ -146,9 +144,7 @@ teardown() {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # HTML report file is created
-    run stat ../tutorial/xspec/escape-for-regex-result.html
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
 }
 
 
@@ -182,9 +178,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # XML report file
-    run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 }
 
 
@@ -192,9 +186,7 @@ teardown() {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # JUnit report file
-    run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	echo "$output"
-    [ "$status" -eq 0 ]
+    [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -483,7 +483,7 @@ teardown() {
     export SAXON_HOME="${PWD}/saxon"
     mkdir $SAXON_HOME
     cp $SAXON_CP $SAXON_HOME
-    cp $XML_RESOLVER_CP $SAXON_HOME
+    cp $XML_RESOLVER_CP $SAXON_HOME/xml-resolver-1.2.jar
     export SAXON_CP=
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
 	echo "$output"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -142,8 +142,9 @@ teardown() {
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 
     # HTML report file is created and contains CSS inline #135
-	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
-	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
+    run java -cp ${SAXON_CP} net.sf.saxon.Transform -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
+    echo "$output"
+    [ "${lines[0]}" = "true" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -338,6 +338,9 @@ teardown() {
 
     echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+
+    # Default compiled-file
+    [ -f "/tmp/xspec-basex-compiled-suite.xq" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -292,6 +292,10 @@ teardown() {
     [ "${lines[4]}" = "Schematron XSLT include" ]
     [ "${lines[5]}" = "Schematron XSLT expand" ]
     [ "${lines[6]}" = "Schematron XSLT compile" ]
+
+    # With the provided dummy XSLTs, XSpec leaves temp files. Delete them.
+    rm ../tutorial/schematron/demo-01.sch-compiled.xsl
+    rm ../tutorial/schematron/demo-01.xspec-compiled.xspec
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -333,14 +333,15 @@ teardown() {
     if [[ -z ${XMLCALABASH_CP} && -z ${BASEX_CP} ]]; then
         skip "test for BaseX skipped as it requires XMLCalabash and a higher version of Saxon";
     else
-        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
+        compiled_file="${work_dir}/compiled.xq"
+        run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -p compiled-file="file:${compiled_file}" -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     fi
 
     echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 
-    # Default compiled-file
-    [ -f "/tmp/xspec-basex-compiled-suite.xq" ]
+    # compiled-file
+    [ -f "${compiled_file}" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -132,16 +132,11 @@ teardown() {
 }
 
 
-@test "invoking xspec generates XML report file" {
+@test "invoking xspec generates XML and HTML report files" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
-}
-
-
-@test "invoking xspec generates HTML report file" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 
     # HTML report file is created
     [ -f "../tutorial/xspec/escape-for-regex-result.html" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -407,7 +407,7 @@ teardown() {
     # For testing -Dxspec.project.dir
     cp ../build.xml "${build_xml}"
 
-    run ant -buildfile "${build_xml}" -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir="${ant_test_dir}" -Dclean.output.dir=true
+    run ant -buildfile "${build_xml}" -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dxspec.properties=${PWD}/schematron.properties -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir="${ant_test_dir}" -Dclean.output.dir=true
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -416,6 +416,18 @@ teardown() {
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
+@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
+    space_dir="${work_dir}/cat a log"
+    mkdir -p "${space_dir}/xspec"
+    cp catalog/catalog-01* "${space_dir}"
+    
+    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
+	run ../bin/xspec.sh -catalog "${space_dir}/catalog-01-catalog.xml" "${space_dir}/catalog-01-xslt.xspec"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+}
+
 @test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
@@ -428,18 +440,6 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=catalog/catalog-01-catalog.xml
 	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
-    space_dir="${work_dir}/cat a log"
-    mkdir -p "${space_dir}/xspec"
-    cp catalog/catalog-01* "${space_dir}"
-    
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog "${space_dir}/catalog-01-catalog.xml" "${space_dir}/catalog-01-xslt.xspec"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -221,8 +221,8 @@ teardown() {
 }
 
 
-@test "invoking xspec.sh with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file" {
-	special_chars_dir="${work_dir}/some'path (84)"
+@test "invoking xspec.sh with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs successfully and generates HTML report file" {
+	special_chars_dir="${work_dir}/some'path (84) here & there"
 	mkdir "${special_chars_dir}"
 	cp ../tutorial/escape-for-regex.* "${special_chars_dir}"
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -428,16 +428,7 @@ teardown() {
 	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
-@test "invoking xspec.sh with XML_CATALOG set uses XML Catalog resolver" {
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-    export XML_CATALOG=catalog/catalog-01-catalog.xml
-	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh using XML_CATALOG with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -20,19 +20,19 @@
 setup() {
 	work_dir="${BATS_TMPDIR}/xspec/bats_work"
 	mkdir -p "${work_dir}"
-	mkdir ../tutorial/xspec
+	mkdir ../test/catalog/xspec
 	mkdir ../test/xspec
 	mkdir ../tutorial/schematron/xspec
-	mkdir ../test/catalog/xspec
+	mkdir ../tutorial/xspec
 }
 
 
 teardown() {
 	rm -rf "${work_dir}"
-	rm -rf ../tutorial/xspec
+	rm -rf ../test/catalog/xspec
 	rm -rf ../test/xspec
 	rm -rf ../tutorial/schematron/xspec
-	rm -rf ../test/catalog/xspec
+	rm -rf ../tutorial/xspec
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -343,6 +343,15 @@ teardown() {
 }
 
 
+@test "Ant for XQuery with default properties" {
+    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/xquery-tutorial.xspec -lib ${SAXON_CP} -Dtest.type=q
+	echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+}
+
+
 @test "Ant for Schematron with minimum properties #168" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
 	echo "$output"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -134,6 +134,8 @@ teardown() {
 
 @test "invoking xspec generates XML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+
+    # XML report file
     run stat ../tutorial/xspec/escape-for-regex-result.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -142,6 +144,8 @@ teardown() {
 
 @test "invoking xspec generates HTML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+
+    # HTML report file is created
     run stat ../tutorial/xspec/escape-for-regex-result.html
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -176,6 +180,8 @@ teardown() {
 
 @test "invoking xspec with -j option generates XML report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+
+    # XML report file
     run stat ../tutorial/xspec/escape-for-regex-result.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -184,6 +190,8 @@ teardown() {
 
 @test "invoking xspec with -j option generates JUnit report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+
+    # JUnit report file
     run stat ../tutorial/xspec/escape-for-regex-junit.xml
 	echo "$output"
     [ "$status" -eq 0 ]
@@ -299,7 +307,11 @@ teardown() {
 @test "Cleanup removes temporary files" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
     [ "$status" -eq 0 ]
+
+    # Cleanup removes compiled .xspec
     [ ! -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
+
+    # Cleanup removes temporary files in TEST_DIR
     run ls ../tutorial/schematron/xspec
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "demo-03-result.html" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -138,11 +138,12 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 
-    # XML report file
+    # XML report file is created
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
 
-    # HTML report file is created
-    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
+    # HTML report file is created and contains CSS inline #135
+	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
+	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
 }
 
 
@@ -318,13 +319,6 @@ teardown() {
 
     # compiled-file
     [ -f "${compiled_file}" ]
-}
-
-
-@test "HTML report contains CSS inline and not as an external file #135" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	grep '<style type="text/css">' ../tutorial/xspec/escape-for-regex-result.html
-	grep 'margin-right:' ../tutorial/xspec/escape-for-regex-result.html
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -482,3 +482,45 @@ teardown() {
         skip "Schema validation for known good tests skipped";
     fi
 }
+
+
+@test "Ant for XSLT with saxon.custom.options" {
+    # Test with a space in file name
+    saxon_config="${work_dir}/saxon config.xml"
+    cp saxon-custom-options/config.xml "${saxon_config}"
+    
+    # via properties file, to convey the options in a stable manner...
+    xspec_properties="${work_dir}/xspec.properties"
+    echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
+    
+    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/saxon-custom-options/test.xspec -lib ${SAXON_CP} -Dxspec.properties="${xspec_properties}"
+	echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+
+    # Verify '-t'
+    [[ "${output}" =~ "Memory used:" ]]
+}
+
+
+@test "Ant for XQuery with saxon.custom.options" {
+    # Test with a space in file name
+    saxon_config="${work_dir}/saxon config.xml"
+    cp saxon-custom-options/config.xml "${saxon_config}"
+    
+    # via properties file, to convey the options in a stable manner...
+    xspec_properties="${work_dir}/xspec.properties"
+    echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
+    
+    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/saxon-custom-options/test.xspec -lib ${SAXON_CP} -Dxspec.properties="${xspec_properties}" -Dtest.type=q
+	echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+
+    # Verify '-t'
+    [[ "${output}" =~ "Memory used:" ]]
+}
+
+

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -225,7 +225,7 @@ teardown() {
 
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
-    run ../bin/xspec.sh ../test/xspec-46.xspec
+    run ../bin/xspec.sh xspec-46.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${lines[3]}" =~ "Testing with" ]]
@@ -275,7 +275,7 @@ teardown() {
 
 
 @test "Schematron phase/parameters are passed to Schematron compile" {
-    run ../bin/xspec.sh -s ../test/schematron-param-001.xspec
+    run ../bin/xspec.sh -s schematron-param-001.xspec
 	echo "${lines[2]}"
     [ "$status" -eq 0 ]
     [ "${lines[2]}" == "Parameters: phase=P1 ?selected=codepoints-to-string((80,49))" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -390,14 +390,10 @@ teardown() {
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
-    # Verify default clean.output.dir is false
+    # Verify that the default clean.output.dir is false and leaves temp files. Delete the left files at the same time.
     [  -d "../tutorial/schematron/xspec/" ]
-    [  -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
-    [  -f "../tutorial/schematron/demo-03.sch-compiled.xsl" ]
-
-    # Delete temp file
-    rm -f "../tutorial/schematron/demo-03.xspec-compiled.xspec"
-    rm -f "../tutorial/schematron/demo-03.sch-compiled.xsl"
+    rm    "../tutorial/schematron/demo-03.xspec-compiled.xspec"
+    rm    "../tutorial/schematron/demo-03.sch-compiled.xsl"
 }
 
 
@@ -437,13 +433,9 @@ teardown() {
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
 
-    # Verify the build fails after Schematron setup
-    [  -f "catalog/xspec-160_schematron.xspec-compiled.xspec" ]
-    [  -f "../tutorial/schematron/demo-04.sch-compiled.xsl" ]
-
-    # Delete temp file
-    rm -f "catalog/xspec-160_schematron.xspec-compiled.xspec"
-    rm -f "../tutorial/schematron/demo-04.sch-compiled.xsl"
+    # Verify that the build fails after Schematron setup and leaves temp files. Delete them at the same time.
+    rm "catalog/xspec-160_schematron.xspec-compiled.xspec"
+    rm "../tutorial/schematron/demo-04.sch-compiled.xsl"
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -353,7 +353,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD FAILED" ]]
+    [[ "${output}" =~ "BUILD FAILED" ]]
 }
 
 
@@ -362,7 +362,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 
@@ -371,7 +371,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 
@@ -380,7 +380,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
     # Verify default clean.output.dir is false
     [  -d "../tutorial/schematron/xspec/" ]
@@ -407,7 +407,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 
     # Verify that -Dxspec-dir was honered and the default dir was not created
     [ ! -d "../tutorial/schematron/xspec/" ]
@@ -424,7 +424,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
-    [[ "${output}" =~  "BUILD FAILED" ]]
+    [[ "${output}" =~ "BUILD FAILED" ]]
 
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
@@ -444,7 +444,7 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
-    [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
+    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
 @test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -273,7 +273,7 @@ teardown() {
 
 
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -132,8 +132,11 @@ teardown() {
 }
 
 
-@test "invoking xspec generates XML and HTML report files" {
+@test "invoking xspec generates message with default report location and creates report files" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
@@ -190,14 +193,6 @@ teardown() {
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
-}
-
-
-@test "invoking xspec.sh without TEST_DIR generates files in default location" {
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo "$output"
-    [ "$status" -eq 0 ]
-    [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -222,8 +222,8 @@ teardown() {
 }
 
 
-@test "invoking xspec.sh with path containing an apostrophe runs successfully #119" {
-	special_chars_dir="${work_dir}/some'path"
+@test "invoking xspec.sh with path containing parentheses #84 or an apostrophe #119 runs successfully and generates HTML report file" {
+	special_chars_dir="${work_dir}/some'path (84)"
 	mkdir "${special_chars_dir}"
 	cp ../tutorial/escape-for-regex.* "${special_chars_dir}"
 
@@ -233,6 +233,7 @@ teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[19]}" = "Report available at ${expected_report}" ]
+	[ -f "${expected_report}" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -166,24 +166,14 @@ teardown() {
 }
 
 
-@test "invoking xspec with -j option generates message with JUnit report location" {
+@test "invoking xspec with -j option generates message with JUnit report location and creates report files" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
-}
-
-
-@test "invoking xspec with -j option generates XML report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
-}
-
-
-@test "invoking xspec with -j option generates JUnit report file" {
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
 
     # JUnit report file
     [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -408,15 +408,7 @@ teardown() {
     [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
 }
 
-@test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
-    export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
-	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
-@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -35,7 +35,7 @@ teardown() {
 
 @test "invoking xspec without arguments prints usage" {
     run ../bin/xspec.sh
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
 }
@@ -43,7 +43,7 @@ teardown() {
 
 @test "invoking xspec with -s and -t prints error message" {
     run ../bin/xspec.sh -s -t
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-s and -t are mutually exclusive" ]
 }
@@ -51,7 +51,7 @@ teardown() {
 
 @test "invoking xspec with -s and -q prints error message" {
     run ../bin/xspec.sh -s -q
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-s and -q are mutually exclusive" ]
 }
@@ -59,7 +59,7 @@ teardown() {
 
 @test "invoking xspec with -t and -q prints error message" {
     run ../bin/xspec.sh -t -q
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-t and -q are mutually exclusive" ]
 }
@@ -68,7 +68,7 @@ teardown() {
 @test "invoking code coverage with Saxon9HE returns error message" {
     export SAXON_CP=/path/to/saxon9he.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -77,7 +77,7 @@ teardown() {
 @test "invoking code coverage with Saxon9SA returns error message" {
     export SAXON_CP=/path/to/saxon9sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -86,7 +86,7 @@ teardown() {
 @test "invoking code coverage with Saxon9 returns error message" {
     export SAXON_CP=/path/to/saxon9.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -95,7 +95,7 @@ teardown() {
 @test "invoking code coverage with Saxon8SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -104,7 +104,7 @@ teardown() {
 @test "invoking code coverage with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
@@ -114,7 +114,7 @@ teardown() {
     # Append non-Saxon jar to see if SAXON_CP is parsed correctly
     export SAXON_CP="/path/to/saxon9ee.jar:$XML_RESOLVER_CP"
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-  	echo $output
+  	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -123,7 +123,7 @@ teardown() {
 @test "invoking code coverage with Saxon9PE creates test stylesheet" {
     export SAXON_CP=/path/to/saxon9pe.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -132,7 +132,7 @@ teardown() {
 @test "invoking xspec generates XML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -140,7 +140,7 @@ teardown() {
 @test "invoking xspec generates HTML report file" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.html
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -148,7 +148,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -157,7 +157,7 @@ teardown() {
 @test "invoking xspec with -j option with Saxon8-SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
@@ -165,7 +165,7 @@ teardown() {
 
 @test "invoking xspec with -j option generates message with JUnit report location" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
 }
@@ -174,7 +174,7 @@ teardown() {
 @test "invoking xspec with -j option generates XML report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-result.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -182,7 +182,7 @@ teardown() {
 @test "invoking xspec with -j option generates JUnit report file" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     run stat ../tutorial/xspec/escape-for-regex-junit.xml
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
 }
 
@@ -190,7 +190,7 @@ teardown() {
 @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 1 ]
   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
 }
@@ -199,7 +199,7 @@ teardown() {
 @test "invoking xspec.sh with TEST_DIR already set externally generates files inside TEST_DIR" {
     export TEST_DIR=/tmp
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at /tmp/escape-for-regex-result.html" ]
 }
@@ -207,7 +207,7 @@ teardown() {
 
 @test "invoking xspec.sh without TEST_DIR generates files in default location" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 }
@@ -215,7 +215,7 @@ teardown() {
 
 @test "invoking xspec.sh that passes a non xs:boolean does not raise a warning #46" {
     run ../bin/xspec.sh ../test/xspec-46.xspec
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${lines[3]}" =~ "Testing with" ]]
 }
@@ -233,7 +233,7 @@ teardown() {
         run java -cp ${SAXON_CP} net.sf.saxon.Query -s:xspec/xspec-72-result.html -qs:"$query" !method=text
     fi
 
-    echo $output
+    echo "$output"
     [ "${lines[0]}" = "true" ]
 }
 
@@ -242,7 +242,7 @@ teardown() {
 	mkdir some\'path
 	cp ../tutorial/escape-for-regex.* some\'path 
 	run ../bin/xspec.sh some\'path/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[19]}" = "Report available at some'path/xspec/escape-for-regex-result.html" ]
 	rm -rf some\'path
@@ -254,7 +254,7 @@ teardown() {
 	chmod +x /tmp/saxon
 	export PATH=$PATH:/tmp
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[0]}" = "Saxon script found, use it." ]
 	rm /tmp/saxon
@@ -275,7 +275,7 @@ teardown() {
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt-compile.xsl
     
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
-	echo $output
+	echo "$output"
     [ "${lines[4]}" = "Schematron XSLT include" ]
     [ "${lines[5]}" = "Schematron XSLT expand" ]
     [ "${lines[6]}" = "Schematron XSLT compile" ]
@@ -285,7 +285,7 @@ teardown() {
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
 	echo "${lines[4]}"
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]
 }
@@ -319,7 +319,7 @@ teardown() {
         run java -Xmx1024m -cp ${XMLCALABASH_CP} com.xmlcalabash.drivers.Main -i source=../tutorial/xquery-tutorial.xspec -p xspec-home=file:${PWD}/../ -p basex-jar=${BASEX_CP} -o result=xspec/xquery-tutorial-result.html ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     fi
 
-    echo $output
+    echo "$output"
     [[ "${output}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 }
 
@@ -333,7 +333,7 @@ teardown() {
 
 @test "Ant for XSLT with default properties fails on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
@@ -342,7 +342,7 @@ teardown() {
 
 @test "Ant for XSLT with xspec.fail=false continues on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib ${SAXON_CP} -Dxspec.fail=false
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -351,7 +351,7 @@ teardown() {
 
 @test "Ant for XSLT with catalog resolves URI" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_xslt.xspec -lib ${SAXON_CP} -Dxspec.fail=false -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -360,7 +360,7 @@ teardown() {
 
 @test "Ant for Schematron with minimum properties #168" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -384,7 +384,7 @@ teardown() {
     cp ../build.xml /tmp/
 
     run ant -buildfile /tmp/build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.project.dir=${PWD}/.. -Dxspec.phase=#ALL -Dxspec.dir=${PWD}/xspec-temp -Dclean.output.dir=true
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -403,7 +403,7 @@ teardown() {
 
 @test "Ant for Schematron with catalog and default xspec.fail fails on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP}
-	echo $output
+	echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD FAILED" ]]
@@ -423,7 +423,7 @@ teardown() {
 
 @test "Ant for Schematron with catalog and xspec.fail=false continues on test failure" {
     run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/catalog/xspec-160_schematron.xspec -lib ${SAXON_CP} -Dtest.type=s -Dxspec.phase=#ALL -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/xspec-160_catalog.xml -lib ${XML_RESOLVER_CP} -Dxspec.fail=false
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 6 / pending: 0 / failed: 1 / total: 7" ]]
     [[ "${output}" =~  "BUILD SUCCESSFUL" ]]
@@ -432,7 +432,7 @@ teardown() {
 @test "invoking xspec.sh for XSLT with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -440,7 +440,7 @@ teardown() {
 @test "invoking xspec.sh for XQuery with -catalog uses XML Catalog resolver" {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -449,7 +449,7 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=catalog/catalog-01-catalog.xml
 	run ../bin/xspec.sh catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
@@ -460,7 +460,7 @@ teardown() {
     cp catalog/catalog-01* cat\ a\ log
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
 	run ../bin/xspec.sh -catalog cat\ a\ log/catalog-01-catalog.xml cat\ a\ log/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf cat\ a\ log
@@ -473,7 +473,7 @@ teardown() {
     export SAXON_CP="$SAXON_CP:$XML_RESOLVER_CP"
     export XML_CATALOG=cat\ a\ log/catalog-01-catalog.xml
 	run ../bin/xspec.sh cat\ a\ log/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf cat\ a\ log
@@ -486,7 +486,7 @@ teardown() {
     cp $XML_RESOLVER_CP $SAXON_HOME
     export SAXON_CP=
 	run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
-	echo $output
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 	rm -rf $SAXON_HOME

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -272,23 +272,18 @@ teardown() {
 }
 
 
-@test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
+@test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131 and removes temporary files" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]
-}
-
-
-@test "Cleanup removes temporary files" {
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
-    [ "$status" -eq 0 ]
 
     # Cleanup removes compiled .xspec
     [ ! -f "../tutorial/schematron/demo-03.xspec-compiled.xspec" ]
 
     # Cleanup removes temporary files in TEST_DIR
     run ls ../tutorial/schematron/xspec
+	echo "$output"
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "demo-03-result.html" ]
     [ "${lines[1]}" = "demo-03-result.xml" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -433,7 +433,7 @@ teardown() {
 	[ "${lines[7]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
-@test "invoking xspec.sh using -catalog with spaces in file path uses XML Catalog resolver" {
+@test "invoking xspec.sh for XSLT using -catalog with spaces in file path uses XML Catalog resolver" {
     space_dir="${work_dir}/cat a log"
     mkdir -p "${space_dir}/xspec"
     cp catalog/catalog-01* "${space_dir}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -274,7 +274,6 @@ teardown() {
 
 @test "invoking xspec.sh with the -s option does not display Schematron warnings #129 #131" {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
-	echo "${lines[4]}"
 	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[4]}" == "Compiling the Schematron tests..." ]


### PR DESCRIPTION
This pull request adds tests for Ant `saxon.custom.options` property both for XSLT and XQuery.

The property is not documented in Wiki, but it's been in `build.xml` for some years. And we know its use case (#235).
So it should be worth testing.

---

This pull request derives from #266 . So needs to be handled after that.
