### PR TITLE
Remove -SNAPSHOT from version in pom.xml for v1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.0</version>
   
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
Looking back the operations happened when releasing v1.1.0 and following https://github.com/xspec/xspec/pull/415#issuecomment-455510906, I guess this is the last required change for v1.2.0 and to be merged immediately before tagging it.

Ccing @cmarchand just in case.