### PR TITLE
Publish XSpec development version as Oxygen add-on

### DIFF
--- a/editors/oxygen/add-on/description/0-0-1.xhtml
+++ b/editors/oxygen/add-on/description/0-0-1.xhtml
@@ -4,10 +4,23 @@
 		<title>XSpec</title>
 	</head>
 	<body>
-		<xi:include href="latest.xhtml" xpointer="base-desc" />
 		<div>
-			<xi:include href="latest.xhtml" xpointer="chg-title" />
-			<xi:include href="latest.xhtml" xpointer="chg-0-0-1" />
+			<p>This add-on installs a recent snapshot of the <span style="color:red">development
+					version</span> of XSpec. See <a
+					href="https://github.com/xspec/xspec/wiki/Running-with-Oxygen">Wiki</a> for
+				details.</p>
+			<p>This add-on does <span style="color:red">not</span> work side by side with <b>XSpec
+					Framework</b> add-on (a companion add-on for <b>XSpec Helper view</b>
+				add-on).</p>
+		</div>
+		<div>
+			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
+			<div>
+				<h3>v1.5.0-SNAPSHOT.1</h3>
+				<ul>
+					<li>Initial integration of XSpec framework</li>
+				</ul>
+			</div>
 		</div>
 	</body>
 </html>

--- a/editors/oxygen/add-on/description/0-0-1.xhtml
+++ b/editors/oxygen/add-on/description/0-0-1.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<head>
+		<title>XSpec</title>
+	</head>
+	<body>
+		<xi:include href="latest.xhtml" xpointer="base-desc" />
+		<div>
+			<xi:include href="latest.xhtml" xpointer="chg-title" />
+			<xi:include href="latest.xhtml" xpointer="chg-0-0-1" />
+		</div>
+	</body>
+</html>

--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>XSpec</title>
+	</head>
+	<body>
+		<div xml:id="base-desc">
+			<p>This add-on installs a recent snapshot of the <span style="color:red">development
+					version</span> of XSpec. See <a
+					href="https://github.com/xspec/xspec/wiki/Running-with-Oxygen">Wiki</a> for
+				details.</p>
+			<p>This add-on does <span style="color:red">not</span> work side by side with <b>XSpec
+					Framework</b> add-on (a companion add-on for <b>XSpec Helper view</b>
+				add-on).</p>
+		</div>
+		<div>
+			<h2 style="margin-top: 8mm" xml:id="chg-title">Changelog (not inclusive)</h2>
+			<div>
+				<h3>v1.5.0-SNAPSHOT.2</h3>
+				<ul>
+					<li>Add Oxygen XQuery XProc transformation scenario (<a
+							href="https://github.com/xspec/xspec/pull/736">#736</a>)</li>
+				</ul>
+			</div>
+			<div xml:id="chg-0-0-1">
+				<h3>v1.5.0-SNAPSHOT.1</h3>
+				<ul>
+					<li>Initial integration of XSpec framework</li>
+				</ul>
+			</div>
+		</div>
+	</body>
+</html>

--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -4,7 +4,7 @@
 		<title>XSpec</title>
 	</head>
 	<body>
-		<div xml:id="base-desc">
+		<div>
 			<p>This add-on installs a recent snapshot of the <span style="color:red">development
 					version</span> of XSpec. See <a
 					href="https://github.com/xspec/xspec/wiki/Running-with-Oxygen">Wiki</a> for
@@ -14,7 +14,7 @@
 				add-on).</p>
 		</div>
 		<div>
-			<h2 style="margin-top: 8mm" xml:id="chg-title">Changelog (not inclusive)</h2>
+			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
 				<h3>v1.5.0-SNAPSHOT.2</h3>
 				<ul>
@@ -22,7 +22,7 @@
 							href="https://github.com/xspec/xspec/pull/736">#736</a>)</li>
 				</ul>
 			</div>
-			<div xml:id="chg-0-0-1">
+			<div>
 				<h3>v1.5.0-SNAPSHOT.1</h3>
 				<ul>
 					<li>Initial integration of XSpec framework</li>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>21.0+</xt:oxy_version>
+		<xt:oxy_version>20.1+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 
@@ -53,7 +53,7 @@
 		<xt:location
 			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
 		<xt:version>0.0.1</xt:version>
-		<xt:oxy_version>21.0+</xt:oxy_version>
+		<xt:oxy_version>20.1+</xt:oxy_version>
 		<xt:type>framework</xt:type>
 		<xt:author>https://github.com/xspec/xspec</xt:author>
 		<xt:name>XSpec</xt:name>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>20.1+</xt:oxy_version>
+		<xt:oxy_version>20.0+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 
@@ -53,7 +53,7 @@
 		<xt:location
 			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
 		<xt:version>0.0.1</xt:version>
-		<xt:oxy_version>20.1+</xt:oxy_version>
+		<xt:oxy_version>20.0+</xt:oxy_version>
 		<xt:type>framework</xt:type>
 		<xt:author>https://github.com/xspec/xspec</xt:author>
 		<xt:name>XSpec</xt:name>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>20.0+</xt:oxy_version>
+		<xt:oxy_version>19.1+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 
@@ -53,7 +53,7 @@
 		<xt:location
 			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
 		<xt:version>0.0.1</xt:version>
-		<xt:oxy_version>20.0+</xt:oxy_version>
+		<xt:oxy_version>19.1+</xt:oxy_version>
 		<xt:type>framework</xt:type>
 		<xt:author>https://github.com/xspec/xspec</xt:author>
 		<xt:name>XSpec</xt:name>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>19.1+</xt:oxy_version>
+		<xt:oxy_version>19.0+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 
@@ -53,7 +53,7 @@
 		<xt:location
 			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
 		<xt:version>0.0.1</xt:version>
-		<xt:oxy_version>19.1+</xt:oxy_version>
+		<xt:oxy_version>19.0+</xt:oxy_version>
 		<xt:type>framework</xt:type>
 		<xt:author>https://github.com/xspec/xspec</xt:author>
 		<xt:name>XSpec</xt:name>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xt:extensions xmlns:xi="http://www.w3.org/2001/XInclude"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:xt="http://www.oxygenxml.com/ns/extension"
+	xsi:schemaLocation="http://www.oxygenxml.com/ns/extension http://www.oxygenxml.com/ns/extension/extensions.xsd">
+
+	<!-- This @id value assumes that https://github.com/xspec/ community owns "xspec.io". -->
+	<xt:extension id="io.xspec.xspec">
+
+		<!-- To publish a new version, update this @href to a specific commit archive and increment
+			<xt:version>. -->
+		<xt:location
+			href="https://github.com/xspec/xspec/archive/b19ccd7e181fddc21bf191ce27d67cefd65bcd1f.zip" />
+
+		<!-- The version of this add-on. Increment only the last numeric part ('z' of "0.0.z")
+			whenever we publish a new version of this add-on.
+			Ideally, this version number should be the same as the version of XSpec being installed
+			by this add-on. But <xt:version> consists of only three numeric parts ("x.y.z") which
+			doesn't accommodate pre-release versions of XSpec ("x.y.z-SNAPSHOT.1" or something like
+			that). Use "0.0.z" until we find a better way. -->
+		<xt:version>0.0.2</xt:version>
+
+		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
+			* oXygen add-on and framework require manual testing.
+			* oXygen framework cannot always be backward compatible. See
+			  https://github.com/TEIC/oxygen-tei/issues/30. -->
+		<xt:oxy_version>21.1</xt:oxy_version>
+
+		<xt:type>framework</xt:type>
+
+		<!-- This could be Jeni, but she's not participated in this add-on release. -->
+		<xt:author>https://github.com/xspec/xspec</xt:author>
+
+		<xt:name>XSpec</xt:name>
+
+		<xt:description>
+			<xi:include href="editors/oxygen/add-on/description/latest.xhtml">
+				<xi:fallback>Visit https://github.com/xspec/xspec and see
+					editors/oxygen/add-on/description/latest.xhtml</xi:fallback>
+			</xi:include>
+		</xt:description>
+
+		<xt:license>
+			<xi:include href="LICENSE" parse="text">
+				<xi:fallback>Visit https://github.com/xspec/xspec and see LICENSE</xi:fallback>
+			</xi:include>
+		</xt:license>
+
+	</xt:extension>
+
+	<!-- This <xt:extension> element is only for upgrade testing. Remove this element later. -->
+	<xt:extension id="io.xspec.xspec">
+		<xt:location
+			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
+		<xt:version>0.0.1</xt:version>
+		<xt:oxy_version>21.1</xt:oxy_version>
+		<xt:type>framework</xt:type>
+		<xt:author>https://github.com/xspec/xspec</xt:author>
+		<xt:name>XSpec</xt:name>
+		<xt:description>
+			<xi:include href="editors/oxygen/add-on/description/0-0-1.xhtml">
+				<xi:fallback>Visit https://github.com/xspec/xspec and see
+					editors/oxygen/add-on/description/0-0-1.xhtml</xi:fallback>
+			</xi:include>
+		</xt:description>
+		<xt:license>
+			<xi:include href="LICENSE" parse="text">
+				<xi:fallback>Visit https://github.com/xspec/xspec and see LICENSE</xi:fallback>
+			</xi:include>
+		</xt:license>
+	</xt:extension>
+
+</xt:extensions>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>21.1</xt:oxy_version>
+		<xt:oxy_version>21.0+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 
@@ -53,7 +53,7 @@
 		<xt:location
 			href="https://github.com/xspec/xspec/archive/2e1f0c210ebbc3cedf0d97977a09a6776e505e6a.zip" />
 		<xt:version>0.0.1</xt:version>
-		<xt:oxy_version>21.1</xt:oxy_version>
+		<xt:oxy_version>21.0+</xt:oxy_version>
 		<xt:type>framework</xt:type>
 		<xt:author>https://github.com/xspec/xspec</xt:author>
 		<xt:name>XSpec</xt:name>


### PR DESCRIPTION
This pull request publishes a snapshot of the development version of XSpec as an Oxygen add-on.

I would like to propose publishing a new development version via this add-on channel whenever a notable change gets merged into `master`.

The initial add-on version is v0.0.2 which installs the snapshot of XSpec b19ccd7e181fddc21bf191ce27d67cefd65bcd1f.
The add-on v0.0.1 exists too, but it's just for upgrade testing.

### What is Oxygen add-on?

See an Oxygen [page](https://www.oxygenxml.com/addons.html). Their [video](https://youtu.be/hfV9Ouw22VY?t=90) demonstrates end-user experience.

### What is the development version of XSpec?

Just a specific commit version of `master` branch.

### Where is the add-on package?

No package built. We can take advantage of this repository's queer structure. (Cloning is deploying.)

This pull request just adds an add-on descriptor file ([`oxygen-addon.xml`](https://github.com/AirQuick/xspec/blob/oxy-addon/oxygen-addon.xml)). The add-on descriptor locates one of the [GitHub tree zips](https://github.com/AirQuick/xspec/blob/03548ecb4eb1ad4aec0c6fc09235c578d31c74b7/oxygen-addon.xml#L12-L13).

Once we merge this pull request, the add-on descriptor URL will be `https://github.com/xspec/xspec/raw/master/oxygen-addon.xml`. We could possibly ask SyncRO Soft to XInclude our URL from their [community descriptor](https://www.oxygenxml.com/InstData/Addons/community/updateSite.xml).

### Why version 0.0.z?

See a [comment](https://github.com/AirQuick/xspec/blob/03548ecb4eb1ad4aec0c6fc09235c578d31c74b7/oxygen-addon.xml#L15-L20) in `oxygen-addon.xml`.

### How I tested it

I tested this add-on on Oxygen

* 19.0 build 2017062918
* 19.1 build 2018122811
* 20.0 build 2018042410
* 20.1 build 2018122403
* 21.0 build 2019040204
* 21.1 build 2019101513

on Windows and Linux using the following steps.

You can also follow this steps to see what will happen when we publish this add-on. If your Oxygen version is older than 19, please let me know and I'll look into what we can do.

#### Preparing the test

1. Make sure you don't have another XSpec installed.
   * If you have, you need to disable it before testing this pull request.
   * You may have another framework installed by one of the common methods described in [Wiki](https://github.com/xspec/xspec/wiki/Running-with-Oxygen#running-the-latest-version-of-xspec-with-oxygen).
   * If you're using **XSpec Helper view** add-on, its companion framework add-on takes precedence. You need to disable the companion framework.

1. Open `test/xspec-variable.xspec` on Oxygen.
   * Oxygen's built-in XSpec framework should take effect.
     * XSpec schema should reject `x:variable`.
     * Running **Run XSpec Test** transformation scenario should fail.

#### Installing v0.0.1 of the add-on

1. Oxygen menu - **Help** - **Install new add-ons**.

1. Specify `https://github.com/AirQuick/xspec/raw/oxy-addon/oxygen-addon.xml` in **Show add-ons from** box.
   * v0.0.2 of this add-on should come up.
   * Its description should tell you that this is a snapshot of the development version and should provide the changelog.

1. Do not install v0.0.2 at this time.

1. Uncheck **Show only the latest versions of the add-ons**.
   * v0.0.1 of this add-on should come up.
   * Again, its description should tell you that this is a snapshot of the development version and should provide the changelog.

1. Check v0.0.**1** (not v0.0.**2**) and click **Next**.
   * **License** should be filled with the MIT License.

1. Check **I accept...** and click **Install**.
   * "Not all selected add-ons have valid signatures..." warning pops up. Click **Continue anyway**.

1. "To apply these changes, you must restart..." notification pops up. Click **OK**.

1. Close Oxygen entirely.

1. Launch Oxygen again. It may take some time.

1. "1 new update(s) are available..." notification pops up. Click **Close** for now.

1. Verify that the installed add-on v0.0.1 takes effect.
   * Open `test/xspec-variable.xspec` on Oxygen.
     * XSpec schema should recognize `x:variable`.
     * Running **Run XSpec Test** transformation scenario should succeed.
     * **XSpec for _XQuery_ using XProc** transformation scenario should **not** be found in **Transformation Scenarios** pane

#### Upgrading from v0.0.1 to v0.0.2

1. Oxygen menu - **Help** - **Check for add-ons updates**.
   * "Update available 0.0.2" should comes up.

1. Make sure you have **XSpec** checked. Click **Update**.

1. Check **I accept...** and click **Finish**.
   * "Not all selected add-ons have valid signatures.." warning pops up. Click **Continue anyway**.

1. "To apply these changes, you must restart..." notification pops up. Click **OK**.

1. Close Oxygen entirely.

1. Launch Oxygen again. It may take some time.

1. Verify that the upgraded add-on v0.0.2 takes effect.
   * Open `test/xspec-variable.xspec` on Oxygen.
     * **XSpec for _XQuery_ using XProc** transformation scenario **should be** found in **Transformation Scenarios** pane. Apply it to the currently opened `xspec-variable.xspec`. It should succeed and the report HTML should be opened.

#### Uninstalling the add-on

1. Oxygen menu - **Help** - **Manage add-ons**.

1. Check **XSpec** v0.0.2 and click the bottom left **Uninstall** button.

1. "Are you sure..." pops up. Click **Yes**.

1. "To apply these changes, you must restart..." notification pops up. Click **OK**.

1. Close Oxygen entirely.

1. Launch Oxygen again. It may take some time.

1. Oxygen menu - **Options** - **Preferences** - **Add-ons**.

1. Delete `https://github.com/AirQuick/xspec/raw/oxy-addon/oxygen-addon.xml` to clear the residue of this testing.
