### PR TITLE
Add Oxygen transformation scenario for Code Coverage

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -717,7 +717,7 @@
 												<String></String>
 											</field>
 											<field name="value">
-												<String>${xpath_eval(if(doc('${currentFileURL}')/*:description/@schematron) then 's' else 't')}</String>
+												<String>t</String>
 											</field>
 											<field name="defaultValue">
 												<null/>

--- a/xspec.framework
+++ b/xspec.framework
@@ -617,7 +617,7 @@
 												<String>xspec.result.html</String>
 											</field>
 											<field name="description">
-												<String>The location where the result will be copied.</String>
+												<String>The file path where the test result HTML will be created.</String>
 											</field>
 											<field name="value">
 												<String>${cfd}/${cfn}-result.html</String>
@@ -980,7 +980,7 @@
 												<String>xspec.result.html</String>
 											</field>
 											<field name="description">
-												<String>The location where the result will be copied.</String>
+												<String>The file path where the test result HTML will be created.</String>
 											</field>
 											<field name="value">
 												<String>${cfd}/${cfn}-result.html</String>

--- a/xspec.framework
+++ b/xspec.framework
@@ -757,6 +757,29 @@
 										</antParameter>
 										<antParameter>
 											<field name="name">
+												<String>xspec.coverage.html</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>${cfd}/${cfn}-coverage.html</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
 												<String>xspec.fail</String>
 											</field>
 											<field name="description">

--- a/xspec.framework
+++ b/xspec.framework
@@ -734,6 +734,29 @@
 										</antParameter>
 										<antParameter>
 											<field name="name">
+												<String>xspec.coverage.enabled</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>true</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
 												<String>xspec.fail</String>
 											</field>
 											<field name="description">

--- a/xspec.framework
+++ b/xspec.framework
@@ -1071,7 +1071,7 @@
 									<null/>
 								</field>
 								<field name="name">
-									<String>XSpec Code Coverage</String>
+									<String>XSLT Code Coverage</String>
 								</field>
 								<field name="baseURL">
 									<null/>

--- a/xspec.framework
+++ b/xspec.framework
@@ -874,7 +874,7 @@
 									<null/>
 								</field>
 								<field name="name">
-									<String>Run XSpec Test - Copy</String>
+									<String>XSpec Code Coverage</String>
 								</field>
 								<field name="baseURL">
 									<null/>

--- a/xspec.framework
+++ b/xspec.framework
@@ -651,6 +651,323 @@
 									</String-array>
 								</field>
 							</antScenario>
+							<antScenario>
+								<field name="additionalAntArgs">
+									<String></String>
+								</field>
+								<field name="buildTarget">
+									<String></String>
+								</field>
+								<field name="buildFilePath">
+									<String>build.xml</String>
+								</field>
+								<field name="ditaParams">
+									<list>
+										<antParameter>
+											<field name="name">
+												<String>catalog</String>
+											</field>
+											<field name="description">
+												<String>The path to a catalog file that will be used for all XSLTs involved in the XSpec execution.</String>
+											</field>
+											<field name="value">
+												<String>${pd}/catalog.xml</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>clean.output.dir</String>
+											</field>
+											<field name="description">
+												<String>Cleans up all the intermediate files created by the unit process. Set in to false if you want to inspect these files.</String>
+											</field>
+											<field name="value">
+												<String>true</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>test.type</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>${xpath_eval(if(doc('${currentFileURL}')/*:description/@schematron) then 's' else 't')}</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>xspec.fail</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>false</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>xspec.project.dir</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>${frameworkDir}/</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>xspec.result.html</String>
+											</field>
+											<field name="description">
+												<String>The location where the result will be copied.</String>
+											</field>
+											<field name="value">
+												<String>${cfd}/${cfn}-result.html</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>xspec.xml</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>${cf}</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>saxon.custom.options</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<null/>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+									</list>
+								</field>
+								<field name="jvmArgs">
+									<String>-Xmx256m</String>
+								</field>
+								<field name="useCustomJavaHome">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="customJavaHomeDir">
+									<String></String>
+								</field>
+								<field name="useCustomANTHome">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="customANTHomeDir">
+									<String></String>
+								</field>
+								<field name="workingDir">
+									<String>${frameworkDir}/</String>
+								</field>
+								<field name="showConsoleAlways">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="advancedOptionsMap">
+									<null/>
+								</field>
+								<field name="name">
+									<String>Run XSpec Test - Copy</String>
+								</field>
+								<field name="baseURL">
+									<null/>
+								</field>
+								<field name="footerURL">
+									<null/>
+								</field>
+								<field name="fOPMethod">
+									<null/>
+								</field>
+								<field name="fOProcessorName">
+									<null/>
+								</field>
+								<field name="headerURL">
+									<null/>
+								</field>
+								<field name="inputXSLURL">
+									<null/>
+								</field>
+								<field name="inputXMLURL">
+									<null/>
+								</field>
+								<field name="defaultScenario">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="isFOPPerforming">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="type">
+									<String>ANT</String>
+								</field>
+								<field name="saveAs">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="openInBrowser">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="outputResource">
+									<null/>
+								</field>
+								<field name="openOtherLocationInBrowser">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="locationToOpenInBrowserURL">
+									<String>${cfd}/${cfn}-result.html</String>
+								</field>
+								<field name="openInEditor">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInHTMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInXMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInSVGPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInResultSetPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="useXSLTInput">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="xsltParams">
+									<list/>
+								</field>
+								<field name="cascadingStylesheets">
+									<String-array/>
+								</field>
+								<field name="xslTransformer">
+									<String>ANT</String>
+								</field>
+								<field name="extensionURLs">
+									<String-array>
+										<String>${oxygenHome}/classes</String>
+										<String>${oxygenHome}/lib/oxygen.jar</String>
+										<String>${oxygenHome}/lib/oxygenDeveloper.jar</String>
+										<String>${oxygenHome}/lib/oxygenEclipse.jar</String>
+										<String>${oxygenHome}/lib/oxygenDeveloperEclipse.jar</String>
+										<String>${oxygenHome}/lib/oxygen-sandbox.jar</String>
+										<String>${oxygenHome}/lib/oxygen-license.jar</String>
+										<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
+										<String>${oxygenHome}/lib/oxygen-editor-variables-parser.jar</String>
+										<String>${oxygenHome}/lib/xml-apis.jar</String>
+										<String>${oxygenHome}/lib/*resolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
+										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*xerces*.jar</String>
+										<String>${oxygenHome}/lib/guava-*.jar</String>
+									</String-array>
+								</field>
+							</antScenario>
 						</scenario-array>
 					</field>
 					<field name="validationScenarios">

--- a/xspec.framework
+++ b/xspec.framework
@@ -965,7 +965,7 @@
 									<Boolean>true</Boolean>
 								</field>
 								<field name="locationToOpenInBrowserURL">
-									<String>${cfd}/${cfn}-result.html</String>
+									<String>${cfd}/${cfn}-coverage.html</String>
 								</field>
 								<field name="openInEditor">
 									<Boolean>false</Boolean>

--- a/xspec.framework
+++ b/xspec.framework
@@ -911,7 +911,7 @@
 												<String>xspec.coverage.html</String>
 											</field>
 											<field name="description">
-												<String></String>
+												<String>The file path where the coverage report HTML will be created.</String>
 											</field>
 											<field name="value">
 												<String>${cfd}/${cfn}-coverage.html</String>


### PR DESCRIPTION
This pull request adds an Oxygen transformation scenario for Code Coverage.

![oxy-cc-trans](https://user-images.githubusercontent.com/8489367/69401962-d5d4a000-0d39-11ea-84b5-2b05f5f841a6.png)

Running this transformation scenario with XSLT XSpec file generates `[XSpec filename]-coverage.html` in the same directory as the `.xspec` file and opens it in the default Web browser.

We could avoid adding this new transformation scenario and just add the Code Coverage parameters (`xspec.coverage.enabled` (value `false`) and `xspec.coverage.html`) to the existing **Run XSpec Test** transformation scenario. But if we do so, those who want to try Code Coverage have to duplicate the transformation scenario, set `xspec.coverage.enabled` to `true` and update `locationToOpenInBrowserURL` to match `xspec.coverage.html`. That would be tedious, so this pull request provides a transformation scenario dedicated to Code Coverage.

On Oxygen 21.1 on Windows and Linux, I verified that the new **XSpec Code Coverage** transformation scenario worked with `tutorial/coverage/demo.xspec` and `test/xspec-variable_stylesheet.xspec`.