### PR TITLE
Skip xspec-xmlns.xspec on Saxon 9.7

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -177,6 +177,13 @@
 							and (x:saxon-version() le x:pack-version(9, 9, 1, 5))">
 						<xsl:text>Requires Saxon bug #4376 to have been fixed</xsl:text>
 					</xsl:when>
+
+					<xsl:when
+						test="
+							($pis = 'require-xspec-issue-720-fixed')
+							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
+						<xsl:text>Requires xspec/xspec#720 to have been fixed</xsl:text>
+					</xsl:when>
 				</xsl:choose>
 			</xsl:variable>
 

--- a/test/xspec-xmlns.xspec
+++ b/test/xspec-xmlns.xspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-xspec-issue-720-fixed?>
 <x:description xmlns="http://docbook.org/ns/docbook"
 	xmlns:t1="http://example.org/ns/my/ns1"
 	xmlns:t2="http://example.org/ns/my/ns2"


### PR DESCRIPTION
To avoid #720, this pull request just excludes `xspec-xmlns.xspec` from testing with Saxon 9.7.

I verified
* the test was skipped on Saxon-EE 9.7 on my local machine
* the test was *not* skipped on Saxon 9.8 and 9.9 on Azure, AppVeyor and Travis CI