### PR TITLE
Test for issue 633 (warning on Ant)

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -873,4 +873,74 @@
         call :verify_line 3 r "WARNING: Saxon version ..*"
     )
 	</case>
+
+	<case name="No warning on Ant (XSLT) #633">
+    java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
+    if not errorlevel 1 (
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
+    )
+
+    set "ANT_LOG=%WORK_DIR%\ant.log"
+
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -verbose ^
+        -Dtest.type=t ^
+        -Dxspec.xml="%CD%\xspec-uri.xspec"
+    call :verify_retval 0
+    call :verify_exist "%ANT_LOG%"
+
+    call :run %SYSTEMROOT%\system32\find /i "warning" "%ANT_LOG%"
+    call :verify_retval 1
+	</case>
+
+	<case name="No warning on Ant (XQuery) #633">
+    java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
+    if not errorlevel 1 (
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
+    )
+
+    set "ANT_LOG=%WORK_DIR%\ant.log"
+
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -verbose ^
+        -Dtest.type=q ^
+        -Dxspec.xml="%CD%\xspec-uri.xspec"
+    call :verify_retval 0
+    call :verify_exist "%ANT_LOG%"
+
+    call :run %SYSTEMROOT%\system32\find /i "warning" "%ANT_LOG%"
+    call :verify_retval 1
+	</case>
+
+	<case name="No warning on Ant (Schematron) #633">
+    java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
+    if not errorlevel 1 (
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
+    )
+
+    set "ANT_LOG=%WORK_DIR%\ant.log"
+
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -verbose ^
+        -Dclean.output.dir=true ^
+        -Dtest.type=s ^
+        -Dxspec.xml="%CD%\xspec-uri.xspec"
+    call :verify_retval 0
+    call :verify_exist "%ANT_LOG%"
+
+    call :run %SYSTEMROOT%\system32\find /i "warning" "%ANT_LOG%"
+    call :verify_retval 1
+	</case>
 </collection>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -877,8 +877,8 @@
 	<case name="No warning on Ant (XSLT) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
-        rem goto :EOF
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"
@@ -900,8 +900,8 @@
 	<case name="No warning on Ant (XQuery) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
-        rem goto :EOF
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"
@@ -923,8 +923,8 @@
 	<case name="No warning on Ant (Schematron) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
-        rem goto :EOF
+        call :skip "Always expect a deprecation warning on Saxon 9.7"
+        goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -921,6 +921,9 @@
 	</case>
 
 	<case name="No warning on Ant (Schematron) #633">
+    call :skip "TODO: #633"
+    goto :EOF
+
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
         call :skip "Always expect a deprecation warning on Saxon 9.7"

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -465,7 +465,11 @@
 	</case>
 
 	<case name="Ant for Schematron with minimum properties #168">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_JAR%" -Dtest.type=s
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=s ^
+        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
     call :verify_line -2 x "BUILD SUCCESSFUL"

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -877,8 +877,8 @@
 	<case name="No warning on Ant (XSLT) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        call :skip "Always expect a deprecation warning on Saxon 9.7"
-        goto :EOF
+        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
+        rem goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"
@@ -900,8 +900,8 @@
 	<case name="No warning on Ant (XQuery) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        call :skip "Always expect a deprecation warning on Saxon 9.7"
-        goto :EOF
+        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
+        rem goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"
@@ -923,8 +923,8 @@
 	<case name="No warning on Ant (Schematron) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if not errorlevel 1 (
-        call :skip "Always expect a deprecation warning on Saxon 9.7"
-        goto :EOF
+        rem call :skip "Always expect a deprecation warning on Saxon 9.7"
+        rem goto :EOF
     )
 
     set "ANT_LOG=%WORK_DIR%\ant.log"

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -175,7 +175,7 @@ rem
     rem    Keep "..\test\" to minimize accident
     rem
     call :rmdir-if-exist ..\test\catalog\xspec
-    call :rmdir          ..\test\xspec
+    call :rmdir-if-exist ..\test\xspec
     call :rmdir-if-exist ..\tutorial\schematron\xspec
     call :rmdir          ..\tutorial\xspec
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -624,7 +624,11 @@ teardown() {
 
 
 @test "Ant for Schematron with minimum properties #168" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib "${SAXON_JAR}" -Dtest.type=s
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=s \
+        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1173,3 +1173,76 @@ teardown() {
 }
 
 
+@test "No warning on Ant (XSLT) #633" {
+    if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
+        skip "Always expect a deprecation warning on Saxon 9.7"
+    fi
+
+    ant_log="${work_dir}/ant.log"
+
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -logfile "${ant_log}" \
+        -verbose \
+        -Dtest.type=t \
+        -Dxspec.xml="${PWD}/xspec-uri.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ -f "${ant_log}" ]
+
+    run grep -F -i "warning" "${ant_log}"
+    echo "$output"
+    [ "$status" -eq 1 ]
+}
+
+
+@test "No warning on Ant (XQuery) #633" {
+    if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
+        skip "Always expect a deprecation warning on Saxon 9.7"
+    fi
+
+    ant_log="${work_dir}/ant.log"
+
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -logfile "${ant_log}" \
+        -verbose \
+        -Dtest.type=q \
+        -Dxspec.xml="${PWD}/xspec-uri.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ -f "${ant_log}" ]
+
+    run grep -F -i "warning" "${ant_log}"
+    echo "$output"
+    [ "$status" -eq 1 ]
+}
+
+
+@test "No warning on Ant (Schematron) #633" {
+    if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
+        skip "Always expect a deprecation warning on Saxon 9.7"
+    fi
+
+    ant_log="${work_dir}/ant.log"
+
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -logfile "${ant_log}" \
+        -verbose \
+        -Dclean.output.dir=true \
+        -Dtest.type=s \
+        -Dxspec.xml="${PWD}/xspec-uri.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ -f "${ant_log}" ]
+
+    run grep -F -i "warning" "${ant_log}"
+    echo "$output"
+    [ "$status" -eq 1 ]
+}
+
+

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1175,7 +1175,7 @@ teardown() {
 
 @test "No warning on Ant (XSLT) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        echo "Always expect a deprecation warning on Saxon 9.7"
+        skip "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"
@@ -1199,7 +1199,7 @@ teardown() {
 
 @test "No warning on Ant (XQuery) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        echo "Always expect a deprecation warning on Saxon 9.7"
+        skip "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"
@@ -1223,7 +1223,7 @@ teardown() {
 
 @test "No warning on Ant (Schematron) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        echo "Always expect a deprecation warning on Saxon 9.7"
+        skip "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1175,7 +1175,7 @@ teardown() {
 
 @test "No warning on Ant (XSLT) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        skip "Always expect a deprecation warning on Saxon 9.7"
+        echo "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"
@@ -1199,7 +1199,7 @@ teardown() {
 
 @test "No warning on Ant (XQuery) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        skip "Always expect a deprecation warning on Saxon 9.7"
+        echo "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"
@@ -1223,7 +1223,7 @@ teardown() {
 
 @test "No warning on Ant (Schematron) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        skip "Always expect a deprecation warning on Saxon 9.7"
+        echo "Always expect a deprecation warning on Saxon 9.7"
     fi
 
     ant_log="${work_dir}/ant.log"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -632,7 +632,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [[ "${lines[${#lines[@]}-2]}" =~ "BUILD SUCCESSFUL" ]]
 
     # Verify that the default clean.output.dir is false and leaves temp files. Delete the left XSLT file at the same time.
     [  -d "../tutorial/schematron/xspec/" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1222,6 +1222,8 @@ teardown() {
 
 
 @test "No warning on Ant (Schematron) #633" {
+    skip "TODO: #633"
+
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
         skip "Always expect a deprecation warning on Saxon 9.7"
     fi


### PR DESCRIPTION
This pull request adds a test for #633.

31a4f2029ce7358064d693f89f64ad7422e1e09b is the test.

cde7e67eec92d49099c768af0d47c16b7aecfd17 is a temporary commit for demonstrating test failures by not skipping the tests on Saxon 9.7: [Azure](https://xspec.visualstudio.com/xspec/_build/results?buildId=156), [Travis](https://travis-ci.org/xspec/xspec/builds/588359811)

2c0fb3b387c544e6bf55471ce37e8faca151861a is for readability. 09227ea6f2a04d416d5bb888fa9e271bb2857fa2 just improves precision of a test. They aren't related directly to #633 but they are so trivial that I included them here.
