### PR TITLE
Address SXWN9000 (child::div) in schut-to-xspec-012.sch

### DIFF
--- a/test/schut-to-xspec-012.sch
+++ b/test/schut-to-xspec-012.sch
@@ -16,7 +16,7 @@
         </sch:rule>
         <sch:rule context="article" id="ru3" role="warn">
             <sch:assert test="div">article should contain div</sch:assert>
-            <sch:report test="div[2]">article has more than 1 div</sch:report>
+            <sch:report test="child::div[2]">article has more than 1 div</sch:report>
         </sch:rule>
     </sch:pattern>
     <sch:pattern id="pattern3">


### PR DESCRIPTION
Saxon warns about `div` (element name vs math division) in `test/schut-to-xspec-012.sch`:

```console
C:\xspec>bin\xspec.bat -s test\schematron-012.xspec
...
Running Tests...
Testing with SAXON EE 9.9.1.2
expect-valid
Warning in xsl:if/@test on line 311 column 29 of schut-to-xspec-012.sch-compiled.xsl:
  SXWN9000: in {div[}:
    The keyword 'div' in this context means 'child::div'. If this was intended, use
  'child::div' or './div' to avoid this warning.
```

This pull request addresses it.