### PR TITLE
Fix issue 682 (Module URIs in coverage report HTML are not formatted)

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -110,7 +110,7 @@
   </xsl:variable>
   <h2>
     <xsl:text>module: </xsl:text>
-    <xsl:value-of select="$stylesheet-uri" />
+    <xsl:value-of select="test:format-URI($stylesheet-uri)" />
     <xsl:text>; </xsl:text>
     <xsl:value-of select="$number-of-lines" />
     <xsl:text> lines</xsl:text>


### PR DESCRIPTION
Fixes #682 

* I visually inspected the coverage report HTML on Windows and Linux with Saxon-EE 9.9.1.5 and verified the fix
* I manually ran the tests with Saxon-EE 9.9.1.5 on Windows and Linux