### PR TITLE
Test with href strip-space=yes

### DIFF
--- a/test/saxon-custom-options/config.xml
+++ b/test/saxon-custom-options/config.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration edition="HE" xmlns="http://saxon.sf.net/ns/configuration">
+	<global recognizeUriQueryParameters="true" />
+
 	<collations>
 		<collation ignore-case="yes" lang="en" uri="x-urn:test:saxon-custom-options:collation" />
 	</collations>

--- a/test/saxon-custom-options/test.xspec
+++ b/test/saxon-custom-options/test.xspec
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xquery"
 	stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="RECOGNIZE_URI_QUERY_PARAMETERS configuration property">
+		<x:scenario label="No query parameter">
+			<x:call function="exactly-one">
+				<x:param href="ws-only-text.xml" />
+			</x:call>
+			<x:expect label="Whitespace-only text nodes are not stripped" select="'A B'"
+				test="normalize-space($x:result)" />
+		</x:scenario>
+
+		<x:scenario label="?strip-space=yes">
+			<x:call function="exactly-one">
+				<x:param href="ws-only-text.xml?strip-space=yes" />
+			</x:call>
+			<x:expect label="Whitespace-only text nodes are stripped" select="'AB'"
+				test="string($x:result)" />
+		</x:scenario>
+	</x:scenario>
+
 	<x:scenario label="Compare 'a' and 'A' using custom collation">
 		<x:call function="compare">
 			<x:param select="'a'" />

--- a/test/saxon-custom-options/ws-only-text.xml
+++ b/test/saxon-custom-options/ws-only-text.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+	<tgroup cols="1">
+		<tbody>
+			<row>
+				<entry>A</entry>
+			</row>
+			<row>
+				<entry>B</entry>
+			</row>
+		</tbody>
+	</tgroup>
+</table>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -952,7 +952,7 @@
         -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" ^
         -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
     call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line  * x "     [xslt] passed: 3 / pending: 0 / failed: 0 / total: 3"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 
     rem Verify '-t'
@@ -971,7 +971,7 @@
         -Dtest.type=q ^
         -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
     call :verify_retval 0
-    call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line  * x "     [xslt] passed: 3 / pending: 0 / failed: 0 / total: 3"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 
     rem Verify '-t'
@@ -990,7 +990,7 @@
     set "SAXON_CUSTOM_OPTIONS=-config:"%SAXON_CONFIG%" -t"
     call :run ..\bin\xspec.bat saxon-custom-options\test.xspec
     call :verify_retval 0
-    call :verify_line -3 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line -3 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
 
     rem Verify '-t'
     call :verify_line  * r "Memory used:"
@@ -1004,7 +1004,7 @@
     set "SAXON_CUSTOM_OPTIONS=-config:"%SAXON_CONFIG%" -t"
     call :run ..\bin\xspec.bat -q saxon-custom-options\test.xspec
     call :verify_retval 0
-    call :verify_line -3 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line -3 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
 
     rem Verify '-t'
     call :verify_line  * r "Memory used:"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1133,7 +1133,7 @@ teardown() {
         -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "passed: 3 / pending: 0 / failed: 0 / total: 3" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify '-t'
@@ -1157,7 +1157,7 @@ teardown() {
         -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${output}" =~ "passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${output}" =~ "passed: 3 / pending: 0 / failed: 0 / total: 3" ]]
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify '-t'
@@ -1177,7 +1177,7 @@ teardown() {
     run ../bin/xspec.sh saxon-custom-options/test.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]}-3]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[${#lines[@]}-3]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]
@@ -1192,7 +1192,7 @@ teardown() {
     run ../bin/xspec.sh -q saxon-custom-options/test.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]}-3]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[${#lines[@]}-3]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
 
     # Verify '-t'
     [[ "${output}" =~ "Memory used:" ]]


### PR DESCRIPTION
This pull request just adds a Bats test for a use case mentioned in https://github.com/xspec/xspec/issues/691#issuecomment-547137347.

The test enables the Saxon option `RECOGNIZE_­URI_­QUERY_­PARAMETERS` not directly in the `SAXON_CUSTOM_OPTIONS` environment variable but indirectly in `config.xml` Saxon configuration file.

### Further work
Mention `?strip-space=` in [Wiki](https://github.com/xspec/xspec/wiki/Writing-Scenarios#whitespace-only-text-nodes).