### PR TITLE
Test for issue 638 (xsl:output in the stylesheet being tested)

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -145,6 +145,14 @@
 							and (x:saxon-version() lt x:pack-version(9, 8, 0, 15))">
 						<xsl:text>Requires Saxon bug #3889 to have been fixed</xsl:text>
 					</xsl:when>
+
+					<xsl:when
+						test="
+							($pis = 'require-saxon-bug-4315-fixed')
+							and (x:saxon-version() ge x:pack-version(9, 9, 0, 0))
+							and (x:saxon-version() le x:pack-version(9, 9, 1, 5))">
+						<xsl:text>Requires Saxon bug #4315 to have been fixed</xsl:text>
+					</xsl:when>
 				</xsl:choose>
 			</xsl:variable>
 

--- a/test/xspec-638.xsl
+++ b/test/xspec-638.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output encoding="UTF-8" method="text" />
+</xsl:stylesheet>

--- a/test/xspec-638.xspec
+++ b/test/xspec-638.xspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-saxon-bug-4315-fixed?>
 <x:description stylesheet="xspec-638.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="Regardless of xsl:output in the stylesheet being tested">
 		<x:context>

--- a/test/xspec-638.xspec
+++ b/test/xspec-638.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="xspec-638.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Regardless of xsl:output in the stylesheet being tested">
+		<x:context>
+			<foo />
+		</x:context>
+		<x:expect label="XSpec report XML should be created successfully" test="true()" />
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
Whatever the root cause of #638 is, there should be a test case for `xsl:output` collision:
https://github.com/xspec/xspec/blob/47f1d47506a801dea2dfe8e836346c172fa35b09/src/compiler/generate-xspec-tests.xsl#L84-L86

This pull request adds a simple test which reproduces #638 on Saxon 9.9.

### Commits

* 43a414cef740bed01d9dbd94f93492c9eb368a56 is the test. It fails on Saxon 9.9: [Azure](https://xspec.visualstudio.com/xspec/_build/results?buildId=152), [AppVeyor](https://ci.appveyor.com/project/xspec/xspec/builds/27583003), [Travis](https://travis-ci.org/xspec/xspec/builds/588162867)
* 38f74fb1402b66dbc5f2ed95e7675cc3bc2fdcea skips the test on Saxon 9.9 assuming its next maintenance release will fix the problem.