### PR TITLE
Fix test/end-to-end/cases/xspec-shared-like.xspec

### DIFF
--- a/test/end-to-end/cases/expected/query/xspec-shared-like-junit.xml
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-junit.xml
@@ -23,9 +23,9 @@
    <testsuite name="Scenario for testing x:like which references unshared scenarios"
               tests="2"
               failures="0">
-      <testcase name="This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
+      <testcase name="explicit one This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
-      <testcase name="This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
+      <testcase name="implicit one This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
    </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
@@ -139,10 +139,18 @@
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
+                  <th>explicit one</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
                      x:scenario and x:like
                   </td>
                   <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>implicit one</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original

--- a/test/end-to-end/cases/expected/query/xspec-shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-result.xml
@@ -38,16 +38,24 @@
    </x:scenario>
    <x:scenario>
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
-      <x:call function="false"/>
-      <x:call function="false"/>
-      <x:result select="xs:boolean('false')"/>
-      <x:test successful="true">
-         <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect test="true()" select="()"/>
-      </x:test>
-      <x:test successful="true">
-         <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect test="true()" select="()"/>
-      </x:test>
+      <x:result select="()"/>
+      <x:scenario>
+         <x:label>explicit one</x:label>
+         <x:call function="false"/>
+         <x:result select="xs:boolean('false')"/>
+         <x:test successful="true">
+            <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
+            <x:expect test="true()" select="()"/>
+         </x:test>
+      </x:scenario>
+      <x:scenario>
+         <x:label>implicit one</x:label>
+         <x:call function="false"/>
+         <x:result select="xs:boolean('false')"/>
+         <x:test successful="true">
+            <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
+            <x:expect test="true()" select="()"/>
+         </x:test>
+      </x:scenario>
    </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-junit.xml
@@ -23,9 +23,9 @@
    <testsuite name="Scenario for testing x:like which references unshared scenarios"
               tests="2"
               failures="0">
-      <testcase name="This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
+      <testcase name="explicit one This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
-      <testcase name="This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
+      <testcase name="implicit one This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
    </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
@@ -136,10 +136,18 @@
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
+                  <th>explicit one</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
                      x:scenario and x:like
                   </td>
                   <td>Success</td>
+               </tr>
+               <tr class="successful">
+                  <th>implicit one</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.xml
@@ -39,16 +39,23 @@
    </x:scenario>
    <x:scenario>
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
-      <x:call function="false"/>
-      <x:call function="false"/>
-      <x:result select="xs:boolean('false')"/>
-      <x:test successful="true">
-         <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect test="true()" select="()"/>
-      </x:test>
-      <x:test successful="true">
-         <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect test="true()" select="()"/>
-      </x:test>
+      <x:scenario>
+         <x:label>explicit one</x:label>
+         <x:call function="false"/>
+         <x:result select="xs:boolean('false')"/>
+         <x:test successful="true">
+            <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
+            <x:expect test="true()" select="()"/>
+         </x:test>
+      </x:scenario>
+      <x:scenario>
+         <x:label>implicit one</x:label>
+         <x:call function="false"/>
+         <x:result select="xs:boolean('false')"/>
+         <x:test successful="true">
+            <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
+            <x:expect test="true()" select="()"/>
+         </x:test>
+      </x:scenario>
    </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/xspec-shared-like.xspec
+++ b/test/end-to-end/cases/xspec-shared-like.xspec
@@ -39,8 +39,12 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing x:like which references unshared scenarios">
-		<x:like label="Referenced and explicitly unshared scenario" />
-		<x:like label="Referenced and implicitly unshared scenario" />
+		<x:scenario label="explicit one">
+			<x:like label="Referenced and explicitly unshared scenario" />
+		</x:scenario>
+		<x:scenario label="implicit one">
+			<x:like label="Referenced and implicitly unshared scenario" />
+		</x:scenario>
 	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
`test/end-to-end/cases/xspec-shared-like.xspec` has an error where two `x:like` are collocated:
https://github.com/xspec/xspec/blob/7ca0c444d089a1b9190440cf5f8cec9379f78114/test/end-to-end/cases/xspec-shared-like.xspec#L41-L44

After unshared, this `x:scenario` looks like this:

```xml
   <x:scenario xslt-version="2"
               label="Scenario for testing x:like which references unshared scenarios">
      <x:call function="false"/>
      <x:expect label="This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
                test="true()"/>
      <x:call function="false"/>
      <x:expect label="This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
                test="true()"/>
   </x:scenario>
```

So one `x:scenario` has two `x:call`, which is not allowed.

This pull request fixes it by putting each `x:like` into its own `x:scenario`.