### PR TITLE
Fix issue 693 (end-to-end test cannot handle svrl:active-pattern/attribute(document) if it's zero-length)

### DIFF
--- a/test/end-to-end/cases/expected/schematron/xspec-693-junit.xml
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-junit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-693.xspec">
+   <testsuite name="Using user-content (not @href) in x:context should work"
+              tests="2"
+              failures="1">
+      <testcase name="This expectation should be Success report bar-exists"
+                status="passed"/>
+      <testcase name="This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[. = ''] report baz-exists"
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/schematron/xspec-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-result.html
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-693.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Schematron: <a href="../../xspec-693.sch">xspec-693.sch</a></p>
+      <p>XSpec: <a href="../../xspec-693.xspec">xspec-693.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 2</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#ELEM-34">Using user-content (not @href) in x:context should work</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">2</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="ELEM-34">
+         <h2 class="failed">Using user-content (not @href) in x:context should work<span class="scenario-totals">passed: 1 / pending: 0 / failed: 1 / total: 2</span></h2>
+         <table class="xspec" id="ELEM-36">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Using user-content (not @href) in x:context should work</th>
+                  <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
+               </tr>
+               <tr class="successful">
+                  <td>This expectation should be Success report bar-exists</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-52">This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[.
+                        = ''] report baz-exists</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-51">
+            <h3>Using user-content (not @href) in x:context should work</h3>
+            <div id="ELEM-52">
+               <h4>This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[.
+                  = ''] report baz-exists
+               </h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code>/element()</code> from:
+                           </p><pre>&lt;svrl:schematron-output xmlns:saxon="http://saxon.sf.net/"
+         xmlns:schold="http://www.ascc.net/xml/schematron"
+         xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+         xmlns:xhtml="http://www.w3.org/1999/xhtml"
+         xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+         title=""
+         schemaVersion=""&gt;&lt;!--   
+		   
+		   
+		 --&gt;
+   &lt;svrl:active-pattern document="" /&gt;
+   &lt;svrl:fired-rule context="foo" /&gt;
+   &lt;svrl:successful-report test="bar"
+                          id="bar-exists"
+                          location="/foo[1]"&gt;
+      &lt;svrl:text&gt;Found bar&lt;/svrl:text&gt;
+   &lt;/svrl:successful-report&gt;
+&lt;/svrl:schematron-output&gt;</pre></td>
+                        <td><pre>exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'baz-exists'])</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/schematron/xspec-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-result.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../xspec-693.sch-preprocessed.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../xspec-693.xspec"
+          schematron="../../xspec-693.sch">
+   <x:scenario>
+      <x:label>Using user-content (not @href) in x:context should work</x:label>
+      <x:context select="self::document-node()">
+         <foo>
+            <bar/>
+            <!--<baz />-->
+         </foo>
+      </x:context>
+      <x:result select="/element()">
+         <svrl:schematron-output xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                 xmlns:saxon="http://saxon.sf.net/"
+                                 xmlns:schold="http://www.ascc.net/xml/schematron"
+                                 xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                 xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                 title=""
+                                 schemaVersion=""><!--   
+		   
+		   
+		 -->
+            <svrl:active-pattern document=""/>
+            <svrl:fired-rule context="foo"/>
+            <svrl:successful-report test="bar" id="bar-exists" location="/foo[1]">
+               <svrl:text>Found bar</svrl:text>
+            </svrl:successful-report>
+         </svrl:schematron-output>
+      </x:result>
+      <x:test successful="true">
+         <x:label>This expectation should be Success report bar-exists</x:label>
+         <x:expect test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'bar-exists'])"
+                   select="()"/>
+      </x:test>
+      <x:test successful="false">
+         <x:label>This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[. = ''] report baz-exists</x:label>
+         <x:expect test="exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'baz-exists'])"
+                   select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/xspec-693.sch
+++ b/test/end-to-end/cases/xspec-693.sch
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+	<sch:pattern>
+		<sch:rule context="foo">
+			<sch:report id="bar-exists" test="bar">Found bar</sch:report>
+			<sch:report id="baz-exists" test="baz">Found baz</sch:report>
+		</sch:rule>
+	</sch:pattern>
+</sch:schema>

--- a/test/end-to-end/cases/xspec-693.xspec
+++ b/test/end-to-end/cases/xspec-693.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="xspec-693.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Using user-content (not @href) in x:context should work">
+		<x:context>
+			<foo>
+				<bar />
+				<!--<baz />-->
+			</foo>
+		</x:context>
+		<x:expect-report id="bar-exists" label="This expectation should be Success" />
+		<x:expect-report id="baz-exists"
+			label="This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[. = '']"
+		 />
+	</x:scenario>
+</x:description>

--- a/test/end-to-end/processor/xml/_normalizer.xsl
+++ b/test/end-to-end/processor/xml/_normalizer.xsl
@@ -52,7 +52,7 @@
 			/report/attribute()[name() = ('query-at', 'schematron', 'stylesheet', 'xspec')]
 			| scenario/call/param/@href
 			| scenario/context/@href
-			| /report[@schematron]//scenario/result/svrl:schematron-output/svrl:active-pattern/@document"
+			| /report[@schematron]//scenario/result/svrl:schematron-output/svrl:active-pattern/@document[string()]"
 		mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 


### PR DESCRIPTION
Fixs #693

### Commits
* 50fe689658683c65a4ad5a7baf282ce73f6b2c0c adds an end-to-end test which produces `svrl:active-pattern/@document[. = '']`. This test terminates the entire end-to-end test. ([Travis](https://travis-ci.org/xspec/xspec/jobs/604067884#L1554))
* db4aee76bd0c028d6555ab75fbb93d23d1c170fe fixes the report XML normalizer to ignore the zero-length attribute.