### PR TITLE
Ant-based test: Parameterize query for fn:collection()

### DIFF
--- a/test/ant/build.xml
+++ b/test/ant/build.xml
@@ -10,6 +10,9 @@
 	<property location="${run-xspec-tests.basedir}/../" name="xspecfiles.dir" />
 	<makeurl file="${xspecfiles.dir}" property="xspecfiles.dir.url" />
 
+	<!-- Query parameter for fn:collection() -->
+	<property name="xspecfiles.dir.url.query" value="select=*.xspec" />
+
 	<!-- Gets processor capabilities -->
 	<target name="get-processor-caps">
 		<echo message="Getting processor capabilities" />
@@ -87,6 +90,7 @@
 			style="worker/generate.xsl">
 			<factory name="net.sf.saxon.TransformerFactoryImpl" />
 			<param expression="${xspecfiles.dir.url}" name="XSPECFILES-DIR-URI" />
+			<param expression="${xspecfiles.dir.url.query}" name="XSPECFILES-DIR-URI-QUERY" />
 			<param expression="${xslt.supports.coverage}" name="XSLT-SUPPORTS-COVERAGE"
 				type="BOOLEAN" />
 			<param expression="${xslt.supports.schema}" name="XSLT-SUPPORTS-SCHEMA" type="BOOLEAN" />

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -16,6 +16,9 @@
 	<!-- Absolute URI of directory where *.xspec files are located. Must ends with '/'. -->
 	<xsl:param as="xs:anyURI" name="XSPECFILES-DIR-URI" required="yes" />
 
+	<!-- Query parameter for fn:collection() -->
+	<xsl:param as="xs:string" name="XSPECFILES-DIR-URI-QUERY" required="yes" />
+
 	<!-- XSLT processor capabilities -->
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-COVERAGE" required="yes" />
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-SCHEMA" required="yes" />
@@ -54,7 +57,7 @@
 			<xsl:apply-templates select="attribute() | node()" />
 
 			<xsl:variable as="xs:string" name="collection-uri"
-				select="concat($XSPECFILES-DIR-URI, '?select=*.xspec')" />
+				select="string-join(($XSPECFILES-DIR-URI, $XSPECFILES-DIR-URI-QUERY), '?')" />
 
 			<!--<xsl:message select="'Collecting:', $collection-uri" />-->
 			<xsl:variable as="document-node()+" name="xspec-docs"


### PR DESCRIPTION
### Summary
`test/ant/worker/generate.xsl` uses `fn:collection()` to collect XSpec files. URI query parameter is hardcoded:
https://github.com/xspec/xspec/blob/66103d760ab9336a92396b6f1872355d3619f997/test/ant/worker/generate.xsl#L57

This pull request parameterizes it.

### Why

With this change, you can quickly experiment query parameters such as recursive option:

```
C:\xspec>test\run-xspec-tests-ant.cmd -Dxspecfiles.dir="C:\test" -Dxspecfiles.dir.url.query="select=*.xspec;recurse=yes"
```

### Scope of this change

This change pertains only to [CI tests](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally). Nothing is changed in XSpec itself.


### Test
I ran the following commands on the current master and on this pr branch
```
C:\xspec>test\run-xspec-tests-ant.cmd -Dthread.count=1 -logfile "test.log"
C:\xspec>test\end-to-end\run-e2e-tests.cmd -Dthread.count=1 -logfile "e2e.log"
```
and compared the logs to verify that there's no unignorable difference between the current master and this pr branch.