### PR TITLE
test(xslt): skip testing additional type report on Saxon 9.7

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -184,6 +184,14 @@
 							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
 						<xsl:text>Requires xspec/xspec#720 to have been fixed</xsl:text>
 					</xsl:when>
+
+					<xsl:when
+						test="
+							($test-type eq 't')
+							and ($pis = 'require-type-available-in-use-when')
+							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
+						<xsl:text>Requires type-available() to be reliable in @use-when</xsl:text>
+					</xsl:when>
 				</xsl:choose>
 			</xsl:variable>
 

--- a/test/end-to-end/cases/xspec-report_schema-aware.xspec
+++ b/test/end-to-end/cases/xspec-report_schema-aware.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test require-xquery-to-support-schema?>
 <?xspec-test require-xslt-to-support-schema?>
+<?xspec-test require-type-available-in-use-when?>
 <x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
 	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/test/generate-tests-utils_schema-aware.xspec
+++ b/test/generate-tests-utils_schema-aware.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test require-xslt-to-support-schema?>
+<?xspec-test require-type-available-in-use-when?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:test="http://www.jenitennison.com/xslt/unit-test"


### PR DESCRIPTION
This XSLT

```xslt
<?xml version="1.0" encoding="UTF-8"?>
<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
	<xsl:output indent="yes" omit-xml-declaration="yes" />
	<xsl:template name="xsl:initial-template">
		<prod>
			<xsl:value-of select="system-property('xsl:product-version')" />
		</prod>
		<test>
			<xsl:value-of select="'Available'" use-when="type-available('xs:ID')" />
		</test>
	</xsl:template>
</xsl:stylesheet>
```

behaves differently on Saxon-EE 9.7:

```console
C:\test>java -jar saxon9ee.jar -it -xsl:test.xsl
<prod>EE 9.7.0.21</prod>
<test/>
```

```
<prod>EE 9.8.0.1</prod>
<test>Available</test>
```

```
<prod>EE 9.8.0.12</prod>
<test>Available</test>
```

```
<prod>EE 9.8.0.14</prod>
<test>Available</test>
```

```
<prod>EE 9.9.1.5</prod>
<test>Available</test>
```

```
<prod>EE 9.9.1.6</prod>
<test>Available</test>
```

Reflecting this behavior, this pull request skips some schema-aware XSLT tests on Saxon 9.7.