### PR TITLE
Add .gitattributes file to checkout shell scripts on Windows with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh   eol=lf
+*.bat  eol=crlf


### PR DESCRIPTION
Makes the shell scripts usable in Windows WSL environment when being cloned on windows and used in WSL.