### PR TITLE
Fix typo in escape-for-regex.xspec (simliarly)

### DIFF
--- a/tutorial/escape-for-regex.xspec
+++ b/tutorial/escape-for-regex.xspec
@@ -24,7 +24,7 @@
   </x:scenario>
   <!--
        This scenario demonstrates:
-       (1) how to test a function (named templates can be simliarly tested)
+       (1) how to test a function (named templates can be similarly tested)
        (2) that scenarios can be nested
        (3) a test can have multiple expectations.
    -->


### PR DESCRIPTION
This pull request just fixes a typo in `tutorial/escape-for-regex.xspec`.