### PR TITLE
Reject Saxon 9.8.0.14 or later when generating expected files

### DIFF
--- a/test/end-to-end/ant/generate-expected/worker/generate.xsl
+++ b/test/end-to-end/ant/generate-expected/worker/generate.xsl
@@ -14,6 +14,23 @@
 	<xsl:import href="../../base/worker/generate.xsl" />
 
 	<!--
+		Overrides an imported template for document node
+		
+		Rejects specific Saxon versions
+	-->
+	<xsl:template as="document-node(element(project))" match="document-node()">
+		<xsl:if test="x:saxon-version() ge x:pack-version(9, 8, 0, 14)">
+			<xsl:message terminate="yes">
+				<xsl:text>Saxon version is </xsl:text>
+				<xsl:value-of select="system-property('xsl:product-version')" />
+				<xsl:text>. Generating the expected files on Saxon 9.8.0.14 or later (including 9.9) will produce unrelated changes. You have to generate the expected files on 9.8.0.12 or less (incluing 9.7).</xsl:text>
+			</xsl:message>
+		</xsl:if>
+
+		<xsl:apply-imports />
+	</xsl:template>
+
+	<!--
 		Overrides an imported named template
 		
 		Inserts <normalize-xspec-report> into the default <post-task>.


### PR DESCRIPTION
Until #588 gets resolved, you have to use Saxon ~9.8.0.12 when generating the expected files of end-to-end test. This pull request enforces it.
No change in XSpec core.