### PR TITLE
ci: remove dependency on 7-zip

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 environment:
   global:
     # full path to Saxon jar

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -13,7 +13,7 @@ if not defined XMLCALABASH_VERSION (
     echo XMLCalabash will not be installed as it uses a higher version of Saxon
 ) else (
     %CURL% -o "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/%XMLCALABASH_VERSION%/xmlcalabash-%XMLCALABASH_VERSION%.zip"
-    7z x "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" -o"%TEMP%\xspec\xmlcalabash"
+    tar -xf "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" -C "%TEMP%\xspec\xmlcalabash"
     set "XMLCALABASH_JAR=%TEMP%\xspec\xmlcalabash\xmlcalabash-%XMLCALABASH_VERSION%\xmlcalabash-%XMLCALABASH_VERSION%.jar"
 )
 
@@ -22,7 +22,7 @@ if not defined BASEX_VERSION (
     echo BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon
 ) else (
     %CURL% -o "%TEMP%\xspec\basex\basex.zip" "http://files.basex.org/releases/%BASEX_VERSION%/BaseX%BASEX_VERSION:.=%.zip"
-    7z x "%TEMP%\xspec\basex\basex.zip" -o"%TEMP%\xspec\basex"
+    tar -xf "%TEMP%\xspec\basex\basex.zip" -C "%TEMP%\xspec\basex"
     set "BASEX_JAR=%TEMP%\xspec\basex\basex\BaseX.jar"
 )
 

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -5,6 +5,10 @@ set "CURL=%SYSTEMROOT%\system32\curl.exe"
 if not exist "%CURL%" set CURL=curl
 set "CURL=%CURL% -fsSL --create-dirs --retry 5"
 
+rem determine tar
+set "TAR=%SYSTEMROOT%\system32\tar.exe"
+if not exist "%TAR%" set TAR=tar
+
 rem install Saxon
 %CURL% -o "%SAXON_JAR%" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/%SAXON_VERSION%/Saxon-HE-%SAXON_VERSION%.jar"
 
@@ -13,7 +17,7 @@ if not defined XMLCALABASH_VERSION (
     echo XMLCalabash will not be installed as it uses a higher version of Saxon
 ) else (
     %CURL% -o "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/%XMLCALABASH_VERSION%/xmlcalabash-%XMLCALABASH_VERSION%.zip"
-    tar -xf "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" -C "%TEMP%\xspec\xmlcalabash"
+    %TAR% -xf "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" -C "%TEMP%\xspec\xmlcalabash"
     set "XMLCALABASH_JAR=%TEMP%\xspec\xmlcalabash\xmlcalabash-%XMLCALABASH_VERSION%\xmlcalabash-%XMLCALABASH_VERSION%.jar"
 )
 
@@ -22,7 +26,7 @@ if not defined BASEX_VERSION (
     echo BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon
 ) else (
     %CURL% -o "%TEMP%\xspec\basex\basex.zip" "http://files.basex.org/releases/%BASEX_VERSION%/BaseX%BASEX_VERSION:.=%.zip"
-    tar -xf "%TEMP%\xspec\basex\basex.zip" -C "%TEMP%\xspec\basex"
+    %TAR% -xf "%TEMP%\xspec\basex\basex.zip" -C "%TEMP%\xspec\basex"
     set "BASEX_JAR=%TEMP%\xspec\basex\basex\BaseX.jar"
 )
 
@@ -42,3 +46,4 @@ if defined JING_JAR %CURL% -o "%JING_JAR%" "http://central.maven.org/maven2/org/
 
 rem clean up
 set CURL=
+set TAR=


### PR DESCRIPTION
This pull request just removes dependency on 7-zip when installing dependencies on Azure Pipelines and AppVeyor.

To realize it, AppVeyor `image` is moved forward to `Visual Studio 2019` (9fa4280a431c5d6c94c3c44ec7ae0178970f5cf1) which is Windows Server 2019 which aligns with our current configuration of [Azure Pipelines](https://github.com/xspec/xspec/blob/e19539062a32ce7424e4a24416498d6dd38a9c0f/test/ci/azure-pipelines_template.yml#L9).

### How I tested it
I visually inspected [AppVeyor log](https://ci.appveyor.com/project/xspec/xspec/builds/27628152) and [Azure Pipelines log](https://xspec.visualstudio.com/xspec/_build/results?buildId=171) and verified that XML Calabash and BaseX tests were executed.