### PR TITLE
ci: skip codespell .git dir

### DIFF
--- a/test/ci/run-codespell.cmd
+++ b/test/ci/run-codespell.cmd
@@ -3,8 +3,10 @@ pip install ^
     --quiet ^
     codespell
 
+rem ".git" dir is not skipped by default: codespell-project/codespell#783
+rem Skipping nested dirs needs "./": codespell-project/codespell#99
 codespell ^
     --check-filenames ^
     --check-hidden ^
     --quiet-level 2 ^
-    --skip="./src/schematron/iso-schematron"
+    --skip=".git,./src/schematron/iso-schematron"

--- a/test/ci/run-codespell.sh
+++ b/test/ci/run-codespell.sh
@@ -11,11 +11,13 @@ if [ "${DO_CODESPELL}" = true ] ; then
         --user \
         codespell
 
+    # ".git" dir is not skipped by default: codespell-project/codespell#783
+    # Skipping nested dirs needs "./": codespell-project/codespell#99
     codespell \
         --check-filenames \
         --check-hidden \
         --quiet-level 2 \
-        --skip="./src/schematron/iso-schematron"
+        --skip=".git,./src/schematron/iso-schematron"
 else
     echo "Skip codespell"
 fi


### PR DESCRIPTION
Depending on the repository state, *codespell* may find "typo" in `.git` dir:

```console
$ test/ci/run-codespell.sh 
find spelling mistakes in source code
./.git/objects/ba/5426ab526c0cc52e49919213c9b4d645b27b75: ba  ==> by, be
```

This pull request excludes `.git` from *codespell*.