### PR TITLE
Remove namespace alias from generate-tests-helper.xsl

### DIFF
--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -9,7 +9,6 @@
 
 
 <xsl:stylesheet version="2.0"
-                xmlns="http://www.w3.org/1999/XSL/TransformAlias"
                 xmlns:pkg="http://expath.org/ns/pkg"
                 xmlns:test="http://www.jenitennison.com/xslt/unit-test"
                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -20,8 +19,6 @@
   
 <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/generate-tests-helper.xsl</pkg:import-uri>
 
-<xsl:namespace-alias stylesheet-prefix="#default" result-prefix="xsl"/>
-
 <xsl:key name="functions" 
          match="xsl:function" 
          use="resolve-QName(@name, .)" />
@@ -29,8 +26,8 @@
 <xsl:key name="named-templates" 
          match="xsl:template[@name]"
          use="if (contains(@name, ':'))
-	            then resolve-QName(@name, .)
-	            else QName('', @name)" />
+              then resolve-QName(@name, .)
+              else QName('', @name)" />
 
 <xsl:key name="matching-templates" 
          match="xsl:template[@match]" 
@@ -49,6 +46,7 @@
   <xsl:param name="var" as="xs:string" required="yes" />
   <xsl:param name="type" as="xs:string" select="'variable'" />
   <xsl:param name="pending" select="()" tunnel="yes" as="node()?"/>
+
   <xsl:variable name="variable-is-pending" as="xs:boolean"
     select="self::x:variable and not(empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus))"/>
   <xsl:variable name="var-doc" as="xs:string?"
@@ -57,13 +55,17 @@
     select="if ($var-doc and @href) then concat($var-doc, '-uri') else ()" />
 
   <xsl:if test="$var-doc-uri">
-    <variable name="{$var-doc-uri}" as="xs:anyURI">
+    <xsl:element name="xsl:variable">
+      <xsl:attribute name="name" select="$var-doc-uri" />
+      <xsl:attribute name="as" select="'xs:anyURI'" />
       <xsl:value-of select="resolve-uri(@href, base-uri())" />
-    </variable>
+    </xsl:element>
   </xsl:if>
 
   <xsl:if test="$var-doc">
-    <variable name="{$var-doc}" as="document-node()">
+    <xsl:element name="xsl:variable">
+      <xsl:attribute name="name" select="$var-doc" />
+      <xsl:attribute name="as" select="'document-node()'" />
       <xsl:sequence select="x:copy-namespaces(.)"/>
       <xsl:choose>
         <xsl:when test="@href">
@@ -75,12 +77,12 @@
         </xsl:when>
 
         <xsl:otherwise>
-          <document>
+          <xsl:element name="xsl:document">
             <xsl:apply-templates mode="test:create-node-generator" />
-          </document>
+          </xsl:element>
         </xsl:otherwise>
       </xsl:choose>
-    </variable>
+    </xsl:element>
   </xsl:if>
 
   <xsl:element name="xsl:{$type}">
@@ -103,9 +105,12 @@
           <xsl:attribute name="as" select="'item()*'" />
         </xsl:if>
 
-        <for-each select="${$var-doc}">
-          <sequence select="{(@select, '.'[current()/@href], 'node()')[1]}" />
-        </for-each>
+        <xsl:element name="xsl:for-each">
+          <xsl:attribute name="select" select="concat('$', $var-doc)" />
+          <xsl:element name="xsl:sequence">
+            <xsl:attribute name="select" select="(@select, '.'[current()/@href], 'node()')[1]" />
+          </xsl:element>
+        </xsl:element>
       </xsl:when>
 
       <xsl:otherwise>
@@ -146,24 +151,28 @@
 <xsl:template match="xsl:*" as="element(xsl:element)" mode="test:create-node-generator">
   <!-- Do not just throw XSLT elements (xsl:*) into identity template.
     If you do so, the element being generated becomes a generator... -->
-  <element name="{name()}">
+  <xsl:element name="xsl:element">
+    <xsl:attribute name="name" select="name()" />
+
     <xsl:variable name="context-element" as="element()" select="." />
     <xsl:for-each select="in-scope-prefixes($context-element)[not(. eq 'xml')]">
-      <namespace name="{.}">
+      <xsl:element name="xsl:namespace">
+        <xsl:attribute name="name" select="." />
         <xsl:value-of select="namespace-uri-for-prefix(., $context-element)" />
-      </namespace>
+      </xsl:element>
     </xsl:for-each>
 
     <xsl:apply-templates select="attribute() | node()" mode="#current" />
-  </element>
+  </xsl:element>
 </xsl:template>
 
 <xsl:function name="test:matching-xslt-elements" as="element()*">
   <xsl:param name="element-kind" as="xs:string"/>
   <xsl:param name="element-id" as="item()"/>
   <xsl:param name="stylesheet" as="document-node()"/>
+
   <xsl:sequence select="key($element-kind, $element-id, $stylesheet)"/>
-</xsl:function>  
+</xsl:function>
 
 </xsl:stylesheet>
 

--- a/src/schematron/generate-step3-wrapper.xsl
+++ b/src/schematron/generate-step3-wrapper.xsl
@@ -3,8 +3,7 @@
 	xmlns="http://www.w3.org/1999/XSL/TransformAlias"
 	xmlns:test="http://www.jenitennison.com/xslt/unit-test"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xpath-default-namespace="http://www.jenitennison.com/xslt/xspec">
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
 		This master stylesheet generates a wrapper stylesheet which imports the actual stylesheet
@@ -23,7 +22,9 @@
 
 	<xsl:output indent="yes" />
 
-	<xsl:template as="element(xsl:stylesheet)" match="description">
+	<xsl:namespace-alias result-prefix="xsl" stylesheet-prefix="#default" />
+
+	<xsl:template as="element(xsl:stylesheet)" match="x:description">
 		<!-- Discard zero-length string -->
 		<xsl:variable as="xs:string?" name="actual-preprocessor-uri"
 			select="$ACTUAL-PREPROCESSOR-URI[.]" />
@@ -46,11 +47,11 @@
 			</xsl:if>
 
 			<!-- Resolve x:param -->
-			<xsl:apply-templates select="param" />
+			<xsl:apply-templates select="x:param" />
 		</stylesheet>
 	</xsl:template>
 
-	<xsl:template as="element()+" match="param">
+	<xsl:template as="element()+" match="x:param">
 		<xsl:apply-templates mode="test:generate-variable-declarations" select=".">
 			<xsl:with-param name="var" select="@name" />
 			<xsl:with-param name="type" select="'param'" />


### PR DESCRIPTION
`src/compiler/generate-tests-helper.xsl` is not a standalone stylesheet but a stylesheet *module* which is intended to be included/imported by the other stylesheets.

However, `generate-tests-helper.xsl` cannot be included/imported freely. It contains `xsl:namespace-alias` which affects the other stylesheets.

This pull request removes `xsl:namespace-alias` from `generate-tests-helper.xsl` so that we can reuse its functions more freely.