### PR TITLE
ci: externalize test dependency installation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,37 +33,7 @@ before_install:
     - unset _JAVA_OPTIONS
 
 before_script:
-    # install Saxon
-    - curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
-    # install XML Calabash
-    - if [ -z ${XMLCALABASH_VERSION} ]; then
-        echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
-      else
-        curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
-        unzip /tmp/xspec/xmlcalabash/xmlcalabash.zip -d /tmp/xspec/xmlcalabash;
-        export XMLCALABASH_JAR=/tmp/xspec/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
-      fi
-    # install BaseX
-    - if [[ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]]; then
-        echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
-      else
-        curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/basex/basex.zip http://files.basex.org/releases/${BASEX_VERSION}/BaseX${BASEX_VERSION//./}.zip;
-        unzip /tmp/xspec/basex/basex.zip -d /tmp/xspec/basex;
-        export BASEX_JAR=/tmp/xspec/basex/basex/BaseX.jar;
-      fi
-    # install Ant
-    - curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
-    - tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
-    - export PATH=/tmp/xspec/ant/apache-ant-${ANT_VERSION}/bin:${PATH}
-    # install XML Resolver
-    - curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
-    # install Jing
-    - if [ -z ${JING_VERSION} ]; then
-        echo "Jing will not be installed";
-      else
-        export JING_JAR=/tmp/xspec/jing/jing.jar;
-        curl -fsSL --create-dirs --retry 5 -o ${JING_JAR} http://central.maven.org/maven2/org/relaxng/jing/${JING_VERSION}/jing-${JING_VERSION}.jar;
-      fi
+    - source ./test/ci/install-deps.sh
 
 script:
     - ant -version

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -24,7 +24,8 @@ fi
 # install Ant
 curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
 tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
-export PATH=/tmp/xspec/ant/apache-ant-${ANT_VERSION}/bin:${PATH}
+export ANT_HOME=/tmp/xspec/ant/apache-ant-${ANT_VERSION}
+export PATH=${ANT_HOME}/bin:${PATH}
 
 # install XML Resolver
 curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+# install Saxon
+curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+
+# install XML Calabash
+if [ -z ${XMLCALABASH_VERSION} ]; then
+    echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
+else
+    curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
+    unzip /tmp/xspec/xmlcalabash/xmlcalabash.zip -d /tmp/xspec/xmlcalabash;
+    export XMLCALABASH_JAR=/tmp/xspec/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
+fi
+
+# install BaseX
+if [[ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]]; then
+    echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
+else
+    curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/basex/basex.zip http://files.basex.org/releases/${BASEX_VERSION}/BaseX${BASEX_VERSION//./}.zip;
+    unzip /tmp/xspec/basex/basex.zip -d /tmp/xspec/basex;
+    export BASEX_JAR=/tmp/xspec/basex/basex/BaseX.jar;
+fi
+
+# install Ant
+curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
+export PATH=/tmp/xspec/ant/apache-ant-${ANT_VERSION}/bin:${PATH}
+
+# install XML Resolver
+curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
+
+#install Jing
+if [ -z ${JING_VERSION} ]; then
+    echo "Jing will not be installed";
+else
+    export JING_JAR=/tmp/xspec/jing/jing.jar;
+    curl -fsSL --create-dirs --retry 5 -o ${JING_JAR} http://central.maven.org/maven2/org/relaxng/jing/${JING_VERSION}/jing-${JING_VERSION}.jar;
+fi


### PR DESCRIPTION
This pull request just pulls `before_script` from `.travis.yml` and puts it into an external shell script. This is supposed to help migrating to another CI or local testing.

This change aligns with what we [did](https://github.com/xspec/xspec/blob/master/test/ci/install-deps.cmd) for Azure Pipelines.

### How I tested it
I visually inspected [Travis CI logs](https://travis-ci.org/xspec/xspec/builds/589087112) and verified these:
* `ant -version` output and `# skip` lines conform to the test matrix
* [`script`](https://github.com/xspec/xspec/blob/b38a0c7e61e99fe84ad235d4b80f97c542f4adc9/.travis.yml#L68-L81) is performed to the end
