### PR TITLE
'fail' and 'cleanup' in 'depends', not as <antcall>

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -480,10 +480,7 @@
   <!-- Main target -->
   <target name="xspec"
           description="Generates the result of XSpec tests"
-          depends="report-html, report-coverage, report-junit">
-    <antcall target="fail" />
-    <antcall target="cleanup" />
-  </target>
+          depends="report-html, report-coverage, report-junit, fail, cleanup" />
 
   <!-- Makes the build fail, unless otherwise specified -->
   <target name="fail" if="${xspec.fail}">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -413,7 +413,7 @@
     call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_JAR%"
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
-    call :verify_line -4 x "BUILD FAILED"
+    call :verify_line -3 x "BUILD FAILED"
 
     rem Verify
     rem * Default xspec.coverage.enabled is false
@@ -506,7 +506,7 @@
     call :run ant -buildfile ..\build.xml -Dxspec.xml="%CD%\catalog\catalog-02-schematron.xspec" -lib "%SAXON_JAR%" -Dtest.type=s -Dclean.output.dir=true -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" -lib "%XML_RESOLVER_JAR%"
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 1 / total: 2"
-    call :verify_line -4 x "BUILD FAILED"
+    call :verify_line -3 x "BUILD FAILED"
 
     rem Verify the build fails before cleanup
     call :verify_exist catalog\xspec\
@@ -689,7 +689,7 @@
     call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_JAR%" -Dxspec.junit.enabled=true
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
-    call :verify_line -4 x "BUILD FAILED"
+    call :verify_line -3 x "BUILD FAILED"
 
     rem XML report file
     call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -381,7 +381,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 9 / pending: 0 / failed: 0 / total: 9" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -416,7 +416,7 @@ teardown() {
     [[ "${output}" =~ "I am schematron-xslt-expand.xsl!" ]]
     [[ "${output}" =~ "I am schematron-xslt-compile.xsl!" ]]
     [[ "${output}" =~ "passed: 3 / pending: 0 / failed: 0 / total: 3" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -553,7 +553,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~ "BUILD FAILED" ]]
+    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
 
     # Verify
     # * Default xspec.coverage.enabled is false
@@ -578,7 +578,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -591,7 +591,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -600,7 +600,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -632,7 +632,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${lines[${#lines[@]}-2]}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify that the default clean.output.dir is false and leaves temp files. Delete the left XSLT file at the same time.
     [  -d "../tutorial/schematron/xspec/" ]
@@ -654,7 +654,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify that -Dxspec-dir was honered and the default dir was not created
     [ ! -d "../tutorial/schematron/xspec/" ]
@@ -674,7 +674,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
-    [[ "${output}" =~ "BUILD FAILED" ]]
+    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
 
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
@@ -693,7 +693,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
 
@@ -832,7 +832,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
@@ -852,7 +852,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
@@ -868,7 +868,7 @@ teardown() {
     run ../bin/xspec.sh saxon-custom-options/test.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [ "${lines[${#lines[@]}-3]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
@@ -884,7 +884,7 @@ teardown() {
     run ../bin/xspec.sh -q saxon-custom-options/test.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [ "${lines[${#lines[@]}-3]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
@@ -900,7 +900,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [[ "${output}" =~ "BUILD SUCCESSFUL" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # XML and HTML report file
     [ -f "../tutorial/coverage/xspec/demo-result.xml" ]
@@ -917,8 +917,8 @@ teardown() {
     run ant -buildfile "${PWD}/../build.xml" -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec" -lib "${SAXON_JAR}" -Dtest.type=q -Dxspec.coverage.enabled=true
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${output}" =~ "BUILD FAILED" ]]
-    [[ "${output}" =~ "Coverage is supported only for XSLT" ]]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
+    [[ "${lines[${#lines[@]}-2]}" =~ "Coverage is supported only for XSLT" ]]
 }
 
 
@@ -926,8 +926,8 @@ teardown() {
     run ant -buildfile "${PWD}/../build.xml" -Dxspec.xml="${PWD}/../tutorial/schematron/demo-01.xspec" -lib "${SAXON_JAR}" -Dtest.type=s -Dxspec.coverage.enabled=true
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${output}" =~ "BUILD FAILED" ]]
-    [[ "${output}" =~ "Coverage is supported only for XSLT" ]]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
+    [[ "${lines[${#lines[@]}-2]}" =~ "Coverage is supported only for XSLT" ]]
 }
 
 
@@ -936,7 +936,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [[ "${output}" =~ "BUILD FAILED" ]]
+    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -553,7 +553,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 
     # Verify
     # * Default xspec.coverage.enabled is false
@@ -674,7 +674,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
-    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 
     # Verify the build fails before cleanup
     [  -d "catalog/xspec/" ]
@@ -936,7 +936,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
-    [ "${lines[${#lines[@]}-4]}" = "BUILD FAILED" ]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 
     # XML report file
     [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]


### PR DESCRIPTION
Alternative to #666.  Because of automatic prefixing with `include`, the `<antcall>` caused problem when `include`ing the XSpec build file in another build file:

````
C:\xspec-1.4.0\build.xml:486: The following error occurred while executing this line:
Target "fail" does not exist in the project "...". 
````