### PR TITLE
fix(xproc): indent results in HTML report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ You are also encouraged to use a scope to highlight which functionality is affec
 | `basex` | BaseX | 
 | `deps` | Dependencies | 
 | `report` | Test result reports | 
+| `xproc` | XProc | 
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
  

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -304,36 +304,48 @@
 
 	<case ifdef="XMLCALABASH_JAR" name="XProc harness for Saxon (XSLT)">
     rem HTML report file
-    set "EXPECTED_REPORT=%WORK_DIR%\xspec-72-result.html"
+    set "ACTUAL_REPORT_DIR=%CD%\end-to-end\cases\actual__\stylesheet"
+    call :mkdir-if-not-exist "%ACTUAL_REPORT_DIR%"
+    set "ACTUAL_REPORT=%ACTUAL_REPORT_DIR%\xspec-serialize-result.html"
 
     rem Run
     call :run java -jar "%XMLCALABASH_JAR%" ^
-        -i source=xspec-72.xspec ^
-        -o result="file:///%EXPECTED_REPORT:\=/%" ^
+        -i source=end-to-end/cases/xspec-serialize.xspec ^
+        -o result="file:///%ACTUAL_REPORT:\=/%" ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xslt-harness.xproc
     call :verify_retval 0
 
-    rem HTML report file should be created and its charset should be UTF-8 #72
-    call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:html-charset.xsl
-    call :verify_line 1 x "true"
+    rem Verify HTML report including #72
+    call :run java -jar "%SAXON_JAR%" ^
+        -s:"%ACTUAL_REPORT%" ^
+        -xsl:end-to-end\processor\html\compare.xsl ^
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/xspec-serialize-result.html" ^
+        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+    call :verify_retval 0
 	</case>
 
 	<case ifdef="XMLCALABASH_JAR" name="XProc harness for Saxon (XQuery)">
     rem HTML report file
-    set "EXPECTED_REPORT=%WORK_DIR%\xspec-72-result.html"
+    set "ACTUAL_REPORT_DIR=%CD%\end-to-end\cases\actual__\query"
+    call :mkdir-if-not-exist "%ACTUAL_REPORT_DIR%"
+    set "ACTUAL_REPORT=%ACTUAL_REPORT_DIR%\xspec-serialize-result.html"
 
     rem Run
     call :run java -jar "%XMLCALABASH_JAR%" ^
-        -i source=xspec-72.xspec ^
-        -o result="file:///%EXPECTED_REPORT:\=/%" ^
+        -i source=end-to-end/cases/xspec-serialize.xspec ^
+        -o result="file:///%ACTUAL_REPORT:\=/%" ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xquery-harness.xproc
     call :verify_retval 0
 
-    rem HTML report file should be created and its charset should be UTF-8 #72
-    call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:html-charset.xsl
-    call :verify_line 1 x "true"
+    rem Verify HTML report including #72
+    call :run java -jar "%SAXON_JAR%" ^
+        -s:"%ACTUAL_REPORT%" ^
+        -xsl:end-to-end\processor\html\compare.xsl ^
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/xspec-serialize-result.html" ^
+        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+    call :verify_retval 0
 	</case>
 
 	<!--
@@ -585,7 +597,7 @@
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\basex\basex-standalone-xquery-harness.xproc
     call :verify_retval 0
-    call :verify_line -1 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line -1 r "..*:passed: 1 / pending: 0 / failed: 0 / total: 1"
 
     rem Compiled file
     call :verify_exist "%COMPILED_FILE%"
@@ -619,7 +631,7 @@
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
     call :verify_line_count 2
-    call :verify_line 2 r "..*/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 2 r "..*:passed: 1 / pending: 0 / failed: 0 / total: 1"
 
     rem HTML report file should be created and its charset should be UTF-8 #72
     call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:html-charset.xsl

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -116,6 +116,10 @@ rem
     if errorlevel 1 call :failed "Failed to mkdir: %~1"
     goto :EOF
 
+:mkdir-if-not-exist
+    if not exist %1 call :mkdir %1
+    goto :EOF
+
 :rmdir
     if exist %1 (
         rem DEL and RMDIR return 0 as long as the parameter is valid

--- a/test/xspec-72.xspec
+++ b/test/xspec-72.xspec
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xquery"
-               stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
-  <x:scenario label="Überprüfung von Umlauten">
-    <x:call function="true" />
-    <x:expect label="Result HTML should specify UTF-8 charset in /html/head/meta to help web browsers to identify umlaut correctly"
-      select="true()" />
-  </x:scenario>
-</x:description>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -373,21 +373,27 @@ teardown() {
     fi
 
     # HTML report file
-    expected_report="${work_dir}/xspec-72-result.html"
+    actual_report_dir="${PWD}/end-to-end/cases/actual__/stylesheet"
+    mkdir -p "${actual_report_dir}"
+    actual_report="${actual_report_dir}/xspec-serialize-result.html"
 
     # Run
     run java -jar "${XMLCALABASH_JAR}" \
-        -i source=xspec-72.xspec \
-        -o result="file:${expected_report}" \
+        -i source=end-to-end/cases/xspec-serialize.xspec \
+        -o result="file:${actual_report}" \
         -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/saxon/saxon-xslt-harness.xproc
     echo "$output"
     [ "$status" -eq 0 ]
 
-    # HTML report file should be created and its charset should be UTF-8 #72
-    run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:html-charset.xsl
+    # Verify HTML report including #72
+    run java -jar "${SAXON_JAR}" \
+        -s:"${actual_report}" \
+        -xsl:end-to-end/processor/html/compare.xsl \
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/xspec-serialize-result.html" \
+        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
     echo "$output"
-    [ "${lines[0]}" = "true" ]
+    [ "$status" -eq 0 ]
 }
 
 @test "XProc harness for Saxon (XQuery)" {
@@ -396,21 +402,27 @@ teardown() {
     fi
 
     # HTML report file
-    expected_report="${work_dir}/xspec-72-result.html"
+    actual_report_dir="${PWD}/end-to-end/cases/actual__/query"
+    mkdir -p "${actual_report_dir}"
+    actual_report="${actual_report_dir}/xspec-serialize-result.html"
 
     # Run
     run java -jar "${XMLCALABASH_JAR}" \
-        -i source=xspec-72.xspec \
-        -o result="file:${expected_report}" \
+        -i source=end-to-end/cases/xspec-serialize.xspec \
+        -o result="file:${actual_report}" \
         -p xspec-home="file:${PWD}/../" \
         ../src/harnesses/saxon/saxon-xquery-harness.xproc
     echo "$output"
     [ "$status" -eq 0 ]
 
-    # HTML report file should be created and its charset should be UTF-8 #72
-    run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:html-charset.xsl
+    # Verify HTML report including #72
+    run java -jar "${SAXON_JAR}" \
+        -s:"${actual_report}" \
+        -xsl:end-to-end/processor/html/compare.xsl \
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/xspec-serialize-result.html" \
+        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
     echo "$output"
-    [ "${lines[0]}" = "true" ]
+    [ "$status" -eq 0 ]
 }
 
 #
@@ -689,7 +701,7 @@ teardown() {
         ../src/harnesses/basex/basex-standalone-xquery-harness.xproc
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${lines[${#lines[@]}-1]}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${lines[${#lines[@]}-1]}" =~ ":passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 
     # Compiled file
     [ -f "${compiled_file}" ]
@@ -730,7 +742,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" = "2" ]
-    [[ "${lines[1]}" =~ "src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
+    [[ "${lines[1]}" =~ ":passed: 1 / pending: 0 / failed: 0 / total: 1" ]]
 
     # HTML report file should be created and its charset should be UTF-8 #72
     run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:html-charset.xsl


### PR DESCRIPTION
Fixes #766 

This pull request inserts a step into the common XProc harness so that the XML report is serialized (on memory) with indentation and reloaded before being consumed by the HTML report.

* fbd21af9e4d917df247d9a047d088bcda6647de9 tests the HTML report generated by XProc harness for Saxon. It fails as expected. ([macOS](https://xspec.visualstudio.com/xspec/_build/results?buildId=687&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=61b979ba-27c9-588c-740e-a675d85b471e&l=274), [Windows](https://ci.appveyor.com/project/xspec/xspec/builds/30483824#L459), [Linux](https://travis-ci.org/xspec/xspec/jobs/644300695#L715-L1269))
* c5b3020318bc9983e85980022adfd663b0e78423 fixes the problem