### PR TITLE
Fix issue 697 (Empty document node is reported without XPath notation)

### DIFF
--- a/src/compiler/generate-query-utils.xql
+++ b/src/compiler/generate-query-utils.xql
@@ -216,7 +216,8 @@ declare function test:report-sequence(
           (: Single document node :)
           else if ($sequence instance of document-node())
           then (
-            (: People do not always notice '/' in the report HTML. So express it more verbosely. :)
+            (: People do not always notice '/' in the report HTML. So express it more verbosely.
+              Also the expression must match the one in ../reporter/format-xspec-report.xsl. :)
             attribute select { "/self::document-node()" },
             test:report-node($sequence)
           )

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -322,7 +322,8 @@
 
         <!-- Single document node -->
         <xsl:when test="$sequence instance of document-node()">
-          <!-- People do not always notice '/' in the report HTML. So express it more verbosely. -->
+          <!-- People do not always notice '/' in the report HTML. So express it more verbosely.
+            Also the expression must match the one in ../reporter/format-xspec-report.xsl. -->
           <xsl:attribute name="select" select="'/self::document-node()'" />
           <xsl:apply-templates select="$sequence" mode="test:report-node" />
         </xsl:when>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -377,7 +377,7 @@
   <xsl:variable name="expected" as="xs:boolean" select=". instance of element(x:expect)" />
 
   <xsl:choose>
-    <xsl:when test="@href or node()">
+    <xsl:when test="@href or node() or (@select eq '/self::document-node()')">
       <xsl:if test="@select">
         <p>XPath <code><xsl:value-of select="@select" /></code> from:</p>
       </xsl:if>

--- a/test/end-to-end/cases/expected/query/xspec-report-junit.xml
+++ b/test/end-to-end/cases/expected/query/xspec-report-junit.xml
@@ -29,4 +29,12 @@
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>
    </testsuite>
+   <testsuite name="Document node with no children (xspec/xspec#697)"
+              tests="1"
+              failures="1">
+      <testcase name="XPath should be reported between Result title and box"
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.html
@@ -311,7 +311,9 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>/self::document-node()</pre></td>
+                        <td>
+                           <p>XPath <code>/self::document-node()</code> from:
+                           </p><pre></pre></td>
                         <td><pre>()</pre></td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.html
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 5 / total:
-         5)
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 6 / total:
+         6)
       </title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
@@ -26,34 +26,41 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 5</th>
-               <th class="totals">total: 5</th>
+               <th class="totals">failed: 6</th>
+               <th class="totals">total: 6</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-56">Function (xspec/xspec#355)</a></th>
+               <th><a href="#ELEM-63">Function (xspec/xspec#355)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">2</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-119">Element, attribute (xspec/xspec#357)</a></th>
+               <th><a href="#ELEM-126">Element, attribute (xspec/xspec#357)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-156">Attributes of the same name (xspec/xspec#358)</a></th>
+               <th><a href="#ELEM-163">Attributes of the same name (xspec/xspec#358)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-192">Attribute, element, attribute (xspec/xspec#360)</a></th>
+               <th><a href="#ELEM-199">Attribute, element, attribute (xspec/xspec#360)</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-238">Document node with no children (xspec/xspec#697)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -61,9 +68,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-56">
+      <div id="ELEM-63">
          <h2 class="successful">Function (xspec/xspec#355)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 2 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-58">
+         <table class="xspec" id="ELEM-65">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -74,28 +81,28 @@
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-82">Array</a></th>
+                  <th><a href="#ELEM-89">Array</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-83">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
+                  <td><a href="#ELEM-90">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                         upon failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-100">Map</a></th>
+                  <th><a href="#ELEM-107">Map</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-101">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
+                  <td><a href="#ELEM-108">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                         upon failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-82">
+         <div id="ELEM-89">
             <h3>Function (xspec/xspec#355) Array</h3>
-            <div id="ELEM-83">
+            <div id="ELEM-90">
                <h4>Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure
                </h4>
@@ -117,9 +124,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-100">
+         <div id="ELEM-107">
             <h3>Function (xspec/xspec#355) Map</h3>
-            <div id="ELEM-101">
+            <div id="ELEM-108">
                <h4>Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure
                </h4>
@@ -142,9 +149,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-119">
+      <div id="ELEM-126">
          <h2 class="failed">Element, attribute (xspec/xspec#357)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-121">
+         <table class="xspec" id="ELEM-128">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -155,14 +162,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-134">@attr should be reported as an attribute</a></td>
+                  <td><a href="#ELEM-141">@attr should be reported as an attribute</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-133">
+         <div id="ELEM-140">
             <h3>Element, attribute (xspec/xspec#357)</h3>
-            <div id="ELEM-134">
+            <div id="ELEM-141">
                <h4>@attr should be reported as an attribute</h4>
                <table class="xspecResult">
                   <thead>
@@ -186,9 +193,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-156">
+      <div id="ELEM-163">
          <h2 class="failed">Attributes of the same name (xspec/xspec#358)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-158">
+         <table class="xspec" id="ELEM-165">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -199,14 +206,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-171">Both @attr=foo and @attr=bar should be reported</a></td>
+                  <td><a href="#ELEM-178">Both @attr=foo and @attr=bar should be reported</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-170">
+         <div id="ELEM-177">
             <h3>Attributes of the same name (xspec/xspec#358)</h3>
-            <div id="ELEM-171">
+            <div id="ELEM-178">
                <h4>Both @attr=foo and @attr=bar should be reported</h4>
                <table class="xspecResult">
                   <thead>
@@ -228,9 +235,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-192">
+      <div id="ELEM-199">
          <h2 class="failed">Attribute, element, attribute (xspec/xspec#360)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-194">
+         <table class="xspec" id="ELEM-201">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -241,14 +248,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-207">[Result] should be reported</a></td>
+                  <td><a href="#ELEM-214">[Result] should be reported</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-206">
+         <div id="ELEM-213">
             <h3>Attribute, element, attribute (xspec/xspec#360)</h3>
-            <div id="ELEM-207">
+            <div id="ELEM-214">
                <h4>[Result] should be reported</h4>
                <table class="xspecResult">
                   <thead>
@@ -266,6 +273,45 @@
    &lt;<span class="diff">elem2</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem2&gt;
 &lt;/pseudo-element&gt;
 &lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>="attr3-val" /&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-238">
+         <h2 class="failed">Document node with no children (xspec/xspec#697)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="ELEM-240">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Document node with no children (xspec/xspec#697)</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-253">XPath should be reported between Result title and box</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-252">
+            <h3>Document node with no children (xspec/xspec#697)</h3>
+            <div id="ELEM-253">
+               <h4>XPath should be reported between Result title and box</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>/self::document-node()</pre></td>
                         <td><pre>()</pre></td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.xml
@@ -92,4 +92,15 @@
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
+   <x:scenario>
+      <x:label>Document node with no children (xspec/xspec#697)</x:label>
+      <x:call function="parse-xml-fragment">
+         <x:param select="''"/>
+      </x:call>
+      <x:result select="/self::document-node()"/>
+      <x:test successful="false">
+         <x:label>XPath should be reported between Result title and box</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
@@ -88,35 +88,35 @@
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-765">For resultant namespace node</a></th>
+               <th><a href="#ELEM-767">For resultant namespace node</a></th>
                <th class="totals">6</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-829">For resultant sequence of multiple nodes</a></th>
+               <th><a href="#ELEM-831">For resultant sequence of multiple nodes</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">3</th>
                <th class="totals">5</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-924">When result is empty sequence</a></th>
+               <th><a href="#ELEM-926">When result is empty sequence</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-957">For resultant atomic value</a></th>
+               <th><a href="#ELEM-959">For resultant atomic value</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-1060">For any resultant item</a></th>
+               <th><a href="#ELEM-1062">For any resultant item</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
@@ -796,7 +796,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-743">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#ELEM-745">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -808,7 +808,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-744">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-746">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -853,7 +853,9 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>/self::document-node()</pre></td>
+                        <td>
+                           <p>XPath <code>/self::document-node()</code> from:
+                           </p><pre></pre></td>
                         <td>
                            <p>XPath <code>/self::document-node()</code> from:
                            </p><pre><span class="diff">...</span></pre></td>
@@ -862,9 +864,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-743">
+         <div id="ELEM-745">
             <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
-            <div id="ELEM-744">
+            <div id="ELEM-746">
                <h4>expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -887,9 +889,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-765">
+      <div id="ELEM-767">
          <h2 class="successful">For resultant namespace node<span class="scenario-totals">passed: 6 / pending: 0 / failed: 1 / total: 7</span></h2>
-         <table class="xspec" id="ELEM-767">
+         <table class="xspec" id="ELEM-769">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -924,7 +926,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-807">When result is xmlns:prefix="..." </a></th>
+                  <th><a href="#ELEM-809">When result is xmlns:prefix="..." </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -936,14 +938,14 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-808">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
+                  <td><a href="#ELEM-810">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-807">
+         <div id="ELEM-809">
             <h3>For resultant namespace node When result is xmlns:prefix="..." </h3>
-            <div id="ELEM-808">
+            <div id="ELEM-810">
                <h4>expecting xmlns:prefix="namespace-uri" should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -966,9 +968,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-829">
+      <div id="ELEM-831">
          <h2 class="successful">For resultant sequence of multiple nodes<span class="scenario-totals">passed: 2 / pending: 0 / failed: 3 / total: 5</span></h2>
-         <table class="xspec" id="ELEM-831">
+         <table class="xspec" id="ELEM-833">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -979,7 +981,7 @@
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-861">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
+                  <th><a href="#ELEM-863">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="successful">
@@ -991,24 +993,24 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-862">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-864">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-882">expecting ...... should be Failure</a></td>
+                  <td><a href="#ELEM-884">expecting ...... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-902">expecting sequence of three ... should be Failure</a></td>
+                  <td><a href="#ELEM-904">expecting sequence of three ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-861">
+         <div id="ELEM-863">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
                /&gt; 
             </h3>
-            <div id="ELEM-862">
+            <div id="ELEM-864">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1030,7 +1032,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-882">
+            <div id="ELEM-884">
                <h4>expecting ...... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1052,7 +1054,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-902">
+            <div id="ELEM-904">
                <h4>expecting sequence of three ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1076,9 +1078,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-924">
+      <div id="ELEM-926">
          <h2 class="failed">When result is empty sequence<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-926">
+         <table class="xspec" id="ELEM-928">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1089,14 +1091,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-939">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-941">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-938">
+         <div id="ELEM-940">
             <h3>When result is empty sequence</h3>
-            <div id="ELEM-939">
+            <div id="ELEM-941">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1117,9 +1119,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-957">
+      <div id="ELEM-959">
          <h2 class="successful">For resultant atomic value<span class="scenario-totals">passed: 2 / pending: 0 / failed: 4 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-959">
+         <table class="xspec" id="ELEM-961">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1130,7 +1132,7 @@
                   <th>passed: 2 / pending: 0 / failed: 4 / total: 6</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-997">When result is 'string'</a></th>
+                  <th><a href="#ELEM-999">When result is 'string'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1138,15 +1140,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-998">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-1000">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1014">expecting '...' should be Failure</a></td>
+                  <td><a href="#ELEM-1016">expecting '...' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-1028">When result is '...'</a></th>
+                  <th><a href="#ELEM-1030">When result is '...'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1154,18 +1156,18 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1029">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-1031">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1045">expecting 'string' should be Failure</a></td>
+                  <td><a href="#ELEM-1047">expecting 'string' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-997">
+         <div id="ELEM-999">
             <h3>For resultant atomic value When result is 'string'</h3>
-            <div id="ELEM-998">
+            <div id="ELEM-1000">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1184,7 +1186,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1014">
+            <div id="ELEM-1016">
                <h4>expecting '...' should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1202,9 +1204,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-1028">
+         <div id="ELEM-1030">
             <h3>For resultant atomic value When result is '...'</h3>
-            <div id="ELEM-1029">
+            <div id="ELEM-1031">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1223,7 +1225,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1045">
+            <div id="ELEM-1047">
                <h4>expecting 'string' should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1242,9 +1244,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-1060">
+      <div id="ELEM-1062">
          <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 4 / total: 4</span></h2>
-         <table class="xspec" id="ELEM-1062">
+         <table class="xspec" id="ELEM-1064">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1255,26 +1257,26 @@
                   <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1087">expecting .... (four dots) should be Failure</a></td>
+                  <td><a href="#ELEM-1089">expecting .... (four dots) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1106">expecting ...x (three dots with extra character) should be Failure</a></td>
+                  <td><a href="#ELEM-1108">expecting ...x (three dots with extra character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1125">expecting ... with surrounding whitespace should be Failure</a></td>
+                  <td><a href="#ELEM-1127">expecting ... with surrounding whitespace should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1144">expecting '...' (xs:string) should be Failure</a></td>
+                  <td><a href="#ELEM-1146">expecting '...' (xs:string) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-1086">
+         <div id="ELEM-1088">
             <h3>For any resultant item</h3>
-            <div id="ELEM-1087">
+            <div id="ELEM-1089">
                <h4>expecting .... (four dots) should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1295,7 +1297,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1106">
+            <div id="ELEM-1108">
                <h4>expecting ...x (three dots with extra character) should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1316,7 +1318,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1125">
+            <div id="ELEM-1127">
                <h4>expecting ... with surrounding whitespace should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1337,7 +1339,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1144">
+            <div id="ELEM-1146">
                <h4>expecting '...' (xs:string) should be Failure</h4>
                <table class="xspecResult">
                   <thead>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-junit.xml
@@ -29,4 +29,12 @@
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>
    </testsuite>
+   <testsuite name="Document node with no children (xspec/xspec#697)"
+              tests="1"
+              failures="1">
+      <testcase name="XPath should be reported between Result title and box"
+                status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -308,7 +308,9 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>/self::document-node()</pre></td>
+                        <td>
+                           <p>XPath <code>/self::document-node()</code> from:
+                           </p><pre></pre></td>
                         <td><pre>()</pre></td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 6 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,34 +23,41 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 5</th>
-               <th class="totals">total: 5</th>
+               <th class="totals">failed: 6</th>
+               <th class="totals">total: 6</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#ELEM-55">Function (xspec/xspec#355)</a></th>
+               <th><a href="#ELEM-62">Function (xspec/xspec#355)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
                <th class="totals">2</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-120">Element, attribute (xspec/xspec#357)</a></th>
+               <th><a href="#ELEM-127">Element, attribute (xspec/xspec#357)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-157">Attributes of the same name (xspec/xspec#358)</a></th>
+               <th><a href="#ELEM-164">Attributes of the same name (xspec/xspec#358)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-193">Attribute, element, attribute (xspec/xspec#360)</a></th>
+               <th><a href="#ELEM-200">Attribute, element, attribute (xspec/xspec#360)</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#ELEM-239">Document node with no children (xspec/xspec#697)</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -58,9 +65,9 @@
             </tr>
          </tbody>
       </table>
-      <div id="ELEM-55">
+      <div id="ELEM-62">
          <h2 class="successful">Function (xspec/xspec#355)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 2 / total: 2</span></h2>
-         <table class="xspec" id="ELEM-57">
+         <table class="xspec" id="ELEM-64">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -71,28 +78,28 @@
                   <th>passed: 0 / pending: 0 / failed: 2 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-81">Array</a></th>
+                  <th><a href="#ELEM-88">Array</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-82">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
+                  <td><a href="#ELEM-89">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                         upon failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-100">Map</a></th>
+                  <th><a href="#ELEM-107">Map</a></th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-101">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
+                  <td><a href="#ELEM-108">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                         upon failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-81">
+         <div id="ELEM-88">
             <h3>Function (xspec/xspec#355) Array</h3>
-            <div id="ELEM-82">
+            <div id="ELEM-89">
                <h4>Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure
                </h4>
@@ -114,9 +121,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-100">
+         <div id="ELEM-107">
             <h3>Function (xspec/xspec#355) Map</h3>
-            <div id="ELEM-101">
+            <div id="ELEM-108">
                <h4>Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure
                </h4>
@@ -139,9 +146,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-120">
+      <div id="ELEM-127">
          <h2 class="failed">Element, attribute (xspec/xspec#357)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-122">
+         <table class="xspec" id="ELEM-129">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -152,14 +159,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-135">@attr should be reported as an attribute</a></td>
+                  <td><a href="#ELEM-142">@attr should be reported as an attribute</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-134">
+         <div id="ELEM-141">
             <h3>Element, attribute (xspec/xspec#357)</h3>
-            <div id="ELEM-135">
+            <div id="ELEM-142">
                <h4>@attr should be reported as an attribute</h4>
                <table class="xspecResult">
                   <thead>
@@ -183,9 +190,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-157">
+      <div id="ELEM-164">
          <h2 class="failed">Attributes of the same name (xspec/xspec#358)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-159">
+         <table class="xspec" id="ELEM-166">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -196,14 +203,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-172">Both @attr=foo and @attr=bar should be reported</a></td>
+                  <td><a href="#ELEM-179">Both @attr=foo and @attr=bar should be reported</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-171">
+         <div id="ELEM-178">
             <h3>Attributes of the same name (xspec/xspec#358)</h3>
-            <div id="ELEM-172">
+            <div id="ELEM-179">
                <h4>Both @attr=foo and @attr=bar should be reported</h4>
                <table class="xspecResult">
                   <thead>
@@ -225,9 +232,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-193">
+      <div id="ELEM-200">
          <h2 class="failed">Attribute, element, attribute (xspec/xspec#360)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-195">
+         <table class="xspec" id="ELEM-202">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -238,14 +245,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-208">[Result] should be reported</a></td>
+                  <td><a href="#ELEM-215">[Result] should be reported</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-207">
+         <div id="ELEM-214">
             <h3>Attribute, element, attribute (xspec/xspec#360)</h3>
-            <div id="ELEM-208">
+            <div id="ELEM-215">
                <h4>[Result] should be reported</h4>
                <table class="xspecResult">
                   <thead>
@@ -263,6 +270,45 @@
    &lt;<span class="diff">elem2</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem2&gt;
 &lt;/pseudo-element&gt;
 &lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>="attr3-val" /&gt;</pre></td>
+                        <td><pre>()</pre></td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="ELEM-239">
+         <h2 class="failed">Document node with no children (xspec/xspec#697)<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="ELEM-241">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Document node with no children (xspec/xspec#697)</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#ELEM-254">XPath should be reported between Result title and box</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="ELEM-253">
+            <h3>Document node with no children (xspec/xspec#697)</h3>
+            <div id="ELEM-254">
+               <h4>XPath should be reported between Result title and box</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><pre>/self::document-node()</pre></td>
                         <td><pre>()</pre></td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
@@ -92,4 +92,15 @@
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
+   <x:scenario>
+      <x:label>Document node with no children (xspec/xspec#697)</x:label>
+      <x:call function="parse-xml-fragment">
+         <x:param select="''"/>
+      </x:call>
+      <x:result select="/self::document-node()"/>
+      <x:test successful="false">
+         <x:label>XPath should be reported between Result title and box</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
 </x:report>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
@@ -87,35 +87,35 @@
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-764">For resultant namespace node</a></th>
+               <th><a href="#ELEM-766">For resultant namespace node</a></th>
                <th class="totals">6</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">7</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-828">For resultant sequence of multiple nodes</a></th>
+               <th><a href="#ELEM-830">For resultant sequence of multiple nodes</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">3</th>
                <th class="totals">5</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-923">When result is empty sequence</a></th>
+               <th><a href="#ELEM-925">When result is empty sequence</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
                <th class="totals">1</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-956">For resultant atomic value</a></th>
+               <th><a href="#ELEM-958">For resultant atomic value</a></th>
                <th class="totals">2</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
                <th class="totals">6</th>
             </tr>
             <tr class="failed">
-               <th><a href="#ELEM-1059">For any resultant item</a></th>
+               <th><a href="#ELEM-1061">For any resultant item</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">4</th>
@@ -795,7 +795,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-742">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#ELEM-744">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -807,7 +807,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-743">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#ELEM-745">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -852,7 +852,9 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>/self::document-node()</pre></td>
+                        <td>
+                           <p>XPath <code>/self::document-node()</code> from:
+                           </p><pre></pre></td>
                         <td>
                            <p>XPath <code>/self::document-node()</code> from:
                            </p><pre><span class="diff">...</span></pre></td>
@@ -861,9 +863,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-742">
+         <div id="ELEM-744">
             <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
-            <div id="ELEM-743">
+            <div id="ELEM-745">
                <h4>expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -886,9 +888,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-764">
+      <div id="ELEM-766">
          <h2 class="successful">For resultant namespace node<span class="scenario-totals">passed: 6 / pending: 0 / failed: 1 / total: 7</span></h2>
-         <table class="xspec" id="ELEM-766">
+         <table class="xspec" id="ELEM-768">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -923,7 +925,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-806">When result is xmlns:prefix="..." </a></th>
+                  <th><a href="#ELEM-808">When result is xmlns:prefix="..." </a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -935,14 +937,14 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-807">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
+                  <td><a href="#ELEM-809">expecting xmlns:prefix="namespace-uri" should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-806">
+         <div id="ELEM-808">
             <h3>For resultant namespace node When result is xmlns:prefix="..." </h3>
-            <div id="ELEM-807">
+            <div id="ELEM-809">
                <h4>expecting xmlns:prefix="namespace-uri" should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -965,9 +967,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-828">
+      <div id="ELEM-830">
          <h2 class="successful">For resultant sequence of multiple nodes<span class="scenario-totals">passed: 2 / pending: 0 / failed: 3 / total: 5</span></h2>
-         <table class="xspec" id="ELEM-830">
+         <table class="xspec" id="ELEM-832">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -978,7 +980,7 @@
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-860">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
+                  <th><a href="#ELEM-862">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="successful">
@@ -990,24 +992,24 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-861">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-863">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-881">expecting ...... should be Failure</a></td>
+                  <td><a href="#ELEM-883">expecting ...... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-901">expecting sequence of three ... should be Failure</a></td>
+                  <td><a href="#ELEM-903">expecting sequence of three ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-860">
+         <div id="ELEM-862">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
                /&gt; 
             </h3>
-            <div id="ELEM-861">
+            <div id="ELEM-863">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1029,7 +1031,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-881">
+            <div id="ELEM-883">
                <h4>expecting ...... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1051,7 +1053,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-901">
+            <div id="ELEM-903">
                <h4>expecting sequence of three ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1075,9 +1077,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-923">
+      <div id="ELEM-925">
          <h2 class="failed">When result is empty sequence<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
-         <table class="xspec" id="ELEM-925">
+         <table class="xspec" id="ELEM-927">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1088,14 +1090,14 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-938">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-940">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-937">
+         <div id="ELEM-939">
             <h3>When result is empty sequence</h3>
-            <div id="ELEM-938">
+            <div id="ELEM-940">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1116,9 +1118,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-956">
+      <div id="ELEM-958">
          <h2 class="successful">For resultant atomic value<span class="scenario-totals">passed: 2 / pending: 0 / failed: 4 / total: 6</span></h2>
-         <table class="xspec" id="ELEM-958">
+         <table class="xspec" id="ELEM-960">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1129,7 +1131,7 @@
                   <th>passed: 2 / pending: 0 / failed: 4 / total: 6</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-996">When result is 'string'</a></th>
+                  <th><a href="#ELEM-998">When result is 'string'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1137,15 +1139,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-997">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-999">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1013">expecting '...' should be Failure</a></td>
+                  <td><a href="#ELEM-1015">expecting '...' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#ELEM-1027">When result is '...'</a></th>
+                  <th><a href="#ELEM-1029">When result is '...'</a></th>
                   <th>passed: 1 / pending: 0 / failed: 2 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -1153,18 +1155,18 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1028">expecting ... should be Failure</a></td>
+                  <td><a href="#ELEM-1030">expecting ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1044">expecting 'string' should be Failure</a></td>
+                  <td><a href="#ELEM-1046">expecting 'string' should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-996">
+         <div id="ELEM-998">
             <h3>For resultant atomic value When result is 'string'</h3>
-            <div id="ELEM-997">
+            <div id="ELEM-999">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1183,7 +1185,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1013">
+            <div id="ELEM-1015">
                <h4>expecting '...' should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1201,9 +1203,9 @@
                </table>
             </div>
          </div>
-         <div id="ELEM-1027">
+         <div id="ELEM-1029">
             <h3>For resultant atomic value When result is '...'</h3>
-            <div id="ELEM-1028">
+            <div id="ELEM-1030">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1222,7 +1224,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1044">
+            <div id="ELEM-1046">
                <h4>expecting 'string' should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1241,9 +1243,9 @@
             </div>
          </div>
       </div>
-      <div id="ELEM-1059">
+      <div id="ELEM-1061">
          <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 4 / total: 4</span></h2>
-         <table class="xspec" id="ELEM-1061">
+         <table class="xspec" id="ELEM-1063">
             <colgroup>
                <col style="width:75%" />
                <col style="width:25%" />
@@ -1254,26 +1256,26 @@
                   <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1086">expecting .... (four dots) should be Failure</a></td>
+                  <td><a href="#ELEM-1088">expecting .... (four dots) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1105">expecting ...x (three dots with extra character) should be Failure</a></td>
+                  <td><a href="#ELEM-1107">expecting ...x (three dots with extra character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1124">expecting ... with surrounding whitespace should be Failure</a></td>
+                  <td><a href="#ELEM-1126">expecting ... with surrounding whitespace should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#ELEM-1143">expecting '...' (xs:string) should be Failure</a></td>
+                  <td><a href="#ELEM-1145">expecting '...' (xs:string) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
-         <div id="ELEM-1085">
+         <div id="ELEM-1087">
             <h3>For any resultant item</h3>
-            <div id="ELEM-1086">
+            <div id="ELEM-1088">
                <h4>expecting .... (four dots) should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1294,7 +1296,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1105">
+            <div id="ELEM-1107">
                <h4>expecting ...x (three dots with extra character) should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1315,7 +1317,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1124">
+            <div id="ELEM-1126">
                <h4>expecting ... with surrounding whitespace should be Failure</h4>
                <table class="xspecResult">
                   <thead>
@@ -1336,7 +1338,7 @@
                   </tbody>
                </table>
             </div>
-            <div id="ELEM-1143">
+            <div id="ELEM-1145">
                <h4>expecting '...' (xs:string) should be Failure</h4>
                <table class="xspecResult">
                   <thead>

--- a/test/end-to-end/cases/xspec-report.xspec
+++ b/test/end-to-end/cases/xspec-report.xspec
@@ -60,4 +60,10 @@
 		<x:expect label="[Result] should be reported" />
 	</x:scenario>
 
+	<x:scenario label="Document node with no children (xspec/xspec#697)">
+		<x:call function="parse-xml-fragment">
+			<x:param select="''" />
+		</x:call>
+		<x:expect label="XPath should be reported between Result title and box" />
+	</x:scenario>
 </x:description>


### PR DESCRIPTION
Fixes #697

### Commits
* 313705945a4da1e3816b3d9eab8701f943c588f4 reproduces the problem ([HTML report](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/313705945a4da1e3816b3d9eab8701f943c588f4/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html#ELEM-254))
* af2fe06445896cf92e7de851f036cb49b75b860c fixes it ([HTML report](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/af2fe06445896cf92e7de851f036cb49b75b860c/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html#ELEM-254))