### PR TITLE
Test with mode="#all"

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -53,8 +53,8 @@
 
     <xsl:apply-templates select="." mode="x:copy-namespaces" />
 
-    <import href="{resolve-uri('generate-tests-utils.xsl', static-base-uri())}"/>
     <import href="{$stylesheet-uri}" />
+    <import href="{resolve-uri('generate-tests-utils.xsl', static-base-uri())}"/>
     <import href="{resolve-uri('../schematron/sch-location-compare.xsl', static-base-uri())}"/>
 
     <include href="{resolve-uri('../common/xspec-utils.xsl', static-base-uri())}" />

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -53,8 +53,8 @@
 
     <xsl:apply-templates select="." mode="x:copy-namespaces" />
 
-    <import href="{$stylesheet-uri}" />
     <import href="{resolve-uri('generate-tests-utils.xsl', static-base-uri())}"/>
+    <import href="{$stylesheet-uri}" />
     <import href="{resolve-uri('../schematron/sch-location-compare.xsl', static-base-uri())}"/>
 
     <include href="{resolve-uri('../common/xspec-utils.xsl', static-base-uri())}" />

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-junit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="mode-all.xspec">
+   <testsuite name="context" tests="2" failures="1">
+      <testcase name="should work" status="passed"/>
+      <testcase name="should report Expected Result correctly on failure"
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="function-call" tests="2" failures="1">
+      <testcase name="should work" status="passed"/>
+      <testcase name="should report Expected Result correctly on failure"
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="template-call" tests="2" failures="1">
+      <testcase name="should work" status="passed"/>
+      <testcase name="should report Expected Result correctly on failure"
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for mode-all.xsl (passed: 3 / pending: 0 / failed: 3 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../mode-all.xsl">mode-all.xsl</a></p>
+      <p>XSpec: <a href="../../mode-all.xspec">mode-all.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <col width="75%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <col width="6.25%" />
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 3</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 6</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#ELEM-47">context</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-82">function-call</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-117">template-call</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-47">
+         <h2 class="failed">context<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-49">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="failed">
+                  <th>context</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>should work</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-64">should report Expected Result correctly on failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-63">
+            <h3>context</h3>
+            <div id="ELEM-64">
+               <h4>should report Expected Result correctly on failure</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>'Caught by #all mode'</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-82">
+         <h2 class="failed">function-call<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-84">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="failed">
+                  <th>function-call</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>should work</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-99">should report Expected Result correctly on failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-98">
+            <h3>function-call</h3>
+            <div id="ELEM-99">
+               <h4>should report Expected Result correctly on failure</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>'Returned from function'</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-117">
+         <h2 class="failed">template-call<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-119">
+            <col width="75%" />
+            <col width="25%" />
+            <tbody>
+               <tr class="failed">
+                  <th>template-call</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>should work</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-134">should report Expected Result correctly on failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-133">
+            <h3>template-call</h3>
+            <div id="ELEM-134">
+               <h4>should report Expected Result correctly on failure</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>'Returned from named template'</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../mode-all.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../mode-all.xspec">
+   <x:scenario>
+      <x:label>context</x:label>
+      <x:context>
+         <foo/>
+      </x:context>
+      <x:result select="'Caught by #all mode'"/>
+      <x:test successful="true">
+         <x:label>should work</x:label>
+         <x:expect select="'Caught by #all mode'"/>
+      </x:test>
+      <x:test successful="false">
+         <x:label>should report Expected Result correctly on failure</x:label>
+         <x:expect select="/element()">
+            <expected-element/>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+   <x:scenario>
+      <x:label>function-call</x:label>
+      <x:call function="string">
+         <x:param select="'Returned from function'"/>
+      </x:call>
+      <x:result select="'Returned from function'"/>
+      <x:test successful="true">
+         <x:label>should work</x:label>
+         <x:expect select="'Returned from function'"/>
+      </x:test>
+      <x:test successful="false">
+         <x:label>should report Expected Result correctly on failure</x:label>
+         <x:expect select="/element()">
+            <expected-element/>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+   <x:scenario>
+      <x:label>template-call</x:label>
+      <x:call template="named-template"/>
+      <x:result select="'Returned from named template'"/>
+      <x:test successful="true">
+         <x:label>should work</x:label>
+         <x:expect select="'Returned from named template'"/>
+      </x:test>
+      <x:test successful="false">
+         <x:label>should report Expected Result correctly on failure</x:label>
+         <x:expect select="/element()">
+            <expected-element/>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/mode-all.xsl
+++ b/test/end-to-end/cases/mode-all.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!-- Catches any item in any mode with highest priority -->
+	<xsl:template as="xs:string" match="." mode="#all" priority="999999999999999999">
+		<xsl:sequence select="'Caught by #all mode'" />
+	</xsl:template>
+
+	<xsl:template as="xs:string" name="named-template">
+		<xsl:sequence select="'Returned from named template'" />
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/end-to-end/cases/mode-all.xspec
+++ b/test/end-to-end/cases/mode-all.xspec
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mode-all.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		Test with mode="#all" template in the stylesheet being tested
+		https://github.com/xspec/xspec/commit/97ce32d134fc3468c0cdac891f098a0363c0561b#diff-624b07e550667dd3e06dae7c0b2bf9bdR149
+	-->
+
+	<x:scenario label="context">
+		<x:context>
+			<foo />
+		</x:context>
+		<x:expect label="should work" select="'Caught by #all mode'" />
+		<x:expect label="should report Expected Result correctly on failure">
+			<expected-element />
+		</x:expect>
+	</x:scenario>
+
+	<x:scenario label="function-call">
+		<x:call function="string">
+			<x:param select="'Returned from function'" />
+		</x:call>
+		<x:expect label="should work" select="'Returned from function'" />
+		<x:expect label="should report Expected Result correctly on failure">
+			<expected-element />
+		</x:expect>
+	</x:scenario>
+
+	<x:scenario label="template-call">
+		<x:call template="named-template" />
+		<x:expect label="should work" select="'Returned from named template'" />
+		<x:expect label="should report Expected Result correctly on failure">
+			<expected-element />
+		</x:expect>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Closes #592

This pull request provides some tests with `mode="#all"` template in the stylesheet being tested.

### Commits
* 5624863a50901b132cf267b6a2b75681d2ca0837
  Primary commit.
  The test has to be in `test/end-to-end/`, because the conflict between `#all` template and XSpec happens when XSpec constructs the test failure report.
* c58ffe630d9f003a25c7d7f24c436f5ff43c0be2
  Temporary commit for demonstrating a test failure ([Travis](https://travis-ci.org/AirQuick/xspec/jobs/577743778#L1966-L2079), [AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/builds/27012822/job/5omdch9r2q9go08k#L865))
* abbc2953369262bc202adf07d4a476439722fd9f reverts the temporary commit
