### PR TITLE
ci: replace .travis.yml before_script with install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
 before_install:
     - unset _JAVA_OPTIONS
 
-before_script:
+install:
     - source ./test/ci/install-deps.sh
 
 script: >


### PR DESCRIPTION
Every Travis CI build executes [`mvn install`](https://travis-ci.org/xspec/xspec/jobs/595375401#L451-L1273) which is useless because
* XSpec doesn't actually depend on Maven
* Maven package is tested separately (#664)

This pull request replaces `before_script` with [`install`](https://docs.travis-ci.com/user/job-lifecycle/#customizing-the-installation-phase) so that
* Useless `mvn install` is no longer executed.
* `install-deps.sh` is executed in a more suitable phase.
