### PR TITLE
Fix issue 681 (Leading slash missing from formatted URI in HTML report on *nix)

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -279,13 +279,27 @@
 		Returns a semi-formatted string of URI
 	-->
 	<xsl:function as="xs:string" name="x:format-uri">
-		<xsl:param as="xs:anyURI" name="URI" />
+		<xsl:param as="xs:string" name="uri" />
+
 		<xsl:choose>
-			<xsl:when test="starts-with($URI, 'file:/')">
-				<xsl:value-of select="replace(substring-after($URI, 'file:/'), '%20', ' ')" />
+			<xsl:when test="starts-with($uri, 'file:')">
+				<!-- Remove 'file:' -->
+				<xsl:variable as="xs:string" name="formatted" select="substring($uri, 6)" />
+
+				<!-- Remove implicit localhost (Consolidate '///' to '/') -->
+				<xsl:variable as="xs:string" name="formatted"
+					select="replace($formatted, '^//(/)', '$1')" />
+
+				<!-- Remove '/' from '/C:' -->
+				<xsl:variable as="xs:string" name="formatted"
+					select="replace($formatted, '^/([A-Za-z]:)', '$1')" />
+
+				<!-- Unescape whitespace -->
+				<xsl:sequence select="replace($formatted, '%20', ' ')" />
 			</xsl:when>
+
 			<xsl:otherwise>
-				<xsl:value-of select="$URI" />
+				<xsl:sequence select="$uri" />
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:function>

--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -278,7 +278,7 @@
 	<!--
 		Returns a semi-formatted string of URI
 	-->
-	<xsl:function as="xs:string" name="x:format-URI">
+	<xsl:function as="xs:string" name="x:format-uri">
 		<xsl:param as="xs:anyURI" name="URI" />
 		<xsl:choose>
 			<xsl:when test="starts-with($URI, 'file:/')">

--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -275,4 +275,19 @@
 		</xsl:choose>
 	</xsl:function>
 
+	<!--
+		Returns a semi-formatted string of URI
+	-->
+	<xsl:function as="xs:string" name="x:format-URI">
+		<xsl:param as="xs:anyURI" name="URI" />
+		<xsl:choose>
+			<xsl:when test="starts-with($URI, 'file:/')">
+				<xsl:value-of select="replace(substring-after($URI, 'file:/'), '%20', ' ')" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$URI" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
+
 </xsl:stylesheet>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -111,7 +111,7 @@
   </xsl:variable>
   <h2>
     <xsl:text>module: </xsl:text>
-    <xsl:value-of select="test:format-URI($stylesheet-uri)" />
+    <xsl:value-of select="x:format-uri($stylesheet-uri)" />
     <xsl:text>; </xsl:text>
     <xsl:value-of select="$number-of-lines" />
     <xsl:text> lines</xsl:text>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -73,7 +73,7 @@
 <xsl:template match="/" mode="test:coverage-report">
   <html>
     <head>
-      <title>Test Coverage Report for <xsl:value-of select="x:format-URI($stylesheet-uri)" /></title>
+      <title>Test Coverage Report for <xsl:value-of select="x:format-uri($stylesheet-uri)" /></title>
       <xsl:call-template name="test:load-css">
         <xsl:with-param name="inline" select="$inline-css cast as xs:boolean" />
         <xsl:with-param name="uri" select="$report-css-uri" />
@@ -81,7 +81,7 @@
     </head>
     <body>
       <h1>Test Coverage Report</h1>
-      <p>Stylesheet:  <a href="{$stylesheet-uri}"><xsl:value-of select="x:format-URI($stylesheet-uri)" /></a></p>
+      <p>Stylesheet:  <a href="{$stylesheet-uri}"><xsl:value-of select="x:format-uri($stylesheet-uri)" /></a></p>
       <xsl:apply-templates select="$stylesheet-trees/xsl:*" mode="test:coverage-report" />
     </body>
   </html>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -13,6 +13,7 @@
                 xmlns:pkg="http://expath.org/ns/pkg"
                 xmlns:saxon="http://saxon.sf.net/"
                 xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 exclude-result-prefixes="#all">
@@ -72,7 +73,7 @@
 <xsl:template match="/" mode="test:coverage-report">
   <html>
     <head>
-      <title>Test Coverage Report for <xsl:value-of select="test:format-URI($stylesheet-uri)" /></title>
+      <title>Test Coverage Report for <xsl:value-of select="x:format-URI($stylesheet-uri)" /></title>
       <xsl:call-template name="test:load-css">
         <xsl:with-param name="inline" select="$inline-css cast as xs:boolean" />
         <xsl:with-param name="uri" select="$report-css-uri" />
@@ -80,7 +81,7 @@
     </head>
     <body>
       <h1>Test Coverage Report</h1>
-      <p>Stylesheet:  <a href="{$stylesheet-uri}"><xsl:value-of select="test:format-URI($stylesheet-uri)" /></a></p>
+      <p>Stylesheet:  <a href="{$stylesheet-uri}"><xsl:value-of select="x:format-URI($stylesheet-uri)" /></a></p>
       <xsl:apply-templates select="$stylesheet-trees/xsl:*" mode="test:coverage-report" />
     </body>
   </html>

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -320,18 +320,6 @@
   <xsl:sequence select="if ($equal) then 'same' else 'diff'" />
 </xsl:function>
 
-<xsl:function name="test:format-URI" as="xs:string">
-  <xsl:param name="URI" as="xs:anyURI" />
-  <xsl:choose>
-    <xsl:when test="starts-with($URI, 'file:/')">
-      <xsl:value-of select="replace(substring-after($URI, 'file:/'), '%20', ' ')" />
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:value-of select="$URI" />
-    </xsl:otherwise>
-  </xsl:choose>
-</xsl:function>
-
 <!-- Generates <style> or <link> for CSS.
   If you enable $inline, you must use test:disable-escaping character map in serialization. -->
 <xsl:template name="test:load-css" as="element()">

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -146,7 +146,7 @@
     <head>
       <title>
          <xsl:text>Test Report for </xsl:text>
-         <xsl:value-of select="x:report/test:format-URI((@schematron,@stylesheet,@query)[1])"/>
+         <xsl:value-of select="x:report/x:format-URI((@schematron,@stylesheet,@query)[1])"/>
          <xsl:text> (</xsl:text>
          <xsl:call-template name="x:totals">
            <xsl:with-param name="tests" select="x:descendant-tests(.)"/>
@@ -194,7 +194,7 @@
 
         <xsl:otherwise>
           <a href="{.}">
-            <xsl:value-of select="test:format-URI(.)" />
+            <xsl:value-of select="x:format-URI(.)" />
           </a>
         </xsl:otherwise>
       </xsl:choose>
@@ -204,7 +204,7 @@
   <p>
     <xsl:text>XSpec: </xsl:text>
     <a href="{@xspec}">
-      <xsl:value-of select="test:format-URI(@xspec)"/>
+      <xsl:value-of select="x:format-URI(@xspec)"/>
     </a>
   </p>
   <p>
@@ -383,7 +383,7 @@
       </xsl:if>
       <xsl:choose>
         <xsl:when test="@href">
-          <p><a href="{@href}"><xsl:value-of select="test:format-URI(@href)" /></a></p>
+          <p><a href="{@href}"><xsl:value-of select="x:format-URI(@href)" /></a></p>
         </xsl:when>
         <xsl:otherwise>
           <xsl:variable name="indentation"

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -146,7 +146,7 @@
     <head>
       <title>
          <xsl:text>Test Report for </xsl:text>
-         <xsl:value-of select="x:report/x:format-URI((@schematron,@stylesheet,@query)[1])"/>
+         <xsl:value-of select="x:report/x:format-uri((@schematron,@stylesheet,@query)[1])"/>
          <xsl:text> (</xsl:text>
          <xsl:call-template name="x:totals">
            <xsl:with-param name="tests" select="x:descendant-tests(.)"/>
@@ -194,7 +194,7 @@
 
         <xsl:otherwise>
           <a href="{.}">
-            <xsl:value-of select="x:format-URI(.)" />
+            <xsl:value-of select="x:format-uri(.)" />
           </a>
         </xsl:otherwise>
       </xsl:choose>
@@ -204,7 +204,7 @@
   <p>
     <xsl:text>XSpec: </xsl:text>
     <a href="{@xspec}">
-      <xsl:value-of select="x:format-URI(@xspec)"/>
+      <xsl:value-of select="x:format-uri(@xspec)"/>
     </a>
   </p>
   <p>
@@ -383,7 +383,7 @@
       </xsl:if>
       <xsl:choose>
         <xsl:when test="@href">
-          <p><a href="{@href}"><xsl:value-of select="x:format-URI(@href)" /></a></p>
+          <p><a href="{@href}"><xsl:value-of select="x:format-uri(@href)" /></a></p>
         </xsl:when>
         <xsl:otherwise>
           <xsl:variable name="indentation"

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -592,4 +592,94 @@
 		</x:scenario>
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing function format-uri">
+		<x:scenario label="file: (%20 should be unescaped)">
+			<x:scenario label="Windows">
+				<x:scenario label="Drive">
+					<x:scenario label="Win32 (file:///C:/)">
+						<x:scenario label="Upper-case drive letter">
+							<x:call function="x:format-uri">
+								<x:param select="'file:///C:/dir/file%20name.ext'" />
+							</x:call>
+							<x:expect label="Discard everything before drive letter"
+								select="'C:/dir/file name.ext'" />
+						</x:scenario>
+
+						<x:scenario label="Lower-case drive letter">
+							<x:call function="x:format-uri">
+								<x:param select="'file:///c:/dir/file%20name.ext'" />
+							</x:call>
+							<x:expect label="Discard everything before drive letter"
+								select="'c:/dir/file name.ext'" />
+						</x:scenario>
+					</x:scenario>
+
+					<x:scenario label="Java (file:/C:/)">
+						<x:scenario label="Upper-case drive letter">
+							<x:call function="x:format-uri">
+								<x:param select="'file:/C:/dir/file%20name.ext'" />
+							</x:call>
+							<x:expect label="Discard everything before drive letter"
+								select="'C:/dir/file name.ext'" />
+						</x:scenario>
+
+						<x:scenario label="Lower-case drive letter">
+							<x:call function="x:format-uri">
+								<x:param select="'file:/c:/dir/file%20name.ext'" />
+							</x:call>
+							<x:expect label="Discard everything before drive letter"
+								select="'c:/dir/file name.ext'" />
+						</x:scenario>
+					</x:scenario>
+				</x:scenario>
+
+				<x:scenario label="UNC">
+					<x:scenario label="Win32 (file://host/)">
+						<x:call function="x:format-uri">
+							<x:param select="'file://host/share/dir/file%20name.ext'" />
+						</x:call>
+						<x:expect label="Discard file:" select="'//host/share/dir/file name.ext'" />
+					</x:scenario>
+
+					<x:scenario label="Java (file:////host/)">
+						<x:call function="x:format-uri">
+							<x:param select="'file:////host/share/dir/file%20name.ext'" />
+						</x:call>
+						<x:expect label="Discard file://" select="'//host/share/dir/file name.ext'"
+						 />
+					</x:scenario>
+				</x:scenario>
+			</x:scenario>
+
+			<x:scenario label="*nix">
+				<x:scenario label="One slash">
+					<x:call function="x:format-uri">
+						<x:param select="'file:/dir/file%20name.ext'" />
+					</x:call>
+					<x:expect label="Discard file:" select="'/dir/file name.ext'" />
+				</x:scenario>
+
+				<x:scenario label="Two slashes">
+					<x:call function="x:format-uri">
+						<x:param select="'file://host/dir/file%20name.ext'" />
+					</x:call>
+					<x:expect label="Discard file:" select="'//host/dir/file name.ext'" />
+				</x:scenario>
+
+				<x:scenario label="Three slashes">
+					<x:call function="x:format-uri">
+						<x:param select="'file:///dir/file%20name.ext'" />
+					</x:call>
+					<x:expect label="Discard file://" select="'/dir/file name.ext'" />
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Non file: (Everything including %20 should be intact)">
+		<x:call function="x:format-uri">
+			<x:param select="'http://www.example.com/dir/file%20name.ext'" />
+		</x:call>
+		<x:expect label="Intact" select="'http://www.example.com/dir/file%20name.ext'" />
+	</x:scenario>
 </x:description>


### PR DESCRIPTION
Fixes #681 

### Commits
* fb480a766e3f432d5c772c16afbdc21dc747d566 pulls `test:format-URI()` out from `format-utils.xsl` and puts it into `xspec-utils.xsl` in order to make the function testable.
* 927aa856d5e0cfa9d5806e781e2f41d79d0f6e66 renames the function to `x:format-uri` to align with the other names
* 7eea9c0b083bc532b0bded148d3155c4cb16c6c8 tests the function
* 3476374b73fcfea9520ed15777faa1a7a096c395 fixes the bug

### Tests
* I visually inspected the test result report HTML and the coverage report HTML on Windows and Linux with Saxon-EE 9.9.1.5 and verified the fix
* I manually ran the tests with Saxon-EE 9.9.1.5 on Windows and Linux