### PR TITLE
ci: unset JVM environment variables in run-bats.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ env:
         # highest deprecated Saxon
         - SAXON_VERSION=9.7.0-21
 
-before_install:
-    - unset _JAVA_OPTIONS
-
 before_script:
     - source ./test/ci/install-deps.sh
 

--- a/test/run-bats.sh
+++ b/test/run-bats.sh
@@ -24,6 +24,10 @@ if java -cp "${SAXON_JAR}" net.sf.saxon.Query -q:ant/caps/v3-1.xquery > /dev/nul
     export XQUERY_SUPPORTS_3_1_DEFAULT=1
 fi
 
+# Unset JVM environment variables which make output line numbers unpredictable
+unset _JAVA_OPTIONS
+unset JAVA_TOOL_OPTIONS
+
 # Reset public environment variables
 export SAXON_CP="${SAXON_JAR}"
 unset SAXON_CUSTOM_OPTIONS


### PR DESCRIPTION
`.travis.yml` unsets `_JAVA_OPTIONS` in order to make Bats output line numbers predictable. `_JAVA_OPTIONS` affects not only Travis CI but also any other environment. So this pull request unsets the environment variables in `run-bats.sh`.

Windows is not affected in the first place, because it filters out the noise line:
https://github.com/xspec/xspec/blob/4197e367ae7487adac9ab5d952d7e258242706e0/test/win-bats/stub.cmd#L240-L243