### PR TITLE
Prefix "init" and "compile" in 'depends'

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -347,7 +347,7 @@
   </target>
 
   <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
-  <target name="compile" depends="init, preprocess-schematron-xspec">
+  <target name="compile" depends="xspec.init, preprocess-schematron-xspec">
     <condition property="xspec.compiler.xsl"
                value="generate-query-tests.xsl"
                else="generate-xspec-tests.xsl">
@@ -362,7 +362,7 @@
   </target>
 
   <!-- Runs the compiled XSpec for XQuery -->
-  <target name="run-xquery-test" depends="compile" if="${xspec.is.xquery}">
+  <target name="run-xquery-test" depends="xspec.compile" if="${xspec.is.xquery}">
     <echo message="Running XQuery Tests..."
           level="info" />
 
@@ -380,7 +380,7 @@
   </target>
 
   <!-- Runs the compiled XSpec for XSLT -->
-  <target name="run-xslt-test" depends="compile" unless="${xspec.is.xquery}">
+  <target name="run-xslt-test" depends="xspec.compile" unless="${xspec.is.xquery}">
     <echo message="Running XSLT Tests..."
           level="info" />
 

--- a/build.xml
+++ b/build.xml
@@ -208,7 +208,7 @@
   </macrodef>
 
   <!-- Prepares the environment before compilation -->
-  <target name="init">
+  <target name="xspec.init">
     <condition property="xspec.coverage.dispchar" value="c" else="">
       <istrue value="${xspec.coverage.enabled}" />
     </condition>

--- a/build.xml
+++ b/build.xml
@@ -347,7 +347,7 @@
   </target>
 
   <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
-  <target name="compile" depends="xspec.init, preprocess-schematron-xspec">
+  <target name="xspec.compile" depends="xspec.init, preprocess-schematron-xspec">
     <condition property="xspec.compiler.xsl"
                value="generate-query-tests.xsl"
                else="generate-xspec-tests.xsl">
@@ -483,12 +483,12 @@
   <target name="xspec"
           description="Generates the result of XSpec tests"
           depends="report-html, report-coverage, report-junit">
-    <antcall target="fail" />
-    <antcall target="cleanup" />
+    <antcall target="xspec.fail" />
+    <antcall target="xspec.cleanup" />
   </target>
 
   <!-- Makes the build fail, unless otherwise specified -->
-  <target name="fail" if="${xspec.fail}">
+  <target name="xspec.fail" if="${xspec.fail}">
     <xml-to-properties in="${xspec.result.xml}" style="find-test-failure.xsl" />
     <fail message="XSpec tests failed. See ${xspec.result.html} for a report.">
       <condition>
@@ -500,7 +500,7 @@
   </target>
 
   <!-- Cleans up the output files, if required-->
-  <target name="cleanup" if="${clean.output.dir}">
+  <target name="xspec.cleanup" if="${clean.output.dir}">
     <echo message="Clean up"
           level="info" />
 


### PR DESCRIPTION
`init` and `compile` are a common target names.

`depends="init"` runs the `init` target in the importing build file, whereas `depends="xspec.init"` runs the `init` target in the `xspec` build file.  Similarly for `compile`.

Conceivably, every target name in a `depends` in XSpec's `build.xml` should be prefixed with the `xspec` build name, but `init` and `compile` are the two most likely to be accidentally overridden by an importing build file.