### PR TITLE
Add appveyor-retry before choco install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ install:
 
     # install Ant without installing JDK
 
-    choco install ant --ignore-dependencies --no-progress --version "${env:ANT_VERSION}"
+    appveyor-retry choco install ant --ignore-dependencies --no-progress --version "${env:ANT_VERSION}"
 
 
     # install XML Resolver


### PR DESCRIPTION
Following the recent [incident](https://appveyor.statuspage.io/incidents/kqwjgg14m71g), this pull request just adds `appveyor-retry` before `choco install` in `appveyor.yml`