### PR TITLE
Test x:is-user-content() with x:variable

### DIFF
--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -221,6 +221,80 @@
 			</x:scenario>
 		</x:scenario>
 
+		<x:scenario label="global variable">
+			<x:scenario label="user-content">
+				<x:scenario label="element">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec" select="/x:description/x:variable/element()"
+						 />
+					</x:call>
+					<x:expect label="True" select="true()" />
+				</x:scenario>
+
+				<x:scenario label="attribute">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec"
+							select="/x:description/x:variable/element()/attribute()" />
+					</x:call>
+					<x:expect label="True" select="true()" />
+				</x:scenario>
+			</x:scenario>
+
+			<x:scenario label="not user-content">
+				<x:scenario label="element">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec" select="(/x:description/x:variable)[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+
+				<x:scenario label="attribute">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec"
+							select="(/x:description/x:variable/attribute())[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="local variable">
+			<x:scenario label="user-content">
+				<x:scenario label="element">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec" select="//x:scenario/x:variable/element()"
+						 />
+					</x:call>
+					<x:expect label="True" select="true()" />
+				</x:scenario>
+
+				<x:scenario label="attribute">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec"
+							select="//x:scenario/x:variable/element()/attribute()" />
+					</x:call>
+					<x:expect label="True" select="true()" />
+				</x:scenario>
+			</x:scenario>
+
+			<x:scenario label="not user-content">
+				<x:scenario label="element">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec" select="(//x:scenario/x:variable)[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+
+				<x:scenario label="attribute">
+					<x:call function="x:is-user-content">
+						<x:param href="xspec-avt.xspec"
+							select="(//x:scenario/x:variable/attribute())[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+
 		<x:scenario label="assertion">
 			<x:scenario label="user-content">
 				<x:scenario label="element">


### PR DESCRIPTION
This pull request just adds some test cases for [`x:is-user-content()`](https://github.com/xspec/xspec/blob/877ed425593ee7ec613669c5df8ce8723013ab7e/src/common/xspec-utils.xsl#L156-L174) with `x:variable`.

The function was created in acd72e031466be8dafb9c5945d452d53e50212cc but it didn't have tests with `x:variable` which wasn't available at that time.