### PR TITLE
Use full path for Windows find command in test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,5 +112,5 @@ test_script:
 
     rem check git status
 
-    git status --porcelain | find /v "" & if errorlevel 1 ( verify > NUL ) else ( verify other 2> NUL )
+    git status --porcelain | %SYSTEMROOT%\system32\find /v "" & if errorlevel 1 ( verify > NUL ) else ( verify other 2> NUL )
 deploy: off

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -691,7 +691,7 @@
     call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\xspec-185\import-1.xspec" -lib "%SAXON_JAR%" -logfile "%ANT_LOG%"
     call :verify_retval 0
 
-    call :run find " Scenario " "%ANT_LOG%"
+    call :run %SYSTEMROOT%\system32\find " Scenario " "%ANT_LOG%"
     call :verify_line_count 9
     call :verify_line  2 x "     [java] Scenario 1-1"
     call :verify_line  3 x "     [java] Scenario 1-2"

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -240,12 +240,12 @@ rem
     rem Remove the JAVA_TOOL_OPTIONS output, to keep the line numbers predictable.
     rem Remove the empty lines, to be compatible with Bats $lines.
     rem
-    type "%OUTPUT_RAW%" | find /v "" | findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" | findstr /r /v /c:"^$" > "%OUTPUT_FILTERED%"
+    type "%OUTPUT_RAW%" | %SYSTEMROOT%\system32\find /v "" | findstr /b /l /v /c:"Picked up JAVA_TOOL_OPTIONS:" | findstr /r /v /c:"^$" > "%OUTPUT_FILTERED%"
 
     rem
     rem Prefix each line with its line number.
     rem
-    type "%OUTPUT_FILTERED%" | find /v /n "" > "%OUTPUT_LINENUM%"
+    type "%OUTPUT_FILTERED%" | %SYSTEMROOT%\system32\find /v /n "" > "%OUTPUT_LINENUM%"
 
     goto :EOF
 
@@ -283,7 +283,7 @@ rem
     rem
 
     set LINE_NUMBER=%~1
-    if not %LINE_NUMBER%==* if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set /a LINE_NUMBER+=%%I+1
+    if not %LINE_NUMBER%==* if %LINE_NUMBER% LSS 0 for /f %%I in ('type "%OUTPUT_LINENUM%" ^| %SYSTEMROOT%\system32\find /v /c ""') do set /a LINE_NUMBER+=%%I+1
 
                         set "FIND_STRING=[%LINE_NUMBER%]%~3"
     if /i "%~2"=="r"    set "FIND_STRING=\[%LINE_NUMBER%\]%~3"
@@ -314,7 +314,7 @@ rem
     goto :EOF
 
 :verify_line_count
-    for /f %%I in ('type "%OUTPUT_LINENUM%" ^| find /v /c ""') do set LINE_COUNT=%%I
+    for /f %%I in ('type "%OUTPUT_LINENUM%" ^| %SYSTEMROOT%\system32\find /v /c ""') do set LINE_COUNT=%%I
     if %LINE_COUNT% EQU %~1 (
         call :verified "Line count: %~1"
     ) else (


### PR DESCRIPTION
This pull request just applies the same change as #464 to the test scripts.