### PR TITLE
build(oxygen): add-on v0.0.5

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v1.6.0-SNAPSHOT.1</h3>
+				<ul>
+					<li>Support Oxygen 22.0 (<a href="https://github.com/xspec/xspec/pull/780"
+							>#780</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v1.5.0</h3>
 				<ul>
 					<li>Official release of v1.5.0</li>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -10,7 +10,7 @@
 		<!-- To publish a new version, update this @href to a specific commit archive and increment
 			<xt:version>. -->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/v1.5.0.zip" />
+			href="https://github.com/xspec/xspec/archive/4f11f0cb3a8458774c49c84249aa8d280bcf56fd.zip" />
 
 		<!-- The version of this add-on. Increment only the last numeric part ('z' of "0.0.z")
 			whenever we publish a new version of this add-on.
@@ -18,7 +18,7 @@
 			by this add-on. But <xt:version> consists of only three numeric parts ("x.y.z") which
 			doesn't accommodate pre-release versions of XSpec ("x.y.z-SNAPSHOT.1" or something like
 			that). Use "0.0.z" until we find a better way. -->
-		<xt:version>0.0.4</xt:version>
+		<xt:version>0.0.5</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
Following #780, this pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 22.0 build 2020021016 using `https://github.com/AirQuick/xspec/raw/oxy-addon_0-0-5/oxygen-addon.xml`