### PR TITLE
fix(oxygen): update Ant scenarios to support Oxygen 22.0

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -761,6 +761,7 @@
 								<field name="extensionURLs">
 									<String-array>
 										<String>${oxygenHome}/classes</String>
+										<String>${oxygenHome}/lib/oxygenCommons.jar</String>
 										<String>${oxygenHome}/lib/oxygen.jar</String>
 										<String>${oxygenHome}/lib/oxygenDeveloper.jar</String>
 										<String>${oxygenHome}/lib/oxygenEclipse.jar</String>
@@ -772,7 +773,7 @@
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/*xerces*.jar</String>
 										<String>${oxygenHome}/lib/guava-*.jar</String>
 									</String-array>
@@ -1124,6 +1125,7 @@
 								<field name="extensionURLs">
 									<String-array>
 										<String>${oxygenHome}/classes</String>
+										<String>${oxygenHome}/lib/oxygenCommons.jar</String>
 										<String>${oxygenHome}/lib/oxygen.jar</String>
 										<String>${oxygenHome}/lib/oxygenDeveloper.jar</String>
 										<String>${oxygenHome}/lib/oxygenEclipse.jar</String>
@@ -1135,7 +1137,7 @@
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/*xerces*.jar</String>
 										<String>${oxygenHome}/lib/guava-*.jar</String>
 									</String-array>

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="21.1">
+<project version="22.0">
     <meta>
         <filters directoryPatterns="" filePatterns="\Qxspec.xpr\E" positiveFilePatterns="" showHiddenFiles="false"/>
         <options>
-            <serialized version="21.1" xml:space="preserve">
+            <serialized version="22.0" xml:space="preserve">
                 <serializableOrderedMap>
                     <entry>
                         <String>additional.frameworks.directories</String>


### PR DESCRIPTION
The Ant scenarios in `xspec.framework` do not work on Oxygen 22:
```console
...
BUILD FAILED
...\xspec\build.xml:366: The following error occurred while executing this line:
...\xspec\build.xml:178: java.lang.NoClassDefFoundError: org/apache/log4j/Logger
```

This pull request fixes it by copying the Ant scenario library configuration from Oxygen 22.0 build 2020021016.
Regarding the backward compatibility, I tested the updated Ant scenarios shortly on 21.1 and 19.0.