### PR TITLE
ci: test Maven package and fix javadoc compatibility with JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
         - SAXON_VERSION=9.9.1-5
           JING_VERSION=20181222
           XMLCALABASH_VERSION=1.1.27-99
+          DO_MAVEN_PACKAGE=true
 
         # latest Saxon 9.8
         - SAXON_VERSION=9.8.0-15
@@ -50,6 +51,8 @@ script:
     - echo "execute XSpec end-to-end tests"
     - cd ..
     - ./test/end-to-end/run-e2e-tests.sh -silent
+    - echo "Maven package"
+    - ./test/ci/maven-package.sh -q
     - echo "compile java"
     - ./test/ci/compile-java.sh -silent
     - echo "check git status"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,9 @@ test_script:
     rem execute XSpec end-to-end tests
     test\end-to-end\run-e2e-tests.cmd -silent
 
+    rem Maven package
+    rem test\ci\maven-package.cmd -q
+
     rem compile java
     test\ci\compile-java.cmd -silent
 

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,7 @@
                 <goals><goal>jar</goal></goals>
                 <configuration>
                   <sourcepath>${project.basedir}/java</sourcepath>
+                  <source>1.7</source>
                 </configuration>
               </execution>
             </executions>

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -23,6 +23,7 @@ jobs:
           SAXON_VERSION: 9.9.1-5
           JING_VERSION: 20181222
           XMLCALABASH_VERSION: 1.1.27-99
+          DO_MAVEN_PACKAGE: true
 
         # latest Saxon 9.8
         Saxon-9-8:
@@ -67,6 +68,10 @@ jobs:
 
       - script: call test\end-to-end\run-e2e-tests.cmd -silent
         displayName: Execute XSpec end-to-end tests
+
+      - script: call test\ci\maven-package.cmd --no-transfer-progress
+        displayName: Maven package
+        condition: and(succeeded(), variables['DO_MAVEN_PACKAGE'])
 
       - script: call test\ci\compile-java.cmd -verbose
         displayName: Compile java

--- a/test/ci/maven-package.cmd
+++ b/test/ci/maven-package.cmd
@@ -1,0 +1,1 @@
+call mvn package -P release %*

--- a/test/ci/maven-package.sh
+++ b/test/ci/maven-package.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+if [ "${DO_MAVEN_PACKAGE}" = true ] ; then
+	mvn package -P release "$@"
+else
+	echo "Skip Maven package"
+fi


### PR DESCRIPTION
This pull request adds `mvn package -P release` to Azure Pipelines (Windows) and Travis CI for making sure `pom.xml` is not broken.
Up until now, only `mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V` was performed (automatically) only on Travis CI.

The added test is skipped
* on AppVeyor where the image does not have Maven
* and on Azure Pipelines (macOS) where its current configuration focuses only on the core tests.

The test fails on JDK 11. ([Azure](https://xspec.visualstudio.com/xspec/_build/results?buildId=241), [Travis](https://travis-ci.org/xspec/xspec/builds/592419298))
281967e78cd35583d746721fb1e84fb6692fee34 fixes it by following https://bugs.openjdk.java.net/browse/JDK-8212233. The source version `1.7` was taken from [the compiler source version](
https://github.com/xspec/xspec/blob/a479c12cb79a5212513deba8fab833df70462d59/pom.xml#L115-L118).