### PR TITLE
Use Bats work dir by default

### DIFF
--- a/test/run-bats.cmd
+++ b/test/run-bats.cmd
@@ -24,6 +24,10 @@ if not errorlevel 1 set XSLT_SUPPORTS_3_0=1
 java -cp "%SAXON_JAR%" net.sf.saxon.Query -q:"%~dp0caps\v3-1.xquery" > NUL 2>&1
 if not errorlevel 1 set XQUERY_SUPPORTS_3_1_DEFAULT=1
 
+rem Unset Ant environment variables
+set ANT_ARGS=
+set ANT_OPTS=
+
 rem Reset public environment variables
 set "SAXON_CP=%SAXON_JAR%"
 set SAXON_CUSTOM_OPTIONS=

--- a/test/run-bats.sh
+++ b/test/run-bats.sh
@@ -32,6 +32,10 @@ fi
 unset _JAVA_OPTIONS
 unset JAVA_TOOL_OPTIONS
 
+# Unset Ant environment variables
+unset ANT_ARGS
+unset ANT_OPTS
+
 # Reset public environment variables
 export SAXON_CP="${SAXON_JAR}"
 unset SAXON_CUSTOM_OPTIONS

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2,6 +2,10 @@
 <collection xmlns="x-urn:xspec:test:xspec-bat" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="x-urn:xspec:test:xspec-bat collection.xsd">
 
+	<!--
+		Usage (CLI)
+	-->
+
 	<case name="invoking xspec without arguments prints usage">
     call :run ..\bin\xspec.bat
     call :verify_retval 1
@@ -22,6 +26,10 @@
     call :verify_line 2 r "Usage: xspec "
 	</case>
 
+	<!--
+		Mutually exclusive test types (CLI)
+	-->
+
 	<case name="invoking xspec with -s and -t prints error message">
     call :run ..\bin\xspec.bat -s -t
     call :verify_retval 1
@@ -39,6 +47,10 @@
     call :verify_retval 1
     call :verify_line 2 x "-t and -q are mutually exclusive"
 	</case>
+
+	<!--
+		Coverage and Saxon versions (CLI)
+	-->
 
 	<case name="invoking xspec -c with Saxon9HE returns error message">
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9he.jar
@@ -78,17 +90,22 @@
 	<case name="invoking xspec -c with Saxon9EE creates test stylesheet">
     rem Append non-Saxon jar to see if SAXON_CP is parsed correctly
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9ee.jar;%SYSTEMDRIVE%\path\to\another.jar
+
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Creating Test Stylesheet..."
+    call :verify_line 3 x "Creating Test Stylesheet..."
 	</case>
 
 	<case name="invoking xspec -c with Saxon9PE creates test stylesheet">
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon9pe.jar
     call :run ..\bin\xspec.bat -c ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Creating Test Stylesheet..."
+    call :verify_line 3 x "Creating Test Stylesheet..."
 	</case>
+
+	<!--
+		Coverage (CLI)
+	-->
 
 	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="invoking xspec -c creates report files">
     rem Other stderr #204
@@ -99,6 +116,8 @@
     call :mkdir "%SPECIAL_CHARS_DIR%"
 
     call :copy ..\tutorial\coverage\demo* "%SPECIAL_CHARS_DIR%"
+    set TEST_DIR=
+
     call :run ..\bin\xspec.bat -c "%SPECIAL_CHARS_DIR%\demo.xspec"
     call :verify_retval 0
 
@@ -125,12 +144,25 @@
     call :verify_line 2 x "Coverage is supported only for XSLT"
 	</case>
 
-	<case name="invoking xspec generates message with default report location and creates report files">
+	<!--
+		CLI without TEST_DIR
+	-->
+
+	<case name="invoking xspec without TEST_DIR set externally (XSLT)">
+    set TEST_DIR=
+
+    rem Delete default output dir if exists, to make the line numbers predictable
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 20 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
 
-    rem Verify
+    rem Verify message
+    call :verify_line 20 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line 21 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
+
+    rem Verify report files
     rem * XML report file is created
     rem * HTML report file is created
     rem * Coverage is disabled by default
@@ -144,7 +176,73 @@
     rem HTML report file contains CSS inline #135
     call :run java -jar "%SAXON_JAR%" -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
     call :verify_line 1 x "true"
+
+    rem Cleanup
+    call :rmdir ..\tutorial\xspec
 	</case>
+
+	<case name="invoking xspec without TEST_DIR set externally (XQuery)">
+    set TEST_DIR=
+
+    rem Delete default output dir if exists, to make the line numbers predictable
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run
+    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :verify_retval 0
+
+    rem Verify message
+    call :verify_line 7 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 8 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\xquery-tutorial-result.html"
+
+    rem Verify report files
+    rem * XML report file is created
+    rem * HTML report file is created
+    rem * JUnit is disabled by default
+    call :run dir /b /o:n ..\tutorial\xspec
+    call :verify_line_count 3
+    call :verify_line 1 x xquery-tutorial-compiled.xq
+    call :verify_line 2 x xquery-tutorial-result.html
+    call :verify_line 3 x xquery-tutorial-result.xml
+
+    rem Cleanup
+    call :rmdir ..\tutorial\xspec
+	</case>
+
+	<case name="invoking xspec without TEST_DIR set externally (Schematron)">
+    set TEST_DIR=
+
+    rem Delete default output dir if exists, to make the line numbers predictable
+    call :rmdir-if-exist ..\tutorial\schematron\xspec
+
+    rem Run
+    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
+    call :verify_retval 0
+
+    rem Verify message
+    rem * No Schematron warnings #129 #131
+    call :verify_line  5 x "Converting Schematron XSpec into XSLT XSpec..."
+    call :verify_line 32 x "passed: 10 / pending: 1 / failed: 0 / total: 11"
+    call :verify_line 33 x "Report available at %PARENT_DIR_ABS%\tutorial\schematron\xspec\demo-03-result.html"
+
+    rem Verify report files
+    rem * XML report file is created
+    rem * HTML report file is created
+    rem * JUnit is disabled by default
+    rem * Schematron-specific temporary files are deleted
+    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :verify_line_count 3
+    call :verify_line 1 x demo-03-compiled.xsl
+    call :verify_line 2 x demo-03-result.html
+    call :verify_line 3 x demo-03-result.xml
+
+    rem Cleanup
+    call :rmdir ..\tutorial\schematron\xspec
+	</case>
+
+	<!--
+		JUnit and Saxon versions (CLI)
+	-->
 
 	<case name="invoking xspec with -j option with Saxon8 returns error message">
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8.jar
@@ -160,67 +258,83 @@
     call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
 	</case>
 
+	<!--
+		JUnit (CLI)
+	-->
+
 	<case name="invoking xspec with -j option generates message with JUnit report location and creates report files">
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 21 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-junit.xml"
+    call :verify_line 22 x "Report available at %TEST_DIR%\escape-for-regex-junit.xml"
 
     rem XML report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
+    call :verify_exist "%TEST_DIR%\escape-for-regex-result.xml"
 
     rem HTML report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
+    call :verify_exist "%TEST_DIR%\escape-for-regex-result.html"
 
     rem JUnit report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml
+    call :verify_exist "%TEST_DIR%\escape-for-regex-junit.xml"
 	</case>
+
+	<!--
+		Saxon-B (CLI)
+	-->
 
 	<case name="invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet">
     set SAXON_CP=%SYSTEMDRIVE%\path\to\saxonb9-1-0-8.jar
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Creating Test Stylesheet..."
+    call :verify_line 3 x "Creating Test Stylesheet..."
 	</case>
 
-	<case name="invoking xspec with TEST_DIR already set externally generates files inside TEST_DIR">
-    set "TEST_DIR=%WORK_DIR%"
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 0
-    call :verify_line 20 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
-	</case>
+	<!--
+		#46
+	-->
 
 	<case name="invoking xspec that passes a non xs:boolean does not raise a warning #46">
     call :run ..\bin\xspec.bat xspec-46.xspec
     call :verify_retval 0
-    call :verify_line 5 r "Testing with"
+    call :verify_line 6 r "Testing with"
 	</case>
 
+	<!--
+		XProc (Saxon)
+	-->
+
 	<case ifdef="XMLCALABASH_JAR" name="executing the Saxon XProc harness generates a report with UTF-8 encoding (XSLT)">
+    set "EXPECTED_REPORT=%WORK_DIR%\xspec-72-result.html"
     call :run java -jar "%XMLCALABASH_JAR%" ^
         -i source=xspec-72.xspec ^
-        -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" ^
-        -o result=xspec/xspec-72-result.html ^
+        -o result="file:///%EXPECTED_REPORT:\=/%" ^
+        -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xslt-harness.xproc
-    call :run java -jar "%SAXON_JAR%" -s:xspec\xspec-72-result.html -xsl:html-charset.xsl
+    call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:html-charset.xsl
     call :verify_line 1 x "true"
 	</case>
 
 	<case ifdef="XMLCALABASH_JAR" name="executing the Saxon XProc harness generates a report with UTF-8 encoding (XQuery)">
+    set "EXPECTED_REPORT=%WORK_DIR%\xspec-72-result.html"
     call :run java -jar "%XMLCALABASH_JAR%" ^
         -i source=xspec-72.xspec ^
-        -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" ^
-        -o result=xspec/xspec-72-result.html ^
+        -o result="file:///%EXPECTED_REPORT:\=/%" ^
+        -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xquery-harness.xproc
-    call :run java -jar "%SAXON_JAR%" -s:xspec\xspec-72-result.html -xsl:html-charset.xsl
+    call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:html-charset.xsl
     call :verify_line 1 x "true"
 	</case>
 
-	<case name="invoking xspec with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs and loads doc #610 successfully and generates HTML report file (XSLT)">
+	<!--
+		Path containing special chars (CLI)
+	-->
+
+	<case name="invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (XSLT)">
     set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84) here &amp; there"
     call :mkdir "%SPECIAL_CHARS_DIR%"
     call :copy do-nothing.xsl         "%SPECIAL_CHARS_DIR%"
     call :copy xspec-node-selection.* "%SPECIAL_CHARS_DIR%"
 
+    set TEST_DIR=
     set "EXPECTED_REPORT=%SPECIAL_CHARS_DIR%\xspec\xspec-node-selection-result.html"
 
     call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\xspec-node-selection.xspec"
@@ -229,12 +343,13 @@
     call :verify_exist "%EXPECTED_REPORT%"
 	</case>
 
-	<case name="invoking xspec with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs and loads doc #610 successfully and generates HTML report file (XQuery)">
+	<case name="invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (XQuery)">
     set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84) here &amp; there"
     call :mkdir "%SPECIAL_CHARS_DIR%"
     call :copy do-nothing.xquery      "%SPECIAL_CHARS_DIR%"
     call :copy xspec-node-selection.* "%SPECIAL_CHARS_DIR%"
 
+    set TEST_DIR=
     set "EXPECTED_REPORT=%SPECIAL_CHARS_DIR%\xspec\xspec-node-selection-result.html"
 
     call :run ..\bin\xspec.bat -q "%SPECIAL_CHARS_DIR%\xspec-node-selection.xspec"
@@ -242,6 +357,24 @@
     call :verify_line 8 x "Report available at %EXPECTED_REPORT%"
     call :verify_exist "%EXPECTED_REPORT%"
 	</case>
+
+	<case ifdef="SKIP_UNTIL_716_GETS_FIXED" name="invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (Schematron)">
+    set "SPECIAL_CHARS_DIR=%WORK_DIR%\some'path (84) here &amp; there"
+    call :mkdir "%SPECIAL_CHARS_DIR%"
+    call :copy ..\tutorial\schematron\demo-03* "%SPECIAL_CHARS_DIR%"
+
+    set TEST_DIR=
+    set "EXPECTED_REPORT=%SPECIAL_CHARS_DIR%\xspec\demo-03-result.html"
+
+    call :run ..\bin\xspec.bat -s "%SPECIAL_CHARS_DIR%\demo-03.xspec"
+    call :verify_retval 0
+    call :verify_line 33 x "Report available at %EXPECTED_REPORT%"
+    call :verify_exist "%EXPECTED_REPORT%"
+	</case>
+
+	<!--
+		saxon script
+	-->
 
 	<!-- bin\xspec.bat does not support saxon script -->
 	<case ifdef="NEVER" name="invoking xspec with saxon script uses the saxon script #121 #122">
@@ -252,28 +385,35 @@
     call :verify_line 1 x "Saxon script found, use it."
 	</case>
 
-	<case name="Schematron phase/parameters are passed to Schematron compile (command line)">
-    rem Make the line numbers predictable by providing an existing output dir
-    set "TEST_DIR=%WORK_DIR%"
+	<!--
+		Schematron phase/parameters
+	-->
 
+	<case name="Schematron phase/parameters are passed to Schematron compile (command line)">
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-param-001-step3.xsl
     call :run ..\bin\xspec.bat -s schematron\schematron-param-001.xspec
     call :verify_retval 0
-    call :verify_line 20 x "passed: 9 / pending: 0 / failed: 0 / total: 9"
+    call :verify_line 21 x "passed: 9 / pending: 0 / failed: 0 / total: 9"
 	</case>
 
 	<case name="Schematron phase/parameters are passed to Schematron compile (Ant)">
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -Dclean.output.dir=true ^
         -Dtest.type=s ^
         -Dxspec.schematron.preprocessor.step3="%CD%\schematron\schematron-param-001-step3.xsl" ^
         -Dxspec.xml="%CD%\schematron\schematron-param-001.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 9 / pending: 0 / failed: 0 / total: 9"
     call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Cleanup
+    call :del schematron\schematron-param-001.sch-preprocessed.xsl
 	</case>
+
+	<!--
+		Schematron XSLTs provided externally
+	-->
 
 	<case name="invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (command line)">
     set SCHEMATRON_XSLT_INCLUDE=schematron\schematron-xslt-include.xsl
@@ -282,17 +422,16 @@
 
     call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
     call :verify_retval 0
-    call :verify_line  4 x "I am schematron-xslt-include.xsl!"
-    call :verify_line  5 x "I am schematron-xslt-expand.xsl!"
-    call :verify_line  6 x "I am schematron-xslt-compile.xsl!"
-    call :verify_line 19 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
+    call :verify_line  5 x "I am schematron-xslt-include.xsl!"
+    call :verify_line  6 x "I am schematron-xslt-expand.xsl!"
+    call :verify_line  7 x "I am schematron-xslt-compile.xsl!"
+    call :verify_line 20 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
 	</case>
 
 	<case name="invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)">
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -Dclean.output.dir=true ^
         -Dtest.type=s ^
         -Dxspec.schematron.preprocessor.step1="%CD%\schematron\schematron-xslt-include.xsl" ^
         -Dxspec.schematron.preprocessor.step2="%CD%\schematron\schematron-xslt-expand.xsl" ^
@@ -304,56 +443,126 @@
     call :verify_line  * x "     [xslt] I am schematron-xslt-compile.xsl!"
     call :verify_line  * x "     [xslt] passed: 3 / pending: 0 / failed: 0 / total: 3"
     call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Cleanup
+    call :del ..\tutorial\schematron\demo-01.sch-preprocessed.xsl
 	</case>
 
-	<case name="invoking xspec with the -s option does not display Schematron warnings #129 #131 and removes temporary files">
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
+	<!--
+		CLI with TEST_DIR
+	-->
+
+	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (XSLT)">
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run with absolute TEST_DIR
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 4 x "Converting Schematron XSpec into XSLT XSpec..."
+    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
-    rem Cleanup removes temporary files in TEST_DIR
-    call :run dir /b /o:n ..\tutorial\schematron\xspec
-    call :verify_line_count 3
-    call :verify_line 1 x demo-03-compiled.xsl
-    call :verify_line 2 x demo-03-result.html
-    call :verify_line 3 x demo-03-result.xml
-	</case>
-
-	<case name="invoking xspec -s with TEST_DIR creates files in TEST_DIR">
-    rem Absolute
-    set "TEST_DIR=%WORK_DIR%\test_dir"
-    call :run ..\bin\xspec.bat -s schematron-017.xspec
-    call :verify_retval 0
-
-    rem Specified TEST_DIR
+    rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017-compiled.xsl
-    call :verify_line 2 x schematron-017-result.html
-    call :verify_line 3 x schematron-017-result.xml
+    call :verify_line 1 x escape-for-regex-compiled.xsl
+    call :verify_line 2 x escape-for-regex-result.html
+    call :verify_line 3 x escape-for-regex-result.xml
 
-    rem Default TEST_DIR
-    call :run dir /b xspec
-    call :verify_line_count 0
+    rem Default output dir should not be created
+    call :verify_not_exist ..\tutorial\xspec\
 
-    rem Relative
-    set TEST_DIR=xspec
-    call :run ..\bin\xspec.bat -s schematron-017.xspec
+    rem Run with relative TEST_DIR
+    set TEST_DIR=..\tutorial\xspec
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
+    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
-    rem Specified TEST_DIR
+    rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017-compiled.xsl
-    call :verify_line 2 x schematron-017-result.html
-    call :verify_line 3 x schematron-017-result.xml
+    call :verify_line 1 x escape-for-regex-compiled.xsl
+    call :verify_line 2 x escape-for-regex-result.html
+    call :verify_line 3 x escape-for-regex-result.xml
+
+    rem Cleanup
+    call :rmdir "%TEST_DIR%"
 	</case>
 
-	<case name="invoking xspec with -q option runs XSpec test for XQuery">
+	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (XQuery)">
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run with absolute TEST_DIR
     call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
     call :verify_retval 0
-    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
+
+    rem Verify files in specified TEST_DIR
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 3
+    call :verify_line 1 x xquery-tutorial-compiled.xq
+    call :verify_line 2 x xquery-tutorial-result.html
+    call :verify_line 3 x xquery-tutorial-result.xml
+
+    rem Default output dir should not be created
+    call :verify_not_exist ..\tutorial\xspec\
+
+    rem Run with relative TEST_DIR
+    set TEST_DIR=..\tutorial\xspec
+    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :verify_retval 0
+    call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
+
+    rem Verify files in specified TEST_DIR
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 3
+    call :verify_line 1 x xquery-tutorial-compiled.xq
+    call :verify_line 2 x xquery-tutorial-result.html
+    call :verify_line 3 x xquery-tutorial-result.xml
+
+    rem Cleanup
+    call :rmdir "%TEST_DIR%"
 	</case>
+
+	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (Schematron)">
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\test\xspec
+
+    rem Run with absolute TEST_DIR
+    call :run ..\bin\xspec.bat -s schematron-017.xspec
+    call :verify_retval 0
+    call :verify_line 17 x "Report available at %TEST_DIR%\schematron-017-result.html"
+
+    rem Verify files in specified TEST_DIR
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 3
+    call :verify_line 1 x schematron-017-compiled.xsl
+    call :verify_line 2 x schematron-017-result.html
+    call :verify_line 3 x schematron-017-result.xml
+
+    rem Default output dir should not be created
+    call :verify_not_exist xspec\
+
+    rem Run with relative TEST_DIR
+    set TEST_DIR=..\test\xspec
+    call :run ..\bin\xspec.bat -s schematron-017.xspec
+    call :verify_retval 0
+    call :verify_line 17 x "Report available at %TEST_DIR%\schematron-017-result.html"
+
+    rem Verify files in specified TEST_DIR
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 3
+    call :verify_line 1 x schematron-017-compiled.xsl
+    call :verify_line 2 x schematron-017-result.html
+    call :verify_line 3 x schematron-017-result.xml
+
+    rem Cleanup
+    call :rmdir "%TEST_DIR%"
+	</case>
+
+	<!--
+		XProc (BaseX)
+	-->
 
 	<case ifdef="BASEX_JAR XMLCALABASH_JAR" name="XProc harness for BaseX (standalone)">
     rem Output files
@@ -362,10 +571,10 @@
 
     call :run java -jar "%XMLCALABASH_JAR%" ^
         -i source=../tutorial/xquery-tutorial.xspec ^
-        -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" ^
+        -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p basex-jar="%BASEX_JAR%" ^
-        -p compiled-file="file:/%COMPILED_FILE:\=/%" ^
-        -o result="file:/%EXPECTED_REPORT:\=/%" ^
+        -p compiled-file="file:///%COMPILED_FILE:\=/%" ^
+        -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
     call :verify_retval 0
     call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
@@ -389,12 +598,12 @@
 
     call :run java -jar "%XMLCALABASH_JAR%" ^
         -i source=../tutorial/xquery-tutorial.xspec ^
-        -p xspec-home="file:/%PARENT_DIR_ABS:\=/%/" ^
-        -p endpoint=http://localhost:8984/rest ^
-        -p username=admin ^
-        -p password=admin ^
+        -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p auth-method=Basic ^
-        -o result="file:/%EXPECTED_REPORT:\=/%" ^
+        -p endpoint=http://localhost:8984/rest ^
+        -p password=admin ^
+        -p username=admin ^
+        -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
     call :verify_line_count 2
@@ -409,13 +618,30 @@
     call :verify_retval 0
 	</case>
 
-	<case name="Ant for XSLT with default properties fails on test failure">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_JAR%"
+	<!--
+		Ant with minimum properties
+	-->
+
+	<case name="Ant with minimum properties (XSLT)">
+    rem Unset any preset args
+    set ANT_ARGS=
+
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
+
+    rem Default xspec.fail is true
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
     call :verify_line -3 x "BUILD FAILED"
 
-    rem Verify
+    rem Verify default output dir
+    rem * Default clean.output.dir is false
     rem * Default xspec.coverage.enabled is false
     rem * Default xspec.junit.enabled is false
     call :run dir /b /o:n ..\tutorial\xspec
@@ -428,30 +654,98 @@
     rem HTML report file contains CSS inline
     call :run java -jar "%SAXON_JAR%" -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
     call :verify_line 1 x "true"
+
+    rem Cleanup
+    call :rmdir ..\tutorial\xspec
 	</case>
 
-	<case name="Ant for XSLT with xspec.fail=false continues on test failure">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_JAR%" -Dxspec.fail=false
+	<case name="Ant with minimum properties (XQuery)">
+    rem Unset any preset args
+    set ANT_ARGS=
+
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\tutorial\xspec
+
+    rem Run
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=q ^
+        -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec"
     call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Verify default output dir
+    rem * Default clean.output.dir is false
+    rem * Default xspec.junit.enabled is false
+    call :run dir /b /o:n ..\tutorial\xspec
+    call :verify_line_count 4
+    call :verify_line 1 x xquery-tutorial_xml-to-properties.xml
+    call :verify_line 2 x xquery-tutorial-compiled.xq
+    call :verify_line 3 x xquery-tutorial-result.html
+    call :verify_line 4 x xquery-tutorial-result.xml
+
+    rem Cleanup
+    call :rmdir ..\tutorial\xspec
 	</case>
 
-	<case ifdef="XML_RESOLVER_JAR" name="Ant for XSLT with catalog resolves URI">
-    call :run ant -buildfile ..\build.xml -Dxspec.xml="%CD%\catalog\catalog-02-xslt.xspec" -lib "%SAXON_JAR%" -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" -lib "%XML_RESOLVER_JAR%"
+	<case name="Ant with minimum properties (Schematron)">
+    rem Unset any preset args
+    set ANT_ARGS=
+
+    rem Delete default output dir if exists
+    call :rmdir-if-exists ..\tutorial\schematron\xspec
+
+    rem Run
+    rem * Should work without phase #168
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=s ^
+        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
+    call :verify_retval 0
+    call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
+    call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Verify default output dir
+    rem * Default clean.output.dir is false
+    rem * Default xspec.junit.enabled is false
+    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :verify_line_count 8
+    call :verify_line 1 x demo-03_xml-to-properties.xml
+    call :verify_line 2 x demo-03-compiled.xsl
+    call :verify_line 3 x demo-03-result.html
+    call :verify_line 4 x demo-03-result.xml
+    call :verify_line 5 x demo-03-sch-preprocessed.xspec
+    call :verify_line 6 x demo-03-sch-step3-wrapper.xsl
+    call :verify_line 7 x demo-03-step1.sch
+    call :verify_line 8 x demo-03-step2.sch
+
+    rem Verify that the preprocessed XSLT is left. Delete it at the same time.
+    call :del ..\tutorial\schematron\demo-03.sch-preprocessed.xsl
+
+    rem Cleanup
+    call :rmdir ..\tutorial\schematron\xspec
+	</case>
+
+	<!--
+		Catalog (Ant)
+	-->
+
+	<case ifdef="XML_RESOLVER_JAR" name="Ant with catalog resolves URI (XSLT)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" ^
+        -Dxspec.xml="%CD%\catalog\catalog-02-xslt.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 	</case>
 
-	<case name="Ant for XQuery with default properties">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec" -lib "%SAXON_JAR%" -Dtest.type=q
-    call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
-    call :verify_line -2 x "BUILD SUCCESSFUL"
-	</case>
-
-	<case ifdef="XML_RESOLVER_JAR" name="Ant for XQuery with catalog resolves URI">
+	<case ifdef="XML_RESOLVER_JAR" name="Ant with catalog resolves URI (XQuery)">
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
@@ -464,63 +758,93 @@
     call :verify_line -2 x "BUILD SUCCESSFUL"
 	</case>
 
-	<case name="Ant for Schematron with minimum properties #168">
+	<case ifdef="XML_RESOLVER_JAR" name="Ant with catalog resolves URI (Schematron)">
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" ^
+        -Dclean.output.dir=true ^
         -Dtest.type=s ^
-        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
-    call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
-    call :verify_line -2 x "BUILD SUCCESSFUL"
+        -Dxspec.xml="%CD%\catalog\catalog-02-schematron.xspec"
 
-    rem Verify that the default clean.output.dir is false and leaves temp files. Delete the left XSLT file at the same time.
-    call :verify_exist ..\tutorial\schematron\xspec\
-    call :del          ..\tutorial\schematron\demo-03.sch-preprocessed.xsl
-	</case>
-
-	<case name="Ant for Schematron with various properties except catalog">
-    set "BUILD_XML=%WORK_DIR%\build.xml"
-    set "ANT_TEST_DIR=%WORK_DIR%\ant-temp"
-
-    rem Remove a temp dir created by setup
-    call :rmdir ..\tutorial\schematron\xspec
-
-    rem For testing -Dxspec.project.dir
-    call :copy ..\build.xml "%BUILD_XML%"
-
-    call :run ant -buildfile "%BUILD_XML%" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec" -lib "%SAXON_JAR%" -Dxspec.properties="%CD%\schematron.properties" -Dxspec.project.dir="%CD%\.." -Dxspec.dir="%ANT_TEST_DIR%" -Dclean.output.dir=true
-    call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
-    call :verify_line -2 x "BUILD SUCCESSFUL"
-
-    rem Verify that -Dxspec-dir was honered and the default dir was not created
-    call :verify_not_exist ..\tutorial\schematron\xspec\
-
-    rem Verify clean.output.dir=true
-    call :verify_not_exist "%ANT_TEST_DIR%"
-    call :verify_not_exist ..\tutorial\schematron\demo-03.sch-preprocessed.xsl
-	</case>
-
-	<case ifdef="XML_RESOLVER_JAR" name="Ant for Schematron with catalog and default xspec.fail resolves URI and fails on test failure">
-    call :run ant -buildfile ..\build.xml -Dxspec.xml="%CD%\catalog\catalog-02-schematron.xspec" -lib "%SAXON_JAR%" -Dtest.type=s -Dclean.output.dir=true -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" -lib "%XML_RESOLVER_JAR%"
+    rem Default xspec.fail should make the build fail on test failure
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 1 / total: 2"
     call :verify_line -3 x "BUILD FAILED"
 
     rem Verify the build fails before cleanup
-    call :verify_exist catalog\xspec\
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 8
 
-    rem Verify that the build fails after Schematron setup and leaves temp XSLT file. Delete it at the same time.
+    rem Verify that the build fails after Schematron preprocess and leaves preprocessed XSLT file. Delete it at the same time.
     call :del catalog\02\tested.sch-preprocessed.xsl
 	</case>
 
+	<!--
+		Ant various properties
+	-->
+
+	<case name="Ant for XSLT with xspec.fail=false continues on test failure">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.fail=false ^
+        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
+    call :verify_retval 0
+    call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line -2 x "BUILD SUCCESSFUL"
+	</case>
+
+	<case name="Ant for Schematron with various properties except catalog">
+    set "BUILD_XML=%WORK_DIR%\build.xml"
+
+    rem For testing -Dxspec.project.dir
+    call :copy ..\build.xml "%BUILD_XML%"
+
+    rem Delete default output dir if exists
+    call :rmdir-if-exist ..\tutorial\schematron\xspec
+
+    rem Run
+    call :run ant ^
+        -buildfile "%BUILD_XML%" ^
+        -lib "%SAXON_JAR%" ^
+        -Dclean.output.dir=true ^
+        -Dxspec.project.dir="%CD%\.." ^
+        -Dxspec.properties="%CD%\schematron.properties" ^
+        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
+    call :verify_retval 0
+    call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
+    call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Verify that -Dxspec.dir was honored and the default output dir was not created
+    call :verify_not_exist ..\tutorial\schematron\xspec\
+
+    rem Verify clean.output.dir=true
+    call :verify_not_exist "%TEST_DIR%"
+    call :verify_not_exist ..\tutorial\schematron\demo-03.sch-preprocessed.xsl
+	</case>
+
 	<case ifdef="XML_RESOLVER_JAR" name="Ant for Schematron with catalog and xspec.fail=false resolves URI and continues on test failure">
-    call :run ant -buildfile ..\build.xml -Dxspec.xml="%CD%\catalog\catalog-02-schematron.xspec" -lib "%SAXON_JAR%" -Dtest.type=s -Dclean.output.dir=true -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" -lib "%XML_RESOLVER_JAR%" -Dxspec.fail=false
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="%CD%\catalog\catalog-02-catalog.xml" ^
+        -Dtest.type=s ^
+        -Dxspec.fail=false ^
+        -Dxspec.xml="%CD%\catalog\catalog-02-schematron.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 1 / total: 2"
     call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Cleanup
+    call :del catalog\02\tested.sch-preprocessed.xsl
 	</case>
+
+	<!--
+		Catalog (CLI) (-catalog)
+	-->
 
 	<case ifdef="XML_RESOLVER_JAR" name="invoking xspec for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path">
     set "SPACE_DIR=%WORK_DIR%\cat a log"
@@ -530,22 +854,26 @@
     set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
     call :run ..\bin\xspec.bat -catalog "%SPACE_DIR%\catalog-01-catalog.xml" "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
-    call :verify_line 9 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 10 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
 
 	<case ifdef="XML_RESOLVER_JAR" name="invoking xspec for XQuery with -catalog uses XML Catalog resolver">
     set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml -q catalog\catalog-01-xquery.xspec
     call :verify_retval 0
-    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 7 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
 
 	<case ifdef="XML_RESOLVER_JAR" name="invoking xspec for Schematron with -catalog uses XML Catalog resolver">
     set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
     call :run ..\bin\xspec.bat -catalog catalog\catalog-02-catalog.xml -s catalog\catalog-02-schematron.xspec
     call :verify_retval 0
-    call :verify_line 14 x "passed: 1 / pending: 0 / failed: 1 / total: 2"
+    call :verify_line 15 x "passed: 1 / pending: 0 / failed: 1 / total: 2"
 	</case>
+
+	<!--
+		Catalog (CLI) (XML_CATALOG)
+	-->
 
 	<case ifdef="XML_RESOLVER_JAR" name="invoking xspec with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path">
     set "SPACE_DIR=%WORK_DIR%\cat a log"
@@ -554,15 +882,20 @@
 
     set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
     set "XML_CATALOG=%SPACE_DIR%\catalog-01-catalog.xml"
+
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01-xslt.xspec"
     call :verify_retval 0
-    call :verify_line 9 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 10 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
+
+	<!--
+		SAXON_HOME (CLI)
+	-->
 
 	<case ifdef="XML_RESOLVER_JAR" name="invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar">
     set "SAXON_HOME=%WORK_DIR%\saxon"
     call :mkdir "%SAXON_HOME%"
-    call :copy "%SAXON_JAR%" "%SAXON_HOME%"
+    call :copy "%SAXON_JAR%"        "%SAXON_HOME%"
     call :copy "%XML_RESOLVER_JAR%" "%SAXON_HOME%\xml-resolver-1.2.jar"
     set SAXON_CP=
 
@@ -572,8 +905,12 @@
 
     call :run ..\bin\xspec.bat -catalog catalog\catalog-01-catalog.xml catalog\catalog-01-xslt.xspec
     call :verify_retval 0
-    call :verify_line 9 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 10 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
+
+	<!--
+		RelaxNG Schema
+	-->
 
 	<case ifdef="JING_JAR" name="Schema detects no error in known good .xspec files">
     call :run ant -buildfile schema\build.xml -lib "%JING_JAR%"
@@ -585,7 +922,7 @@
 	</case>
 
 	<case ifdef="JING_JAR" name="Schema detects errors in node-selection test">
-    rem -t for identifying the last line
+    rem '-t' for identifying the last line
     call :run java -jar "%JING_JAR%" -c -t ..\src\schemas\xspec.rnc ^
         xspec-node-selection.xspec ^
         xspec-node-selection_stylesheet.xspec
@@ -600,12 +937,20 @@
     call :verify_line 8 r "Elapsed time"
 	</case>
 
+	<!--
+		saxon.custom.options (Ant)
+	-->
+
 	<case name="Ant for XSLT with saxon.custom.options">
     rem Test with a space in file name
     set "SAXON_CONFIG=%WORK_DIR%\saxon config.xml"
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\saxon-custom-options\test.xspec" -lib "%SAXON_JAR%" -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t"
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" ^
+        -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -619,7 +964,12 @@
     set "SAXON_CONFIG=%WORK_DIR%\saxon config.xml"
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\saxon-custom-options\test.xspec" -lib "%SAXON_JAR%" -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" -Dtest.type=q
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" ^
+        -Dtest.type=q ^
+        -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -627,6 +977,10 @@
     rem Verify '-t'
     call :verify_line  * r "     \[java\] Memory used:"
 	</case>
+
+	<!--
+		SAXON_CUSTOM_OPTIONS (CLI)
+	-->
 
 	<case name="invoking xspec for XSLT with SAXON_CUSTOM_OPTIONS">
     rem Test with a space in file name
@@ -656,72 +1010,103 @@
     call :verify_line  * r "Memory used:"
 	</case>
 
+	<!--
+		Coverage (Ant)
+	-->
+
 	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="Ant for XSLT with coverage creates report files">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\coverage\demo.xspec" -lib "%SAXON_JAR%" -Dxspec.coverage.enabled=true
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.coverage.enabled=true ^
+        -Dxspec.xml="%CD%\..\tutorial\coverage\demo.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 
     rem XML and HTML report file
-    call :verify_exist ..\tutorial\coverage\xspec\demo-result.xml
-    call :verify_exist ..\tutorial\coverage\xspec\demo-result.html
+    call :verify_exist "%TEST_DIR%\demo-result.xml"
+    call :verify_exist "%TEST_DIR%\demo-result.html"
 
     rem Coverage report file is created and contains CSS inline
-    call :run java -jar "%SAXON_JAR%" -s:..\tutorial\coverage\xspec\demo-coverage.html -xsl:html-css.xsl
+    call :run java -jar "%SAXON_JAR%" -s:"%TEST_DIR%\demo-coverage.html" -xsl:html-css.xsl
     call :verify_line 1 x "true"
 	</case>
 
 	<case name="Ant for XQuery with coverage fails">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec" -lib "%SAXON_JAR%" -Dtest.type=q -Dxspec.coverage.enabled=true
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=q ^
+        -Dxspec.coverage.enabled=true ^
+        -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec"
     call :verify_retval 1
     call :verify_line -3 x "BUILD FAILED"
     call :verify_line -2 r ".*Coverage is supported only for XSLT"
 	</case>
 
 	<case name="Ant for Schematron with coverage fails">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\schematron\demo-01.xspec" -lib "%SAXON_JAR%" -Dtest.type=s -Dxspec.coverage.enabled=true
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=s ^
+        -Dxspec.coverage.enabled=true ^
+        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-01.xspec"
     call :verify_retval 1
     call :verify_line -3 x "BUILD FAILED"
     call :verify_line -2 r ".*Coverage is supported only for XSLT"
 	</case>
 
+	<!--
+		JUnit (Ant)
+	-->
+
 	<case name="Ant for XSLT with JUnit creates report files">
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec" -lib "%SAXON_JAR%" -Dxspec.junit.enabled=true
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.junit.enabled=true ^
+        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
     call :verify_retval 1
     call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
     call :verify_line -3 x "BUILD FAILED"
 
     rem XML report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.xml
+    call :verify_exist "%TEST_DIR%\escape-for-regex-result.xml"
 
     rem HTML report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-result.html
+    call :verify_exist "%TEST_DIR%\escape-for-regex-result.html"
 
     rem JUnit report file
-    call :verify_exist ..\tutorial\xspec\escape-for-regex-junit.xml
+    call :verify_exist "%TEST_DIR%\escape-for-regex-junit.xml"
 	</case>
 
-	<case name="Import order #185">
-    rem Make the line numbers predictable by providing an existing output dir
-    set "TEST_DIR=%WORK_DIR%"
+	<!--
+		#185
+	-->
 
+	<case name="Import order #185">
     call :run ..\bin\xspec.bat xspec-185\import-1.xspec
     call :verify_retval 0
-    call :verify_line  6 x "Scenario 1-1"
-    call :verify_line  7 x "Scenario 1-2"
-    call :verify_line  8 x "Scenario 1-3"
-    call :verify_line  9 x "Scenario 2a-1"
-    call :verify_line 10 x "Scenario 2a-2"
-    call :verify_line 11 x "Scenario 2b-1"
-    call :verify_line 12 x "Scenario 2b-2"
-    call :verify_line 13 x "Scenario 3"
-    call :verify_line 14 x "Formatting Report..."
+    call :verify_line  7 x "Scenario 1-1"
+    call :verify_line  8 x "Scenario 1-2"
+    call :verify_line  9 x "Scenario 1-3"
+    call :verify_line 10 x "Scenario 2a-1"
+    call :verify_line 11 x "Scenario 2a-2"
+    call :verify_line 12 x "Scenario 2b-1"
+    call :verify_line 13 x "Scenario 2b-2"
+    call :verify_line 14 x "Scenario 3"
+    call :verify_line 15 x "Formatting Report..."
 	</case>
 
 	<case name="Import order with Ant #185">
     set "ANT_LOG=%WORK_DIR%\ant.log"
 
-    call :run ant -buildfile "%CD%\..\build.xml" -Dxspec.xml="%CD%\xspec-185\import-1.xspec" -lib "%SAXON_JAR%" -logfile "%ANT_LOG%"
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -Dxspec.xml="%CD%\xspec-185\import-1.xspec"
     call :verify_retval 0
 
     call :run %SYSTEMROOT%\system32\find " Scenario " "%ANT_LOG%"
@@ -736,15 +1121,21 @@
     call :verify_line  9 x "     [java] Scenario 3"
 	</case>
 
+	<!--
+		Ambiguous x:expect
+	-->
+
 	<case name="Ambiguous x:expect generates warning">
-    rem Provide TEST_DIR with an existing directory to make the output lines predictable
-    set "TEST_DIR=%WORK_DIR%"
     call :run ..\bin\xspec.bat end-to-end\cases\xspec-ambiguous-expect.xspec
-    call :verify_line 11 r "WARNING: x:expect has boolean @test"
-    call :verify_line 16 r "WARNING: x:expect has boolean @test"
-    call :verify_line 23 r "WARNING: x:expect has boolean @test"
-    call :verify_line 32 x "Formatting Report..."
+    call :verify_line 12 r "WARNING: x:expect has boolean @test"
+    call :verify_line 17 r "WARNING: x:expect has boolean @test"
+    call :verify_line 24 r "WARNING: x:expect has boolean @test"
+    call :verify_line 33 x "Formatting Report..."
 	</case>
+
+	<!--
+		Obsolete x:space
+	-->
 
 	<case name="Obsolete x:space">
     call :run ..\bin\xspec.bat obsolete-space\test.xspec
@@ -752,6 +1143,10 @@
     call :verify_line  * x "x:space is obsolete. Use x:text instead."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
+
+	<!--
+		#423
+	-->
 
 	<case ifdef="XMLCALABASH_JAR" name="XSLT selecting nodes without context should be error (XProc) #423">
     call :run java -jar "%XMLCALABASH_JAR%" ^
@@ -774,6 +1169,7 @@
 	</case>
 
 	<case name="XSLT selecting nodes without context should be error (Ant) #423">
+    rem Should be error even when xspec.fail=false
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
@@ -805,12 +1201,20 @@
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
-	<case name="Invalid xquery-version should be error">
+	<!--
+		Invalid @xquery-version
+	-->
+
+	<case name="Invalid @xquery-version should be error">
     call :run ..\bin\xspec.bat -q xquery-version\invalid.xspec
     call :verify_retval 2
     call :verify_line  * r ".*XQST0031..*InVaLiD"
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
+
+	<!--
+		report-css-uri
+	-->
 
 	<case name="report-css-uri for HTML report file">
     call :run ant ^
@@ -822,7 +1226,7 @@
     call :verify_retval 0
 
     call :run java -jar "%SAXON_JAR%" ^
-        -s:..\tutorial\xspec\escape-for-regex-result.html ^
+        -s:"%TEST_DIR%\escape-for-regex-result.html" ^
         -xsl:html-css.xsl ^
         STYLE-CONTAINS="This CSS file is for testing report-css-uri parameter"
     call :verify_line 1 x "true"
@@ -838,41 +1242,51 @@
     call :verify_retval 0
 
     call :run java -jar "%SAXON_JAR%" ^
-        -s:..\tutorial\coverage\xspec\demo-coverage.html ^
+        -s:"%TEST_DIR%\demo-coverage.html" ^
         -xsl:html-css.xsl ^
         STYLE-CONTAINS="This CSS file is for testing report-css-uri parameter"
     call :verify_line 1 x "true"
 	</case>
 
+	<!--
+		#522
+	-->
+
 	<case name="Error message when source is not XSpec #522">
     call :run ..\bin\xspec.bat do-nothing.xsl
     call :verify_retval 2
-    call :verify_line 4 r "Source document is not XSpec"
+    call :verify_line 5 r "Source document is not XSpec"
 	</case>
+
+	<!--
+		User-defined variable in XSpec namespace
+	-->
 
 	<case name="Error on user-defined variable in XSpec namespace">
-    rem Make the line numbers predictable by providing an existing output dir
-    set "TEST_DIR=%WORK_DIR%"
-
     call :run ..\bin\xspec.bat variable\reserved-name.xspec
     call :verify_retval 2
-    call :verify_line 5 r ".*x:XSPEC008:"
+    call :verify_line 6 r ".*x:XSPEC008:"
 	</case>
 
-	<case name="Deprecated Saxon version">
-    rem Make the line numbers predictable by providing an existing output dir
-    set "TEST_DIR=%WORK_DIR%"
+	<!--
+		Deprecated Saxon version
+	-->
 
+	<case name="Deprecated Saxon version">
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
 
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
     if errorlevel 1 (
-        call :verify_line 3 x " "
+        call :verify_line 4 x " "
     ) else (
-        call :verify_line 3 r "WARNING: Saxon version ..*"
+        call :verify_line 4 r "WARNING: Saxon version ..*"
     )
 	</case>
+
+	<!--
+		No warning on Ant
+	-->
 
 	<case name="No warning on Ant (XSLT) #633">
     java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&amp;1 | %SYSTEMROOT%\system32\find " 9.7."
@@ -934,7 +1348,6 @@
         -lib "%SAXON_JAR%" ^
         -logfile "%ANT_LOG%" ^
         -verbose ^
-        -Dclean.output.dir=true ^
         -Dtest.type=s ^
         -Dxspec.xml="%CD%\xspec-uri.xspec"
     call :verify_retval 0
@@ -946,7 +1359,14 @@
     rem Verify Ant makepath task
     call :run type "%ANT_LOG%"
     call :verify_line * x " [makepath] Setting xspec.schematron.file to file path %CD%\do-nothing.sch"
+
+    rem Cleanup
+    call :del do-nothing.sch-preprocessed.xsl
 	</case>
+
+	<!--
+		@catch should not catch error outside SUT
+	-->
 
 	<case ifdef="XSLT_SUPPORTS_3_0" name="@catch should not catch error outside SUT (XSLT)">
     call :run ..\bin\xspec.bat catch\compiler-error.xspec
@@ -996,6 +1416,10 @@
     call :verify_line * r ".*XPST0017:"
 	</case>
 
+	<!--
+		Error in SUT should not be caught by default
+	-->
+
 	<case name="Error in SUT should not be caught by default (XSLT)">
     call :run ..\bin\xspec.bat catch\no-by-default.xspec
     call :verify_retval 2
@@ -1008,6 +1432,10 @@
     call :verify_line * r "  my-error-code: Error signalled .*"
 	</case>
 
+	<!--
+		Importing Ant build file
+	-->
+
 	<case name="Importing Ant build file">
     call :run ant ^
         -buildfile ant-import\build.xml ^
@@ -1018,6 +1446,10 @@
     call :verify_line -5 x "     [echo] Target overridden!"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 	</case>
+
+	<!--
+		#655
+	-->
 
 	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="Trace listener should not hardcode output dir #655">
     rem TEST_DIR should not contain "xspec". (Assume TEMP does not contain it.)
@@ -1033,13 +1465,14 @@
     call :rmdir "%TEST_DIR%"
 	</case>
 
-	<case name="x:like errors">
-    rem Make the line numbers predictable by providing an existing output dir
-    set "TEST_DIR=%WORK_DIR%"
+	<!--
+		x:like errors
+	-->
 
+	<case name="x:like errors">
     call :run ..\bin\xspec.bat like\none.xspec
     call :verify_retval 2
-    call :verify_line 5 x "  x:XSPEC009: x:like: Scenario not found: none"
+    call :verify_line 6 x "  x:XSPEC009: x:like: Scenario not found: none"
 
     call :run ..\bin\xspec.bat like\multiple.xspec
     call :verify_retval 2

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -160,25 +160,14 @@ rem
     call :mkdir "%WORK_DIR%"
 
     rem
-    rem Create the XSpec output directories
+    rem Set TEST_DIR and xspec.dir within the work directory so that it's cleaned up by teardown
     rem
-    call :mkdir ..\test\catalog\xspec
-    call :mkdir ..\test\xspec
-    call :mkdir ..\tutorial\schematron\xspec
-    call :mkdir ..\tutorial\xspec
+    set "TEST_DIR=%WORK_DIR%\output_%RANDOM%"
+    set ANT_ARGS=-Dxspec.dir="%TEST_DIR%"
 
     goto :EOF
 
 :teardown
-    rem
-    rem Remove the XSpec output directories
-    rem    Keep "..\test\" to minimize accident
-    rem
-    call :rmdir-if-exist ..\test\catalog\xspec
-    call :rmdir-if-exist ..\test\xspec
-    call :rmdir-if-exist ..\tutorial\schematron\xspec
-    call :rmdir          ..\tutorial\xspec
-
     rem
     rem Remove the work directory
     rem
@@ -305,6 +294,9 @@ rem
     )
     if errorlevel 1 (
         call :failed "Line %LINE_NUMBER% does not match the expected string"
+        echo Expected:
+        call :echo "%FIND_STRING%"
+        echo Actual:
         echo ---------- "%OUTPUT_LINENUM%"
         type "%OUTPUT_LINENUM%"
         echo ----------
@@ -329,13 +321,13 @@ rem
     if exist %1 (
         call :verified "Exist: %~1"
     ) else (
-        call :failed "Not exist: %~1"
+        call :failed "Not exist (Expected to exist): %~1"
     )
     goto :EOF
 
 :verify_not_exist
     if exist %1 (
-        call :failed "Exist: %~1"
+        call :failed "Exist (Expected not to exist): %~1"
     ) else (
         call :verified "Not exist: %~1"
     )

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -17,24 +17,25 @@
 #
 #===============================================================================
 
-setup() {
-	work_dir="${BATS_TMPDIR}/xspec/bats_work"
-	mkdir -p "${work_dir}"
-	mkdir ../test/catalog/xspec
-	mkdir ../test/xspec
-	mkdir ../tutorial/schematron/xspec
-	mkdir ../tutorial/xspec
-}
+#
+# Setup and teardown
+#
 
+setup() {
+    work_dir="${BATS_TMPDIR}/xspec/bats_work"
+    mkdir -p "${work_dir}"
+
+    export TEST_DIR="${work_dir}/output_${RANDOM}"
+    export ANT_ARGS="-Dxspec.dir=${TEST_DIR}"
+}
 
 teardown() {
-	rm -rf "${work_dir}"
-	rm -rf ../test/catalog/xspec
-	rm -rf ../test/xspec
-	rm -rf ../tutorial/schematron/xspec
-	rm -rf ../tutorial/xspec
+    rm -r "${work_dir}"
 }
 
+#
+# Usage (CLI)
+#
 
 @test "invoking xspec without arguments prints usage" {
     run ../bin/xspec.sh
@@ -42,7 +43,6 @@ teardown() {
     [ "$status" -eq 1 ]
     [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
 }
-
 
 @test "invoking xspec without arguments prints usage even if Saxon environment variables are not defined" {
     unset SAXON_CP
@@ -53,7 +53,6 @@ teardown() {
     [[ "${lines[4]}" =~ "Usage: xspec " ]]
 }
 
-
 @test "invoking xspec with -h prints usage and does so even when it is 11th argument" {
     run ../bin/xspec.sh -t -t -t -t -t -t -t -t -t -t -h
     echo "$output"
@@ -61,6 +60,9 @@ teardown() {
     [[ "${lines[1]}" =~ "Usage: xspec " ]]
 }
 
+#
+# Mutually exclusive test types (CLI)
+#
 
 @test "invoking xspec with -s and -t prints error message" {
     run ../bin/xspec.sh -s -t
@@ -69,14 +71,12 @@ teardown() {
     [ "${lines[1]}" = "-s and -t are mutually exclusive" ]
 }
 
-
 @test "invoking xspec with -s and -q prints error message" {
     run ../bin/xspec.sh -s -q
     echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "-s and -q are mutually exclusive" ]
 }
-
 
 @test "invoking xspec with -t and -q prints error message" {
     run ../bin/xspec.sh -t -q
@@ -85,6 +85,9 @@ teardown() {
     [ "${lines[1]}" = "-t and -q are mutually exclusive" ]
 }
 
+#
+# Coverage and Saxon versions (CLI)
+#
 
 @test "invoking xspec -c with Saxon9HE returns error message" {
     export SAXON_CP=/path/to/saxon9he.jar
@@ -94,7 +97,6 @@ teardown() {
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
 
-
 @test "invoking xspec -c with Saxon9SA returns error message" {
     export SAXON_CP=/path/to/saxon9sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
@@ -102,7 +104,6 @@ teardown() {
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
-
 
 @test "invoking xspec -c with Saxon9 returns error message" {
     export SAXON_CP=/path/to/saxon9.jar
@@ -112,7 +113,6 @@ teardown() {
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
 
-
 @test "invoking xspec -c with Saxon8SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
@@ -120,7 +120,6 @@ teardown() {
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
-
 
 @test "invoking xspec -c with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
@@ -130,25 +129,27 @@ teardown() {
     [ "${lines[1]}" = "Code coverage requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
 }
 
-
 @test "invoking xspec -c with Saxon9EE creates test stylesheet" {
     # Append non-Saxon jar to see if SAXON_CP is parsed correctly
     export SAXON_CP="/path/to/saxon9ee.jar:/path/to/another.jar"
+
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Creating Test Stylesheet..." ]
+    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
 }
-
 
 @test "invoking xspec -c with Saxon9PE creates test stylesheet" {
     export SAXON_CP=/path/to/saxon9pe.jar
     run ../bin/xspec.sh -c ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Creating Test Stylesheet..." ]
+    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
 }
 
+#
+# Coverage (CLI)
+#
 
 @test "invoking xspec -c creates report files" {
     if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
@@ -163,6 +164,8 @@ teardown() {
     mkdir "${special_chars_dir}"
 
     cp ../tutorial/coverage/demo* "${special_chars_dir}"
+    unset TEST_DIR
+
     run ../bin/xspec.sh -c "${special_chars_dir}/demo.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -178,7 +181,6 @@ teardown() {
     [ "${lines[0]}" = "true" ]
 }
 
-
 @test "invoking xspec -c -q prints error message" {
     export SAXON_CP=/path/to/saxon9ee.jar
     run ../bin/xspec.sh -c -q ../tutorial/xquery-tutorial.xspec
@@ -186,7 +188,6 @@ teardown() {
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "Coverage is supported only for XSLT" ]
 }
-
 
 @test "invoking xspec -c -s prints error message" {
     export SAXON_CP=/path/to/saxon9ee.jar
@@ -196,14 +197,26 @@ teardown() {
     [ "${lines[1]}" = "Coverage is supported only for XSLT" ]
 }
 
+#
+# CLI without TEST_DIR
+#
 
-@test "invoking xspec generates message with default report location and creates report files" {
+@test "invoking xspec without TEST_DIR set externally (XSLT)" {
+    unset TEST_DIR
+
+    # Delete default output dir if exists, to make the line numbers predictable
+    rm -rf ../tutorial/xspec
+
+    # Run
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[19]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
 
-    # Verify
+    # Verify message
+    [ "${lines[19]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
+    [ "${lines[20]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+
+    # Verify report files
     # * XML report file is created
     # * HTML report file is created
     # * Coverage is disabled by default
@@ -219,8 +232,77 @@ teardown() {
     run java -jar "${SAXON_JAR}" -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
+
+    # Cleanup
+    rm -r ../tutorial/xspec
 }
 
+@test "invoking xspec without TEST_DIR set externally (XQuery)" {
+    unset TEST_DIR
+
+    # Delete default output dir if exists, to make the line numbers predictable
+    rm -rf ../tutorial/xspec
+
+    # Run
+    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    # Verify message
+    [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[7]}" = "Report available at ../tutorial/xspec/xquery-tutorial-result.html" ]
+
+    # Verify report files
+    # * XML report file is created
+    # * HTML report file is created
+    # * JUnit is disabled by default
+    run ls ../tutorial/xspec
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
+    [ "${lines[1]}" = "xquery-tutorial-result.html" ]
+    [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
+
+    # Cleanup
+    rm -r ../tutorial/xspec
+}
+
+@test "invoking xspec without TEST_DIR set externally (Schematron)" {
+    unset TEST_DIR
+
+    # Delete default output dir if exists, to make the line numbers predictable
+    rm -rf ../tutorial/schematron/xspec
+
+    # Run
+    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    # Verify message
+    # * No Schematron warnings #129 #131
+    [ "${lines[4]}"  = "Converting Schematron XSpec into XSLT XSpec..." ]
+    [ "${lines[31]}" = "passed: 10 / pending: 1 / failed: 0 / total: 11" ]
+    [ "${lines[32]}" = "Report available at ../tutorial/schematron/xspec/demo-03-result.html" ]
+
+    # Verify report files
+    # * XML report file is created
+    # * HTML report file is created
+    # * JUnit is disabled by default
+    # * Schematron-specific temporary files are deleted
+    run ls ../tutorial/schematron/xspec
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
+    [ "${lines[1]}" = "demo-03-result.html" ]
+    [ "${lines[2]}" = "demo-03-result.xml" ]
+
+    # Cleanup
+    rm -r ../tutorial/schematron/xspec
+}
+
+#
+# JUnit and Saxon versions (CLI)
+#
 
 @test "invoking xspec with -j option with Saxon8 returns error message" {
     export SAXON_CP=/path/to/saxon8.jar
@@ -230,7 +312,6 @@ teardown() {
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
 
-
 @test "invoking xspec with -j option with Saxon8-SA returns error message" {
     export SAXON_CP=/path/to/saxon8sa.jar
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
@@ -239,88 +320,96 @@ teardown() {
     [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
 
+#
+# JUnit (CLI)
+#
 
 @test "invoking xspec with -j option generates message with JUnit report location and creates report files" {
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[20]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
+    [ "${lines[21]}" = "Report available at ${TEST_DIR}/escape-for-regex-junit.xml" ]
 
     # XML report file
-    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
+    [ -f "${TEST_DIR}/escape-for-regex-result.xml" ]
 
     # HTML report file
-    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
+    [ -f "${TEST_DIR}/escape-for-regex-result.html" ]
 
     # JUnit report file
-    [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]
+    [ -f "${TEST_DIR}/escape-for-regex-junit.xml" ]
 }
 
+#
+# Saxon-B (CLI)
+#
 
 @test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
     export SAXON_CP=/path/to/saxonb9-1-0-8.jar
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Creating Test Stylesheet..." ]
+    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
 }
 
-
-@test "invoking xspec with TEST_DIR already set externally generates files inside TEST_DIR" {
-    export TEST_DIR="${work_dir}"
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [ "${lines[19]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
-}
-
+#
+# #46
+#
 
 @test "invoking xspec that passes a non xs:boolean does not raise a warning #46" {
     run ../bin/xspec.sh xspec-46.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${lines[4]}" =~ "Testing with" ]]
+    [[ "${lines[5]}" =~ "Testing with" ]]
 }
 
+#
+# XProc (Saxon)
+#
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding (XSLT)" {
     if [ -z "${XMLCALABASH_JAR}" ]; then
         skip "XMLCALABASH_JAR is not defined"
     fi
 
+    expected_report="${work_dir}/xspec-72-result.html"
     run java -jar "${XMLCALABASH_JAR}" \
         -i source=xspec-72.xspec \
-        -p xspec-home=file:${PWD}/../ \
-        -o result=xspec/xspec-72-result.html \
+        -o result="file:${expected_report}" \
+        -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/saxon/saxon-xslt-harness.xproc
-    run java -jar "${SAXON_JAR}" -s:xspec/xspec-72-result.html -xsl:html-charset.xsl
+    run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:html-charset.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
 }
-
 
 @test "executing the Saxon XProc harness generates a report with UTF-8 encoding (XQuery)" {
     if [ -z "${XMLCALABASH_JAR}" ]; then
         skip "XMLCALABASH_JAR is not defined"
     fi
 
+    expected_report="${work_dir}/xspec-72-result.html"
     run java -jar "${XMLCALABASH_JAR}" \
         -i source=xspec-72.xspec \
-        -p xspec-home=file:${PWD}/../ \
-        -o result=xspec/xspec-72-result.html \
+        -o result="file:${expected_report}" \
+        -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/saxon/saxon-xquery-harness.xproc
-    run java -jar "${SAXON_JAR}" -s:xspec/xspec-72-result.html -xsl:html-charset.xsl
+    run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:html-charset.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
 }
 
+#
+# Path containing special chars (CLI)
+#
 
-@test "invoking xspec with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs and loads doc #610 successfully and generates HTML report file (XSLT)" {
+@test "invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (XSLT)" {
     special_chars_dir="${work_dir}/some'path (84) here & there"
     mkdir "${special_chars_dir}"
     cp do-nothing.xsl         "${special_chars_dir}"
     cp xspec-node-selection.* "${special_chars_dir}"
 
+    unset TEST_DIR
     expected_report="${special_chars_dir}/xspec/xspec-node-selection-result.html"
 
     run ../bin/xspec.sh "${special_chars_dir}/xspec-node-selection.xspec"
@@ -330,13 +419,13 @@ teardown() {
     [ -f "${expected_report}" ]
 }
 
-
-@test "invoking xspec with path containing parentheses #84, an apostrophe #119 or an ampersand #202 runs and loads doc #610 successfully and generates HTML report file (XQuery)" {
+@test "invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (XQuery)" {
     special_chars_dir="${work_dir}/some'path (84) here & there"
     mkdir "${special_chars_dir}"
     cp do-nothing.xquery      "${special_chars_dir}"
     cp xspec-node-selection.* "${special_chars_dir}"
 
+    unset TEST_DIR
     expected_report="${special_chars_dir}/xspec/xspec-node-selection-result.html"
 
     run ../bin/xspec.sh -q "${special_chars_dir}/xspec-node-selection.xspec"
@@ -346,6 +435,26 @@ teardown() {
     [ -f "${expected_report}" ]
 }
 
+@test "invoking xspec with path containing special chars (#84 #119 #202 #716) runs and loads doc (#610) successfully and generates HTML report file (Schematron)" {
+    skip "Skip until #716 gets fixed"
+
+    special_chars_dir="${work_dir}/some'path (84) here & there"
+    mkdir "${special_chars_dir}"
+    cp ../tutorial/schematron/demo-03* "${special_chars_dir}"
+
+    unset TEST_DIR
+    expected_report="${special_chars_dir}/xspec/demo-03-result.html"
+
+    run ../bin/xspec.sh -s "${special_chars_dir}/demo-03.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[32]}" = "Report available at ${expected_report}" ]
+    [ -f "${expected_report}" ]
+}
+
+#
+# saxon script
+#
 
 @test "invoking xspec with saxon script uses the saxon script #121 #122" {
     echo "echo 'Saxon script with EXPath Packaging System'" > "${work_dir}/saxon"
@@ -357,24 +466,22 @@ teardown() {
     [ "${lines[0]}" = "Saxon script found, use it." ]
 }
 
+#
+# Schematron phase/parameters
+#
 
 @test "Schematron phase/parameters are passed to Schematron compile (command line)" {
-    # Make the line numbers predictable by providing an existing output dir
-    export TEST_DIR="${work_dir}"
-
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-param-001-step3.xsl
     run ../bin/xspec.sh -s schematron/schematron-param-001.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[19]}" == "passed: 9 / pending: 0 / failed: 0 / total: 9" ]
+    [ "${lines[20]}" = "passed: 9 / pending: 0 / failed: 0 / total: 9" ]
 }
-
 
 @test "Schematron phase/parameters are passed to Schematron compile (Ant)" {
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -Dclean.output.dir=true \
         -Dtest.type=s \
         -Dxspec.schematron.preprocessor.step3="${PWD}/schematron/schematron-param-001-step3.xsl" \
         -Dxspec.xml="${PWD}/schematron/schematron-param-001.xspec"
@@ -382,8 +489,14 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 9 / pending: 0 / failed: 0 / total: 9" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Cleanup
+    rm schematron/schematron-param-001.sch-preprocessed.xsl
 }
 
+#
+# Schematron XSLTs provided externally
+#
 
 @test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (command line)" {
     export SCHEMATRON_XSLT_INCLUDE=schematron/schematron-xslt-include.xsl
@@ -393,18 +506,16 @@ teardown() {
     run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[3]}"  = "I am schematron-xslt-include.xsl!" ]
-    [ "${lines[4]}"  = "I am schematron-xslt-expand.xsl!" ]
-    [ "${lines[5]}"  = "I am schematron-xslt-compile.xsl!" ]
-    [ "${lines[18]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
+    [ "${lines[4]}"  = "I am schematron-xslt-include.xsl!" ]
+    [ "${lines[5]}"  = "I am schematron-xslt-expand.xsl!" ]
+    [ "${lines[6]}"  = "I am schematron-xslt-compile.xsl!" ]
+    [ "${lines[19]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
 }
-
 
 @test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)" {
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -Dclean.output.dir=true \
         -Dtest.type=s \
         -Dxspec.schematron.preprocessor.step1="${PWD}/schematron/schematron-xslt-include.xsl" \
         -Dxspec.schematron.preprocessor.step2="${PWD}/schematron/schematron-xslt-expand.xsl" \
@@ -417,68 +528,138 @@ teardown() {
     [[ "${output}" =~ "I am schematron-xslt-compile.xsl!" ]]
     [[ "${output}" =~ "passed: 3 / pending: 0 / failed: 0 / total: 3" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Cleanup
+    rm ../tutorial/schematron/demo-01.sch-preprocessed.xsl
 }
 
+#
+# CLI with TEST_DIR
+#
 
-@test "invoking xspec with the -s option does not display Schematron warnings #129 #131 and removes temporary files" {
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
+@test "invoking xspec with TEST_DIR creates files in TEST_DIR (XSLT)" {
+    # Delete default output dir if exists
+    rm -rf ../tutorial/xspec
+
+    # Run with absolute TEST_DIR
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[3]}" == "Converting Schematron XSpec into XSLT XSpec..." ]
+    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
 
-    # Cleanup removes temporary files in TEST_DIR
-    run ls ../tutorial/schematron/xspec
-    echo "$output"
-    [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
-    [ "${lines[1]}" = "demo-03-result.html" ]
-    [ "${lines[2]}" = "demo-03-result.xml" ]
-}
-
-
-@test "invoking xspec -s with TEST_DIR creates files in TEST_DIR" {
-    # Absolute
-    export TEST_DIR="${work_dir}/test_dir"
-    run ../bin/xspec.sh -s schematron-017.xspec
-    echo "$output"
-    [ "$status" -eq 0 ]
-
-    # Specified TEST_DIR
+    # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
-    [ "${lines[1]}" = "schematron-017-result.html" ]
-    [ "${lines[2]}" = "schematron-017-result.xml" ]
+    [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
+    [ "${lines[1]}" = "escape-for-regex-result.html" ]
+    [ "${lines[2]}" = "escape-for-regex-result.xml" ]
 
-    # Default TEST_DIR
-    run ls xspec
-    echo "$output"
-    [ "${#lines[@]}" = "0" ]
+    # Default output dir should not be created
+    [ ! -d ../tutorial/xspec ]
 
-    # Relative
-    export TEST_DIR=xspec
-    run ../bin/xspec.sh -s schematron-017.xspec
+    # Run with relative TEST_DIR
+    export TEST_DIR=../tutorial/xspec
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
+    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
 
-    # Specified TEST_DIR
+    # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
-    [ "${lines[1]}" = "schematron-017-result.html" ]
-    [ "${lines[2]}" = "schematron-017-result.xml" ]
+    [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
+    [ "${lines[1]}" = "escape-for-regex-result.html" ]
+    [ "${lines[2]}" = "escape-for-regex-result.xml" ]
+
+    # Cleanup
+    rm -r "${TEST_DIR}"
 }
 
+@test "invoking xspec with TEST_DIR creates files in TEST_DIR (XQuery)" {
+    # Delete default output dir if exists
+    rm -rf ../tutorial/xspec
 
-@test "invoking xspec with -q option runs XSpec test for XQuery" {
+    # Run with absolute TEST_DIR
     run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
-    echo "${lines[5]}"
+    echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
+
+    # Verify files in specified TEST_DIR
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
+    [ "${lines[1]}" = "xquery-tutorial-result.html" ]
+    [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
+
+    # Default output dir should not be created
+    [ ! -d ../tutorial/xspec ]
+
+    # Run with relative TEST_DIR
+    export TEST_DIR=../tutorial/xspec
+    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
+
+    # Verify files in specified TEST_DIR
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
+    [ "${lines[1]}" = "xquery-tutorial-result.html" ]
+    [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
+
+    # Cleanup
+    rm -r "${TEST_DIR}"
 }
 
+@test "invoking xspec with TEST_DIR creates files in TEST_DIR (Schematron)" {
+    # Delete default output dir if exists
+    rm -rf ../test/xspec
+
+    # Run with absolute TEST_DIR
+    run ../bin/xspec.sh -s schematron-017.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[16]}" = "Report available at ${TEST_DIR}/schematron-017-result.html" ]
+
+    # Verify files in specified TEST_DIR
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
+    [ "${lines[1]}" = "schematron-017-result.html" ]
+    [ "${lines[2]}" = "schematron-017-result.xml" ]
+
+    # Default output dir should not be created
+    [ ! -d xspec ]
+
+    # Run with relative TEST_DIR
+    export TEST_DIR=../test/xspec
+    run ../bin/xspec.sh -s schematron-017.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[16]}" = "Report available at ${TEST_DIR}/schematron-017-result.html" ]
+
+    # Verify files in specified TEST_DIR
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
+    [ "${lines[1]}" = "schematron-017-result.html" ]
+    [ "${lines[2]}" = "schematron-017-result.xml" ]
+
+    # Cleanup
+    rm -r "${TEST_DIR}"
+}
+
+#
+# XProc (BaseX)
+#
 
 @test "XProc harness for BaseX (standalone)" {
     if [ -z "${BASEX_JAR}" ]; then
@@ -494,10 +675,10 @@ teardown() {
 
     run java -jar "${XMLCALABASH_JAR}" \
         -i source=../tutorial/xquery-tutorial.xspec \
-        -p xspec-home="file:${PWD}/../" \
+        -o result="file:${expected_report}" \
         -p basex-jar="${BASEX_JAR}" \
         -p compiled-file="file:${compiled_file}" \
-        -o result="file:${expected_report}" \
+        -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     echo "$output"
     [ "$status" -eq 0 ]
@@ -507,7 +688,6 @@ teardown() {
     [ -f "${compiled_file}" ]
     [ -f "${expected_report}" ]
 }
-
 
 @test "XProc harness for BaseX (server)" {
     if [ -z "${BASEX_JAR}" ]; then
@@ -528,12 +708,12 @@ teardown() {
 
     run java -jar "${XMLCALABASH_JAR}" \
         -i source=../tutorial/xquery-tutorial.xspec \
-        -p xspec-home="file:${PWD}/../" \
-        -p endpoint=http://localhost:8984/rest \
-        -p username=admin \
-        -p password=admin \
-        -p auth-method=Basic \
         -o result="file:${expected_report}" \
+        -p auth-method=Basic \
+        -p endpoint=http://localhost:8984/rest \
+        -p password=admin \
+        -p username=admin \
+        -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/basex/basex-server-xquery-harness.xproc
     echo "$output"
     [ "$status" -eq 0 ]
@@ -547,15 +727,31 @@ teardown() {
     "${basex_home}/bin/basexhttpstop"
 }
 
+#
+# Ant with minimum properties
+#
 
-@test "Ant for XSLT with default properties fails on test failure" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib "${SAXON_JAR}"
+@test "Ant with minimum properties (XSLT)" {
+    # Unset any preset args
+    unset ANT_ARGS
+
+    # Delete default output dir if exists
+    rm -rf ../tutorial/xspec
+
+    # Run
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
     echo "$output"
+
+    # Default xspec.fail is true
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 
-    # Verify
+    # Verify default output dir
+    # * Default clean.output.dir is false
     # * Default xspec.coverage.enabled is false
     # * Default xspec.junit.enabled is false
     run env LC_ALL=C ls ../tutorial/xspec
@@ -570,41 +766,107 @@ teardown() {
     run java -jar "${SAXON_JAR}" -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
+
+    # Cleanup
+    rm -r ../tutorial/xspec
 }
 
+@test "Ant with minimum properties (XQuery)" {
+    # Unset any preset args
+    unset ANT_ARGS
 
-@test "Ant for XSLT with xspec.fail=false continues on test failure" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib "${SAXON_JAR}" -Dxspec.fail=false
+    # Delete default output dir if exists
+    rm -rf ../tutorial/xspec
+
+    # Run
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=q \
+        -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
+    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Verify default output dir
+    # * Default clean.output.dir is false
+    # * Default xspec.junit.enabled is false
+    run env LC_ALL=C ls ../tutorial/xspec
+    echo "$output"
+    [ "${#lines[@]}" = "4" ]
+    [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
+    [ "${lines[1]}" = "xquery-tutorial-result.html" ]
+    [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
+    [ "${lines[3]}" = "xquery-tutorial_xml-to-properties.xml" ]
+
+    # Cleanup
+    rm -r ../tutorial/xspec
 }
 
+@test "Ant with minimum properties (Schematron)" {
+    # Unset any preset args
+    unset ANT_ARGS
 
-@test "Ant for XSLT with catalog resolves URI" {
+    # Delete default output dir if exists
+    rm -rf ../tutorial/schematron/xspec
+
+    # Run
+    # * Should work without phase #168
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=s \
+        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-03.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Verify default output dir
+    # * Default clean.output.dir is false
+    # * Default xspec.junit.enabled is false
+    run env LC_ALL=C ls ../tutorial/schematron/xspec
+    echo "$output"
+    [ "${#lines[@]}" = "8" ]
+    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
+    [ "${lines[1]}" = "demo-03-result.html" ]
+    [ "${lines[2]}" = "demo-03-result.xml" ]
+    [ "${lines[3]}" = "demo-03-sch-preprocessed.xspec" ]
+    [ "${lines[4]}" = "demo-03-sch-step3-wrapper.xsl" ]
+    [ "${lines[5]}" = "demo-03-step1.sch" ]
+    [ "${lines[6]}" = "demo-03-step2.sch" ]
+    [ "${lines[7]}" = "demo-03_xml-to-properties.xml" ]
+
+    # Verify that the preprocessed XSLT is left. Delete it at the same time.
+    rm ../tutorial/schematron/demo-03.sch-preprocessed.xsl
+
+    # Cleanup
+    rm -r ../tutorial/schematron/xspec
+}
+
+#
+# Catalog (Ant)
+#
+
+@test "Ant with catalog resolves URI (XSLT)" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
         skip "XML_RESOLVER_JAR is not defined"
     fi
 
-    run ant -buildfile ../build.xml -Dxspec.xml=${PWD}/catalog/catalog-02-xslt.xspec -lib "${SAXON_JAR}" -Dcatalog=${PWD}/catalog/catalog-02-catalog.xml -lib "${XML_RESOLVER_JAR}"
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="${PWD}/catalog/catalog-02-catalog.xml" \
+        -Dxspec.xml="${PWD}/catalog/catalog-02-xslt.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
-
-@test "Ant for XQuery with default properties" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/xquery-tutorial.xspec -lib "${SAXON_JAR}" -Dtest.type=q
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
-    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
-}
-
-
-@test "Ant for XQuery with catalog resolves URI" {
+@test "Ant with catalog resolves URI (XQuery)" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
         skip "XML_RESOLVER_JAR is not defined"
     fi
@@ -622,80 +884,106 @@ teardown() {
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
+@test "Ant with catalog resolves URI (Schematron)" {
+    if [ -z "${XML_RESOLVER_JAR}" ]; then
+        skip "XML_RESOLVER_JAR is not defined"
+    fi
 
-@test "Ant for Schematron with minimum properties #168" {
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="${PWD}/catalog/catalog-02-catalog.xml" \
+        -Dclean.output.dir=true \
         -Dtest.type=s \
+        -Dxspec.xml="${PWD}/catalog/catalog-02-schematron.xspec"
+    echo "$output"
+
+    # Default xspec.fail should make the build fail on test failure
+    [ "$status" -eq 1 ]
+    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
+    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
+
+    # Verify the build fails before cleanup
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "8" ]
+
+    # Verify that the build fails after Schematron preprocess and leaves preprocessed XSLT file. Delete it at the same time.
+    rm catalog/02/tested.sch-preprocessed.xsl
+}
+
+#
+# Ant various properties
+#
+
+@test "Ant for XSLT with xspec.fail=false continues on test failure" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.fail=false \
+        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+}
+
+@test "Ant for Schematron with various properties except catalog" {
+    build_xml="${work_dir}/build.xml"
+
+    # For testing -Dxspec.project.dir
+    cp ../build.xml "${build_xml}"
+
+    # Delete default output dir if exists
+    rm -rf ../tutorial/schematron/xspec
+
+    # Run
+    run ant \
+        -buildfile "${build_xml}" \
+        -lib "${SAXON_JAR}" \
+        -Dclean.output.dir=true \
+        -Dxspec.project.dir="${PWD}/.." \
+        -Dxspec.properties="${PWD}/schematron.properties" \
         -Dxspec.xml="${PWD}/../tutorial/schematron/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
-    # Verify that the default clean.output.dir is false and leaves temp files. Delete the left XSLT file at the same time.
-    [  -d "../tutorial/schematron/xspec/" ]
-    rm    "../tutorial/schematron/demo-03.sch-preprocessed.xsl"
-}
-
-
-@test "Ant for Schematron with various properties except catalog" {
-    build_xml="${work_dir}/build.xml"
-    ant_test_dir="${work_dir}/ant-temp"
-
-    # Remove a temp dir created by setup
-    rm -r ../tutorial/schematron/xspec
-
-    # For testing -Dxspec.project.dir
-    cp ../build.xml "${build_xml}"
-
-    run ant -buildfile "${build_xml}" -Dxspec.xml=${PWD}/../tutorial/schematron/demo-03.xspec -lib "${SAXON_JAR}" -Dxspec.properties=${PWD}/schematron.properties -Dxspec.project.dir=${PWD}/.. -Dxspec.dir="${ant_test_dir}" -Dclean.output.dir=true
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 10 / pending: 1 / failed: 0 / total: 11" ]]
-    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
-
-    # Verify that -Dxspec-dir was honered and the default dir was not created
-    [ ! -d "../tutorial/schematron/xspec/" ]
+    # Verify that -Dxspec.dir was honored and the default output dir was not created
+    [ ! -d ../tutorial/schematron/xspec ]
 
     # Verify clean.output.dir=true
-    [ ! -d "${ant_test_dir}" ]
-    [ ! -f "../tutorial/schematron/demo-03.sch-preprocessed.xsl" ]
+    [ ! -d "${TEST_DIR}" ]
+    [ ! -f ../tutorial/schematron/demo-03.sch-preprocessed.xsl ]
 }
-
-
-@test "Ant for Schematron with catalog and default xspec.fail resolves URI and fails on test failure" {
-    if [ -z "${XML_RESOLVER_JAR}" ]; then
-        skip "XML_RESOLVER_JAR is not defined"
-    fi
-
-    run ant -buildfile ../build.xml -Dxspec.xml=${PWD}/catalog/catalog-02-schematron.xspec -lib "${SAXON_JAR}" -Dtest.type=s -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/catalog-02-catalog.xml -lib "${XML_RESOLVER_JAR}"
-    echo "$output"
-    [ "$status" -eq 1 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
-    [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
-
-    # Verify the build fails before cleanup
-    [  -d "catalog/xspec/" ]
-
-    # Verify that the build fails after Schematron setup and leaves temp XSLT file. Delete it at the same time.
-    rm catalog/02/tested.sch-preprocessed.xsl
-}
-
 
 @test "Ant for Schematron with catalog and xspec.fail=false resolves URI and continues on test failure" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
         skip "XML_RESOLVER_JAR is not defined"
     fi
 
-    run ant -buildfile ../build.xml -Dxspec.xml=${PWD}/catalog/catalog-02-schematron.xspec -lib "${SAXON_JAR}" -Dtest.type=s -Dclean.output.dir=true -Dcatalog=${PWD}/catalog/catalog-02-catalog.xml -lib "${XML_RESOLVER_JAR}" -Dxspec.fail=false
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="${PWD}/catalog/catalog-02-catalog.xml" \
+        -Dtest.type=s \
+        -Dxspec.fail=false \
+        -Dxspec.xml="${PWD}/catalog/catalog-02-schematron.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 1 / total: 2" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Cleanup
+    rm catalog/02/tested.sch-preprocessed.xsl
 }
 
+#
+# Catalog (CLI -catalog)
+#
 
 @test "invoking xspec for XSLT with -catalog uses XML Catalog resolver and does so even with spaces in file path" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
@@ -710,9 +998,8 @@ teardown() {
     run ../bin/xspec.sh -catalog "${space_dir}/catalog-01-catalog.xml" "${space_dir}/catalog-01-xslt.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[8]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[9]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
-
 
 @test "invoking xspec for XQuery with -catalog uses XML Catalog resolver" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
@@ -723,9 +1010,8 @@ teardown() {
     run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml -q catalog/catalog-01-xquery.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
-
 
 @test "invoking xspec for Schematron with -catalog uses XML Catalog resolver" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
@@ -736,9 +1022,12 @@ teardown() {
     run ../bin/xspec.sh -catalog catalog/catalog-02-catalog.xml -s catalog/catalog-02-schematron.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[13]}" = "passed: 1 / pending: 0 / failed: 1 / total: 2" ]
+    [ "${lines[14]}" = "passed: 1 / pending: 0 / failed: 1 / total: 2" ]
 }
 
+#
+# Catalog (XML_CATALOG)
+#
 
 @test "invoking xspec with XML_CATALOG set uses XML Catalog resolver and does so even with spaces in file path" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
@@ -751,12 +1040,16 @@ teardown() {
 
     export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
     export XML_CATALOG="${space_dir}/catalog-01-catalog.xml"
+
     run ../bin/xspec.sh "${space_dir}/catalog-01-xslt.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[8]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[9]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
+#
+# SAXON_HOME (CLI)
+#
 
 @test "invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
     if [ -z "${XML_RESOLVER_JAR}" ]; then
@@ -765,7 +1058,7 @@ teardown() {
 
     export SAXON_HOME="${work_dir}/saxon"
     mkdir "${SAXON_HOME}"
-    cp "${SAXON_JAR}" "${SAXON_HOME}"
+    cp "${SAXON_JAR}"        "${SAXON_HOME}"
     cp "${XML_RESOLVER_JAR}" "${SAXON_HOME}/xml-resolver-1.2.jar"
     unset SAXON_CP
 
@@ -778,9 +1071,12 @@ teardown() {
     run ../bin/xspec.sh -catalog catalog/catalog-01-catalog.xml catalog/catalog-01-xslt.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[8]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[9]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
+#
+# RelaxNG Schema
+#
 
 @test "Schema detects no error in known good .xspec files" {
     if [ -z "${JING_JAR}" ]; then
@@ -796,13 +1092,12 @@ teardown() {
     [[ "${output}" =~ "/tutorial/coverage/" ]]
 }
 
-
 @test "Schema detects errors in node-selection test" {
     if [ -z "${JING_JAR}" ]; then
         skip "JING_JAR is not defined"
     fi
 
-    # -t for identifying the last line
+    # '-t' for identifying the last line
     run java -jar "${JING_JAR}" -c -t ../src/schemas/xspec.rnc \
         xspec-node-selection.xspec \
         xspec-node-selection_stylesheet.xspec
@@ -818,6 +1113,9 @@ teardown() {
     [[ "${lines[7]}" =~ "Elapsed time" ]]
 }
 
+#
+# saxon.custom.options (Ant)
+#
 
 @test "Ant for XSLT with saxon.custom.options" {
     # Test with a space in file name
@@ -828,7 +1126,11 @@ teardown() {
     xspec_properties="${work_dir}/xspec.properties"
     echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
 
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/saxon-custom-options/test.xspec -lib "${SAXON_JAR}" -Dxspec.properties="${xspec_properties}"
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.properties="${xspec_properties}" \
+        -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
@@ -837,7 +1139,6 @@ teardown() {
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
 }
-
 
 @test "Ant for XQuery with saxon.custom.options" {
     # Test with a space in file name
@@ -848,7 +1149,12 @@ teardown() {
     xspec_properties="${work_dir}/xspec.properties"
     echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
 
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/saxon-custom-options/test.xspec -lib "${SAXON_JAR}" -Dxspec.properties="${xspec_properties}" -Dtest.type=q
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=q \
+        -Dxspec.properties="${xspec_properties}" \
+        -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
@@ -858,6 +1164,9 @@ teardown() {
     [[ "${output}" =~ "Memory used:" ]]
 }
 
+#
+# SAXON_CUSTOM_OPTIONS (CLI)
+#
 
 @test "invoking xspec for XSLT with SAXON_CUSTOM_OPTIONS" {
     # Test with a space in file name
@@ -874,7 +1183,6 @@ teardown() {
     [[ "${output}" =~ "Memory used:" ]]
 }
 
-
 @test "invoking xspec for XQuery with SAXON_CUSTOM_OPTIONS" {
     # Test with a space in file name
     saxon_config="${work_dir}/saxon config.xml"
@@ -890,88 +1198,113 @@ teardown() {
     [[ "${output}" =~ "Memory used:" ]]
 }
 
+#
+# Coverage (Ant)
+#
 
 @test "Ant for XSLT with coverage creates report files" {
     if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
         skip "XSLT_SUPPORTS_COVERAGE is not defined"
     fi
 
-    run ant -buildfile "${PWD}/../build.xml" -Dxspec.xml="${PWD}/../tutorial/coverage/demo.xspec" -lib "${SAXON_JAR}" -Dxspec.coverage.enabled=true
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.coverage.enabled=true \
+        -Dxspec.xml="${PWD}/../tutorial/coverage/demo.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # XML and HTML report file
-    [ -f "../tutorial/coverage/xspec/demo-result.xml" ]
-    [ -f "../tutorial/coverage/xspec/demo-result.html" ]
+    [ -f "${TEST_DIR}/demo-result.xml" ]
+    [ -f "${TEST_DIR}/demo-result.html" ]
 
     # Coverage report file is created and contains CSS inline
-    run java -jar "${SAXON_JAR}" -s:../tutorial/coverage/xspec/demo-coverage.html -xsl:html-css.xsl
+    run java -jar "${SAXON_JAR}" -s:"${TEST_DIR}/demo-coverage.html" -xsl:html-css.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
 }
 
-
 @test "Ant for XQuery with coverage fails" {
-    run ant -buildfile "${PWD}/../build.xml" -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec" -lib "${SAXON_JAR}" -Dtest.type=q -Dxspec.coverage.enabled=true
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=q \
+        -Dxspec.coverage.enabled=true \
+        -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
     [[ "${lines[${#lines[@]}-2]}" =~ "Coverage is supported only for XSLT" ]]
 }
-
 
 @test "Ant for Schematron with coverage fails" {
-    run ant -buildfile "${PWD}/../build.xml" -Dxspec.xml="${PWD}/../tutorial/schematron/demo-01.xspec" -lib "${SAXON_JAR}" -Dtest.type=s -Dxspec.coverage.enabled=true
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=s \
+        -Dxspec.coverage.enabled=true \
+        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-01.xspec"
     echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
     [[ "${lines[${#lines[@]}-2]}" =~ "Coverage is supported only for XSLT" ]]
 }
 
+#
+# JUnit (Ant)
+#
 
 @test "Ant for XSLT with JUnit creates report files" {
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/../tutorial/escape-for-regex.xspec -lib "${SAXON_JAR}" -Dxspec.junit.enabled=true
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.junit.enabled=true \
+        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 1 ]
     [[ "${output}" =~ "passed: 5 / pending: 0 / failed: 1 / total: 6" ]]
     [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 
     # XML report file
-    [ -f "../tutorial/xspec/escape-for-regex-result.xml" ]
+    [ -f "${TEST_DIR}/escape-for-regex-result.xml" ]
 
     # HTML report file
-    [ -f "../tutorial/xspec/escape-for-regex-result.html" ]
+    [ -f "${TEST_DIR}/escape-for-regex-result.html" ]
 
     # JUnit report file
-    [ -f "../tutorial/xspec/escape-for-regex-junit.xml" ]
+    [ -f "${TEST_DIR}/escape-for-regex-junit.xml" ]
 }
 
+#
+# #185
+#
 
 @test "Import order #185" {
-    # Make the line numbers predictable by providing an existing output dir
-    export TEST_DIR="${work_dir}"
-
     run ../bin/xspec.sh xspec-185/import-1.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[5]}"  = "Scenario 1-1" ]
-    [ "${lines[6]}"  = "Scenario 1-2" ]
-    [ "${lines[7]}"  = "Scenario 1-3" ]
-    [ "${lines[8]}"  = "Scenario 2a-1" ]
-    [ "${lines[9]}"  = "Scenario 2a-2" ]
-    [ "${lines[10]}" = "Scenario 2b-1" ]
-    [ "${lines[11]}" = "Scenario 2b-2" ]
-    [ "${lines[12]}" = "Scenario 3" ]
-    [ "${lines[13]}" = "Formatting Report..." ]
+    [ "${lines[6]}"  = "Scenario 1-1" ]
+    [ "${lines[7]}"  = "Scenario 1-2" ]
+    [ "${lines[8]}"  = "Scenario 1-3" ]
+    [ "${lines[9]}"  = "Scenario 2a-1" ]
+    [ "${lines[10]}" = "Scenario 2a-2" ]
+    [ "${lines[11]}" = "Scenario 2b-1" ]
+    [ "${lines[12]}" = "Scenario 2b-2" ]
+    [ "${lines[13]}" = "Scenario 3" ]
+    [ "${lines[14]}" = "Formatting Report..." ]
 }
-
 
 @test "Import order with Ant #185" {
     ant_log="${work_dir}/ant.log"
 
-    run ant -buildfile ${PWD}/../build.xml -Dxspec.xml=${PWD}/xspec-185/import-1.xspec -lib "${SAXON_JAR}" -logfile "${ant_log}"
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -logfile "${ant_log}" \
+        -Dxspec.xml="${PWD}/xspec-185/import-1.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -988,18 +1321,22 @@ teardown() {
     [ "${lines[7]}" = "     [java] Scenario 3" ]
 }
 
+#
+# Ambiguous x:expect
+#
 
 @test "Ambiguous x:expect generates warning" {
-    # Provide TEST_DIR with an existing directory to make the output lines predictable
-    export TEST_DIR="${work_dir}"
     run ../bin/xspec.sh end-to-end/cases/xspec-ambiguous-expect.xspec
     echo "$output"
-    [[ "${lines[10]}" =~ "WARNING: x:expect has boolean @test" ]]
-    [[ "${lines[15]}" =~ "WARNING: x:expect has boolean @test" ]]
-    [[ "${lines[22]}" =~ "WARNING: x:expect has boolean @test" ]]
-    [  "${lines[31]}" =  "Formatting Report..." ]
+    [[ "${lines[11]}" =~ "WARNING: x:expect has boolean @test" ]]
+    [[ "${lines[16]}" =~ "WARNING: x:expect has boolean @test" ]]
+    [[ "${lines[23]}" =~ "WARNING: x:expect has boolean @test" ]]
+    [  "${lines[32]}" =  "Formatting Report..." ]
 }
 
+#
+# Obsolete x:space
+#
 
 @test "Obsolete x:space" {
     run ../bin/xspec.sh obsolete-space/test.xspec
@@ -1009,6 +1346,9 @@ teardown() {
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
+#
+# #423
+#
 
 @test "XSLT selecting nodes without context should be error (XProc) #423" {
     if [ -z "${XMLCALABASH_JAR}" ]; then
@@ -1025,7 +1365,6 @@ teardown() {
     [[ "${lines[${#lines[@]}-1]}" =~ "ERROR:" ]]
 }
 
-
 @test "XQuery selecting nodes without context should be error (XProc) #423" {
     if [ -z "${XMLCALABASH_JAR}" ]; then
         skip "XMLCALABASH_JAR is not defined"
@@ -1041,8 +1380,8 @@ teardown() {
     [[ "${lines[${#lines[@]}-1]}" =~ "ERROR:" ]]
 }
 
-
 @test "XSLT selecting nodes without context should be error (Ant) #423" {
+    # Should be error even when xspec.fail=false
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
@@ -1054,7 +1393,6 @@ teardown() {
     [ "${lines[${#lines[@]}-3]}" = "BUILD FAILED" ]
 }
 
-
 @test "XSLT selecting nodes without context should be error (command line) #423" {
     run ../bin/xspec.sh xspec-423/test.xspec
     echo "$output"
@@ -1062,7 +1400,6 @@ teardown() {
     [[ "${output}" =~ "  XPDY0002:" ]]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
-
 
 @test "XSLT selecting nodes without context should be error (command line -c) #423" {
     if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
@@ -1076,7 +1413,6 @@ teardown() {
     [ "${lines[${#lines[@]}-1]}" = "*** Error collecting test coverage data" ]
 }
 
-
 @test "XQuery selecting nodes without context should be error (command line) #423" {
     run ../bin/xspec.sh -q xspec-423/test.xspec
     echo "$output"
@@ -1085,8 +1421,11 @@ teardown() {
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
+#
+# Invalid @xquery-version
+#
 
-@test "Invalid xquery-version should be error" {
+@test "Invalid @xquery-version should be error" {
     run ../bin/xspec.sh -q xquery-version/invalid.xspec
     echo "$output"
     [ "$status" -eq 1 ]
@@ -1095,6 +1434,9 @@ teardown() {
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
+#
+# report-css-uri
+#
 
 @test "report-css-uri for HTML report file" {
     run ant \
@@ -1107,13 +1449,12 @@ teardown() {
     [ "$status" -eq 0 ]
 
     run java -jar "${SAXON_JAR}" \
-        -s:../tutorial/xspec/escape-for-regex-result.html \
+        -s:"${TEST_DIR}/escape-for-regex-result.html" \
         -xsl:html-css.xsl \
         STYLE-CONTAINS="This CSS file is for testing report-css-uri parameter"
     echo "$output"
     [ "${lines[0]}" = "true" ]
 }
-
 
 @test "report-css-uri for coverage report file" {
     if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
@@ -1130,48 +1471,54 @@ teardown() {
     [ "$status" -eq 0 ]
 
     run java -jar "${SAXON_JAR}" \
-        -s:../tutorial/coverage/xspec/demo-coverage.html \
+        -s:"${TEST_DIR}/demo-coverage.html" \
         -xsl:html-css.xsl \
         STYLE-CONTAINS="This CSS file is for testing report-css-uri parameter"
     echo "$output"
     [ "${lines[0]}" = "true" ]
 }
 
+#
+# #522
+#
 
 @test "Error message when source is not XSpec #522" {
     run ../bin/xspec.sh do-nothing.xsl
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${lines[3]}" =~ "Source document is not XSpec" ]]
+    [[ "${lines[4]}" =~ "Source document is not XSpec" ]]
 }
 
+#
+# User-defined variable in XSpec namespace
+#
 
 @test "Error on user-defined variable in XSpec namespace" {
-    # Make the line numbers predictable by providing an existing output dir
-    export TEST_DIR="${work_dir}"
-
     run ../bin/xspec.sh variable/reserved-name.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${lines[4]}" =~ "x:XSPEC008:" ]]
+    [[ "${lines[5]}" =~ "x:XSPEC008:" ]]
 }
 
+#
+# Deprecated Saxon version
+#
 
 @test "Deprecated Saxon version" {
-    # Make the line numbers predictable by providing an existing output dir
-    export TEST_DIR="${work_dir}"
-
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
 
     if ! java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
-        [ "${lines[2]}" = " " ]
+        [ "${lines[3]}" = " " ]
     else
-        [[ "${lines[2]}" =~ "WARNING: Saxon version " ]]
+        [[ "${lines[3]}" =~ "WARNING: Saxon version " ]]
     fi
 }
 
+#
+# No warning on Ant
+#
 
 @test "No warning on Ant (XSLT) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
@@ -1196,7 +1543,6 @@ teardown() {
     [ "$status" -eq 1 ]
 }
 
-
 @test "No warning on Ant (XQuery) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
         skip "Always expect a deprecation warning on Saxon 9.7"
@@ -1220,7 +1566,6 @@ teardown() {
     [ "$status" -eq 1 ]
 }
 
-
 @test "No warning on Ant (Schematron) #633" {
     if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9.7."; then
         skip "Always expect a deprecation warning on Saxon 9.7"
@@ -1233,7 +1578,6 @@ teardown() {
         -lib "${SAXON_JAR}" \
         -logfile "${ant_log}" \
         -verbose \
-        -Dclean.output.dir=true \
         -Dtest.type=s \
         -Dxspec.xml="${PWD}/xspec-uri.xspec"
     echo "$output"
@@ -1248,8 +1592,14 @@ teardown() {
     run cat "${ant_log}"
     echo "$output"
     [[ "${output}" =~ " [makepath] Setting xspec.schematron.file to file path ${PWD}/do-nothing.sch" ]]
+
+    # Cleanup
+    rm do-nothing.sch-preprocessed.xsl
 }
 
+#
+# @catch should not catch error outside SUT
+#
 
 @test "@catch should not catch error outside SUT (XSLT)" {
     if [ -z "${XSLT_SUPPORTS_3_0}" ]; then
@@ -1292,7 +1642,6 @@ teardown() {
     [[ "${output}" =~ "XPST0017:" ]]
 }
 
-
 @test "@catch should not catch error outside SUT (XQuery)" {
     if [ -z "${XQUERY_SUPPORTS_3_1_DEFAULT}" ]; then
         skip "XQUERY_SUPPORTS_3_1_DEFAULT is not defined"
@@ -1319,6 +1668,9 @@ teardown() {
     [[ "${output}" =~ "XPST0017:" ]]
 }
 
+#
+# Error in SUT should not be caught by default
+#
 
 @test "Error in SUT should not be caught by default (XSLT)" {
     run ../bin/xspec.sh catch/no-by-default.xspec
@@ -1327,7 +1679,6 @@ teardown() {
     [[ "${output}" =~ "  my-error-code: Error signalled " ]]
 }
 
-
 @test "Error in SUT should not be caught by default (XQuery)" {
     run ../bin/xspec.sh -q catch/no-by-default.xspec
     echo "$output"
@@ -1335,6 +1686,9 @@ teardown() {
     [[ "${output}" =~ "  my-error-code: Error signalled " ]]
 }
 
+#
+# Importing Ant build file
+#
 
 @test "Importing Ant build file" {
     run ant \
@@ -1348,6 +1702,9 @@ teardown() {
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 }
 
+#
+# #655
+#
 
 @test "Trace listener should not hardcode output dir #655" {
     if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
@@ -1369,15 +1726,15 @@ teardown() {
     rm -r "${TEST_DIR}"
 }
 
+#
+# x:like errors
+#
 
 @test "x:like errors" {
-    # Make the line numbers predictable by providing an existing output dir
-    export TEST_DIR="${work_dir}"
-
     run ../bin/xspec.sh like/none.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "  x:XSPEC009: x:like: Scenario not found: none" ]
+    [ "${lines[5]}" = "  x:XSPEC009: x:like: Scenario not found: none" ]
 
     run ../bin/xspec.sh like/multiple.xspec
     echo "$output"
@@ -1389,5 +1746,4 @@ teardown() {
     [ "$status" -eq 1 ]
     [ "${lines[4]}" = "  x:XSPEC011: x:like: Reference to ancestor scenario creates infinite loop: parent scenario" ]
 }
-
 


### PR DESCRIPTION
Fixes #583 

The current Bats script creates XSpec output directories here and there inside the repository, and deletes them later. That doesn't scale.
This pull request directs XSpec CLI and Ant to use a common work directory outside the repository.

**Current `master`**
https://github.com/xspec/xspec/blob/5c9015213238be365c5e9b016b5d420230b33c53/test/xspec.bats#L20-L36

**This pull request**
https://github.com/xspec/xspec/blob/f9eac4823bf420b074ac56c392be32b832c5c948/test/xspec.bats#L24-L34

Also
* Some other adjustments are made throughout the Bats script.
* Some test cases are added.

### Further work
Remove `If you earlier ran tests manually without removing the temporary...` from [Wiki](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally#tips).