### PR TITLE
Ignore Oxygen project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Maven target directory
 /target/
 
+# Oxygen project file
+/*.xpr
+
 # Eclipse project information
 /.project
 


### PR DESCRIPTION
This pull request just adds `/*.xpr` to `.gitignore` to ignore Oxygen XML Editor project files in the repository root.