### PR TITLE
release: remove SNAPSHOT from version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.5.0</version>
   
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
Based on our [workflow](https://github.com/xspec/xspec/wiki/Release-Workflow), this is the last pull request to be merged into master before the release of XSpec v1.5.0. (unless something goes wrong in deploying the XSpec artifact to Maven Central)