### PR TITLE
ci: set Saxon and XML Resolver path in test/ci/install-deps.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ jdk:
 
 env:
     global:
-        # full path to Saxon jar
-        - SAXON_JAR=/tmp/xspec/saxon/saxon9he.jar
         # latest Ant
         - ANT_VERSION=1.10.5
-        # full path to XML Resolver jar
-        - XML_RESOLVER_JAR=/tmp/xspec/xml-resolver/resolver.jar
     matrix:
         # latest Saxon 9.9 version and Jing
         #   * XML Calabash will use Saxon jar in its own lib directory.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,8 @@ image: Visual Studio 2019
 
 environment:
   global:
-    # full path to Saxon jar
-    SAXON_JAR: '%TEMP%\xspec\saxon\saxon9he.jar'
     # latest Ant
     ANT_VERSION: 1.10.5
-    # full path to XML Resolver jar
-    XML_RESOLVER_JAR: '%TEMP%\xspec\xml-resolver\resolver.jar'
 
   matrix:
     # Non-mainstream jobs are disabled in favor of Azure Pipelines

--- a/test/ci/azure-pipelines_template.yml
+++ b/test/ci/azure-pipelines_template.yml
@@ -9,14 +9,8 @@ jobs:
       vmImage: windows-latest
 
     variables:
-      # full path to Saxon jar
-      SAXON_JAR: $(Agent.TempDirectory)\xspec\saxon\saxon9he.jar
-
       # latest Ant
       ANT_VERSION: 1.10.5
-
-      # full path to XML Resolver jar
-      XML_RESOLVER_JAR: $(Agent.TempDirectory)\xspec\xml-resolver\resolver.jar
 
     strategy:
       maxParallel: 4

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -10,6 +10,7 @@ set "TAR=%SYSTEMROOT%\system32\tar.exe"
 if not exist "%TAR%" set TAR=tar
 
 rem install Saxon
+set "SAXON_JAR=%TEMP%\xspec\saxon\saxon9he.jar"
 %CURL% -o "%SAXON_JAR%" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/%SAXON_VERSION%/Saxon-HE-%SAXON_VERSION%.jar"
 
 rem install XML Calabash
@@ -34,6 +35,7 @@ rem install Ant without installing JDK
 call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
 
 rem install XML Resolver
+set "XML_RESOLVER_JAR=%TEMP%\xspec\xml-resolver\resolver.jar"
 %CURL% -o "%XML_RESOLVER_JAR%" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
 
 rem install Jing

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -1,5 +1,8 @@
 echo on
 
+rem root dir
+if not defined XSPEC_DEPS set "XSPEC_DEPS=%TEMP%\xspec"
+
 rem determine curl
 set "CURL=%SYSTEMROOT%\system32\curl.exe"
 if not exist "%CURL%" set CURL=curl
@@ -10,39 +13,39 @@ set "TAR=%SYSTEMROOT%\system32\tar.exe"
 if not exist "%TAR%" set TAR=tar
 
 rem install Saxon
-set "SAXON_JAR=%TEMP%\xspec\saxon\saxon9he.jar"
+set "SAXON_JAR=%XSPEC_DEPS%\saxon\saxon9he.jar"
 %CURL% -o "%SAXON_JAR%" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/%SAXON_VERSION%/Saxon-HE-%SAXON_VERSION%.jar"
 
 rem install XML Calabash
 if not defined XMLCALABASH_VERSION (
     echo XMLCalabash will not be installed as it uses a higher version of Saxon
 ) else (
-    %CURL% -o "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/%XMLCALABASH_VERSION%/xmlcalabash-%XMLCALABASH_VERSION%.zip"
-    %TAR% -xf "%TEMP%\xspec\xmlcalabash\xmlcalabash.zip" -C "%TEMP%\xspec\xmlcalabash"
-    set "XMLCALABASH_JAR=%TEMP%\xspec\xmlcalabash\xmlcalabash-%XMLCALABASH_VERSION%\xmlcalabash-%XMLCALABASH_VERSION%.jar"
+    %CURL% -o "%XSPEC_DEPS%\xmlcalabash\xmlcalabash.zip" "https://github.com/ndw/xmlcalabash1/releases/download/%XMLCALABASH_VERSION%/xmlcalabash-%XMLCALABASH_VERSION%.zip"
+    %TAR% -xf "%XSPEC_DEPS%\xmlcalabash\xmlcalabash.zip" -C "%XSPEC_DEPS%\xmlcalabash"
+    set "XMLCALABASH_JAR=%XSPEC_DEPS%\xmlcalabash\xmlcalabash-%XMLCALABASH_VERSION%\xmlcalabash-%XMLCALABASH_VERSION%.jar"
 )
 
 rem install BaseX
 if not defined BASEX_VERSION (
     echo BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon
 ) else (
-    %CURL% -o "%TEMP%\xspec\basex\basex.zip" "http://files.basex.org/releases/%BASEX_VERSION%/BaseX%BASEX_VERSION:.=%.zip"
-    %TAR% -xf "%TEMP%\xspec\basex\basex.zip" -C "%TEMP%\xspec\basex"
-    set "BASEX_JAR=%TEMP%\xspec\basex\basex\BaseX.jar"
+    %CURL% -o "%XSPEC_DEPS%\basex\basex.zip" "http://files.basex.org/releases/%BASEX_VERSION%/BaseX%BASEX_VERSION:.=%.zip"
+    %TAR% -xf "%XSPEC_DEPS%\basex\basex.zip" -C "%XSPEC_DEPS%\basex"
+    set "BASEX_JAR=%XSPEC_DEPS%\basex\basex\BaseX.jar"
 )
 
 rem install Ant without installing JDK
 call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
 
 rem install XML Resolver
-set "XML_RESOLVER_JAR=%TEMP%\xspec\xml-resolver\resolver.jar"
+set "XML_RESOLVER_JAR=%XSPEC_DEPS%\xml-resolver\resolver.jar"
 %CURL% -o "%XML_RESOLVER_JAR%" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
 
 rem install Jing
 if not defined JING_VERSION (
     echo Jing will not be installed
 ) else (
-    set "JING_JAR=%TEMP%\xspec\jing\jing.jar"
+    set "JING_JAR=%XSPEC_DEPS%\jing\jing.jar"
 )
 if defined JING_JAR %CURL% -o "%JING_JAR%" "http://central.maven.org/maven2/org/relaxng/jing/%JING_VERSION%/jing-%JING_VERSION%.jar"
 

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 # install Saxon
+export SAXON_JAR=/tmp/xspec/saxon/saxon9he.jar
 curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
 
 # install XML Calabash
@@ -28,6 +29,7 @@ export ANT_HOME=/tmp/xspec/ant/apache-ant-${ANT_VERSION}
 export PATH=${ANT_HOME}/bin:${PATH}
 
 # install XML Resolver
+export XML_RESOLVER_JAR=/tmp/xspec/xml-resolver/resolver.jar
 curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
 
 #install Jing

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -1,41 +1,46 @@
 #! /bin/bash
 
+# root dir
+if [ -z ${XSPEC_DEPS} ]; then
+    export XSPEC_DEPS=/tmp/xspec
+fi
+
 # install Saxon
-export SAXON_JAR=/tmp/xspec/saxon/saxon9he.jar
+export SAXON_JAR=${XSPEC_DEPS}/saxon/saxon9he.jar
 curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
 
 # install XML Calabash
 if [ -z ${XMLCALABASH_VERSION} ]; then
     echo "XMLCalabash will not be installed as it uses a higher version of Saxon";
 else
-    curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
-    unzip /tmp/xspec/xmlcalabash/xmlcalabash.zip -d /tmp/xspec/xmlcalabash;
-    export XMLCALABASH_JAR=/tmp/xspec/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
+    curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/xmlcalabash/xmlcalabash.zip https://github.com/ndw/xmlcalabash1/releases/download/${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.zip;
+    unzip ${XSPEC_DEPS}/xmlcalabash/xmlcalabash.zip -d ${XSPEC_DEPS}/xmlcalabash;
+    export XMLCALABASH_JAR=${XSPEC_DEPS}/xmlcalabash/xmlcalabash-${XMLCALABASH_VERSION}/xmlcalabash-${XMLCALABASH_VERSION}.jar;
 fi
 
 # install BaseX
 if [[ -z ${XMLCALABASH_VERSION} && -z ${BASEX_VERSION} ]]; then
     echo "BaseX will not be installed as it requires to run XMLCalabash with a higher version of Saxon";
 else
-    curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/basex/basex.zip http://files.basex.org/releases/${BASEX_VERSION}/BaseX${BASEX_VERSION//./}.zip;
-    unzip /tmp/xspec/basex/basex.zip -d /tmp/xspec/basex;
-    export BASEX_JAR=/tmp/xspec/basex/basex/BaseX.jar;
+    curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/basex/basex.zip http://files.basex.org/releases/${BASEX_VERSION}/BaseX${BASEX_VERSION//./}.zip;
+    unzip ${XSPEC_DEPS}/basex/basex.zip -d ${XSPEC_DEPS}/basex;
+    export BASEX_JAR=${XSPEC_DEPS}/basex/basex/BaseX.jar;
 fi
 
 # install Ant
-curl -fsSL --create-dirs --retry 5 -o /tmp/xspec/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
-tar xf /tmp/xspec/ant/ant.tar.gz -C /tmp/xspec/ant;
-export ANT_HOME=/tmp/xspec/ant/apache-ant-${ANT_VERSION}
+curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+tar xf ${XSPEC_DEPS}/ant/ant.tar.gz -C ${XSPEC_DEPS}/ant;
+export ANT_HOME=${XSPEC_DEPS}/ant/apache-ant-${ANT_VERSION}
 export PATH=${ANT_HOME}/bin:${PATH}
 
 # install XML Resolver
-export XML_RESOLVER_JAR=/tmp/xspec/xml-resolver/resolver.jar
+export XML_RESOLVER_JAR=${XSPEC_DEPS}/xml-resolver/resolver.jar
 curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
 
 #install Jing
 if [ -z ${JING_VERSION} ]; then
     echo "Jing will not be installed";
 else
-    export JING_JAR=/tmp/xspec/jing/jing.jar;
+    export JING_JAR=${XSPEC_DEPS}/jing/jing.jar;
     curl -fsSL --create-dirs --retry 5 -o ${JING_JAR} http://central.maven.org/maven2/org/relaxng/jing/${JING_VERSION}/jing-${JING_VERSION}.jar;
 fi


### PR DESCRIPTION
Just for historical reasons, `SAXON_JAR` and `XML_RESOLVER_JAR` are defined in each CI's YAML.
This pull request moves them to `test/ci/install-deps.*`. This change is supposed to help migrating to another CI or local testing.

### Further work
Update [Wiki](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to direct readers to `test/ci/install-deps.*` for instant installation.