### PR TITLE
ci: suppress codespell warnings about fixes disabled in dictionary

### DIFF
--- a/test/ci/run-codespell.cmd
+++ b/test/ci/run-codespell.cmd
@@ -6,5 +6,5 @@ pip install ^
 codespell ^
     --check-filenames ^
     --check-hidden ^
-    --quiet-level 2 ^
+    --quiet-level 6 ^
     --skip="./src/schematron/iso-schematron"

--- a/test/ci/run-codespell.sh
+++ b/test/ci/run-codespell.sh
@@ -14,7 +14,7 @@ if [ "${DO_CODESPELL}" = true ] ; then
     codespell \
         --check-filenames \
         --check-hidden \
-        --quiet-level 2 \
+        --quiet-level 6 \
         --skip="./src/schematron/iso-schematron"
 else
     echo "Skip codespell"


### PR DESCRIPTION
The latest *codespell* warns a lot about `thead  ==> thread` disabled in dictionary:

```console
$ pip install --upgrade git+https://github.com/codespell-project/codespell.git
...
Successfully installed codespell-1.17.0.dev0
$ codespell --quiet-level 2 --skip=".git,./src/schematron/iso-schematron"
./src/reporter/format-xspec-report.xsl:223: thead  ==> thread  | disabled due to the html tag
./src/reporter/format-xspec-report.xsl:232: thead  ==> thread  | disabled due to the html tag
./src/reporter/format-xspec-report.xsl:328: thead  ==> thread  | disabled due to the html tag
./src/reporter/format-xspec-report.xsl:338: thead  ==> thread  | disabled due to the html tag
./test/xspec-param-position.xspec:20: poisition  ==> position
...
```

The warnings are too many. To suppress it, this pull request adds [bitmask `4`](https://github.com/codespell-project/codespell/blob/44fea6d0e9729a9f8a9a50d3091992a6566b465c/codespell_lib/_codespell.py#L269-L270) to `QUIET_LEVEL`:

```console
$ codespell --quiet-level 6 --skip=".git,./src/schematron/iso-schematron"
./test/xspec-param-position.xspec:20: poisition  ==> position
```

(`poisition` is addressed in #774.)
