### PR TITLE
Support XQuery in Run XSpec Test transformation scenario

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -400,7 +400,7 @@
 												<String></String>
 											</field>
 											<field name="value">
-												<String>${xpath_eval(if(doc('${currentFileURL}')/*:description/@schematron) then 's' else 't')}</String>
+												<String>${ask('Select test type:', editable_combobox, (${xpath_eval(doc('${currentFileURL}')/*:description ! (@schematron, @query, @stylesheet) ! ('''' || (map{'schematron':'s', 'query':'q', 'stylesheet':'t'})?(name()) || ''':''' || name() || ''';'))}))}</String>
 											</field>
 											<field name="defaultValue">
 												<null/>

--- a/xspec.framework
+++ b/xspec.framework
@@ -551,7 +551,7 @@
 												<String></String>
 											</field>
 											<field name="value">
-												<String>${ask('Select test type:', editable_combobox, (${xpath_eval(doc('${currentFileURL}')/*:description ! (@schematron, @query, @stylesheet) ! ('''' || (map{'schematron':'s', 'query':'q', 'stylesheet':'t'})?(name()) || ''':''' || name() || ''';'))}))}</String>
+												<String>${xpath_eval(((doc('${currentFileURL}')!*:description!(@query,@schematron)!substring(name(),1,1)),'t')[1])}</String>
 											</field>
 											<field name="defaultValue">
 												<null/>


### PR DESCRIPTION
Right now, **Run XSpec Test** transformation scenario 

* cannot test XQuery
* cannot test XSLT when XSpec is both for XSLT and Schematron
  * [`test/xspec-uri.xspec`](https://github.com/xspec/xspec/blob/master/test/xspec-uri.xspec), for example, though I don't think there are many use cases like it

This pull request includes XQuery in the candidates of `test.type` of **Run XSpec Test** transformation scenario.

<details><summary>Initial comment (abandoned)</summary>
<div>

With this change, **Run XSpec Test** transformation scenario interactively asks which test type (XSLT, XQuery, or Schematron) the user wants to run.

![select-test-type](https://user-images.githubusercontent.com/8489367/69404521-d886c380-0d40-11ea-9b9f-bdf5221edc16.gif)

Some users may find this feature annoying, because it's likely that most people write XSpec only for either XSLT or Schematron.
I wanted to make Oxygen run XSpec silently if `x:description` has only one test type (`@query`, `@schematron` or `@stylesheet`). But I don't know how to write Oxygen [editor variables](https://www.oxygenxml.com/doc/versions/21.1/ug-editor/topics/editor-variables.html) to realize it. Feedback is welcome.

I tested this transformation scenario on Oxygen 21.1 on Windows and Linux.
</div>
</details>