### PR TITLE
docs: add PlantUML diagram to test/ant/README.md

### DIFF
--- a/test/ant/README.md
+++ b/test/ant/README.md
@@ -1,3 +1,6 @@
+<!-- "?v=" in the src parameter value is to invalidate cache -->
+![diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/AirQuick/xspec/puml_run-xspec-tests-ant/test/ant/diagram.txt?v=1)
+
 1. Run `../run-xspec-tests-ant.sh` (or `.cmd`)
 
 	Alternatively you can open `build.xml` in oXygen and apply **ANT (with Saxon 9 EE XSLT support)** in **Transformation Scenarios** pane. (You may want to duplicate the transformation scenario and set `-silent` in **Additional arguments**.) 

--- a/test/ant/README.md
+++ b/test/ant/README.md
@@ -1,7 +1,7 @@
 # Testing .xspec files
 
 <!-- "?v=" in the src parameter value is to invalidate cache -->
-![diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/AirQuick/xspec/puml_run-xspec-tests-ant/test/ant/diagram.txt?v=1)
+![diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/xspec/xspec/master/test/ant/diagram.txt?v=1)
 
 1. Put `.xspec` files in a directory.
 

--- a/test/ant/README.md
+++ b/test/ant/README.md
@@ -1,17 +1,43 @@
+# Testing .xspec files
+
 <!-- "?v=" in the src parameter value is to invalidate cache -->
 ![diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.github.com/AirQuick/xspec/puml_run-xspec-tests-ant/test/ant/diagram.txt?v=1)
 
+1. Put `.xspec` files in a directory.
+
+   * The default directory is `../` defined by `xspecfiles.dir` Ant property.
+
 1. Run `../run-xspec-tests-ant.sh` (or `.cmd`)
 
-	Alternatively you can open `build.xml` in oXygen and apply **ANT (with Saxon 9 EE XSLT support)** in **Transformation Scenarios** pane. (You may want to duplicate the transformation scenario and set `-silent` in **Additional arguments**.) 
+   * Alternatively you can open `build.xml` in oXygen and apply **ANT (with Saxon 9 EE XSLT support)** in **Transformation Scenarios** pane.
+
+     * You may want to duplicate the transformation scenario and set `-silent` in **Additional arguments**.
 
 1. `run-xspec-tests-ant.sh` (or `.cmd`) runs `build.xml` in this directory.
-1. `build.xml` runs `worker/generate.xsl`.
-1. `generate.xsl` transforms `build-worker_template.xml` into `build-worker.xml`
-	* In doing so, it inspects all `../*.xspec` files and creates a series of `<run-xspec>` elements with every applicable `@test-type`.
-1. `build-worker.xml` runs all the `<run-xspec>` elements.
-	* `<run-xspec>` element is just a handy wrapper to call `xspec` target in XSpec's main Ant build file (`../../build.xml`).
-	* If all the tests in the `.xspec` files passed, `build-worker.xml` exits successfully ("BUILD SUCCESSFUL")
-	* If one of the tests failed, `build-worker.xml` terminates ("BUILD FAILED").
-1. Once you get "BUILD SUCCESSFUL" or "BUILD FAILED", you can delete `build-worker.xml`.
 
+1. `build.xml` runs `worker/generate.xsl`.
+
+1. `generate.xsl` collects `.xspec` files.
+
+1. `generate.xsl` transforms `build-worker_template.xml` into `build-worker.xml`
+
+   * For each `.xspec` file, `<run-xspec>` element is created with every applicable `@test-type`.
+
+1. Done generating `build-worker.xml`.
+
+1. `build.xml` runs the generated `build-worker.xml`.
+
+1. `build-worker.xml` runs all the `<run-xspec>` elements.
+
+   * `<run-xspec>` element is just a handy wrapper to call `xspec` target in XSpec's   main Ant build file (`../../build.xml`).
+   * `<run-xspec>` elements run in parallel (one element in one thread, one thread per logical processor).
+
+1. XSpec's `build.xml` terminates on any Failure.
+
+1. Any Failure bubbles up. If all the tests in the `.xspec` files passed, `build-worker.xml` exits successfully.
+
+   * Now you can delete `build-worker.xml`.
+
+1. `build.xml` returns "BUILD SUCCESSFUL" or "BUILD FAILED".
+
+1. `run-xspec-tests-ant.sh` (or `.cmd`) returns zero on Success, otherwise non zero.

--- a/test/ant/diagram.txt
+++ b/test/ant/diagram.txt
@@ -1,0 +1,71 @@
+@startuml run-xspec-tests-ant
+
+skinparam roundcorner	5
+skinparam sequence {
+	ArrowThickness		1.4
+	ParticipantFontName	Monospaced
+}
+
+hide footbox
+
+actor		"User"								as USER
+collections	".xspec files"						as XSPEC_FILES
+participant	"run-xspec-tests-ant.sh\n(or .cmd)"	as SCRIPT
+participant	"build.xml"							as MAIN_BUILD
+participant	"generate.xsl"						as GENERATOR
+participant	"build-worker.xml"					as WORKER
+participant	"XSpec\nbuild.xml"					as XSPEC_BUILD
+
+autonumber
+
+create XSPEC_FILES
+USER -> XSPEC_FILES: Put
+
+USER -> SCRIPT: Run
+activate SCRIPT
+
+SCRIPT -> MAIN_BUILD: Run
+activate MAIN_BUILD
+
+' == Generate Worker ==
+
+MAIN_BUILD -> GENERATOR: Run
+activate MAIN_BUILD
+activate GENERATOR
+
+GENERATOR -> XSPEC_FILES: Scan
+
+create WORKER
+hnote over WORKER #FEFECE: Transformed from\n""build-worker_template.xml""
+GENERATOR -> WORKER: Generate
+
+GENERATOR --> MAIN_BUILD: Done
+deactivate GENERATOR
+deactivate MAIN_BUILD
+
+' == Run Worker ==
+
+MAIN_BUILD -> WORKER: Run
+activate MAIN_BUILD
+activate WORKER
+
+loop for each .xspec file\nand every applicable test type\n(Schematron, XQuery, XSLT)
+	WORKER -> XSPEC_BUILD: Run
+	activate XSPEC_BUILD
+	XSPEC_BUILD --> WORKER: Success or Failure
+	deactivate XSPEC_BUILD
+end
+
+WORKER --> MAIN_BUILD: Success or Failure
+deactivate WORKER
+deactivate MAIN_BUILD
+
+hnote over WORKER #WhiteSmoke: Can be deleted
+
+MAIN_BUILD --> SCRIPT: Success or Failure
+deactivate MAIN_BUILD
+
+SCRIPT --> USER: Success or Failure
+deactivate SCRIPT
+
+@enduml


### PR DESCRIPTION
`test/ant/` is used for testing `test/*.xspec` and also referenced from [Wiki](https://github.com/xspec/xspec/wiki/Running-with-Ant#using-ant-to-run-multiple-xspec-tests). However, I'm afraid it is somewhat blackboxed.
This pull request adds a PlantUML diagram to `README.md` and describes the overview.