### PR TITLE
ci: test with XML Calabash 1.1.*-98

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,21 @@ env:
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.
 
-        # latest Saxon 9.9 version and Jing
+        # latest Saxon 9.9 and Jing
         - SAXON_VERSION=9.9.1-5
           JING_VERSION=20181222
           XMLCALABASH_VERSION=1.1.27-99
 
-        # latest Saxon 9.8 version
+        # latest Saxon 9.8
         - SAXON_VERSION=9.8.0-15
           XMLCALABASH_VERSION=1.1.27-98
 
-        # Saxon and Ant used in oXygen
+        # latest oXygen
         - SAXON_VERSION=9.8.0-12
           ANT_VERSION=1.9.8
+          XMLCALABASH_VERSION=1.1.24-98
 
-        # highest deprecated Saxon version
+        # highest deprecated Saxon
         - SAXON_VERSION=9.7.0-21
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,27 @@ env:
     global:
         # latest Ant
         - ANT_VERSION=1.10.5
+
+        - BASEX_VERSION=8.6.4
+
     matrix:
-        # latest Saxon 9.9 version and Jing
+        # Note
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.
+
+        # latest Saxon 9.9 version and Jing
         - SAXON_VERSION=9.9.1-5
           JING_VERSION=20181222
           XMLCALABASH_VERSION=1.1.27-99
-          BASEX_VERSION=8.6.4
+
         # latest Saxon 9.8 version
         - SAXON_VERSION=9.8.0-15
+          XMLCALABASH_VERSION=1.1.27-98
+
         # Saxon and Ant used in oXygen
         - SAXON_VERSION=9.8.0-12
           ANT_VERSION=1.9.8
+
         # highest deprecated Saxon version
         - SAXON_VERSION=9.7.0-21
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,20 +14,21 @@ environment:
     #   * XML Calabash will use Saxon jar in its own lib directory.
     #   * BaseX test requires XML Calabash.
 
-    # latest Saxon 9.9 version and Jing
+    # latest Saxon 9.9 and Jing
     - SAXON_VERSION: 9.9.1-5
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.27-99
 
-    # latest Saxon 9.8 version
+    # latest Saxon 9.8
     # - SAXON_VERSION: 9.8.0-15
     #   XMLCALABASH_VERSION: 1.1.27-98
 
-    # Saxon and Ant used in oXygen
+    # latest oXygen
     # - SAXON_VERSION: 9.8.0-12
     #   ANT_VERSION: 1.9.8
+    #   XMLCALABASH_VERSION: 1.1.24-98
 
-    # highest deprecated Saxon version
+    # highest deprecated Saxon
     # - SAXON_VERSION: 9.7.0-21
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,19 +5,23 @@ environment:
     # latest Ant
     ANT_VERSION: 1.10.5
 
+    BASEX_VERSION: 8.6.4
+
   matrix:
     # Non-mainstream jobs are disabled in favor of Azure Pipelines
 
-    # latest Saxon 9.9 version and Jing
+    # Note
     #   * XML Calabash will use Saxon jar in its own lib directory.
     #   * BaseX test requires XML Calabash.
+
+    # latest Saxon 9.9 version and Jing
     - SAXON_VERSION: 9.9.1-5
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.27-99
-      BASEX_VERSION: 8.6.4
 
     # latest Saxon 9.8 version
     # - SAXON_VERSION: 9.8.0-15
+    #   XMLCALABASH_VERSION: 1.1.27-98
 
     # Saxon and Ant used in oXygen
     # - SAXON_VERSION: 9.8.0-12

--- a/test/ci/azure-pipelines_template.yml
+++ b/test/ci/azure-pipelines_template.yml
@@ -33,12 +33,13 @@ jobs:
           SAXON_VERSION: 9.8.0-15
           XMLCALABASH_VERSION: 1.1.27-98
 
-        # Saxon and Ant used in oXygen
+        # latest oXygen
         Oxygen:
           SAXON_VERSION: 9.8.0-12
           ANT_VERSION: 1.9.8
+          XMLCALABASH_VERSION: 1.1.24-98
 
-        # highest deprecated Saxon version
+        # highest deprecated Saxon
         Saxon-9-7:
           SAXON_VERSION: 9.7.0-21
 

--- a/test/ci/azure-pipelines_template.yml
+++ b/test/ci/azure-pipelines_template.yml
@@ -12,22 +12,26 @@ jobs:
       # latest Ant
       ANT_VERSION: 1.10.5
 
+      BASEX_VERSION: 8.6.4
+
     strategy:
       maxParallel: 4
 
       matrix:
-        # latest Saxon and Jing
+        # Note
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.
+
+        # latest Saxon and Jing
         Saxon-9-9:
           SAXON_VERSION: 9.9.1-5
           JING_VERSION: 20181222
           XMLCALABASH_VERSION: 1.1.27-99
-          BASEX_VERSION: 8.6.4
 
         # latest Saxon 9.8
         Saxon-9-8:
           SAXON_VERSION: 9.8.0-15
+          XMLCALABASH_VERSION: 1.1.27-98
 
         # Saxon and Ant used in oXygen
         Oxygen:


### PR DESCRIPTION
XML Calabash maintains two lines of [releases](https://github.com/ndw/xmlcalabash1/releases). `*-99` for Saxon 9.9. `*-98` for Saxon 9.8. Our CI has been testing only one line.
This pull request adds the 9.8 line to the text matrix.
