### PR TITLE
Test with Ant 1.10 and revert #608

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
     global:
         # full path to Saxon jar
         - SAXON_JAR=/tmp/xspec/saxon/saxon9he.jar
-        # Ant version used in oXygen
-        - ANT_VERSION=1.9.8
+        # latest Ant
+        - ANT_VERSION=1.10.5
         # full path to XML Resolver jar
         - XML_RESOLVER_JAR=/tmp/xspec/xml-resolver/resolver.jar
     matrix:
@@ -19,8 +19,9 @@ env:
           BASEX_VERSION=8.6.4
         # latest Saxon 9.8 version
         - SAXON_VERSION=9.8.0-15
-        # Saxon version used in oXygen
+        # Saxon and Ant used in oXygen
         - SAXON_VERSION=9.8.0-12
+          ANT_VERSION=1.9.8
 
 before_install:
     - unset _JAVA_OPTIONS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   global:
     # full path to Saxon jar
     SAXON_JAR: '%TEMP%\xspec\saxon\saxon9he.jar'
-    # Ant version used in oXygen
-    ANT_VERSION: 1.9.8
+    # latest Ant
+    ANT_VERSION: 1.10.5
     # full path to XML Resolver jar
     XML_RESOLVER_JAR: '%TEMP%\xspec\xml-resolver\resolver.jar'
   matrix:
@@ -16,8 +16,9 @@ environment:
       BASEX_VERSION: 8.6.4
     # latest Saxon 9.8 version
     - SAXON_VERSION: 9.8.0-15
-    # Saxon version used in oXygen
+    # Saxon and Ant used in oXygen
     - SAXON_VERSION: 9.8.0-12
+      ANT_VERSION: 1.9.8
 
 install:
 - ps: >-

--- a/test/end-to-end/ant/base/worker/build-worker.xml
+++ b/test/end-to-end/ant/base/worker/build-worker.xml
@@ -34,10 +34,10 @@
 			<local name="style-path" />
 			<makepath property="style-path" url="@{style-url}" />
 
-			<!-- Use the NUL (null) device, if the macro caller doesn't care about the output -->
-			<condition else="/dev/null" property="out-path" value="NUL">
-				<os family="dos" />
-			</condition>
+			<!-- Use a temporary output file, if the macro caller doesn't care about the output -->
+			<tempfile deleteonexit="true" destdir="${java.io.tmpdir}"
+				prefix="xslt-url_deleteonexit_" property="out-path" suffix=".tmp"
+				unless:set="out-path" />
 
 			<!-- Perform XSLT -->
 			<saxon-xslt in="${in-path}" out="${out-path}" style="${style-path}">

--- a/test/end-to-end/ant/base/worker/build-worker.xml
+++ b/test/end-to-end/ant/base/worker/build-worker.xml
@@ -34,7 +34,8 @@
 			<local name="style-path" />
 			<makepath property="style-path" url="@{style-url}" />
 
-			<!-- Use a temporary output file, if the macro caller doesn't care about the output -->
+			<!-- Use a temporary output file, if the macro caller doesn't care about the output.
+				Can't use the Windows NUL device on Ant 1.10: https://bz.apache.org/bugzilla/show_bug.cgi?id=62330 -->
 			<tempfile deleteonexit="true" destdir="${java.io.tmpdir}"
 				prefix="xslt-url_deleteonexit_" property="out-path" suffix=".tmp"
 				unless:set="out-path" />


### PR DESCRIPTION
This pull request updates Ant version used for testing. As a result, this reverts #608.

#### Commits
* b8167de65225b0fd959facd5c01e4ddf8dd2782a updates Ant version from 1.9 to 1.10.
    * 1.9 is kept in the test matrix for oXygen.
    * The latest Ant release is 1.10.7 as of now, but 1.10.5 is the latest available on Chocolatey.
    * This change reveals an Ant 1.10 regression [bug](https://bz.apache.org/bugzilla/show_bug.cgi?id=62330) which is triggered by #608. ([AppVeyor](https://ci.appveyor.com/project/AirQuick/xspec/builds/27433506/job/jlstgdhnkwjnlt7t#L894))
* 4b1656496106928ebc2001408066250e212ff915 reverts #608.
* ff7a3c62207d990dc902acadcacb395b4f4e5985 adds a comment about the Ant bug.