### PR TITLE
ci: fix .travis.yml according to build config validation message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 language: java
 dist: trusty
 
@@ -12,7 +13,7 @@ env:
 
         - BASEX_VERSION=8.6.4
 
-    matrix:
+    jobs:
         # Note
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.


### PR DESCRIPTION
When enabled, Travis CI [Build Config Validation](https://blog.travis-ci.com/2019-10-24-build-config-validation) throws these two informational messages:

* `root`: missing `os`, using the default `linux`
* `env`: key `matrix` is an alias for `jobs`, using `jobs`

This pull request just fixes them. No substantial change.