### PR TITLE
Test with XML Calabash 1.1.21-97

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
           JING_CP=/tmp/xspec/jing/jing.jar
         # latest Saxon 9.7 version
         - SAXON_VERSION=9.7.0-21
-          XMLCALABASH_VERSION=1.1.16-97
+          XMLCALABASH_VERSION=1.1.21-97
           BASEX_VERSION=8.6.4
         # Saxon version used in oXygen
         - SAXON_VERSION=9.7.0-19

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
       JING_CP: '%TEMP%\xspec\jing\jing.jar'
     # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-21
-      XMLCALABASH_VERSION: 1.1.16-97
+      XMLCALABASH_VERSION: 1.1.21-97
     # Saxon version used in oXygen
     - SAXON_VERSION: 9.7.0-19
 


### PR DESCRIPTION
This pull request just updates the version of XML Calabash, used on Travis and AppVeyor, to 1.1.21-97: https://github.com/ndw/xmlcalabash1/releases/latest