### PR TITLE
Test with Saxon 9.8.0-14 and 9.8.0-12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
         - XML_RESOLVER_CP=/tmp/xspec/xml-resolver/xml-resolver-1.2.jar
     matrix:
         # latest Saxon 9.8 version and full path to Jing jar
-        - SAXON_VERSION=9.8.0-7
+        - SAXON_VERSION=9.8.0-14
           JING_CP=/tmp/xspec/jing/jing.jar
         # latest Saxon 9.7 version
         - SAXON_VERSION=9.7.0-21
           XMLCALABASH_VERSION=1.1.16-97
           BASEX_VERSION=8.6.4
         # Saxon version used in oXygen
-        - SAXON_VERSION=9.7.0-19
+        - SAXON_VERSION=9.8.0-12
 
 before_install:
     - unset _JAVA_OPTIONS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,13 @@ environment:
     XML_RESOLVER_CP: '%TEMP%\xspec\xml-resolver\xml-resolver-1.2.jar'
   matrix:
     # latest Saxon 9.8 version and full path to Jing jar
-    - SAXON_VERSION: 9.8.0-7
+    - SAXON_VERSION: 9.8.0-14
       JING_CP: '%TEMP%\xspec\jing\jing.jar'
     # latest Saxon 9.7 version
     - SAXON_VERSION: 9.7.0-21
       XMLCALABASH_VERSION: 1.1.16-97
     # Saxon version used in oXygen
-    - SAXON_VERSION: 9.7.0-19
+    - SAXON_VERSION: 9.8.0-12
 
 install:
 - ps: >-


### PR DESCRIPTION
This pull request just updates Saxon version, used on Travis and AppVeyor, to [9.8.0.14](https://www.saxonica.com/download/download_page.xml) and [9.8.0.12](https://www.oxygenxml.com/xml_editor/whats_new.html#20.1Component_Updates).