### PR TITLE
Test inheritance in x:copy-namespaces()

### DIFF
--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -136,14 +136,19 @@
 
 	<x:scenario label="Scenario for testing function copy-namespaces">
 		<x:call function="x:copy-namespaces">
-			<x:param>
-				<input-element xmlns="default-ns" xmlns:prefix="prefixed-ns" />
+			<x:param select="//*:input-element">
+				<wrapper-element xmlns="wrapper-default-ns"
+					xmlns:wrapper-prefix="wrapper-prefixed-ns">
+					<input-element xmlns="default-ns" xmlns:prefix="prefixed-ns" />
+				</wrapper-element>
 			</x:param>
 		</x:call>
 		<x:expect label="Default namespace is copied" select="'default-ns'"
 			test="$x:result[name() eq '']/string()" />
 		<x:expect label="Prefixed namespace is copied" select="'prefixed-ns'"
 			test="$x:result[name() eq 'prefix']/string()" />
+		<x:expect label="Inherited prefixed namespace is copied" select="'wrapper-prefixed-ns'"
+			test="$x:result[name() eq 'wrapper-prefix']/string()" />
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function is-user-content">


### PR DESCRIPTION
While reviewing #640, I thought that incorporating a part of the proposed tests beforehand would help narrowing down the scope of #640.