### PR TITLE
Update for XSpec release v1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   
   <name>XSpec implementation</name>
-  <description>A unit test framework for Xsl, XQuery and Schematron</description>
+  <description>A unit test framework for XSLT, XQuery and Schematron</description>
   <inceptionYear>2008</inceptionYear>
   <url>https://github.com/xspec/xspec</url>
   
@@ -17,7 +17,7 @@
       <name>The MIT License</name>
       <distribution>repo | manually</distribution>
       <url>https://opensource.org/licenses/MIT</url>
-      <comments>Copyright (c) 2008-2017 Jeni Tennison</comments>
+      <comments>Copyright (c) 2008-2018 Jeni Tennison</comments>
     </license>
   </licenses>
   


### PR DESCRIPTION
## Summary

This pull request addresses the discussion in [#395](https://github.com/xspec/xspec/issues/395#issuecomment-429645051) and updates the version number to the latest XSpec release. Other minor changes include updates in the year for the copyright and the use of 'XSLT' instead of 'Xsl' in the description.

@cmarchand: could you review this pull request and check that it is fine? I have not included the second patch that uses the version `1.1.1-SNAPSHOT`, I guess this will be applied at the next release (please correct me if I'm wrong). 