### PR TITLE
Append -compiled to compiled query/stylesheet file name

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -463,10 +463,11 @@ if not defined TEST_DIR for %%I in ("%XSPEC%") do set "TEST_DIR=%%~dpIxspec"
 
 for %%I in ("%XSPEC%") do set "TARGET_FILE_NAME=%%~nI"
 
+set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%-compiled"
 if defined XSLT (
-    set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xsl"
+    set "COMPILED=%COMPILED%.xsl"
 ) else (
-    set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%.xq"
+    set "COMPILED=%COMPILED%.xq"
 )
 set "COVERAGE_XML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.xml"
 set "COVERAGE_HTML=%TEST_DIR%\%TARGET_FILE_NAME%-coverage.html"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -285,10 +285,11 @@ fi
 
 TARGET_FILE_NAME=$(basename "$XSPEC" | sed 's:\.[^.]*$::')
 
+COMPILED="${TEST_DIR}/${TARGET_FILE_NAME}-compiled"
 if test -n "$XSLT"; then
-    COMPILED=$TEST_DIR/$TARGET_FILE_NAME.xsl
+    COMPILED="${COMPILED}.xsl"
 else
-    COMPILED=$TEST_DIR/$TARGET_FILE_NAME.xq
+    COMPILED="${COMPILED}.xq"
 fi
 COVERAGE_XML=$TEST_DIR/$TARGET_FILE_NAME-coverage.xml
 COVERAGE_HTML=$TEST_DIR/$TARGET_FILE_NAME-coverage.html

--- a/build.xml
+++ b/build.xml
@@ -145,7 +145,7 @@
 
   <!-- File path of the compiled XSLT/XQuery file that finally runs the tests -->
   <property name="xspec.compiled.runner.without.ext" 
-            value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}" />
+            value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-compiled" />
   <condition property="xspec.compiled.runner"
              value="${xspec.compiled.runner.without.ext}.xq"
              else="${xspec.compiled.runner.without.ext}.xsl">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -137,7 +137,7 @@
     rem * JUnit is disabled by default
     call :run dir /b /o:n ..\tutorial\xspec
     call :verify_line_count 3
-    call :verify_line 1 x escape-for-regex.xsl
+    call :verify_line 1 x escape-for-regex-compiled.xsl
     call :verify_line 2 x escape-for-regex-result.html
     call :verify_line 3 x escape-for-regex-result.xml
 
@@ -314,7 +314,7 @@
     rem Cleanup removes temporary files in TEST_DIR
     call :run dir /b /o:n ..\tutorial\schematron\xspec
     call :verify_line_count 3
-    call :verify_line 1 x demo-03.xsl
+    call :verify_line 1 x demo-03-compiled.xsl
     call :verify_line 2 x demo-03-result.html
     call :verify_line 3 x demo-03-result.xml
 	</case>
@@ -328,7 +328,7 @@
     rem Specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017.xsl
+    call :verify_line 1 x schematron-017-compiled.xsl
     call :verify_line 2 x schematron-017-result.html
     call :verify_line 3 x schematron-017-result.xml
 
@@ -344,7 +344,7 @@
     rem Specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017.xsl
+    call :verify_line 1 x schematron-017-compiled.xsl
     call :verify_line 2 x schematron-017-result.html
     call :verify_line 3 x schematron-017-result.xml
 	</case>
@@ -420,8 +420,8 @@
     rem * Default xspec.junit.enabled is false
     call :run dir /b /o:n ..\tutorial\xspec
     call :verify_line_count 4
-    call :verify_line 1 x escape-for-regex.xsl
-    call :verify_line 2 x escape-for-regex_xml-to-properties.xml
+    call :verify_line 1 x escape-for-regex_xml-to-properties.xml
+    call :verify_line 2 x escape-for-regex-compiled.xsl
     call :verify_line 3 x escape-for-regex-result.html
     call :verify_line 4 x escape-for-regex-result.xml
 

--- a/test/xspec-catch.xspec
+++ b/test/xspec-catch.xspec
@@ -29,7 +29,7 @@
 
 					<!-- The error is raised by fn:error() at a line in the compiled stylsheet/query -->
 					<x:expect label="err:module"
-						test="matches($x:result?err?module treat as xs:string, '.+/xspec-catch\.(xq|xsl)$')" />
+						test="matches($x:result?err?module treat as xs:string, '.+/xspec-catch-compiled\.(xq|xsl)$')" />
 					<x:expect label="err:line-number"
 						test="($x:result?err?line-number treat as xs:integer) ge 1" />
 					<x:expect label="err:column-number"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -211,9 +211,9 @@ teardown() {
     run ls ../tutorial/xspec
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "escape-for-regex-result.html" ]
-    [ "${lines[1]}" = "escape-for-regex-result.xml" ]
-    [ "${lines[2]}" = "escape-for-regex.xsl" ]
+    [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
+    [ "${lines[1]}" = "escape-for-regex-result.html" ]
+    [ "${lines[2]}" = "escape-for-regex-result.xml" ]
 
     # HTML report file contains CSS inline #135
     run java -jar "${SAXON_JAR}" -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
@@ -430,9 +430,9 @@ teardown() {
     run ls ../tutorial/schematron/xspec
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "demo-03-result.html" ]
-    [ "${lines[1]}" = "demo-03-result.xml" ]
-    [ "${lines[2]}" = "demo-03.xsl" ]
+    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
+    [ "${lines[1]}" = "demo-03-result.html" ]
+    [ "${lines[2]}" = "demo-03-result.xml" ]
 }
 
 
@@ -447,9 +447,9 @@ teardown() {
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-result.html" ]
-    [ "${lines[1]}" = "schematron-017-result.xml" ]
-    [ "${lines[2]}" = "schematron-017.xsl" ]
+    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
+    [ "${lines[1]}" = "schematron-017-result.html" ]
+    [ "${lines[2]}" = "schematron-017-result.xml" ]
 
     # Default TEST_DIR
     run ls xspec
@@ -466,9 +466,9 @@ teardown() {
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-result.html" ]
-    [ "${lines[1]}" = "schematron-017-result.xml" ]
-    [ "${lines[2]}" = "schematron-017.xsl" ]
+    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
+    [ "${lines[1]}" = "schematron-017-result.html" ]
+    [ "${lines[2]}" = "schematron-017-result.xml" ]
 }
 
 
@@ -561,9 +561,9 @@ teardown() {
     run env LC_ALL=C ls ../tutorial/xspec
     echo "$output"
     [ "${#lines[@]}" = "4" ]
-    [ "${lines[0]}" = "escape-for-regex-result.html" ]
-    [ "${lines[1]}" = "escape-for-regex-result.xml" ]
-    [ "${lines[2]}" = "escape-for-regex.xsl" ]
+    [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
+    [ "${lines[1]}" = "escape-for-regex-result.html" ]
+    [ "${lines[2]}" = "escape-for-regex-result.xml" ]
     [ "${lines[3]}" = "escape-for-regex_xml-to-properties.xml" ]
 
     # HTML report file contains CSS inline


### PR DESCRIPTION
It usually happens that you have files like these

* `myStylesheet.xsl`
* `myStylesheet.xspec`

and run XSpec over `myStylesheet.xspec`.
Then XSpec creates a compiled stylesheet (`xspec/myStylesheet.xsl`) which happens to have the same name as the tested stylesheet.
Having two files of the same name is confusing, particularly when you're diagnosing an error message or debugging XSpec.

This pull request appends `-compiled` to the compiled query/stylesheet file name. In the above example, `xspec/myStylesheet-compiled.xsl`.
