### PR TITLE
Set dist trusty in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk: oraclejdk8
 env:
     global:


### PR DESCRIPTION
Looks like Travis CI is gradually deploying Ubuntu Xenial 16.04 as the default Travis CI build environment
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Unfortunately, [on Travis with Ubuntu Xenial](https://travis-ci.org/AirQuick/xspec/jobs/562906822#L9), `jdk: oraclejdk8` [fails](https://travis-ci.org/AirQuick/xspec/jobs/562906822#L160-L167).
(See also https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766)

We could switch to `openjdk8` or something. But if we do so, we would need to recompile [`XSLTCoverageTraceListener.class`](https://github.com/xspec/xspec/blob/master/java/com/jenitennison/xslt/tests/XSLTCoverageTraceListener.class) otherwise [a test](https://github.com/xspec/xspec/pull/296) would fail.

So, right now, just setting `dist: trusty` (Ubuntu Trusty 14.04) explicitly seems to be the easiest. This pull request sets it.

Note:
Ubuntu Xenial doesn't seem to have been deployed to `xspec/xspec`. It's still running [on Ubuntu Trusty 14.04](https://travis-ci.org/xspec/xspec/jobs/562906706#L9).