### PR TITLE
ci(deps): bump Oxygen lib versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         # latest Ant
         - ANT_VERSION=1.10.7
 
+        # latest BaseX
         - BASEX_VERSION=9.3.1
 
     jobs:
@@ -30,9 +31,9 @@ env:
           XMLCALABASH_VERSION=1.1.30-98
 
         # latest oXygen
-        - SAXON_VERSION=9.8.0-12
-          ANT_VERSION=1.9.8
-          XMLCALABASH_VERSION=1.1.24-98
+        - SAXON_VERSION=9.9.1-5
+          ANT_VERSION=1.10.7
+          XMLCALABASH_VERSION=1.1.30-99
 
         # highest deprecated Saxon
         - SAXON_VERSION=9.7.0-21

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
     # latest Ant
     ANT_VERSION: 1.10.7
 
+    # latest BaseX
     BASEX_VERSION: 9.3.1
 
   matrix:
@@ -23,9 +24,9 @@ environment:
     #   XMLCALABASH_VERSION: 1.1.30-98
 
     # latest oXygen
-    # - SAXON_VERSION: 9.8.0-12
-    #   ANT_VERSION: 1.9.8
-    #   XMLCALABASH_VERSION: 1.1.24-98
+    # - SAXON_VERSION: 9.9.1-5
+    #   ANT_VERSION: 1.10.7
+    #   XMLCALABASH_VERSION: 1.1.30-99
 
     # highest deprecated Saxon
     # - SAXON_VERSION: 9.7.0-21

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ variables:
   # latest Ant
   ANT_VERSION: 1.10.7
 
+  # latest BaseX
   BASEX_VERSION: 9.3.1
 
 jobs:

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -33,9 +33,9 @@ jobs:
 
         # latest oXygen
         Oxygen:
-          SAXON_VERSION: 9.8.0-12
-          ANT_VERSION: 1.9.8
-          XMLCALABASH_VERSION: 1.1.24-98
+          SAXON_VERSION: 9.9.1-5
+          ANT_VERSION: 1.10.7
+          XMLCALABASH_VERSION: 1.1.30-99
 
         # highest deprecated Saxon
         Saxon-9-7:


### PR DESCRIPTION
This pull request just updates the versions of Saxon, Ant and XML Calabash used for testing in the latest Oxygen environment (22.0 build 2020021016).