### PR TITLE
ci: use HTTPS for fetching Maven files

### DIFF
--- a/test/ci/install-deps.cmd
+++ b/test/ci/install-deps.cmd
@@ -10,7 +10,7 @@ set "CURL=%CURL% -fsSL --create-dirs --retry 5"
 
 rem install Saxon
 set "SAXON_JAR=%XSPEC_DEPS%\saxon\saxon9he.jar"
-%CURL% -o "%SAXON_JAR%" "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/%SAXON_VERSION%/Saxon-HE-%SAXON_VERSION%.jar"
+%CURL% -o "%SAXON_JAR%" "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/%SAXON_VERSION%/Saxon-HE-%SAXON_VERSION%.jar"
 
 rem install XML Calabash
 if not defined XMLCALABASH_VERSION (
@@ -43,7 +43,7 @@ path %ANT_HOME%\bin;%PATH%
 
 rem install XML Resolver
 set "XML_RESOLVER_JAR=%XSPEC_DEPS%\xml-resolver\resolver.jar"
-%CURL% -o "%XML_RESOLVER_JAR%" "http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+%CURL% -o "%XML_RESOLVER_JAR%" "https://repo1.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
 
 rem install Jing
 if not defined JING_VERSION (
@@ -51,7 +51,7 @@ if not defined JING_VERSION (
 ) else (
     set "JING_JAR=%XSPEC_DEPS%\jing\jing.jar"
 )
-if defined JING_JAR %CURL% -o "%JING_JAR%" "http://central.maven.org/maven2/org/relaxng/jing/%JING_VERSION%/jing-%JING_VERSION%.jar"
+if defined JING_JAR %CURL% -o "%JING_JAR%" "https://repo1.maven.org/maven2/org/relaxng/jing/%JING_VERSION%/jing-%JING_VERSION%.jar"
 
 rem clean up
 set CURL=

--- a/test/ci/install-deps.sh
+++ b/test/ci/install-deps.sh
@@ -7,7 +7,7 @@ fi
 
 # install Saxon
 export SAXON_JAR=${XSPEC_DEPS}/saxon/saxon9he.jar
-curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
+curl -fsSL --create-dirs --retry 5 -o ${SAXON_JAR} https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar
 
 # install XML Calabash
 if [ -z ${XMLCALABASH_VERSION} ]; then
@@ -39,12 +39,12 @@ export PATH=${ANT_HOME}/bin:${PATH}
 
 # install XML Resolver
 export XML_RESOLVER_JAR=${XSPEC_DEPS}/xml-resolver/resolver.jar
-curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} http://central.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
+curl -fsSL --create-dirs --retry 5 -o ${XML_RESOLVER_JAR} https://repo1.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
 
 #install Jing
 if [ -z ${JING_VERSION} ]; then
     echo "Jing will not be installed";
 else
     export JING_JAR=${XSPEC_DEPS}/jing/jing.jar;
-    curl -fsSL --create-dirs --retry 5 -o ${JING_JAR} http://central.maven.org/maven2/org/relaxng/jing/${JING_VERSION}/jing-${JING_VERSION}.jar;
+    curl -fsSL --create-dirs --retry 5 -o ${JING_JAR} https://repo1.maven.org/maven2/org/relaxng/jing/${JING_VERSION}/jing-${JING_VERSION}.jar;
 fi


### PR DESCRIPTION
In response to https://links.sonatype.com/central/501-https-required, this pull request replaces `http://central.` with `https://repo1.`.

Just replacing `http:` with `https:` didn't work, because of the host name in the cert.