### PR TITLE
Remove unnecessary static-base-uri()

### DIFF
--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -36,7 +36,7 @@
        MarkLogic).
    -->
    <xsl:param name="utils-library-at" select="
-       resolve-uri('generate-query-utils.xql', static-base-uri())"/>
+       resolve-uri('generate-query-utils.xql')"/>
 
    <!-- TODO: The at hint should not be always resolved (e.g. for MarkLogic). -->
    <xsl:param name="query-at" as="xs:string?" select="

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -54,10 +54,10 @@
     <xsl:apply-templates select="." mode="x:copy-namespaces" />
 
     <import href="{$stylesheet-uri}" />
-    <import href="{resolve-uri('generate-tests-utils.xsl', static-base-uri())}"/>
-    <import href="{resolve-uri('../schematron/sch-location-compare.xsl', static-base-uri())}"/>
+    <import href="{resolve-uri('generate-tests-utils.xsl')}"/>
+    <import href="{resolve-uri('../schematron/sch-location-compare.xsl')}"/>
 
-    <include href="{resolve-uri('../common/xspec-utils.xsl', static-base-uri())}" />
+    <include href="{resolve-uri('../common/xspec-utils.xsl')}" />
 
     <!-- Serialization parameters -->
     <output name="{x:xspec-name('report')}" method="xml" indent="yes" />

--- a/src/reporter/format-xspec-report-folding.xsl
+++ b/src/reporter/format-xspec-report-folding.xsl
@@ -36,13 +36,13 @@ function toggle(scenarioID) {
     } catch(err) {
       table.style.display = "block";
     }
-    icon.src = "<xsl:value-of select="resolve-uri('../../graphics/3angle-down.gif', static-base-uri())"/>" ;
+    icon.src = "<xsl:value-of select="resolve-uri('../../graphics/3angle-down.gif')"/>" ;
     icon.alt = "collapse" ;
     icon.title = "collapse" ;
   }
   else {
     table.style.display = "none";
-    icon.src = "<xsl:value-of select="resolve-uri('../../graphics/3angle-right.gif', static-base-uri())"/>" ;
+    icon.src = "<xsl:value-of select="resolve-uri('../../graphics/3angle-right.gif')"/>" ;
     icon.alt = "expand" ;
     icon.title = "expand" ;
   };
@@ -63,7 +63,7 @@ function toggle(scenarioID) {
     <h2 id="h-{generate-id()}"
       class="{if ($pending) then 'pending' else if ($any-failure) then 'failed' else 'successful'}">
       <a href="javascript:toggle('{generate-id()}')">
-        <img src="{resolve-uri(concat('../../graphics/', if ($any-descendant-failure) then '3angle-down.gif' else '3angle-right.gif'), static-base-uri())}"
+        <img src="{resolve-uri(concat('../../graphics/', if ($any-descendant-failure) then '3angle-down.gif' else '3angle-right.gif'))}"
           alt="{if ($any-descendant-failure) then 'collapse' else 'expand'}" id="icon-{generate-id()}"/>
       </a>
       <xsl:sequence select="x:pending-callback(@pending)"/>

--- a/test/end-to-end/ant/base/worker/generate.xsl
+++ b/test/end-to-end/ant/base/worker/generate.xsl
@@ -24,7 +24,7 @@
 
 		<!-- Directory URI of the processor root -->
 		<xsl:variable as="xs:anyURI" name="processor-dir-uri"
-			select="resolve-uri('../../../processor/', static-base-uri())" />
+			select="resolve-uri('../../../processor/')" />
 
 		<!-- Directory URIs where the XSpec report files are put -->
 		<xsl:variable as="xs:anyURI" name="actual-reports-dir-uri"


### PR DESCRIPTION
This pull request just removes `static-base-uri()` calls which are not necessary.

There is no automated test for `format-xspec-report-folding.xsl`. So I manually tested this pull request and verified this:

* `ant -lib "saxon9ee.jar" -Dxspec.xml=tutorial\escape-for-regex.xspec -Dxspec.html.reporter.xsl=src\reporter\format-xspec-report-folding.xsl` generates the same `escape-for-regex-result.html` as the current master (except for timestamp).
