### PR TITLE
Add Schematron template for Oxygen

### DIFF
--- a/templates/schematron.properties
+++ b/templates/schematron.properties
@@ -1,0 +1,1 @@
+displayName=Schematron Unit Test

--- a/templates/schematron.xspec
+++ b/templates/schematron.xspec
@@ -9,7 +9,9 @@
 
     <x:scenario label="Scenario for testing a rule">
         <x:context>
-            <example>XML fragment to be validated by the Schematron being tested</example>
+            <example>
+                <section>XML fragment to be validated by the Schematron being tested</section>
+            </example>
         </x:context>
 
         <x:expect-assert id="my-assert-001" location="/example[1]/section[1]" />

--- a/templates/schematron.xspec
+++ b/templates/schematron.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    * Update /x:description/@schematron which should point to the Schematron file being tested.
+    * Write your test scenario.
+      See https://github.com/xspec/xspec/wiki/Writing-Scenarios-for-Schematron#writing-tests for details.
+-->
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="path/to/my-schematron.sch">
+
+    <x:scenario label="Scenario for testing a rule">
+        <x:context>
+            <example>XML fragment to be validated by the Schematron being tested</example>
+        </x:context>
+
+        <x:expect-assert id="my-assert-001" location="/example[1]/section[1]" />
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Like #737, this pull request adds an Oxygen template for Schematron XSpec.

Compared to the Oxygen 21.1's built-in template, this template is simplified and a little bit more focused on being a template than being a tutorial.

This template has the same name (**Schematron Unit Test**) as the Oxygen 21.1's built-in template in **New Document**. On Oxygen 21.1, the built-in one is a static template which does not have a custom dialog, so I think this pull request can just replace the built-in one. (On the other hand, the built-in **XSLT Unit Test** has a custom dialog. We can't replace it with a static template.)
If the situation remains unchanged on the next version of Oxygen, I would like SyncRO Soft to take this XSpec framework and remove the built-in one on the next version of Oxygen to avoid duplication.