### PR TITLE
Add XQuery template for Oxygen

### DIFF
--- a/templates/xquery.properties
+++ b/templates/xquery.properties
@@ -1,0 +1,1 @@
+displayName=XQuery Unit Test

--- a/templates/xquery.xspec
+++ b/templates/xquery.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    * Update /x:description/@query which should be the namespace URI of the XQuery module being tested.
+    * Update /x:description/@query-at which should point to the XQuery module file being tested.
+    * Write your test scenario. See https://github.com/xspec/xspec/wiki/Writing-Scenarios for details.
+-->
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    query="http://www.example.com/my-module" query-at="uri/to/my-module.xquery">
+
+    <x:scenario label="Scenario for testing a function">
+        <x:call function="function-name">
+            <x:param select="" />
+        </x:call>
+
+        <x:expect label="" select="" />
+    </x:scenario>
+
+</x:description>

--- a/templates/xquery.xspec
+++ b/templates/xquery.xspec
@@ -5,7 +5,7 @@
     * Write your test scenario. See https://github.com/xspec/xspec/wiki/Writing-Scenarios for details.
 -->
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    query="http://www.example.com/my-module" query-at="uri/to/my-module.xquery">
+    query="http://www.example.com/my-module" query-at="path/to/my-module.xquery">
 
     <x:scenario label="Scenario for testing a function">
         <x:call function="function-name">


### PR DESCRIPTION
This pull request adds an XQuery template for Oxygen.
With this change and `xspec.framework` enabled, Oyxgen menu - **File** - **New** will look like this:

![xq-tmpl](https://user-images.githubusercontent.com/8489367/69398209-93f12d00-0d2c-11ea-8873-1aee62e69907.png)

The past directory structure of this repository suggests that the Oxygen template files should go in `editors/oxygen/templates/`, but that doesn't seem to fit very nicely into `[Oxygen installation]/frameworks/xspec`. Also `xspec.framework` already has this field:

```xml
<field name="templatesLocations">
	<String-array>
		<String>${frameworkDir}/templates</String>
	</String-array>
</field>
```

That's why the files are placed in `templates/`.