### PR TITLE
ci: test with Ant 1.10.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
         # full path to Saxon jar
         - SAXON_JAR=/tmp/xspec/saxon/saxon9he.jar
         # latest Ant
-        - ANT_VERSION=1.10.5
+        - ANT_VERSION=1.10.7
         # full path to XML Resolver jar
         - XML_RESOLVER_JAR=/tmp/xspec/xml-resolver/resolver.jar
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # full path to Saxon jar
     SAXON_JAR: '%TEMP%\xspec\saxon\saxon9he.jar'
     # latest Ant
-    ANT_VERSION: 1.10.5
+    ANT_VERSION: 1.10.7
     # full path to XML Resolver jar
     XML_RESOLVER_JAR: '%TEMP%\xspec\xml-resolver\resolver.jar'
 

--- a/test/ci/azure-pipelines_template.yml
+++ b/test/ci/azure-pipelines_template.yml
@@ -13,7 +13,7 @@ jobs:
       SAXON_JAR: $(Agent.TempDirectory)\xspec\saxon\saxon9he.jar
 
       # latest Ant
-      ANT_VERSION: 1.10.5
+      ANT_VERSION: 1.10.7
 
       # full path to XML Resolver jar
       XML_RESOLVER_JAR: $(Agent.TempDirectory)\xspec\xml-resolver\resolver.jar


### PR DESCRIPTION
Now that we don't depend on Chocolatey (#646), we can select Ant version more freely. This pull request advances Ant version to the latest.