### PR TITLE
ci(deps): bump BaseX from 8.6.4 to 9.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         # latest Ant
         - ANT_VERSION=1.10.7
 
-        - BASEX_VERSION=8.6.4
+        - BASEX_VERSION=9.3.1
 
     jobs:
         # Note

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     # latest Ant
     ANT_VERSION: 1.10.7
 
-    BASEX_VERSION: 8.6.4
+    BASEX_VERSION: 9.3.1
 
   matrix:
     # Non-mainstream jobs are disabled in favor of Azure Pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ variables:
   # latest Ant
   ANT_VERSION: 1.10.7
 
-  BASEX_VERSION: 8.6.4
+  BASEX_VERSION: 9.3.1
 
 jobs:
   - template: test/ci/azure-pipelines_windows.yml


### PR DESCRIPTION
This pull request just updates the version of BaseX used for testing.

From now on, I'd like to update the BaseX version more frequently just like the other test dependencies such as Saxon and XML Calabash.