### PR TITLE
ci: print environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
       fi
 
 script:
-    - ant -version
+    - ./test/ci/print-env.sh
     - cd test
     - echo "execute bats unit tests"
     - ./run-bats.sh --tap

--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -1,11 +1,41 @@
-echo Print Java version
+@echo off
+
+setlocal
+
+echo:
+echo === Print Java version
 java -version
 
-echo Print Ant version
+echo:
+echo === Print Ant version
 call ant -version
 
-echo Print Saxon version
+echo:
+echo === Print Saxon version
 java -cp "%SAXON_JAR%" net.sf.saxon.Version
 
-echo Print environment variables
+echo:
+echo === Check XML Calabash
+java -jar "%XMLCALABASH_JAR%" 2> NUL
+
+echo:
+echo === Print XML Resolver version
+java -cp "%XML_RESOLVER_JAR%" org.apache.xml.resolver.Version
+
+echo:
+echo === Check Jing
+java -jar "%JING_JAR%"
+
+echo:
+echo === Check BaseX
+java -cp "%BASEX_JAR%" org.basex.BaseX -h
+
+echo:
+echo === Check BaseX server start and stop
+call "%BASEX_JAR%\..\bin\basexhttp.bat" -S
+call "%BASEX_JAR%\..\bin\basexhttpstop.bat"
+
+echo:
+echo === Print environment variables
 set
+

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+echo
+echo "=== Print Java version"
+java -version
+
+echo
+echo "=== Print Ant version"
+ant -version
+
+echo
+echo "=== Print Saxon version"
+java -cp "${SAXON_JAR}" net.sf.saxon.Version
+
+echo
+echo "=== Check XML Calabash"
+java -jar "${XMLCALABASH_JAR}" 2> /dev/null
+
+echo
+echo "=== Print XML Resolver version"
+java -cp "${XML_RESOLVER_JAR}" org.apache.xml.resolver.Version
+
+echo
+echo "=== Check Jing"
+java -jar "${JING_JAR}"
+
+echo
+echo "=== Check BaseX"
+java -cp "${BASEX_JAR}" org.basex.BaseX -h
+
+echo
+echo "=== Check BaseX server start and stop"
+basex_home=$(dirname -- "${BASEX_JAR}")
+"${basex_home}/bin/basexhttp" -S
+"${basex_home}/bin/basexhttpstop"
+
+echo
+echo "=== Print Bats version"
+bats --version
+
+echo
+echo "=== Print environment variables"
+printenv
+


### PR DESCRIPTION
This pull request extends `test/ci/print-env.cmd` to align with the command line in [Wiki](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally#windows).

For Linux/MacOS, an equivalent script is created. (`test/ci/print-env.sh`)

### Further work

Update [Wiki](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to direct readers to `test/ci/print-env.cmd` (Windows) and `test/ci/print-env.sh` (Linux/MacOS) instead of the current command line snippet.