### PR TITLE
Add Oxygen XQuery XProc transformation scenario

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -407,7 +407,7 @@
 									<null/>
 								</field>
 								<field name="name">
-									<String>XSpec for XSLT using XProc - Copy</String>
+									<String>XSpec for XQuery using XProc</String>
 								</field>
 								<field name="baseURL">
 									<null/>
@@ -425,7 +425,7 @@
 									<null/>
 								</field>
 								<field name="inputXSLURL">
-									<String>${framework}/src/harnesses/saxon/saxon-xslt-harness.xproc</String>
+									<String>${framework}/src/harnesses/saxon/saxon-xquery-harness.xproc</String>
 								</field>
 								<field name="inputXMLURL">
 									<String></String>

--- a/xspec.framework
+++ b/xspec.framework
@@ -334,6 +334,157 @@
 									<String-array/>
 								</field>
 							</xprocScenario>
+							<xprocScenario>
+								<field name="inputPorts">
+									<xprocInputPort-array>
+										<xprocInputPort>
+											<field name="portName">
+												<String>source</String>
+											</field>
+											<field name="urls">
+												<String-array>
+													<String>${currentFileURL}</String>
+												</String-array>
+											</field>
+										</xprocInputPort>
+									</xprocInputPort-array>
+								</field>
+								<field name="outputPorts">
+									<xprocOutputPort-array>
+										<xprocOutputPort>
+											<field name="portName">
+												<String>result</String>
+											</field>
+											<field name="url">
+												<String>${cfdu}/${cfn}.html</String>
+											</field>
+											<field name="showInSequenceView">
+												<Boolean>false</Boolean>
+											</field>
+										</xprocOutputPort>
+									</xprocOutputPort-array>
+								</field>
+								<field name="xprocOptions">
+									<xprocOption-array>
+										<xprocOption>
+											<field name="namespaceURI">
+												<String></String>
+											</field>
+											<field name="localName">
+												<String>xspec-home</String>
+											</field>
+											<field name="value">
+												<String>${framework}/</String>
+											</field>
+										</xprocOption>
+									</xprocOption-array>
+								</field>
+								<field name="xprocParameters">
+									<xprocParameterPort-array>
+										<xprocParameterPort>
+											<field name="portName">
+												<String>parameters</String>
+											</field>
+											<field name="parameters">
+												<xprocParameter-array>
+													<xprocParameter>
+														<field name="namespaceURI">
+															<String></String>
+														</field>
+														<field name="localName">
+															<String>xspec-home</String>
+														</field>
+														<field name="value">
+															<String>${framework}/</String>
+														</field>
+													</xprocParameter>
+												</xprocParameter-array>
+											</field>
+										</xprocParameterPort>
+									</xprocParameterPort-array>
+								</field>
+								<field name="advancedOptionsMap">
+									<null/>
+								</field>
+								<field name="name">
+									<String>XSpec for XSLT using XProc - Copy</String>
+								</field>
+								<field name="baseURL">
+									<null/>
+								</field>
+								<field name="footerURL">
+									<null/>
+								</field>
+								<field name="fOPMethod">
+									<null/>
+								</field>
+								<field name="fOProcessorName">
+									<null/>
+								</field>
+								<field name="headerURL">
+									<null/>
+								</field>
+								<field name="inputXSLURL">
+									<String>${framework}/src/harnesses/saxon/saxon-xslt-harness.xproc</String>
+								</field>
+								<field name="inputXMLURL">
+									<String></String>
+								</field>
+								<field name="defaultScenario">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="isFOPPerforming">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="type">
+									<String>XPROC</String>
+								</field>
+								<field name="saveAs">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="openInBrowser">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="outputResource">
+									<null/>
+								</field>
+								<field name="openOtherLocationInBrowser">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="locationToOpenInBrowserURL">
+									<String>${cfdu}/${cfn}.html</String>
+								</field>
+								<field name="openInEditor">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInHTMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInXMLPane">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="showInSVGPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInResultSetPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="useXSLTInput">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="xsltParams">
+									<list/>
+								</field>
+								<field name="cascadingStylesheets">
+									<String-array/>
+								</field>
+								<field name="xslTransformer">
+									<String>Add-on for Calabash XProc Engine</String>
+								</field>
+								<field name="extensionURLs">
+									<String-array/>
+								</field>
+							</xprocScenario>
 							<antScenario>
 								<field name="additionalAntArgs">
 									<String></String>


### PR DESCRIPTION
This pull request adds **XSpec for _XQuery_ using XProc** transformation scenario to the Oxygen framework.

![xq-xproc](https://user-images.githubusercontent.com/8489367/69397854-1973dd80-0d2b-11ea-8cfa-09bc2ae5f897.png)

Aside from their names, the only difference between the existing **XSpec for _XSLT_ using XProc** and this new additional **XSpec for _XQuery_ using XProc** is this field:

```xml
<field name="inputXSLURL">
	<String>${framework}/src/harnesses/saxon/saxon-xquery-harness.xproc</String>
</field>
```

That should be enough according to our [Wiki](https://github.com/xspec/xspec/wiki/Running-with-XProc).

On Oxygen 21.1 on Windows and Linux, I verified that the new **XSpec for XQuery using XProc** transformation scenario worked with `tutorial/xquery-tutorial.xspec` and `test/xspec-variable.xspec`.
