### PR TITLE
Fix `xspec.bat` to accommodate 11+ params

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -150,12 +150,7 @@ rem ##
     )
 
     shift
-
-    rem
-    rem %* doesn't reflect shift. Pass %n individually.
-    rem
-    call :win_get_options %1 %2 %3 %4 %5 %6 %7 %8 %9
-    goto :EOF
+    goto :win_get_options
 
 
 :schematron_compile

--- a/test/xspec-bat.cmd
+++ b/test/xspec-bat.cmd
@@ -60,6 +60,16 @@ setlocal
 endlocal
 
 setlocal
+    call :setup "invoking xspec with -h prints usage and does so even when it is 11th argument"
+
+    call :run ..\bin\xspec.bat -t -t -t -t -t -t -t -t -t -t -h
+    call :verify_retval 0
+    call :verify_line 2 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]"
+
+    call :teardown
+endlocal
+
+setlocal
     call :setup "invoking xspec with -s and -t prints error message"
 
     call :run ..\bin\xspec.bat -s -t

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -43,7 +43,7 @@ teardown() {
 
 @test "invoking xspec with -h prints usage and does so even when it is 11th argument" {
     run ../bin/xspec.sh -t -t -t -t -t -t -t -t -t -t -h
-	echo $output
+	echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[1]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
 }

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -41,6 +41,14 @@ teardown() {
 }
 
 
+@test "invoking xspec with -h prints usage and does so even when it is 11th argument" {
+    run ../bin/xspec.sh -t -t -t -t -t -t -t -t -t -t -h
+	echo $output
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
+}
+
+
 @test "invoking xspec with -s and -t prints error message" {
     run ../bin/xspec.sh -s -t
 	echo $output


### PR DESCRIPTION
`xspec.bat` (the command line for Windows) drops the 11th+ arguments.

This pull request

* adds test cases (99180e9b50c19673149aec0253cea281b44a59d3) for the bug. You can see the test fails on [AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/build/517-fix_many-params/job/29t5dfhv0c30x59m#L77) before committing the fix.
* fixes the bug (7c3fbf9dd64ef6b7ee2be8f300bd66b6795dbb09). You can see it takes effect on [AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/build/520-fix_many-params).

---

As a bonus, we now have a test for `-h`.