### PR TITLE
refactor(report): right-trim labels in HTML report

### DIFF
--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -369,6 +369,12 @@
   </div>
 </xsl:template>
 
+<xsl:template match="x:label" as="text()" mode="x:html-report">
+  <!-- TODO: Consider doing more whitespace normalization or normalizing
+    at an earlier stage (the compiler or the XML report) -->
+  <xsl:value-of select=" replace(., '\s+$', '')" />
+</xsl:template>
+
 <!-- Formats the Actual Result or the Expected Result in HTML -->
 <xsl:template match="element()" as="element()+" mode="x:format-result">
   <xsl:param name="result-to-compare-with" as="element()?" required="yes" />

--- a/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
@@ -137,7 +137,7 @@
                   <th>passed: 5 / pending: 0 / failed: 2 / total: 7</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;elem&gt;text&lt;/elem&gt; </th>
+                  <th>When result is &lt;elem&gt;text&lt;/elem&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -149,7 +149,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario1-scenario2">When result is &lt;elem /&gt; </a></th>
+                  <th><a href="#scenario1-scenario2">When result is &lt;elem /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -161,7 +161,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario1-scenario3">When result is &lt;elem&gt;...&lt;/elem&gt; </a></th>
+                  <th><a href="#scenario1-scenario3">When result is &lt;elem&gt;...&lt;/elem&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -179,7 +179,7 @@
             </tbody>
          </table>
          <div id="scenario1-scenario2">
-            <h3>For resultant element (simple) When result is &lt;elem /&gt; </h3>
+            <h3>For resultant element (simple) When result is &lt;elem /&gt;</h3>
             <div id="scenario1-scenario2-expect2">
                <h4>expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -203,7 +203,7 @@
             </div>
          </div>
          <div id="scenario1-scenario3">
-            <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt; </h3>
+            <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt;</h3>
             <div id="scenario1-scenario3-expect3">
                <h4>expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -240,7 +240,7 @@
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario2-scenario1">When result is &lt;elem attrib="val" /&gt; </a></th>
+                  <th><a href="#scenario2-scenario1">When result is &lt;elem attrib="val" /&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -258,7 +258,7 @@
             </tbody>
          </table>
          <div id="scenario2-scenario1">
-            <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt; </h3>
+            <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt;</h3>
             <div id="scenario2-scenario1-expect3">
                <h4>expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -295,7 +295,7 @@
                   <th>passed: 4 / pending: 0 / failed: 1 / total: 5</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt; </th>
+                  <th>When result is &lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;</th>
                   <th>passed: 3 / pending: 0 / failed: 0 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -311,7 +311,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario3-scenario2">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt; </a></th>
+                  <th><a href="#scenario3-scenario2">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -325,9 +325,7 @@
             </tbody>
          </table>
          <div id="scenario3-scenario2">
-            <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
-               
-            </h3>
+            <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</h3>
             <div id="scenario3-scenario2-expect2">
                <h4>expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -367,7 +365,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is @attrib="val" </th>
+                  <th>When result is @attrib="val"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -379,7 +377,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is @attrib="" </th>
+                  <th>When result is @attrib=""</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -387,7 +385,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario4-scenario3">When result is @attrib="..." </a></th>
+                  <th><a href="#scenario4-scenario3">When result is @attrib="..."</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -405,7 +403,7 @@
             </tbody>
          </table>
          <div id="scenario4-scenario3">
-            <h3>For resultant attribute When result is @attrib="..." </h3>
+            <h3>For resultant attribute When result is @attrib="..."</h3>
             <div id="scenario4-scenario3-expect3">
                <h4>expecting @attrib="val" should be Failure</h4>
                <table class="xspecResult">
@@ -622,7 +620,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;!--comment--&gt; </th>
+                  <th>When result is &lt;!--comment--&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -634,7 +632,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;!----&gt; </th>
+                  <th>When result is &lt;!----&gt;</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -642,7 +640,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario6-scenario3">When result is &lt;!--...--&gt; </a></th>
+                  <th><a href="#scenario6-scenario3">When result is &lt;!--...--&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -660,7 +658,7 @@
             </tbody>
          </table>
          <div id="scenario6-scenario3">
-            <h3>For resultant comment When result is &lt;!--...--&gt; </h3>
+            <h3>For resultant comment When result is &lt;!--...--&gt;</h3>
             <div id="scenario6-scenario3-expect3">
                <h4>expecting &lt;!--comment--&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -697,7 +695,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;?pi data?&gt; </th>
+                  <th>When result is &lt;?pi data?&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -709,7 +707,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;?pi?&gt; </th>
+                  <th>When result is &lt;?pi?&gt;</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -717,7 +715,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario7-scenario3">When result is &lt;?pi ...?&gt; </a></th>
+                  <th><a href="#scenario7-scenario3">When result is &lt;?pi ...?&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -735,7 +733,7 @@
             </tbody>
          </table>
          <div id="scenario7-scenario3">
-            <h3>For resultant processing instruction When result is &lt;?pi ...?&gt; </h3>
+            <h3>For resultant processing instruction When result is &lt;?pi ...?&gt;</h3>
             <div id="scenario7-scenario3-expect3">
                <h4>expecting &lt;?pi data?&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -772,7 +770,7 @@
                   <th>passed: 4 / pending: 0 / failed: 3 / total: 7</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
@@ -784,7 +782,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt; </a></th>
+                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -796,7 +794,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -815,7 +813,7 @@
          </table>
          <div id="scenario8-scenario1">
             <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt; 
+               /&gt;&lt;/xsl:document&gt;
             </h3>
             <div id="scenario8-scenario1-expect1">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
@@ -841,7 +839,7 @@
             </div>
          </div>
          <div id="scenario8-scenario2">
-            <h3>For resultant document node When result is &lt;xsl:document /&gt; </h3>
+            <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
             <div id="scenario8-scenario2-expect2">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -865,7 +863,7 @@
             </div>
          </div>
          <div id="scenario8-scenario3">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
+            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario3-expect3">
                <h4>expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -902,7 +900,7 @@
                   <th>passed: 6 / pending: 0 / failed: 1 / total: 7</th>
                </tr>
                <tr class="successful">
-                  <th>When result is xmlns:prefix="namespace-uri" </th>
+                  <th>When result is xmlns:prefix="namespace-uri"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -914,7 +912,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is xmlns="namespace-uri" </th>
+                  <th>When result is xmlns="namespace-uri"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -926,7 +924,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario9-scenario3">When result is xmlns:prefix="..." </a></th>
+                  <th><a href="#scenario9-scenario3">When result is xmlns:prefix="..."</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -944,7 +942,7 @@
             </tbody>
          </table>
          <div id="scenario9-scenario3">
-            <h3>For resultant namespace node When result is xmlns:prefix="..." </h3>
+            <h3>For resultant namespace node When result is xmlns:prefix="..."</h3>
             <div id="scenario9-scenario3-expect3">
                <h4>expecting xmlns:prefix="namespace-uri" should be Failure</h4>
                <table class="xspecResult">
@@ -981,7 +979,7 @@
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario10-scenario1">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
+                  <th><a href="#scenario10-scenario1">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="successful">
@@ -1008,7 +1006,7 @@
          </table>
          <div id="scenario10-scenario1">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
-               /&gt; 
+               /&gt;
             </h3>
             <div id="scenario10-scenario1-expect3">
                <h4>expecting ... should be Failure</h4>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
@@ -136,7 +136,7 @@
                   <th>passed: 5 / pending: 0 / failed: 2 / total: 7</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;elem&gt;text&lt;/elem&gt; </th>
+                  <th>When result is &lt;elem&gt;text&lt;/elem&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -148,7 +148,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario1-scenario2">When result is &lt;elem /&gt; </a></th>
+                  <th><a href="#scenario1-scenario2">When result is &lt;elem /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -160,7 +160,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario1-scenario3">When result is &lt;elem&gt;...&lt;/elem&gt; </a></th>
+                  <th><a href="#scenario1-scenario3">When result is &lt;elem&gt;...&lt;/elem&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -178,7 +178,7 @@
             </tbody>
          </table>
          <div id="scenario1-scenario2">
-            <h3>For resultant element (simple) When result is &lt;elem /&gt; </h3>
+            <h3>For resultant element (simple) When result is &lt;elem /&gt;</h3>
             <div id="scenario1-scenario2-expect2">
                <h4>expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -202,7 +202,7 @@
             </div>
          </div>
          <div id="scenario1-scenario3">
-            <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt; </h3>
+            <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt;</h3>
             <div id="scenario1-scenario3-expect3">
                <h4>expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -239,7 +239,7 @@
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario2-scenario1">When result is &lt;elem attrib="val" /&gt; </a></th>
+                  <th><a href="#scenario2-scenario1">When result is &lt;elem attrib="val" /&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -257,7 +257,7 @@
             </tbody>
          </table>
          <div id="scenario2-scenario1">
-            <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt; </h3>
+            <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt;</h3>
             <div id="scenario2-scenario1-expect3">
                <h4>expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -294,7 +294,7 @@
                   <th>passed: 4 / pending: 0 / failed: 1 / total: 5</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt; </th>
+                  <th>When result is &lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;</th>
                   <th>passed: 3 / pending: 0 / failed: 0 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -310,7 +310,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario3-scenario2">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt; </a></th>
+                  <th><a href="#scenario3-scenario2">When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -324,9 +324,7 @@
             </tbody>
          </table>
          <div id="scenario3-scenario2">
-            <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
-               
-            </h3>
+            <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</h3>
             <div id="scenario3-scenario2-expect2">
                <h4>expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -366,7 +364,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is @attrib="val" </th>
+                  <th>When result is @attrib="val"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -378,7 +376,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is @attrib="" </th>
+                  <th>When result is @attrib=""</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -386,7 +384,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario4-scenario3">When result is @attrib="..." </a></th>
+                  <th><a href="#scenario4-scenario3">When result is @attrib="..."</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -404,7 +402,7 @@
             </tbody>
          </table>
          <div id="scenario4-scenario3">
-            <h3>For resultant attribute When result is @attrib="..." </h3>
+            <h3>For resultant attribute When result is @attrib="..."</h3>
             <div id="scenario4-scenario3-expect3">
                <h4>expecting @attrib="val" should be Failure</h4>
                <table class="xspecResult">
@@ -621,7 +619,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;!--comment--&gt; </th>
+                  <th>When result is &lt;!--comment--&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -633,7 +631,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;!----&gt; </th>
+                  <th>When result is &lt;!----&gt;</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -641,7 +639,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario6-scenario3">When result is &lt;!--...--&gt; </a></th>
+                  <th><a href="#scenario6-scenario3">When result is &lt;!--...--&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -659,7 +657,7 @@
             </tbody>
          </table>
          <div id="scenario6-scenario3">
-            <h3>For resultant comment When result is &lt;!--...--&gt; </h3>
+            <h3>For resultant comment When result is &lt;!--...--&gt;</h3>
             <div id="scenario6-scenario3-expect3">
                <h4>expecting &lt;!--comment--&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -696,7 +694,7 @@
                   <th>passed: 5 / pending: 0 / failed: 1 / total: 6</th>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;?pi data?&gt; </th>
+                  <th>When result is &lt;?pi data?&gt;</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -708,7 +706,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is &lt;?pi?&gt; </th>
+                  <th>When result is &lt;?pi?&gt;</th>
                   <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
                </tr>
                <tr class="successful">
@@ -716,7 +714,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario7-scenario3">When result is &lt;?pi ...?&gt; </a></th>
+                  <th><a href="#scenario7-scenario3">When result is &lt;?pi ...?&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -734,7 +732,7 @@
             </tbody>
          </table>
          <div id="scenario7-scenario3">
-            <h3>For resultant processing instruction When result is &lt;?pi ...?&gt; </h3>
+            <h3>For resultant processing instruction When result is &lt;?pi ...?&gt;</h3>
             <div id="scenario7-scenario3-expect3">
                <h4>expecting &lt;?pi data?&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -771,7 +769,7 @@
                   <th>passed: 4 / pending: 0 / failed: 3 / total: 7</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
@@ -783,7 +781,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt; </a></th>
+                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -795,7 +793,7 @@
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </a></th>
+                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -814,7 +812,7 @@
          </table>
          <div id="scenario8-scenario1">
             <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt; 
+               /&gt;&lt;/xsl:document&gt;
             </h3>
             <div id="scenario8-scenario1-expect1">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
@@ -840,7 +838,7 @@
             </div>
          </div>
          <div id="scenario8-scenario2">
-            <h3>For resultant document node When result is &lt;xsl:document /&gt; </h3>
+            <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
             <div id="scenario8-scenario2-expect2">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -864,7 +862,7 @@
             </div>
          </div>
          <div id="scenario8-scenario3">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt; </h3>
+            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario3-expect3">
                <h4>expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -901,7 +899,7 @@
                   <th>passed: 6 / pending: 0 / failed: 1 / total: 7</th>
                </tr>
                <tr class="successful">
-                  <th>When result is xmlns:prefix="namespace-uri" </th>
+                  <th>When result is xmlns:prefix="namespace-uri"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -913,7 +911,7 @@
                   <td>Success</td>
                </tr>
                <tr class="successful">
-                  <th>When result is xmlns="namespace-uri" </th>
+                  <th>When result is xmlns="namespace-uri"</th>
                   <th>passed: 2 / pending: 0 / failed: 0 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -925,7 +923,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario9-scenario3">When result is xmlns:prefix="..." </a></th>
+                  <th><a href="#scenario9-scenario3">When result is xmlns:prefix="..."</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
@@ -943,7 +941,7 @@
             </tbody>
          </table>
          <div id="scenario9-scenario3">
-            <h3>For resultant namespace node When result is xmlns:prefix="..." </h3>
+            <h3>For resultant namespace node When result is xmlns:prefix="..."</h3>
             <div id="scenario9-scenario3-expect3">
                <h4>expecting xmlns:prefix="namespace-uri" should be Failure</h4>
                <table class="xspecResult">
@@ -980,7 +978,7 @@
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario10-scenario1">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt; </a></th>
+                  <th><a href="#scenario10-scenario1">When result is sequence of &lt;elem1 /&gt;&lt;elem2 /&gt;</a></th>
                   <th>passed: 2 / pending: 0 / failed: 3 / total: 5</th>
                </tr>
                <tr class="successful">
@@ -1007,7 +1005,7 @@
          </table>
          <div id="scenario10-scenario1">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
-               /&gt; 
+               /&gt;
             </h3>
             <div id="scenario10-scenario1-expect3">
                <h4>expecting ... should be Failure</h4>


### PR DESCRIPTION
In preparation for #588, this pull request removes all whitespace at the end of the label when formatting the HTML report.
As demonstrated in `test/end-to-end/cases/expected/`, this change affects only some headings in the HTML report.

We could possibly perform whitespace normalization in another way. But doing that requires the specification of `@label` and `x:label` to be defined in more details. So this pull request just right-trims HTML headings. For further consideration, I left a [TODO](https://github.com/xspec/xspec/commit/48e3b8872e51dc849859b3c6c8f31303676841ca#diff-40221cb332026fb902b3c89c756e4062R373-R374) comment.