### PR TITLE
Fix issue 689 (Namespace and attribute nodes are serialized with misaligned indentation)

### DIFF
--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -65,7 +65,7 @@
     <xsl:value-of>
       <xsl:text>&#xA;</xsl:text>
       <xsl:for-each select="1 to $level"><xsl:text>   </xsl:text></xsl:for-each>
-      <xsl:value-of select="replace(name(parent::*), '.', ' ')" />
+      <xsl:value-of select="replace(concat('&lt;', name()), '.', ' ')" />
     </xsl:value-of>
   </xsl:variable>
 

--- a/test/end-to-end/cases/expected/query/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-467-result.html
@@ -75,8 +75,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns:ns4="ns4"
-      xmlns:ns3="ns3"
-      xmlns="ns2"&gt;
+       xmlns:ns3="ns3"
+       xmlns="ns2"&gt;
       &lt;<span class="diff">ns3:e3</span>&gt;
          &lt;<span class="diff">e4</span> /&gt;
       &lt;/ns3:e3&gt;
@@ -86,8 +86,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns:ns4="ns4"
-      xmlns:ns3="ns3"
-      xmlns="ns2!"&gt;
+       xmlns:ns3="ns3"
+       xmlns="ns2!"&gt;
       &lt;<span class="diff">ns3:e3</span> xmlns:ns3="ns3!"&gt;
          &lt;<span class="diff">e4</span> xmlns="" /&gt;
       &lt;/ns3:e3&gt;

--- a/test/end-to-end/cases/expected/query/xspec-serialize-junit.xml
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-junit.xml
@@ -64,4 +64,32 @@
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>
    </testsuite>
+   <testsuite name="When the result contains an element, the report HTML must serialize nodes in its&#xA;&#x9;&#x9;&#x9;opening tag with aligned indentation. (xspec/xspec#689) So..."
+              tests="6"
+              failures="6">
+      <testcase name="When the report XML contains an element with several namespaces in x:result, [Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several namespaces in x:result, [Result] without diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several namespaces in x:expect, [Expected Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:result, [Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:result, [Result] without diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:expect, [Expected Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-result.html
@@ -666,9 +666,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns:ns3="ns3"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns1="ns1"
-                                          xmlns="ns"&gt;
+         xmlns:ns2="ns2"
+         xmlns:ns1="ns1"
+         xmlns="ns"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -692,9 +692,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test xmlns:ns3="ns3"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns1="ns1"
-                                          xmlns="ns"&gt;
+         xmlns:ns2="ns2"
+         xmlns:ns1="ns1"
+         xmlns="ns"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -725,9 +725,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns:ns3="ns3"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns1="ns1"
-                                          xmlns="ns"&gt;
+         xmlns:ns2="ns2"
+         xmlns:ns1="ns1"
+         xmlns="ns"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -756,8 +756,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
-                                          <span class="diff">attr2</span>="val2"
-                                          <span class="diff">attr3</span>="val3"&gt;
+         <span class="diff">attr2</span>="val2"
+         <span class="diff">attr3</span>="val3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -781,8 +781,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test attr1="val1"
-                                          attr2="val2"
-                                          attr3="val3"&gt;
+         attr2="val2"
+         attr3="val3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -813,8 +813,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
-                                          <span class="diff">attr2</span>="val2"
-                                          <span class="diff">attr3</span>="val3"&gt;
+         <span class="diff">attr2</span>="val2"
+         <span class="diff">attr3</span>="val3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>

--- a/test/end-to-end/cases/expected/query/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-result.html
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:xspec-items (passed: 0 / pending: 0 / failed: 12 / total:
-         12)
+      <title>Test Report for x-urn:test:xspec-items (passed: 0 / pending: 0 / failed: 18 / total:
+         18)
       </title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
@@ -26,13 +26,13 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 12</th>
-               <th class="totals">total: 12</th>
+               <th class="totals">failed: 18</th>
+               <th class="totals">total: 18</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-56">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
+               <th><a href="#ELEM-63">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                      (xspec/xspec#356) So...</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
@@ -40,7 +40,7 @@
                <th class="totals">3</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-138">When the result is indented in the report XML file, the report HTML must serialize
+               <th><a href="#ELEM-145">When the result is indented in the report XML file, the report HTML must serialize
                      it with indentation.</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
@@ -48,25 +48,33 @@
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-345">When x:expect has an element of '...',</a></th>
+               <th><a href="#ELEM-352">When x:expect has an element of '...',</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-384">When the result contains significant text nodes,</a></th>
+               <th><a href="#ELEM-391">When the result contains significant text nodes,</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">2</th>
             </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-472">When the result contains an element, the report HTML must serialize nodes in its opening
+                     tag with aligned indentation. (xspec/xspec#689) So...</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">6</th>
+               <th class="totals">6</th>
+            </tr>
          </tbody>
       </table>
-      <div id="ELEM-56">
+      <div id="ELEM-63">
          <h2 class="successful">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
             (xspec/xspec#356) So...<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
-         <table class="xspec" id="ELEM-58">
+         <table class="xspec" id="ELEM-65">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -79,32 +87,32 @@
                   <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-86">When x:result in the report XML contains a comment node,</a></th>
+                  <th><a href="#ELEM-93">When x:result in the report XML contains a comment node,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-87">[Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-94">[Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-103">[Result] without diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-110">[Result] without diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-119">When x:expect in the report XML contains a comment node,</a></th>
+                  <th><a href="#ELEM-126">When x:expect in the report XML contains a comment node,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-120">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-127">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-86">
+         <div id="ELEM-93">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                (xspec/xspec#356) So... When x:result in the report XML contains a comment node,
             </h3>
-            <div id="ELEM-87">
+            <div id="ELEM-94">
                <h4>[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -123,7 +131,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-103">
+            <div id="ELEM-110">
                <h4>[Result] without diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -143,11 +151,11 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-119">
+         <div id="ELEM-126">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,
             </h3>
-            <div id="ELEM-120">
+            <div id="ELEM-127">
                <h4>[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -168,10 +176,10 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-138">
+      <div id="ELEM-145">
          <h2 class="successful">When the result is indented in the report XML file, the report HTML must serialize
             it with indentation.<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-140">
+         <table class="xspec" id="ELEM-147">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -184,66 +192,66 @@
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-192">So... (xspec/xspec#359) When x:result in the report XML file is a sequence of simple
+                  <th><a href="#ELEM-199">So... (xspec/xspec#359) When x:result in the report XML file is a sequence of simple
                         nested elements serialized with indentation,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-193">all elements in [Result] with diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-200">all elements in [Result] with diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-213">all elements in [Result] without diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-220">all elements in [Result] without diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-229">So... (xspec/xspec#359) When x:expect in the report XML file is a sequence of simple
+                  <th><a href="#ELEM-236">So... (xspec/xspec#359) When x:expect in the report XML file is a sequence of simple
                         nested elements serialized with indentation,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-230">all elements in [Expected Result] with diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-237">all elements in [Expected Result] with diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-251">But the diff must not be affected by indentation. So... When a node is indented, the
+                  <th><a href="#ELEM-258">But the diff must not be affected by indentation. So... When a node is indented, the
                         diff of the indented node itself must not be affected. (xspec/xspec#367) So... When
                         &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report XML file,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-252">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#ELEM-259">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-284">But the diff must not be affected by indentation. So... When a node is indented, the
+                  <th><a href="#ELEM-291">But the diff must not be affected by indentation. So... When a node is indented, the
                         diff of the indented node itself must not be affected. (xspec/xspec#367) So... When
                         &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report XML file,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-285">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#ELEM-292">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-317">But the diff must not be affected by indentation. So... When a child node of an element
+                  <th><a href="#ELEM-324">But the diff must not be affected by indentation. So... When a child node of an element
                         is indented, the diff of the element must not be affected. So, when the same &lt;bar&gt;
                         in &lt;foo&gt; is indented in x:result and x:expect of the report XML file with different
                         indentation length,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-318">&lt;foo&gt; must be green.</a></td>
+                  <td><a href="#ELEM-325">&lt;foo&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-192">
+         <div id="ELEM-199">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:result in the report XML file
                is a sequence of simple nested elements serialized with indentation,
             </h3>
-            <div id="ELEM-193">
+            <div id="ELEM-200">
                <h4>all elements in [Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -268,7 +276,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-213">
+            <div id="ELEM-220">
                <h4>all elements in [Result] without diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -294,12 +302,12 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-229">
+         <div id="ELEM-236">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:expect in the report XML file
                is a sequence of simple nested elements serialized with indentation,
             </h3>
-            <div id="ELEM-230">
+            <div id="ELEM-237">
                <h4>all elements in [Expected Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -325,14 +333,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-251">
+         <div id="ELEM-258">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
                XML file,
             </h3>
-            <div id="ELEM-252">
+            <div id="ELEM-259">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -363,14 +371,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-284">
+         <div id="ELEM-291">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
                XML file,
             </h3>
-            <div id="ELEM-285">
+            <div id="ELEM-292">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -401,14 +409,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-317">
+         <div id="ELEM-324">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a child node of an element is indented, the diff of the element must not be affected.
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
                XML file with different indentation length,
             </h3>
-            <div id="ELEM-318">
+            <div id="ELEM-325">
                <h4>&lt;foo&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -441,9 +449,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-345">
+      <div id="ELEM-352">
          <h2 class="failed">When x:expect has an element of '...',<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-347">
+         <table class="xspec" id="ELEM-354">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -454,14 +462,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-360">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
+                  <td><a href="#ELEM-367">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-359">
+         <div id="ELEM-366">
             <h3>When x:expect has an element of '...',</h3>
-            <div id="ELEM-360">
+            <div id="ELEM-367">
                <h4>the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
                <table class="xspecResult">
                   <thead>
@@ -485,9 +493,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-384">
+      <div id="ELEM-391">
          <h2 class="failed">When the result contains significant text nodes,<span class="scenario-totals">passed: 0 / pending: 0 / failed: 2 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-386">
+         <table class="xspec" id="ELEM-393">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -498,19 +506,19 @@
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-403">both in [Result] and [Expected Result] with diff, the significant text nodes must
+                  <td><a href="#ELEM-410">both in [Result] and [Expected Result] with diff, the significant text nodes must
                         be serialized with color. (xspec/xspec#386)</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-446">in [Result] without diff, the significant text nodes must be serialized without color.</a></td>
+                  <td><a href="#ELEM-453">in [Result] without diff, the significant text nodes must be serialized without color.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-402">
+         <div id="ELEM-409">
             <h3>When the result contains significant text nodes,</h3>
-            <div id="ELEM-403">
+            <div id="ELEM-410">
                <h4>both in [Result] and [Expected Result] with diff, the significant text nodes must
                   be serialized with color. (xspec/xspec#386)
                </h4>
@@ -551,7 +559,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-446">
+            <div id="ELEM-453">
                <h4>in [Result] without diff, the significant text nodes must be serialized without color.</h4>
                <table class="xspecResult">
                   <thead>
@@ -575,6 +583,241 @@
    &lt;/significant-whitespace-only-text-node&gt;
 &lt;/test&gt;</pre></td>
                         <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-472">
+         <h2 class="successful">When the result contains an element, the report HTML must serialize nodes in its opening
+            tag with aligned indentation. (xspec/xspec#689) So...<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
+         <table class="xspec" id="ELEM-474">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>When the result contains an element, the report HTML must serialize nodes in its opening
+                     tag with aligned indentation. (xspec/xspec#689) So...
+                  </th>
+                  <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-522">When the report XML contains an element with several namespaces in x:result,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-523">[Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-541">[Result] without diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-557">When the report XML contains an element with several namespaces in x:expect,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-558">[Expected Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-577">When the report XML contains an element with several attributes in x:result,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-578">[Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-599">[Result] without diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-615">When the report XML contains an element with several attributes in x:expect,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-616">[Expected Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-522">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several namespaces in x:result,
+            </h3>
+            <div id="ELEM-523">
+               <h4>[Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> xmlns:ns3="ns3"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns1="ns1"
+                                          xmlns="ns"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="ELEM-541">
+               <h4>[Result] without diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+   &lt;test xmlns:ns3="ns3"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns1="ns1"
+                                          xmlns="ns"&gt;
+      &lt;a /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-557">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several namespaces in x:expect,
+            </h3>
+            <div id="ELEM-558">
+               <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>xs:boolean('false')</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> xmlns:ns3="ns3"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns1="ns1"
+                                          xmlns="ns"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-577">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several attributes in x:result,
+            </h3>
+            <div id="ELEM-578">
+               <h4>[Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
+                                          <span class="diff">attr2</span>="val2"
+                                          <span class="diff">attr3</span>="val3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="ELEM-599">
+               <h4>[Result] without diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+   &lt;test attr1="val1"
+                                          attr2="val2"
+                                          attr3="val3"&gt;
+      &lt;a /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-615">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several attributes in x:expect,
+            </h3>
+            <div id="ELEM-616">
+               <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>xs:boolean('false')</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
+                                          <span class="diff">attr2</span>="val2"
+                                          <span class="diff">attr3</span>="val3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-result.xml
@@ -289,4 +289,95 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
+   <x:scenario>
+      <x:label>When the result contains an element, the report HTML must serialize nodes in its
+			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
+      <x:result select="()"/>
+      <x:scenario>
+         <x:label>When the report XML contains an element with several namespaces</x:label>
+         <x:result select="()"/>
+         <x:scenario>
+            <x:label>in x:result,</x:label>
+            <x:call function="exactly-one">
+               <x:param select="$test"/>
+            </x:call>
+            <x:result select="/element()">
+               <looooooooooooooooooooooooooooooooooong>
+                  <test xmlns:ns3="ns3" xmlns:ns2="ns2" xmlns:ns1="ns1" xmlns="ns">
+                     <a/>
+                  </test>
+               </looooooooooooooooooooooooooooooooooong>
+            </x:result>
+            <x:test successful="false">
+               <x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="()"/>
+            </x:test>
+            <x:test successful="false">
+               <x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect test="false()" select="()"/>
+            </x:test>
+         </x:scenario>
+         <x:scenario>
+            <x:label>in x:expect,</x:label>
+            <x:call function="false"/>
+            <x:result select="xs:boolean('false')"/>
+            <x:test successful="false">
+               <x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="/element()">
+                  <looooooooooooooooooooooooooooooooooong>
+                     <test xmlns:ns3="ns3" xmlns:ns2="ns2" xmlns:ns1="ns1" xmlns="ns">
+                        <a/>
+                     </test>
+                  </looooooooooooooooooooooooooooooooooong>
+               </x:expect>
+            </x:test>
+         </x:scenario>
+      </x:scenario>
+      <x:scenario>
+         <x:label>When the report XML contains an element with several attributes</x:label>
+         <x:result select="()"/>
+         <x:scenario>
+            <x:label>in x:result,</x:label>
+            <x:call function="exactly-one">
+               <x:param select="$test"/>
+            </x:call>
+            <x:result select="/element()">
+               <looooooooooooooooooooooooooooooooooong>
+                  <test attr1="val1" attr2="val2" attr3="val3">
+                     <a/>
+                  </test>
+               </looooooooooooooooooooooooooooooooooong>
+            </x:result>
+            <x:test successful="false">
+               <x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="()"/>
+            </x:test>
+            <x:test successful="false">
+               <x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect test="false()" select="()"/>
+            </x:test>
+         </x:scenario>
+         <x:scenario>
+            <x:label>in x:expect,</x:label>
+            <x:call function="false"/>
+            <x:result select="xs:boolean('false')"/>
+            <x:test successful="false">
+               <x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="/element()">
+                  <looooooooooooooooooooooooooooooooooong>
+                     <test attr1="val1" attr2="val2" attr3="val3">
+                        <a/>
+                     </test>
+                  </looooooooooooooooooooooooooooooooooong>
+               </x:expect>
+            </x:test>
+         </x:scenario>
+      </x:scenario>
+   </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/expected/schematron/xspec-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-result.html
@@ -78,20 +78,20 @@
                         <td>
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;svrl:schematron-output xmlns:saxon="http://saxon.sf.net/"
-         xmlns:schold="http://www.ascc.net/xml/schematron"
-         xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-         xmlns:xhtml="http://www.w3.org/1999/xhtml"
-         xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-         title=""
-         schemaVersion=""&gt;&lt;!--   
+                        xmlns:schold="http://www.ascc.net/xml/schematron"
+                        xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                        xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+                        title=""
+                        schemaVersion=""&gt;&lt;!--   
 		   
 		   
 		 --&gt;
    &lt;svrl:active-pattern document="" /&gt;
    &lt;svrl:fired-rule context="foo" /&gt;
    &lt;svrl:successful-report test="bar"
-                          id="bar-exists"
-                          location="/foo[1]"&gt;
+                           id="bar-exists"
+                           location="/foo[1]"&gt;
       &lt;svrl:text&gt;Found bar&lt;/svrl:text&gt;
    &lt;/svrl:successful-report&gt;
 &lt;/svrl:schematron-output&gt;</pre></td>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
@@ -71,11 +71,11 @@
                         <td>
                            <p>XPath <code>/self::document-node()</code> from:
                            </p><pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
-         <span class="diff">bar</span>="true" /&gt;</pre></td>
+     <span class="diff">bar</span>="true" /&gt;</pre></td>
                         <td>
                            <p>XPath <code>/self::document-node()</code> from:
                            </p><pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
-         <span class="diff">bar</span>="false" /&gt;</pre></td>
+     <span class="diff">bar</span>="false" /&gt;</pre></td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
@@ -72,8 +72,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2"
-      xmlns:ns3="ns3"
-      xmlns:ns4="ns4"&gt;
+       xmlns:ns3="ns3"
+       xmlns:ns4="ns4"&gt;
       &lt;<span class="diff">ns3:e3</span>&gt;
          &lt;<span class="diff">e4</span> /&gt;
       &lt;/ns3:e3&gt;
@@ -83,8 +83,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2!"
-      xmlns:ns3="ns3"
-      xmlns:ns4="ns4"&gt;
+       xmlns:ns3="ns3"
+       xmlns:ns4="ns4"&gt;
       &lt;<span class="diff">ns3:e3</span> xmlns:ns3="ns3!"&gt;
          &lt;<span class="diff">e4</span> xmlns="" /&gt;
       &lt;/ns3:e3&gt;

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-junit.xml
@@ -64,4 +64,32 @@
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>
    </testsuite>
+   <testsuite name="When the result contains an element, the report HTML must serialize nodes in its&#xA;&#x9;&#x9;&#x9;opening tag with aligned indentation. (xspec/xspec#689) So..."
+              tests="6"
+              failures="6">
+      <testcase name="When the report XML contains an element with several namespaces in x:result, [Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several namespaces in x:result, [Result] without diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several namespaces in x:expect, [Expected Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:result, [Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:result, [Result] without diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+      <testcase name="When the report XML contains an element with several attributes in x:expect, [Expected Result] with diff must be serialized with aligned&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;indentation."
+                status="failed">
+         <failure message="expect assertion failed">Expected: /element()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for items.xsl (passed: 0 / pending: 0 / failed: 12 / total: 12)</title>
+      <title>Test Report for items.xsl (passed: 0 / pending: 0 / failed: 18 / total: 18)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,13 +23,13 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 12</th>
-               <th class="totals">total: 12</th>
+               <th class="totals">failed: 18</th>
+               <th class="totals">total: 18</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-55">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
+               <th><a href="#ELEM-62">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                      (xspec/xspec#356) So...</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
@@ -37,7 +37,7 @@
                <th class="totals">3</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-137">When the result is indented in the report XML file, the report HTML must serialize
+               <th><a href="#ELEM-144">When the result is indented in the report XML file, the report HTML must serialize
                      it with indentation.</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
@@ -45,25 +45,33 @@
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-344">When x:expect has an element of '...',</a></th>
+               <th><a href="#ELEM-351">When x:expect has an element of '...',</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-383">When the result contains significant text nodes,</a></th>
+               <th><a href="#ELEM-390">When the result contains significant text nodes,</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">2</th>
             </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-471">When the result contains an element, the report HTML must serialize nodes in its opening
+                     tag with aligned indentation. (xspec/xspec#689) So...</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">6</th>
+               <th class="totals">6</th>
+            </tr>
          </tbody>
       </table>
-      <div id="ELEM-55">
+      <div id="ELEM-62">
          <h2 class="successful">When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
             (xspec/xspec#356) So...<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
-         <table class="xspec" id="ELEM-57">
+         <table class="xspec" id="ELEM-64">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -76,32 +84,32 @@
                   <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-85">When x:result in the report XML contains a comment node,</a></th>
+                  <th><a href="#ELEM-92">When x:result in the report XML contains a comment node,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-86">[Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-93">[Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-102">[Result] without diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-109">[Result] without diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-118">When x:expect in the report XML contains a comment node,</a></th>
+                  <th><a href="#ELEM-125">When x:expect in the report XML contains a comment node,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-119">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
+                  <td><a href="#ELEM-126">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-85">
+         <div id="ELEM-92">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                (xspec/xspec#356) So... When x:result in the report XML contains a comment node,
             </h3>
-            <div id="ELEM-86">
+            <div id="ELEM-93">
                <h4>[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -120,7 +128,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-102">
+            <div id="ELEM-109">
                <h4>[Result] without diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -140,11 +148,11 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-118">
+         <div id="ELEM-125">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
                (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,
             </h3>
-            <div id="ELEM-119">
+            <div id="ELEM-126">
                <h4>[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
                   <thead>
@@ -165,10 +173,10 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-137">
+      <div id="ELEM-144">
          <h2 class="successful">When the result is indented in the report XML file, the report HTML must serialize
             it with indentation.<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-139">
+         <table class="xspec" id="ELEM-146">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -181,66 +189,66 @@
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-191">So... (xspec/xspec#359) When x:result in the report XML file is a sequence of simple
+                  <th><a href="#ELEM-198">So... (xspec/xspec#359) When x:result in the report XML file is a sequence of simple
                         nested elements serialized with indentation,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-192">all elements in [Result] with diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-199">all elements in [Result] with diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-212">all elements in [Result] without diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-219">all elements in [Result] without diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-228">So... (xspec/xspec#359) When x:expect in the report XML file is a sequence of simple
+                  <th><a href="#ELEM-235">So... (xspec/xspec#359) When x:expect in the report XML file is a sequence of simple
                         nested elements serialized with indentation,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-229">all elements in [Expected Result] with diff must be serialized with indentation.</a></td>
+                  <td><a href="#ELEM-236">all elements in [Expected Result] with diff must be serialized with indentation.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-250">But the diff must not be affected by indentation. So... When a node is indented, the
+                  <th><a href="#ELEM-257">But the diff must not be affected by indentation. So... When a node is indented, the
                         diff of the indented node itself must not be affected. (xspec/xspec#367) So... When
                         &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report XML file,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-251">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#ELEM-258">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-283">But the diff must not be affected by indentation. So... When a node is indented, the
+                  <th><a href="#ELEM-290">But the diff must not be affected by indentation. So... When a node is indented, the
                         diff of the indented node itself must not be affected. (xspec/xspec#367) So... When
                         &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report XML file,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-284">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#ELEM-291">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-316">But the diff must not be affected by indentation. So... When a child node of an element
+                  <th><a href="#ELEM-323">But the diff must not be affected by indentation. So... When a child node of an element
                         is indented, the diff of the element must not be affected. So, when the same &lt;bar&gt;
                         in &lt;foo&gt; is indented in x:result and x:expect of the report XML file with different
                         indentation length,</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-317">&lt;foo&gt; must be green.</a></td>
+                  <td><a href="#ELEM-324">&lt;foo&gt; must be green.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-191">
+         <div id="ELEM-198">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:result in the report XML file
                is a sequence of simple nested elements serialized with indentation,
             </h3>
-            <div id="ELEM-192">
+            <div id="ELEM-199">
                <h4>all elements in [Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -265,7 +273,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-212">
+            <div id="ELEM-219">
                <h4>all elements in [Result] without diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -291,12 +299,12 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-228">
+         <div id="ELEM-235">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:expect in the report XML file
                is a sequence of simple nested elements serialized with indentation,
             </h3>
-            <div id="ELEM-229">
+            <div id="ELEM-236">
                <h4>all elements in [Expected Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
                   <thead>
@@ -322,14 +330,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-250">
+         <div id="ELEM-257">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
                XML file,
             </h3>
-            <div id="ELEM-251">
+            <div id="ELEM-258">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -360,14 +368,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-283">
+         <div id="ELEM-290">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
                XML file,
             </h3>
-            <div id="ELEM-284">
+            <div id="ELEM-291">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -398,14 +406,14 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-316">
+         <div id="ELEM-323">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. But the diff must not be affected by indentation. So... When
                a child node of an element is indented, the diff of the element must not be affected.
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
                XML file with different indentation length,
             </h3>
-            <div id="ELEM-317">
+            <div id="ELEM-324">
                <h4>&lt;foo&gt; must be green.</h4>
                <table class="xspecResult">
                   <thead>
@@ -438,9 +446,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-344">
+      <div id="ELEM-351">
          <h2 class="failed">When x:expect has an element of '...',<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-346">
+         <table class="xspec" id="ELEM-353">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -451,14 +459,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-359">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
+                  <td><a href="#ELEM-366">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-358">
+         <div id="ELEM-365">
             <h3>When x:expect has an element of '...',</h3>
-            <div id="ELEM-359">
+            <div id="ELEM-366">
                <h4>the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
                <table class="xspecResult">
                   <thead>
@@ -482,9 +490,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-383">
+      <div id="ELEM-390">
          <h2 class="failed">When the result contains significant text nodes,<span class="scenario-totals">passed: 0 / pending: 0 / failed: 2 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-385">
+         <table class="xspec" id="ELEM-392">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -495,19 +503,19 @@
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-402">both in [Result] and [Expected Result] with diff, the significant text nodes must
+                  <td><a href="#ELEM-409">both in [Result] and [Expected Result] with diff, the significant text nodes must
                         be serialized with color. (xspec/xspec#386)</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-445">in [Result] without diff, the significant text nodes must be serialized without color.</a></td>
+                  <td><a href="#ELEM-452">in [Result] without diff, the significant text nodes must be serialized without color.</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-401">
+         <div id="ELEM-408">
             <h3>When the result contains significant text nodes,</h3>
-            <div id="ELEM-402">
+            <div id="ELEM-409">
                <h4>both in [Result] and [Expected Result] with diff, the significant text nodes must
                   be serialized with color. (xspec/xspec#386)
                </h4>
@@ -548,7 +556,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-445">
+            <div id="ELEM-452">
                <h4>in [Result] without diff, the significant text nodes must be serialized without color.</h4>
                <table class="xspecResult">
                   <thead>
@@ -572,6 +580,241 @@
    &lt;/significant-whitespace-only-text-node&gt;
 &lt;/test&gt;</pre></td>
                         <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-471">
+         <h2 class="successful">When the result contains an element, the report HTML must serialize nodes in its opening
+            tag with aligned indentation. (xspec/xspec#689) So...<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
+         <table class="xspec" id="ELEM-473">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>When the result contains an element, the report HTML must serialize nodes in its opening
+                     tag with aligned indentation. (xspec/xspec#689) So...
+                  </th>
+                  <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-521">When the report XML contains an element with several namespaces in x:result,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-522">[Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-540">[Result] without diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-556">When the report XML contains an element with several namespaces in x:expect,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-557">[Expected Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-576">When the report XML contains an element with several attributes in x:result,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-577">[Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-598">[Result] without diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#ELEM-614">When the report XML contains an element with several attributes in x:expect,</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-615">[Expected Result] with diff must be serialized with aligned indentation.</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-521">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several namespaces in x:result,
+            </h3>
+            <div id="ELEM-522">
+               <h4>[Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> xmlns="ns"
+                                          xmlns:ns1="ns1"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns3="ns3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="ELEM-540">
+               <h4>[Result] without diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+   &lt;test xmlns="ns"
+                                          xmlns:ns1="ns1"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns3="ns3"&gt;
+      &lt;a /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-556">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several namespaces in x:expect,
+            </h3>
+            <div id="ELEM-557">
+               <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>xs:boolean('false')</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> xmlns="ns"
+                                          xmlns:ns1="ns1"
+                                          xmlns:ns2="ns2"
+                                          xmlns:ns3="ns3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-576">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several attributes in x:result,
+            </h3>
+            <div id="ELEM-577">
+               <h4>[Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
+                                          <span class="diff">attr2</span>="val2"
+                                          <span class="diff">attr3</span>="val3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="ELEM-598">
+               <h4>[Result] without diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+   &lt;test attr1="val1"
+                                          attr2="val2"
+                                          attr3="val3"&gt;
+      &lt;a /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+                        <td><pre>false()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="ELEM-614">
+            <h3>When the result contains an element, the report HTML must serialize nodes in its opening
+               tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
+               an element with several attributes in x:expect,
+            </h3>
+            <div id="ELEM-615">
+               <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>xs:boolean('false')</pre></td>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+   &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
+                                          <span class="diff">attr2</span>="val2"
+                                          <span class="diff">attr3</span>="val3"&gt;
+      &lt;<span class="diff">a</span> /&gt;
+   &lt;/test&gt;
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
@@ -663,9 +663,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
-                                          xmlns:ns1="ns1"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns3="ns3"&gt;
+         xmlns:ns1="ns1"
+         xmlns:ns2="ns2"
+         xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -689,9 +689,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test xmlns="ns"
-                                          xmlns:ns1="ns1"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns3="ns3"&gt;
+         xmlns:ns1="ns1"
+         xmlns:ns2="ns2"
+         xmlns:ns3="ns3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -722,9 +722,9 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
-                                          xmlns:ns1="ns1"
-                                          xmlns:ns2="ns2"
-                                          xmlns:ns3="ns3"&gt;
+         xmlns:ns1="ns1"
+         xmlns:ns2="ns2"
+         xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -753,8 +753,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
-                                          <span class="diff">attr2</span>="val2"
-                                          <span class="diff">attr3</span>="val3"&gt;
+         <span class="diff">attr2</span>="val2"
+         <span class="diff">attr3</span>="val3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -778,8 +778,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test attr1="val1"
-                                          attr2="val2"
-                                          attr3="val3"&gt;
+         attr2="val2"
+         attr3="val3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
@@ -810,8 +810,8 @@
                            <p>XPath <code>/element()</code> from:
                            </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>="val1"
-                                          <span class="diff">attr2</span>="val2"
-                                          <span class="diff">attr3</span>="val3"&gt;
+         <span class="diff">attr2</span>="val2"
+         <span class="diff">attr3</span>="val3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
 &lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.xml
@@ -284,4 +284,92 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
+   <x:scenario>
+      <x:label>When the result contains an element, the report HTML must serialize nodes in its
+			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
+      <x:scenario>
+         <x:label>When the report XML contains an element with several namespaces</x:label>
+         <x:scenario>
+            <x:label>in x:result,</x:label>
+            <x:call function="exactly-one">
+               <x:param select="$test"/>
+            </x:call>
+            <x:result select="/element()">
+               <looooooooooooooooooooooooooooooooooong>
+                  <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
+                     <a/>
+                  </test>
+               </looooooooooooooooooooooooooooooooooong>
+            </x:result>
+            <x:test successful="false">
+               <x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="()"/>
+            </x:test>
+            <x:test successful="false">
+               <x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect test="false()" select="()"/>
+            </x:test>
+         </x:scenario>
+         <x:scenario>
+            <x:label>in x:expect,</x:label>
+            <x:call function="false"/>
+            <x:result select="xs:boolean('false')"/>
+            <x:test successful="false">
+               <x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="/element()">
+                  <looooooooooooooooooooooooooooooooooong>
+                     <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
+                        <a/>
+                     </test>
+                  </looooooooooooooooooooooooooooooooooong>
+               </x:expect>
+            </x:test>
+         </x:scenario>
+      </x:scenario>
+      <x:scenario>
+         <x:label>When the report XML contains an element with several attributes</x:label>
+         <x:scenario>
+            <x:label>in x:result,</x:label>
+            <x:call function="exactly-one">
+               <x:param select="$test"/>
+            </x:call>
+            <x:result select="/element()">
+               <looooooooooooooooooooooooooooooooooong>
+                  <test attr1="val1" attr2="val2" attr3="val3">
+                     <a/>
+                  </test>
+               </looooooooooooooooooooooooooooooooooong>
+            </x:result>
+            <x:test successful="false">
+               <x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="()"/>
+            </x:test>
+            <x:test successful="false">
+               <x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect test="false()" select="()"/>
+            </x:test>
+         </x:scenario>
+         <x:scenario>
+            <x:label>in x:expect,</x:label>
+            <x:call function="false"/>
+            <x:result select="xs:boolean('false')"/>
+            <x:test successful="false">
+               <x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+               <x:expect select="/element()">
+                  <looooooooooooooooooooooooooooooooooong>
+                     <test attr1="val1" attr2="val2" attr3="val3">
+                        <a/>
+                     </test>
+                  </looooooooooooooooooooooooooooooooooong>
+               </x:expect>
+            </x:test>
+         </x:scenario>
+      </x:scenario>
+   </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/xspec-serialize.xspec
+++ b/test/end-to-end/cases/xspec-serialize.xspec
@@ -201,4 +201,78 @@
 		</x:expect>
 	</x:scenario>
 
+	<x:scenario>
+		<x:label>When the result contains an element, the report HTML must serialize nodes in its
+			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
+		<x:scenario>
+			<x:label>When the report XML contains an element with several namespaces</x:label>
+			<x:variable name="test">
+				<looooooooooooooooooooooooooooooooooong>
+					<test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
+						<a />
+					</test>
+				</looooooooooooooooooooooooooooooooooong>
+			</x:variable>
+
+			<x:scenario>
+				<x:label>in x:result,</x:label>
+				<x:call function="exactly-one">
+					<x:param select="$test" />
+				</x:call>
+				<x:expect>
+					<x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+				<x:expect test="false()">
+					<x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+			</x:scenario>
+
+			<x:scenario>
+				<x:label>in x:expect,</x:label>
+				<x:call function="false" />
+				<x:expect select="$test">
+					<x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario>
+			<x:label>When the report XML contains an element with several attributes</x:label>
+			<x:variable name="test">
+				<looooooooooooooooooooooooooooooooooong>
+					<test attr1="val1" attr2="val2" attr3="val3">
+						<a />
+					</test>
+				</looooooooooooooooooooooooooooooooooong>
+			</x:variable>
+
+			<x:scenario>
+				<x:label>in x:result,</x:label>
+				<x:call function="exactly-one">
+					<x:param select="$test" />
+				</x:call>
+				<x:expect>
+					<x:label>[Result] with diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+				<x:expect test="false()">
+					<x:label>[Result] without diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+			</x:scenario>
+
+			<x:scenario>
+				<x:label>in x:expect,</x:label>
+				<x:call function="false" />
+				<x:expect select="$test">
+					<x:label>[Expected Result] with diff must be serialized with aligned
+						indentation.</x:label>
+				</x:expect>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
 </x:description>


### PR DESCRIPTION
Fixes #689 

### Commits
* e64d351408fd56f602b73c4c1241e3f5b1e953cc reproduces the problem. ([XSLT report HTML](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/e64d351408fd56f602b73c4c1241e3f5b1e953cc/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html#ELEM-471))
* f67437fa99fc6c6b36bc3dfeec750a114858db33 fixes it.  ([XSLT report HTML](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/f67437fa99fc6c6b36bc3dfeec750a114858db33/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html#ELEM-471))