### PR TITLE
Add xsl:context-item to named templates

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -12,6 +12,9 @@
 		Identity template
 	-->
 	<xsl:template as="node()" name="x:identity">
+		<xsl:context-item as="node()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:copy>
 			<xsl:apply-templates mode="#current" select="attribute() | node()" />
 		</xsl:copy>

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -56,6 +56,12 @@
        the x:description element, in the mode
    -->
    <xsl:template name="x:generate-tests">
+      <!-- Actually, xsl:context-item/@as is "document-node(element(x:description))".
+         "element(x:description)" is omitted in order to enable the "Source document is not XSpec..."
+         error message. -->
+      <xsl:context-item as="document-node()" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:variable name="deprecation-warning" as="xs:string?" select="
          if (x:saxon-version() lt x:pack-version(9,8,0,0))
          then 'Saxon version 9.7 or less is deprecated. XSpec will stop supporting it in the near future.'
@@ -205,8 +211,12 @@
        corresponding call instruction at some point).
    -->
    <xsl:template name="x:call-scenarios">
+      <xsl:context-item as="element()" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <!-- Default value of $pending does not affect compiler output but is here if needed in the future -->
       <xsl:param name="pending" select="(.//@focus)[1]" tunnel="yes" as="node()?"/>
+
       <xsl:variable name="this" select="." as="element()"/>
       <xsl:if test="empty($this[self::x:description|self::x:scenario])">
          <xsl:sequence select="
@@ -221,6 +231,9 @@
    </xsl:template>
 
    <xsl:template name="x:continue-call-scenarios">
+      <xsl:context-item as="element()" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <!-- Continue walking the siblings. -->
       <xsl:apply-templates select="following-sibling::*[1]" mode="#current"/>
    </xsl:template>
@@ -352,6 +365,9 @@
        and variables).
    -->
    <xsl:template name="x:compile-params">
+      <xsl:context-item as="element(x:description)" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:variable name="this" select="." as="element(x:description)"/>
       <xsl:apply-templates select="$this/(x:param|x:variable)" mode="x:generate-declarations"/>
    </xsl:template>
@@ -372,7 +388,11 @@
        templates or XQuery functions.
    -->
    <xsl:template name="x:compile-scenarios">
+      <xsl:context-item as="element()" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="pending" as="node()?" select="(.//@focus)[1]" tunnel="yes"/>
+
       <xsl:variable name="this" select="." as="element()"/>
       <xsl:if test="empty($this[self::x:description|self::x:scenario])">
          <xsl:sequence select="
@@ -640,7 +660,8 @@
       The actual instruction to enter SUT is provided by the caller. The instruction
       should not contain other actions. -->
    <xsl:template name="x:enter-sut" as="node()+">
-      <!--<xsl:context-item as="element(x:scenario)" use="required" />-->
+      <xsl:context-item as="element(x:scenario)" use="required"
+         use-when="element-available('xsl:context-item')" />
 
       <xsl:param name="instruction" as="node()+" required="yes" />
 
@@ -661,7 +682,8 @@
 
    <!-- Generates variable declarations for x:expect -->
    <xsl:template name="x:setup-expected" as="node()+">
-      <!--<xsl:context-item as="element(x:expect)" use="required" />-->
+      <xsl:context-item as="element(x:expect)" use="required"
+         use-when="element-available('xsl:context-item')" />
 
       <xsl:param name="var" as="xs:string" required="yes" />
 
@@ -682,6 +704,9 @@
    <!-- Generate error message for user-defined usage of names in XSpec namespace.
         Context node is an x:variable element. -->
    <xsl:template name="x:detect-reserved-variable-name" as="empty-sequence()">
+      <xsl:context-item as="element(x:variable)" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:variable name="msg" as="xs:string"
          select="concat('User-defined XSpec variable, ',@name,', must not use the XSpec namespace.')"/>
       <xsl:choose>

--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -152,6 +152,9 @@
          let $NAME as TYPE := ( VALUE )
    -->
    <xsl:template name="test:declare-or-let-variable" as="node()+">
+      <xsl:context-item use="absent"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="is-global" as="xs:boolean" required="yes" />
       <xsl:param name="name" as="xs:string" required="yes" />
       <xsl:param name="type" as="xs:string?" required="yes" />
@@ -220,6 +223,9 @@
    </xsl:template>
 
    <xsl:template name="test:create-zero-or-more-node-generators" as="node()+">
+      <xsl:context-item use="absent"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="nodes" as="node()*" />
 
       <xsl:choose>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -181,9 +181,13 @@
    <!-- Generates a call to the function compiled from a scenario or an expect element. --> 
 
    <xsl:template name="x:output-call">
+      <xsl:context-item as="element()" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="local-name" as="xs:string"/>
       <xsl:param name="last"       as="xs:boolean"/>
       <xsl:param name="params"     as="element(param)*"/>
+
       <xsl:if test="exists(preceding-sibling::x:*[1][self::x:pending])">
          <xsl:text>,&#10;</xsl:text>
       </xsl:if>
@@ -217,6 +221,9 @@
    -->
 
    <xsl:template name="x:output-scenario" as="node()+">
+      <xsl:context-item as="element(x:scenario)" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="pending" select="()" tunnel="yes" as="node()?"/>
       <xsl:param name="context" select="()" tunnel="yes" as="element(x:context)?"/>
       <xsl:param name="call"    select="()" tunnel="yes" as="element(x:call)?"/>
@@ -335,6 +342,9 @@
    </xsl:template>
 
    <xsl:template name="x:output-try-catch" as="text()+">
+      <xsl:context-item use="absent"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="instruction" as="text()+" required="yes" />
 
       <xsl:text>    try {&#x0A;</xsl:text>
@@ -371,9 +381,13 @@
        element for the XML report.
    -->
    <xsl:template name="x:output-expect" as="node()+">
+      <xsl:context-item as="element(x:expect)" use="required"
+         use-when="element-available('xsl:context-item')" />
+
       <xsl:param name="pending" select="()"    tunnel="yes" as="node()?"/>
       <xsl:param name="call"    required="yes" tunnel="yes" as="element(x:call)?"/>
       <xsl:param name="params"  required="yes"              as="element(param)*"/>
+
       <xsl:variable name="pending-p" select="exists($pending) and empty(ancestor::*/@focus)"/>
       <!--
         declare function local:...($t:result as item()*)

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -280,6 +280,9 @@
 </xsl:function>
   
 <xsl:template name="test:report-sequence" as="element()">
+  <xsl:context-item use="absent"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="sequence" as="item()*" required="yes" />
   <xsl:param name="wrapper-name" as="xs:string" required="yes" />
   <xsl:param name="wrapper-ns" as="xs:string" select="'http://www.jenitennison.com/xslt/xspec'" />

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -112,6 +112,9 @@
 <!-- Generates a call to the template compiled from a scenario or an expect element. --> 
 
 <xsl:template name="x:output-call">
+   <xsl:context-item as="element()" use="required"
+      use-when="element-available('xsl:context-item')" />
+
    <xsl:param name="local-name" as="xs:string"/>
    <xsl:param name="last"       as="xs:boolean"/>
    <xsl:param name="params"     as="element(param)*"/>
@@ -130,6 +133,9 @@
 <!-- Generates the templates that perform the tests -->
 
 <xsl:template name="x:output-scenario" as="element(xsl:template)+">
+  <xsl:context-item as="element(x:scenario)" use="required"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="pending"   select="()" tunnel="yes" as="node()?"/>
   <xsl:param name="apply"     select="()" tunnel="yes" as="element(x:apply)?"/>
   <xsl:param name="call"      select="()" tunnel="yes" as="element(x:call)?"/>
@@ -343,6 +349,9 @@
 </xsl:template>
 
 <xsl:template name="x:output-try-catch" as="element(xsl:try)">
+  <xsl:context-item use="absent"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="instruction" as="element()" required="yes" />
 
   <try>
@@ -373,6 +382,9 @@
 </xsl:template>
 
 <xsl:template name="x:output-expect" as="element(xsl:template)">
+  <xsl:context-item as="element(x:expect)" use="required"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="pending" select="()"    tunnel="yes" as="node()?"/>
   <xsl:param name="context" required="yes" tunnel="yes" as="element(x:context)?"/>
   <xsl:param name="call"    required="yes" tunnel="yes" as="element(x:call)?"/>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -190,11 +190,15 @@
 </xsl:variable>
 
 <xsl:template name="test:output-lines">
+  <xsl:context-item use="absent"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="line-number" as="xs:integer" required="yes" />
   <xsl:param name="stylesheet-string" as="xs:string" required="yes" />
   <xsl:param name="node" as="node()" required="yes" />
   <xsl:param name="number-format" tunnel="yes" as="xs:string" required="yes" />
   <xsl:param name="module" tunnel="yes" as="xs:string" required="yes" />
+
   <xsl:variable name="analyzed">
     <xsl:analyze-string select="$stylesheet-string"
       regex="{$construct-regex}" flags="sx">

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -335,6 +335,9 @@
 <!-- Generates <style> or <link> for CSS.
   If you enable $inline, you must use test:disable-escaping character map in serialization. -->
 <xsl:template name="test:load-css" as="element()">
+  <xsl:context-item use="absent"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="inline" as="xs:boolean" required="yes" />
   <xsl:param name="uri" as="xs:string?" />
 

--- a/src/reporter/format-xspec-report-folding.xsl
+++ b/src/reporter/format-xspec-report-folding.xsl
@@ -21,6 +21,9 @@
 <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/format-xspec-report-folding.xsl</pkg:import-uri>
 
 <xsl:template name="x:html-head-callback" as="element(xhtml:script)">
+  <xsl:context-item as="document-node(element(x:report))" use="required"
+    use-when="element-available('xsl:context-item')" />
+
   <script language="javascript" type="text/javascript">
 function toggle(scenarioID) {
   table = document.getElementById("t-"+scenarioID);
@@ -53,6 +56,9 @@ function toggle(scenarioID) {
 </xsl:template>
 
 <xsl:template name="x:format-top-level-scenario" as="element(xhtml:div)">
+  <xsl:context-item as="element(x:scenario)" use="required"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:variable name="pending" as="xs:boolean"
     select="exists(@pending)" />
   <xsl:variable name="any-failure" as="xs:boolean"

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -49,9 +49,15 @@
 
 <!-- Named template to be overridden.
   Override this template to insert additional nodes at the end of /html/head. -->
-<xsl:template name="x:html-head-callback" as="empty-sequence()"/>
+<xsl:template name="x:html-head-callback" as="empty-sequence()">
+  <xsl:context-item as="document-node(element(x:report))" use="required"
+    use-when="element-available('xsl:context-item')" />
+</xsl:template>
   
 <xsl:template name="x:format-top-level-scenario" as="element(xhtml:div)">
+  <xsl:context-item as="element(x:scenario)" use="required"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:variable name="pending" as="xs:boolean"
     select="exists(@pending)" />
   <xsl:variable name="any-failure" as="xs:boolean"
@@ -419,8 +425,12 @@
 </xsl:template>
 
 <xsl:template name="x:totals" as="text()?">
+  <xsl:context-item use="absent"
+    use-when="element-available('xsl:context-item')" />
+
   <xsl:param name="tests" as="element(x:test)*" required="yes" />
   <xsl:param name="labels" as="xs:boolean" select="false()" />
+
   <xsl:if test="$tests">
     <xsl:variable name="counts" select="x:totals($tests)"/>
 

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -168,6 +168,9 @@
     <xsl:template match="@count | @label" mode="make-predicate"/>
     
     <xsl:template name="make-label">
+        <xsl:context-item as="element()" use="required"
+            use-when="element-available('xsl:context-item')" />
+
         <xsl:attribute name="label" select="string-join((@label, tokenize(local-name(),'-')[.=('report','assert','not','rule')], @id, @role, @location, @context, current()[@count]/string('count:'), @count), ' ')"/>
     </xsl:template>
 

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -231,6 +231,9 @@
 
 	<!-- Override this template to provide <run-xspec> with additional nodes -->
 	<xsl:template as="empty-sequence()" name="on-run-xspec">
+		<xsl:context-item as="attribute()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="xs:boolean" name="coverage-enabled" />
 	</xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/ant/base/worker/generate.xsl
+++ b/test/end-to-end/ant/base/worker/generate.xsl
@@ -20,6 +20,9 @@
 		Context node is in each .xspec file's /x:description/@*.
 	-->
 	<xsl:template as="node()+" name="on-run-xspec">
+		<xsl:context-item as="attribute()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="xs:boolean" name="coverage-enabled" required="yes" />
 
 		<!-- Directory URI of the processor root -->
@@ -94,6 +97,9 @@
 
 	<!-- Override this template to provide <post-task> with additional nodes -->
 	<xsl:template as="empty-sequence()" name="on-post-task">
+		<xsl:context-item as="attribute()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="element(reports)" name="reports" />
 	</xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/ant/generate-expected/worker/generate.xsl
+++ b/test/end-to-end/ant/generate-expected/worker/generate.xsl
@@ -20,6 +20,9 @@
 		Context node is in each .xspec file's /x:description/@*.
 	-->
 	<xsl:template as="element(normalize-xspec-report)+" name="on-post-task">
+		<xsl:context-item as="attribute()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="element(reports)" name="reports" required="yes" />
 
 		<!-- Normalize the actual report files -->

--- a/test/end-to-end/ant/run-e2e-tests/worker/generate.xsl
+++ b/test/end-to-end/ant/run-e2e-tests/worker/generate.xsl
@@ -19,6 +19,9 @@
 		Context node is in each .xspec file's /x:description/@*.
 	-->
 	<xsl:template as="element(compare-xspec-report)+" name="on-post-task">
+		<xsl:context-item as="attribute()" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="element(reports)" name="reports" required="yes" />
 
 		<!-- Compare the actual report files with the expected ones -->

--- a/test/end-to-end/processor/base/_normalizer.xsl
+++ b/test/end-to-end/processor/base/_normalizer.xsl
@@ -56,6 +56,9 @@
 			This template makes them predictable while keeping uniqueness within document.
 	-->
 	<xsl:template as="attribute()" name="normalizer:normalize-external-link-attribute">
+		<xsl:context-item as="attribute(href)" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
 		<!-- Absolute URI -->

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -89,6 +89,9 @@
 	<!-- Makes @id predictable -->
 	<xsl:template as="attribute(id)" match="@id" mode="normalizer:normalize"
 		name="normalize-id-attribute">
+		<xsl:context-item as="attribute(id)" use="required"
+			use-when="element-available('xsl:context-item')" />
+
 		<xsl:attribute name="{local-name()}" namespace="{namespace-uri()}"
 			select="local:generate-predictable-id(parent::element())" />
 	</xsl:template>

--- a/test/win-bats/generate.xsl
+++ b/test/win-bats/generate.xsl
@@ -64,6 +64,8 @@
 
 	<!-- Writes lines with CR LF -->
 	<xsl:template as="text()+" name="write">
+		<xsl:context-item use="absent" use-when="element-available('xsl:context-item')" />
+
 		<xsl:param as="xs:string" name="text" required="yes" />
 
 		<xsl:value-of select="tokenize($text, '\n')" separator="&#x0D;&#x0A;" />


### PR DESCRIPTION
This pull request just adds `xsl:context-item` to `xsl:template[@name]` to clarify what context each template expects.

`@use-when` is for compatibility with XSLT 2.0.

There is no automated test for `format-xspec-report-folding.xsl`. So I manually tested this pull request and verified this:

* `ant -lib "saxon9ee.jar" -Dxspec.xml=tutorial\escape-for-regex.xspec -Dxspec.html.reporter.xsl=src\reporter\format-xspec-report-folding.xsl` generates the same `escape-for-regex-result.html` as the current master.
