### PR TITLE
Fix "find"-command in `xspec.bat`

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -278,7 +278,7 @@ if not defined XSPEC_HOME set "XSPEC_HOME=%~dp0.."
 rem
 rem # safety checks
 rem
-for %%I in ("%XSPEC_HOME%") do echo "%%~aI" | findstr "d" > NUL
+for %%I in ("%XSPEC_HOME%") do echo "%%~aI" | %SYSTEMROOT%\system32\find "d" > NUL
 if errorlevel 1 (
     call :win_echo "ERROR: XSPEC_HOME is not a directory: %XSPEC_HOME%"
     exit /b 1

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -278,7 +278,7 @@ if not defined XSPEC_HOME set "XSPEC_HOME=%~dp0.."
 rem
 rem # safety checks
 rem
-for %%I in ("%XSPEC_HOME%") do echo "%%~aI" | find "d" > NUL
+for %%I in ("%XSPEC_HOME%") do echo "%%~aI" | findstr "d" > NUL
 if errorlevel 1 (
     call :win_echo "ERROR: XSPEC_HOME is not a directory: %XSPEC_HOME%"
     exit /b 1


### PR DESCRIPTION
XSpec failed with message:
```
find: ÔÇÿdÔÇÖ: No such file or directory
ERROR: XSPEC_HOME is not a directory
```
It seems the "find"-command is supposed to look for a letter "d" in file properties.
correct command for this task seems to be "findstr".
Line 281 changed this way things work 


