### PR TITLE
Increment version in pom.xml to 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
According to https://github.com/xspec/xspec/wiki/pom.xml-version which is based on https://github.com/xspec/xspec/pull/415#issuecomment-455510906, I guess this should be the very first change when we start v1.3.0 after completing v1.2.0 release.

Feel free to resolve conflict if any.