### PR TITLE
ci: invalidate preinstalled Ant

### DIFF
--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -36,7 +36,7 @@ if not defined BASEX_VERSION (
 
 rem install Ant without installing JDK
 rem call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
-%CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
+%CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
 %TAR% -xf "%TEMP%\xspec\ant\ant.tar.gz" -C "%TEMP%\xspec\ant"
 set "ANT_HOME=%TEMP%\xspec\ant\apache-ant-%ANT_VERSION%"
 if not exist "%ANT_HOME%" (

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -36,7 +36,7 @@ if not defined BASEX_VERSION (
 
 rem install Ant without installing JDK
 rem call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --no-progress --version "%ANT_VERSION%"
-%CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
+%CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
 %TAR% -xf "%TEMP%\xspec\ant\ant.tar.gz" -C "%TEMP%\xspec\ant"
 set "ANT_HOME=%TEMP%\xspec\ant\apache-ant-%ANT_VERSION%"
 path %ANT_HOME%\bin;%PATH%

--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -39,6 +39,10 @@ rem call "%~dp0choco-install.cmd" ant --allow-downgrade --ignore-dependencies --
 %CURL% -o "%TEMP%\xspec\ant\ant.tar.gz" "http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.tar.gz"
 %TAR% -xf "%TEMP%\xspec\ant\ant.tar.gz" -C "%TEMP%\xspec\ant"
 set "ANT_HOME=%TEMP%\xspec\ant\apache-ant-%ANT_VERSION%"
+if not exist "%ANT_HOME%" (
+    rem Create dir to invalidate any preinstalled Ant
+    mkdir "%ANT_HOME%"
+)
 path %ANT_HOME%\bin;%PATH%
 
 rem install XML Resolver

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -31,6 +31,10 @@ fi
 curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
 tar -xf ${XSPEC_DEPS}/ant/ant.tar.gz -C ${XSPEC_DEPS}/ant;
 export ANT_HOME=${XSPEC_DEPS}/ant/apache-ant-${ANT_VERSION}
+if [ ! -d "${ANT_HOME}" ] ; then
+    # Create dir to invalidate any preinstalled Ant
+    mkdir -p "${ANT_HOME}"
+fi
 export PATH=${ANT_HOME}/bin:${PATH}
 
 # install XML Resolver

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # install Ant
-curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
 tar -xf ${XSPEC_DEPS}/ant/ant.tar.gz -C ${XSPEC_DEPS}/ant;
 export ANT_HOME=${XSPEC_DEPS}/ant/apache-ant-${ANT_VERSION}
 if [ ! -d "${ANT_HOME}" ] ; then

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # install Ant
-curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
+curl -fsSL --create-dirs --retry 5 -o ${XSPEC_DEPS}/ant/ant.tar.gz http://BOGUS.archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
 tar -xf ${XSPEC_DEPS}/ant/ant.tar.gz -C ${XSPEC_DEPS}/ant;
 export ANT_HOME=${XSPEC_DEPS}/ant/apache-ant-${ANT_VERSION}
 export PATH=${ANT_HOME}/bin:${PATH}


### PR DESCRIPTION
Travis CI fails to download Ant occasionally. When it happens, the preinstalled Ant still works and confuses the test result.
This pull request invalidates the preinstalled Ant when the download fails.

### Commits
* 85e0c596e884d18077e60507fb44866ea8d6925b demonstrates a download failure. [Travis CI](https://travis-ci.org/xspec/xspec/jobs/599537102#L470-L471) picks up the preinstalled Ant 1.9.3. Only a few tests failed (possibly because of [this](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=552032)?)
* b842167e5dc633eccc48302c0b5392677f4f7c88 invalidates the preinstalled Ant. [This time](https://travis-ci.org/xspec/xspec/jobs/599544015#L470-L471), the preinstalled Ant is not used and many tests failed to launch Ant.
* 9dec0a86790e400613f7a7079009072ad0561f1f reverts the deliberate failure.