### PR TITLE
Fix typo 'inherrit' in schematron-012.xspec

### DIFF
--- a/test/schematron-012.xspec
+++ b/test/schematron-012.xspec
@@ -53,7 +53,7 @@
             <x:expect-not-report id="r2" role="info" location="/article[1]/div[4]"/>
         </x:scenario>
     </x:scenario>
-    <x:scenario label="inherrit from rule">
+    <x:scenario label="inherit from rule">
         <x:scenario label="id and role from rule">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
             <x:expect-assert id="ru1" role="error"/>
@@ -73,7 +73,7 @@
             <x:expect-report id="ru3" role="warn" location="/article[1]"/>
         </x:scenario>
     </x:scenario>
-    <x:scenario label="inherrit from pattern">
+    <x:scenario label="inherit from pattern">
         <x:scenario label="id from pattern">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
             <x:expect-assert id="pattern3"/>

--- a/test/schematron/schut-to-xspec-012-out.xspec
+++ b/test/schematron/schut-to-xspec-012-out.xspec
@@ -53,7 +53,7 @@
             <x:expect label="not report r2 info /article[1]/div[4]" test="boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'r2'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'info'][x:schematron-location-compare('/article[1]/div[4]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
         </x:scenario>
     </x:scenario>
-    <x:scenario label="inherrit from rule">
+    <x:scenario label="inherit from rule">
         <x:scenario label="id and role from rule">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
             <x:expect label="assert ru1 error" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru1'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'error'])"/>
@@ -73,7 +73,7 @@
             <x:expect label="report ru3 warn /article[1]" test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'ru3'][(@role, preceding-sibling::svrl:fired-rule[1]/@role, preceding-sibling::svrl:active-pattern[1]/@role)[1] = 'warn'][x:schematron-location-compare('/article[1]', @location, preceding-sibling::svrl:ns-prefix-in-attribute-values)])"/>
         </x:scenario>
     </x:scenario>
-    <x:scenario label="inherrit from pattern">
+    <x:scenario label="inherit from pattern">
         <x:scenario label="id from pattern">
             <x:context href="schematron/schut-to-xspec-012-02.xml"/>
             <x:expect label="assert pattern3" test="exists(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'pattern3'])"/>


### PR DESCRIPTION
This pull request just fixes a typo in `test/schematron-012.xspec`.