### PR TITLE
Reuse xquery-tutorial

### DIFF
--- a/test/end-to-end/cases/xquery-tutorial.xq
+++ b/test/end-to-end/cases/xquery-tutorial.xq
@@ -1,8 +1,0 @@
-module namespace functx = "http://www.functx.com";
-
-declare function functx:capitalize-first
-($arg as xs:string?) as xs:string? {
-    
-    concat(upper-case(substring($arg, 1, 1)),
-    substring($arg, 2))
-};

--- a/test/end-to-end/cases/xquery-tutorial.xspec
+++ b/test/end-to-end/cases/xquery-tutorial.xspec
@@ -2,15 +2,6 @@
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" 
                xmlns:functx="http://www.functx.com"
                query="http://www.functx.com" 
-               query-at="xquery-tutorial.xq">
-
-  <x:scenario label="Calling function capitalize-first">
-    <x:call function="functx:capitalize-first">
-      <x:param select="'hello'"/>
-    </x:call>
-
-    <x:expect label="should capitalize the first character of the string" select="'Hello'"/>
-
-  </x:scenario>
-
+               query-at="../../../tutorial/xquery-tutorial.xq">
+  <x:import href="../../../tutorial/xquery-tutorial.xspec" />
 </x:description>


### PR DESCRIPTION
* `test/end-to-end/cases/xquery-tutorial.xq`
* `test/end-to-end/cases/xquery-tutorial.xspec`

They are exactly the same as the ones in `tutorial/`.
So, just reuse them.
