### PR TITLE
Detect x:like errors

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -624,7 +624,25 @@
 
          <!-- Replace x:like with specified scenario's child elements -->
          <xsl:when test="self::x:like">
-            <xsl:apply-templates select="key('scenarios', x:label(.))/element()" mode="#current" />
+            <xsl:variable name="label" as="element(x:label)" select="x:label(.)" />
+            <xsl:variable name="scenario" as="element(x:scenario)*" select="key('scenarios', $label)" />
+            <xsl:choose>
+               <xsl:when test="empty($scenario)">
+                  <xsl:sequence select="error(xs:QName('x:XSPEC009'),
+                     concat(name(), ': Scenario not found: ', $label))" />
+               </xsl:when>
+               <xsl:when test="$scenario[2]">
+                  <xsl:sequence select="error(xs:QName('x:XSPEC010'),
+                     concat(name(), ': Multiple scenarios found: ', $label))" />
+               </xsl:when>
+               <xsl:when test="$scenario intersect ancestor::x:scenario">
+                  <xsl:sequence select="error(xs:QName('x:XSPEC011'),
+                     concat(name(), ': Scenario is looping: ', $label))" />
+               </xsl:when>
+               <xsl:otherwise>
+                  <xsl:apply-templates select="$scenario/element()" mode="#current" />
+               </xsl:otherwise>
+            </xsl:choose>
          </xsl:when>
 
          <!-- By default, apply identity template -->

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -648,11 +648,11 @@
                </xsl:when>
                <xsl:when test="$scenario[2]">
                   <xsl:sequence select="error(xs:QName('x:XSPEC010'),
-                     concat(name(), ': Multiple scenarios found: ', $label))" />
+                     concat(name(), ': ', count($scenario), ' scenarios found with same label: ', $label))" />
                </xsl:when>
                <xsl:when test="$scenario intersect ancestor::x:scenario">
                   <xsl:sequence select="error(xs:QName('x:XSPEC011'),
-                     concat(name(), ': Scenario is looping: ', $label))" />
+                     concat(name(), ': Reference to ancestor scenario creates infinite loop: ', $label))" />
                </xsl:when>
                <xsl:otherwise>
                   <xsl:apply-templates select="$scenario/element()" mode="#current" />

--- a/test/like/loop.xspec
+++ b/test/like/loop.xspec
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="parent scenario">
+		<x:scenario label="this scenario">
+			<x:like label="parent scenario" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/like/multiple.xspec
+++ b/test/like/multiple.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="shared scenario" shared="yes">
+		<x:expect label="expect-1" />
+	</x:scenario>
+	<x:scenario label="shared scenario" shared="yes">
+		<x:expect label="expect-2" />
+	</x:scenario>
+
+	<x:scenario label="multiple scenarios matched">
+		<x:call function="false" />
+		<x:like label="shared scenario" />
+	</x:scenario>
+
+</x:description>

--- a/test/like/none.xspec
+++ b/test/like/none.xspec
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="no scenario matched">
+		<x:like label="none" />
+	</x:scenario>
+
+</x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1032,4 +1032,21 @@
 
     call :rmdir "%TEST_DIR%"
 	</case>
+
+	<case name="x:like errors">
+    rem Make the line numbers predictable by providing an existing output dir
+    set "TEST_DIR=%WORK_DIR%"
+
+    call :run ..\bin\xspec.bat like\none.xspec
+    call :verify_retval 2
+    call :verify_line 5 x "  x:XSPEC009: x:like: Scenario not found: none"
+
+    call :run ..\bin\xspec.bat like\multiple.xspec
+    call :verify_retval 2
+    call :verify_line 5 x "  x:XSPEC010: x:like: Multiple scenarios found: shared scenario"
+
+    call :run ..\bin\xspec.bat like\loop.xspec
+    call :verify_retval 2
+    call :verify_line 5 x "  x:XSPEC011: x:like: Scenario is looping: parent scenario"
+	</case>
 </collection>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1043,10 +1043,10 @@
 
     call :run ..\bin\xspec.bat like\multiple.xspec
     call :verify_retval 2
-    call :verify_line 5 x "  x:XSPEC010: x:like: Multiple scenarios found: shared scenario"
+    call :verify_line 5 x "  x:XSPEC010: x:like: 2 scenarios found with same label: shared scenario"
 
     call :run ..\bin\xspec.bat like\loop.xspec
     call :verify_retval 2
-    call :verify_line 5 x "  x:XSPEC011: x:like: Scenario is looping: parent scenario"
+    call :verify_line 5 x "  x:XSPEC011: x:like: Reference to ancestor scenario creates infinite loop: parent scenario"
 	</case>
 </collection>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -961,7 +961,7 @@ teardown() {
     [ "${lines[7]}"  = "Scenario 1-3" ]
     [ "${lines[8]}"  = "Scenario 2a-1" ]
     [ "${lines[9]}"  = "Scenario 2a-2" ]
-    [ "${lines[10]}"  = "Scenario 2b-1" ]
+    [ "${lines[10]}" = "Scenario 2b-1" ]
     [ "${lines[11]}" = "Scenario 2b-2" ]
     [ "${lines[12]}" = "Scenario 3" ]
     [ "${lines[13]}" = "Formatting Report..." ]
@@ -994,7 +994,7 @@ teardown() {
     export TEST_DIR="${work_dir}"
     run ../bin/xspec.sh end-to-end/cases/xspec-ambiguous-expect.xspec
     echo "$output"
-    [[ "${lines[10]}"  =~ "WARNING: x:expect has boolean @test" ]]
+    [[ "${lines[10]}" =~ "WARNING: x:expect has boolean @test" ]]
     [[ "${lines[15]}" =~ "WARNING: x:expect has boolean @test" ]]
     [[ "${lines[22]}" =~ "WARNING: x:expect has boolean @test" ]]
     [  "${lines[31]}" =  "Formatting Report..." ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1382,12 +1382,12 @@ teardown() {
     run ../bin/xspec.sh like/multiple.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "  x:XSPEC010: x:like: Multiple scenarios found: shared scenario" ]
+    [ "${lines[4]}" = "  x:XSPEC010: x:like: 2 scenarios found with same label: shared scenario" ]
 
     run ../bin/xspec.sh like/loop.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "  x:XSPEC011: x:like: Scenario is looping: parent scenario" ]
+    [ "${lines[4]}" = "  x:XSPEC011: x:like: Reference to ancestor scenario creates infinite loop: parent scenario" ]
 }
 
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1370,3 +1370,24 @@ teardown() {
 }
 
 
+@test "x:like errors" {
+    # Make the line numbers predictable by providing an existing output dir
+    export TEST_DIR="${work_dir}"
+
+    run ../bin/xspec.sh like/none.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[4]}" = "  x:XSPEC009: x:like: Scenario not found: none" ]
+
+    run ../bin/xspec.sh like/multiple.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[4]}" = "  x:XSPEC010: x:like: Multiple scenarios found: shared scenario" ]
+
+    run ../bin/xspec.sh like/loop.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[4]}" = "  x:XSPEC011: x:like: Scenario is looping: parent scenario" ]
+}
+
+


### PR DESCRIPTION
This pull request generates explicit errors when one of the errors happens in resolving `x:like`:
* `x:like` cannot find a scenario: [`none.xspec`](https://github.com/AirQuick/xspec/blob/19aba7d23213d789609d70fab2a42a8685471b29/test/like/none.xspec)
* `x:like` pulls multiple scenarios: [`multiple.xspec`](https://github.com/AirQuick/xspec/blob/19aba7d23213d789609d70fab2a42a8685471b29/test/like/multiple.xspec)
* `x:like` falls into an infinite loop: [`loop.xspc`](https://github.com/AirQuick/xspec/blob/19aba7d23213d789609d70fab2a42a8685471b29/test/like/loop.xspec)

### Test
71f591faf42206e7fec9568ef993cab5c971b6c2 tests the implementation on XSLT.
Since the errors are detected in `generate-common-tests.xsl` and common to XSLT/XQuery/Schematron, I didn't write tests specifically for XQuery and Schematron.

### Gray zone

> * `x:like` cannot find a scenario: [`none.xspec`](https://github.com/AirQuick/xspec/blob/19aba7d23213d789609d70fab2a42a8685471b29/test/like/none.xspec)
> * `x:like` pulls multiple scenarios: [`multiple.xspec`](https://github.com/AirQuick/xspec/blob/19aba7d23213d789609d70fab2a42a8685471b29/test/like/multiple.xspec)

I guess that in most cases, these two ways of writing tests happen only by mistake and it's worth rejecting them as errors. But some people may consider those two ways as valid and useful. Feedback is welcome.

### Documentation

`x:like` has not been documented yet. (#477)