### PR TITLE
Accept x:description without XSpec namespace prefix

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -23,16 +23,22 @@
    <xsl:variable name="actual-document-uri" as="xs:anyURI"
       select="x:resolve-xml-uri-with-catalog(document-uri(/))"/>
 
+   <!-- XSpec namespace URI -->
    <xsl:variable name="xspec-namespace" as="xs:anyURI"
       select="xs:anyURI('http://www.jenitennison.com/xslt/xspec')" />
 
+   <!-- XSpec namespace prefix -->
    <xsl:variable name="xspec-prefix" as="xs:string">
       <xsl:variable name="e" select="/element()" as="element(x:description)" />
       <xsl:sequence select="
-         in-scope-prefixes($e)
-            [namespace-uri-for-prefix(., $e) eq $xspec-namespace]
-            [. (: Do not allow zero-length string :)]
-            [1]"/>
+         (
+            in-scope-prefixes($e)
+               [namespace-uri-for-prefix(., $e) eq $xspec-namespace]
+               [. (: Do not allow zero-length string :)],
+            
+            (: Fallback. Intentionally made weird in order to avoid collision. :)
+            'XsPeC'
+         )[1]"/>
    </xsl:variable>
 
    <xsl:variable name="html-reporter-pi" as="processing-instruction(xml-stylesheet)">

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -53,10 +53,18 @@
 
       <xsl:variable name="e" as="element()" select="."/>
       <xsl:for-each select="in-scope-prefixes($e)[not(. = ('xml', $except))]">
-         <xsl:text>declare namespace </xsl:text>
-         <xsl:value-of select="."/>
-         <xsl:text> = "</xsl:text>
-         <xsl:value-of select="namespace-uri-for-prefix(., $e)"/>
+         <xsl:variable name="prefix" as="xs:string" select="." />
+         <xsl:text>declare </xsl:text>
+         <xsl:if test="not($prefix)">
+            <xsl:text>default element </xsl:text>
+         </xsl:if>
+         <xsl:text>namespace </xsl:text>
+         <xsl:if test="$prefix">
+            <xsl:value-of select="$prefix"/>
+            <xsl:text> = </xsl:text>
+         </xsl:if>
+         <xsl:text>"</xsl:text>
+         <xsl:value-of select="namespace-uri-for-prefix($prefix, $e)"/>
          <xsl:text>";&#10;</xsl:text>
       </xsl:for-each>
    </xsl:template>

--- a/test/xspec-no-prefix.xspec
+++ b/test/xspec-no-prefix.xspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description query="x-urn:test:do-nothing" query-at="do-nothing.xquery" stylesheet="do-nothing.xsl"
+	xmlns="http://www.jenitennison.com/xslt/xspec" xslt-version="3.0">
+
+	<scenario label="Describing scenarios using default namespace">
+		<call function="false" />
+		<expect label="should work"
+			test="($Q{http://www.jenitennison.com/xslt/xspec}result treat as xs:boolean) eq false()"
+		 />
+	</scenario>
+
+</description>

--- a/test/xspec-no-prefix_schematron.xspec
+++ b/test/xspec-no-prefix_schematron.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copy of schematron-01.xspec with x: prefix removed -->
+<description xmlns="http://www.jenitennison.com/xslt/xspec" schematron="schematron-01.sch">
+    <scenario label="schematron-01">
+        <context href="schematron-01.xml"/>
+        <scenario label="article should have a title">
+            <expect-not-assert id="a001"/>
+        </scenario>
+        <scenario label="section should have a title">
+            <expect-assert id="a002" location="/article[1]/section[2]"/>
+            <expect-assert id="a002" location="/article[1]/section[3]"/>
+        </scenario>
+    </scenario>
+</description>

--- a/test/xspec-no-prefix_stylesheet.xspec
+++ b/test/xspec-no-prefix_stylesheet.xspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copy of xspec-eqname_stylesheet.xspec with x: prefix removed -->
+<description stylesheet="xspec-eqname.xsl" xmlns="http://www.jenitennison.com/xslt/xspec"
+	xslt-version="3.0">
+
+	<scenario label="Using EQName in">
+		<scenario label="context @mode and template-param @name">
+			<context mode="Q{x-urn:test:xspec-eqname}param-mirror-mode">
+				<param name="Q{x-urn:test:xspec-eqname}param-items">
+					<template-param-child xmlns="" />
+				</param>
+				<context-child xmlns="" />
+			</context>
+			<expect label="should be possible">
+				<template-param-child xmlns="" />
+			</expect>
+		</scenario>
+
+		<scenario label="template-call @template and template-param @name">
+			<call template="Q{x-urn:test:xspec-eqname}param-mirror-template">
+				<param name="Q{x-urn:test:xspec-eqname}param-items">
+					<template-param-child xmlns="" />
+				</param>
+			</call>
+			<expect label="should be possible">
+				<template-param-child xmlns="" />
+			</expect>
+		</scenario>
+	</scenario>
+
+</description>


### PR DESCRIPTION
Closes #572 

This pull request 
* sets a fallback prefix (`XsPeC:`) when the test author does not provide a prefix to the XSpec namespace (`http://www.jenitennison.com/xslt/xspec`) in `x:description`.
* also modifies a namespace declaration on XQuery so that it works without a prefix.

## Tests

As far as I know, most test authors provide a prefix (`x:` in most cases) to the XSpec namespace. [SchXslt](https://github.com/schxslt/schxslt/tree/master/src/test/resources/spec) is the only use case I've ever found. So I didn't write the test for this pull request extensively.

* `xspec-no-prefix.xspec` tests both XQuery and XSLT.
* For Schematron (`xspec-no-prefix_schematron.xspec`) and XSLT-only (`xspec-no-prefix_stylesheet.xspec`), I just copied some of the existing test files and removed the `x:` prefix.

### Note for the test result

I found weird behaviors in `xspec-no-prefix_stylesheet.xspec` with some Saxon versions:

#### 9.7.0.21-EE
* The tests are reported as Failure. (**not** expected)
* The report XML (created as `test/xspec/xspec-no-prefix_stylesheet-result.xml`) omits `xmlns=""` from elements in `x:result` and `x:expect`. (**not** expected)

#### 9.7.0.21-HE, 9.8.0.12-EE/HE, 9.8.0.14-EE/HE
* The tests are reported as Success. (as expected)
* The report XML omits `xmlns=""` from elements in `x:result` and `x:expect`. (**not** expected)

#### 9.8.0.15-EE/HE, 9.9.1.4-EE/HE
* The tests are reported as Success. (as expected)
* The report XML has ` xmlns=""`. (as expected)

Because the latest Saxon versions are working as expected, I haven't investigated the problem further.
Probably it's related to [Saxon bug 3889](https://saxonica.plan.io/issues/3889) which was fixed on 9.9.0.1 and 9.8.0.15.
