### PR TITLE
ci: remove dependency on Chocolatey

### DIFF
--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -31,7 +31,11 @@ if not defined BASEX_VERSION (
 )
 
 rem install Ant without installing JDK
-call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
+rem call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
+%CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
+%TAR% -xf "%TEMP%\xspec\ant\ant.tar.gz" -C "%TEMP%\xspec\ant"
+set "ANT_HOME=%TEMP%\xspec\ant\apache-ant-%ANT_VERSION%"
+path %ANT_HOME%\bin;%PATH%
 
 rem install XML Resolver
 %CURL% -o "%XML_RESOLVER_JAR%" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"

--- a/test/end-to-end/ant/base/worker/build-worker.xml
+++ b/test/end-to-end/ant/base/worker/build-worker.xml
@@ -34,11 +34,10 @@
 			<local name="style-path" />
 			<makepath property="style-path" url="@{style-url}" />
 
-			<!-- Use a temporary output file, if the macro caller doesn't care about the output.
-				Can't use the Windows NUL device on Ant 1.10: https://bz.apache.org/bugzilla/show_bug.cgi?id=62330 -->
-			<tempfile deleteonexit="true" destdir="${java.io.tmpdir}"
-				prefix="xslt-url_deleteonexit_" property="out-path" suffix=".tmp"
-				unless:set="out-path" />
+			<!-- Use the NUL (null) device, if the macro caller doesn't care about the output -->
+			<condition else="/dev/null" property="out-path" value="NUL">
+				<os family="dos" />
+			</condition>
 
 			<!-- Perform XSLT -->
 			<saxon-xslt in="${in-path}" out="${out-path}" style="${style-path}">

--- a/test/end-to-end/ant/base/worker/build-worker.xml
+++ b/test/end-to-end/ant/base/worker/build-worker.xml
@@ -34,10 +34,11 @@
 			<local name="style-path" />
 			<makepath property="style-path" url="@{style-url}" />
 
-			<!-- Use the NUL (null) device, if the macro caller doesn't care about the output -->
-			<condition else="/dev/null" property="out-path" value="NUL">
-				<os family="dos" />
-			</condition>
+			<!-- Use a temporary output file, if the macro caller doesn't care about the output.
+				Can't use the Windows NUL device on Ant 1.10: https://bz.apache.org/bugzilla/show_bug.cgi?id=62330 -->
+			<tempfile deleteonexit="true" destdir="${java.io.tmpdir}"
+				prefix="xslt-url_deleteonexit_" property="out-path" suffix=".tmp"
+				unless:set="out-path" />
 
 			<!-- Perform XSLT -->
 			<saxon-xslt in="${in-path}" out="${out-path}" style="${style-path}">


### PR DESCRIPTION
Following #645, this pull request just removes dependency on Chocolatey when installing Ant on Azure Pipelines and AppVeyor.

50beffa86caa9fde00108f8645062ac768336920 is a temporary commit for verifying that the specified version of Ant is installed and takes effect. As expected, the tests failed on Ant 1.10 jobs and succeeded on Ant 1.9 jobs: [Azure](https://xspec.visualstudio.com/xspec/_build/results?buildId=173), [AppVeyor](https://ci.appveyor.com/project/xspec/xspec/builds/27631938)

---

Although `test/ci/choco-install.cmd` is no longer necessary, I didn't remove it, for the sake of any future use.