### PR TITLE
test: generate end-to-end test expected result using Saxon 9.9

### DIFF
--- a/test/end-to-end/ant/generate-expected/worker/generate.xsl
+++ b/test/end-to-end/ant/generate-expected/worker/generate.xsl
@@ -19,11 +19,11 @@
 		Rejects specific Saxon versions
 	-->
 	<xsl:template as="document-node(element(project))" match="document-node()">
-		<xsl:if test="x:saxon-version() ge x:pack-version(9, 8, 0, 14)">
+		<xsl:if test="x:saxon-version() lt x:pack-version(9, 9, 0, 2)">
 			<xsl:message terminate="yes">
 				<xsl:text>Saxon version is </xsl:text>
 				<xsl:value-of select="system-property('xsl:product-version')" />
-				<xsl:text>. Generating the expected files on Saxon 9.8.0.14 or later (including 9.9) will produce unrelated changes. You have to generate the expected files on 9.8.0.12 or less (including 9.7).</xsl:text>
+				<xsl:text>. Generating the expected files on Saxon 9.9.0.1 or less will produce unrelated changes. You have to generate the expected files on 9.9.0.2 or later.</xsl:text>
 			</xsl:message>
 		</xsl:if>
 

--- a/test/end-to-end/cases/expected/query/xspec-151-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-151-result.html
@@ -70,14 +70,17 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/*</code> from:
-                           </p><pre>&lt;pseudo-element xmlns:test-mix="x-urn:test-mix"&gt;
+                           <p>XPath <code>/*</code> from:</p>
+                           <pre>&lt;pseudo-element xmlns:test-mix="x-urn:test-mix"&gt;
    &lt;test-mix:fooElement&gt;
       &lt;test-mix:barElement /&gt;
    &lt;/test-mix:fooElement&gt;
 &lt;/pseudo-element&gt;
-&lt;pseudo-atomic-value xmlns:test-mix="x-urn:test-mix"&gt;'string'&lt;/pseudo-atomic-value&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;pseudo-atomic-value xmlns:test-mix="x-urn:test-mix"&gt;'string'&lt;/pseudo-atomic-value&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-153-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-153-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total:
-         2)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -75,8 +73,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:dateTime('2000-01-01T12:00:00+12:00')</pre></td>
-                        <td><pre>xs:dateTime('1234-01-01T00:00:00Z')</pre></td>
+                        <td>
+                           <pre>xs:dateTime('2000-01-01T12:00:00+12:00')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:dateTime('1234-01-01T00:00:00Z')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-177-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-177-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total:
-         2)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -71,8 +69,7 @@
             <div id="scenario1-expect1">
                <h4>When @test is "empty($x:result/self::element(foo))" (i.e. boolean), then the HTML
                   report should be "Result" = "&lt;foo /&gt;" and "Expecting" = "empty($x:result/self::element(foo))"
-                  without diff.
-               </h4>
+                  without diff.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -83,9 +80,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;foo /&gt;</pre></td>
-                        <td><pre>empty($x:result/self::element(foo))</pre></td>
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;foo /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>empty($x:result/self::element(foo))</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -93,8 +93,7 @@
             <div id="scenario1-expect2">
                <h4>When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non
                   boolean), then the HTML report should be "Result" = "&lt;foo /&gt;" and "Expected Result"
-                  = "&lt;bar /&gt;" with diff.
-               </h4>
+                  = "&lt;bar /&gt;" with diff.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -105,11 +104,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">bar</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">bar</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-346-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -72,18 +70,20 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">p</span>&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    <span class="diff whitespace">␣</span>
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
-&lt;/p&gt;</pre></td>
+&lt;/p&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">p</span>&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
-&lt;/p&gt;</pre></td>
+&lt;/p&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-447_1-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_1-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-447_2-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_2-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-447_3-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_3-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-448-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-448-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total:
-         2)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-449-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-449-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total:
-         2)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-450-451-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-450-451-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 7 / pending: 0 / failed: 0 / total:
-         7)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 7 / pending: 0 / failed: 0 / total: 7)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-452-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 4 / total:
-         4)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -93,9 +91,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">t</span></pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">t</span></pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -134,9 +135,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--c--&gt;</span></pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--c--&gt;</span></pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -175,9 +179,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;</pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -216,9 +223,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-467-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -72,8 +70,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -81,10 +79,11 @@
          &lt;<span class="diff">e4</span> /&gt;
       &lt;/ns3:e3&gt;
    &lt;/e2&gt;
-&lt;/e1&gt;</pre></td>
+&lt;/e1&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2!"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -92,7 +91,8 @@
          &lt;<span class="diff">e4</span> xmlns="" /&gt;
       &lt;/ns3:e3&gt;
    &lt;/e2&gt;
-&lt;/e1&gt;</pre></td>
+&lt;/e1&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-50-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-50-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total:
-         1)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -63,8 +61,7 @@
             <h3>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</h3>
             <div id="scenario1-expect1">
                <h4>must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
-                  and [Expected Result] = "xs:hexBinary('0123')"
-               </h4>
+                  and [Expected Result] = "xs:hexBinary('0123')"</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -74,8 +71,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:untypedAtomic('0123')</pre></td>
-                        <td><pre>xs:hexBinary('0123')</pre></td>
+                        <td>
+                           <pre>xs:untypedAtomic('0123')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:hexBinary('0123')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-55-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total:
-         3)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -80,16 +78,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>1.0</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>1.0</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
             </div>
             <div id="scenario1-expect2">
                <h4>[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
-                  double)
-               </h4>
+                  double)</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -99,8 +100,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>xs:double('1')</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:double('1')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -116,8 +121,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>1</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-67-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-67-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:xspec-items (passed: 2 / pending: 0 / failed: 1 / total:
-         3)
-      </title>
+      <title>Test Report for x-urn:test:xspec-items (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -124,11 +122,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:namespace-name="namespace-text" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:namespace-name="namespace-text" /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:another-namespace-name="another-namespace-text" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:another-namespace-name="another-namespace-text" /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-67-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-67-result.xml
@@ -11,14 +11,14 @@
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                xmlns:namespace-name="namespace-text"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>must be Success</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                   xmlns:namespace-name="namespace-text"/>
+            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:expect>
       </x:test>
    </x:scenario>
@@ -45,14 +45,14 @@
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                xmlns:namespace-name="namespace-text"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>must be Failure</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                   xmlns:another-namespace-name="another-namespace-text"/>
+            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
+                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:expect>
       </x:test>
    </x:scenario>

--- a/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 5 / pending: 0 / failed: 5 / total:
-         10)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 5 / pending: 0 / failed: 5 / total: 10)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -101,10 +99,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -150,8 +151,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
-                        <td><pre>$x:result treat as xs:boolean</pre></td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>$x:result treat as xs:boolean</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -186,8 +191,7 @@
          </table>
          <div id="scenario3-scenario1">
             <h3>Scenario for verifying that boolean @test precedes child node When function returns
-               true,
-            </h3>
+               true,</h3>
             <div id="scenario3-scenario1-expect1">
                <h4>Expecting element(foo) via child node should be Failure</h4>
                <table class="xspecResult">
@@ -199,10 +203,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -220,8 +227,7 @@
             <tbody>
                <tr class="successful">
                   <th>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select
-                     or child node)
-                  </th>
+                     or child node)</th>
                   <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
                </tr>
                <tr class="failed">
@@ -238,8 +244,7 @@
                </tr>
                <tr class="successful">
                   <td>Expecting empty sequence (no @href, @select or child node) along with @test=$x:result
-                     should be Success
-                  </td>
+                     should be Success</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -250,8 +255,7 @@
          </table>
          <div id="scenario4-scenario1">
             <h3>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select
-               or child node) When function returns true,
-            </h3>
+               or child node) When function returns true,</h3>
             <div id="scenario4-scenario1-expect1">
                <h4>Expecting empty sequence (no @href, @select or child node) should be Failure</h4>
                <table class="xspecResult">
@@ -263,8 +267,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -280,8 +288,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-focus-1-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-focus-1-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 2 / failed: 1 / total:
-         4)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -111,8 +109,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-focus-2-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-focus-2-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 3 / pending: 3 / failed: 0 / total:
-         6)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 3 / pending: 3 / failed: 0 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xspec-function-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-function-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 2 / pending: 0 / failed: 2 / total:
-         4)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -105,8 +103,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -122,8 +124,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-import-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-import-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 3 / pending: 0 / failed: 2 / total:
-         5)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 3 / pending: 0 / failed: 2 / total: 5)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -115,8 +113,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -173,8 +175,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-imported-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-imported-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 0 / failed: 1 / total:
-         2)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -97,8 +95,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-pending-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-pending-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 4 / failed: 1 / total:
-         6)
-      </title>
+      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 4 / failed: 1 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -125,8 +123,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 8 / total:
-         8)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 8 / total: 8)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -111,8 +109,7 @@
             <h3>Function (xspec/xspec#355) Array</h3>
             <div id="scenario1-scenario1-expect1">
                <h4>Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
-                  upon failure
-               </h4>
+                  upon failure</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -123,9 +120,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -135,8 +135,7 @@
             <h3>Function (xspec/xspec#355) Map</h3>
             <div id="scenario1-scenario2-expect1">
                <h4>Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
-                  upon failure
-               </h4>
+                  upon failure</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -147,9 +146,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -188,12 +190,15 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/(@* | node())</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-element</span>&gt;
+                           <p>XPath <code class="diff">/*/(@* | node())</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-element</span>&gt;
    &lt;<span class="diff">elem1</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem1&gt;
 &lt;/pseudo-element&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"attr-val"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"attr-val"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -232,10 +237,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/@*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"foo"</span> /&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"bar"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"foo"</span> /&gt;
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"bar"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -274,13 +282,16 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/(@* | node())</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr1</span>=<span class="diff">"attr1-val"</span> /&gt;
+                           <p>XPath <code class="diff">/*/(@* | node())</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr1</span>=<span class="diff">"attr1-val"</span> /&gt;
 &lt;<span class="diff">pseudo-element</span>&gt;
    &lt;<span class="diff">elem2</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem2&gt;
 &lt;/pseudo-element&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>=<span class="diff">"attr3-val"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>=<span class="diff">"attr3-val"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -319,9 +330,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre></pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre></pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -360,8 +374,7 @@
          </table>
          <div id="scenario6-scenario1">
             <h3>XPath is different, but serialized node looks as if same [Result] = document node,
-               [Expected Result] = element
-            </h3>
+               [Expected Result] = element</h3>
             <div id="scenario6-scenario1-expect1">
                <h4>XPath should be colored as different. Serialized node should be colored as same.</h4>
                <table class="xspecResult">
@@ -374,11 +387,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -386,8 +401,7 @@
          </div>
          <div id="scenario6-scenario2">
             <h3>XPath is different, but serialized node looks as if same [Result] = element, [Expected
-               Result] = document node.
-            </h3>
+               Result] = document node.</h3>
             <div id="scenario6-scenario2-expect1">
                <h4>XPath should be colored as different. Serialized node should be colored as same.</h4>
                <table class="xspecResult">
@@ -400,11 +414,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report_schema-aware-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 21 / total:
-         21)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 21 / total: 21)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -235,8 +233,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -255,8 +257,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -275,8 +281,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -295,8 +305,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -315,8 +329,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'en'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'en'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -335,8 +353,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -355,8 +377,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -375,8 +401,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -395,8 +425,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'foo'</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>'foo'</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -415,8 +449,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>-1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>-1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -435,8 +473,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>0</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>0</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -455,8 +497,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -475,8 +521,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -495,8 +545,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -515,8 +569,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -535,8 +593,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -555,8 +617,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -575,8 +641,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -595,8 +665,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -615,8 +689,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>1</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -635,8 +713,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>0</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>0</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:xspec-items (passed: 0 / pending: 0 / failed: 22 / total:
-         22)
-      </title>
+      <title>Test Report for x-urn:test:xspec-items (passed: 0 / pending: 0 / failed: 22 / total: 22)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -96,8 +94,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-                     (xspec/xspec#356) So...
-                  </th>
+                     (xspec/xspec#356) So...</th>
                   <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
                </tr>
                <tr class="failed">
@@ -124,8 +121,7 @@
          </table>
          <div id="scenario1-scenario1">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-               (xspec/xspec#356) So... When x:result in the report XML contains a comment node,
-            </h3>
+               (xspec/xspec#356) So... When x:result in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario1-expect1">
                <h4>[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
@@ -138,9 +134,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment-text--&gt;</span></pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment-text--&gt;</span></pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -157,9 +156,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/comment()</code> from:
-                           </p><pre>&lt;!--comment-text--&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+                           <p>XPath <code>/comment()</code> from:</p>
+                           <pre>&lt;!--comment-text--&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -167,8 +169,7 @@
          </div>
          <div id="scenario1-scenario2">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-               (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,
-            </h3>
+               (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
@@ -180,10 +181,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment-text--&gt;</span></pre></td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment-text--&gt;</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -201,8 +205,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result is indented in the report XML file, the report HTML must serialize
-                     it with indentation.
-                  </th>
+                     it with indentation.</th>
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
@@ -263,8 +266,7 @@
          <div id="scenario2-scenario1-scenario1">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:result in the report XML file
-               is a sequence of simple nested elements serialized with indentation,
-            </h3>
+               is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario1-expect1">
                <h4>all elements in [Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
@@ -277,15 +279,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;
 &lt;<span class="diff">bar</span>&gt;
    &lt;<span class="diff">baz</span> /&gt;
 &lt;/bar&gt;
 &lt;<span class="diff">qux</span>&gt;
    &lt;<span class="diff">quux</span> /&gt;
-&lt;/qux&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -302,15 +307,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;foo /&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;foo /&gt;
 &lt;bar&gt;
    &lt;baz /&gt;
 &lt;/bar&gt;
 &lt;qux&gt;
    &lt;quux /&gt;
-&lt;/qux&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -319,8 +327,7 @@
          <div id="scenario2-scenario1-scenario2">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:expect in the report XML file
-               is a sequence of simple nested elements serialized with indentation,
-            </h3>
+               is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario2-expect1">
                <h4>all elements in [Expected Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
@@ -332,16 +339,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;
 &lt;<span class="diff">bar</span>&gt;
    &lt;<span class="diff">baz</span> /&gt;
 &lt;/bar&gt;
 &lt;<span class="diff">qux</span>&gt;
    &lt;<span class="diff">quux</span> /&gt;
-&lt;/qux&gt;</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -352,8 +362,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
-               XML file,
-            </h3>
+               XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
@@ -366,20 +375,22 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>
       &lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">foo</span>&lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">foo</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -390,8 +401,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
-               XML file,
-            </h3>
+               XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
@@ -404,20 +414,22 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">foo</span>&lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">foo</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>
       &lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -428,8 +440,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a child node of an element is indented, the diff of the element must not be affected.
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
-               XML file with different indentation length,
-            </h3>
+               XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1">
                <h4>&lt;foo&gt; must be green.</h4>
                <table class="xspecResult">
@@ -442,21 +453,23 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="same">foo</span>&gt;
       &lt;<span class="same">bar</span> /&gt;
    &lt;/foo&gt;
    &lt;<span class="diff">baz</span> /&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="same">foo</span>&gt;
       &lt;<span class="same">bar</span> /&gt;
    &lt;/foo&gt;
    &lt;<span class="diff">qux</span> /&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -495,12 +508,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">foo</span>&gt;<span class="same ellipsis">...</span>&lt;/foo&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">foo</span>&gt;<span class="same ellipsis">...</span>&lt;/foo&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">foo</span>&gt;<span class="same">...</span>&lt;/foo&gt;
-&lt;<span class="diff">qux</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">foo</span>&gt;<span class="same">...</span>&lt;/foo&gt;
+&lt;<span class="diff">qux</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -534,8 +549,7 @@
             <h3>When the result contains significant text nodes,</h3>
             <div id="scenario4-expect1">
                <h4>both in [Result] and [Expected Result] with diff, the significant text nodes must
-                  be serialized with color. (xspec/xspec#386)
-               </h4>
+                  be serialized with color. (xspec/xspec#386)</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -546,8 +560,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">actual</span>&lt;/diff&gt;
@@ -556,10 +570,11 @@
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">\t\n\r␣</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">expect</span>&lt;/diff&gt;
@@ -568,7 +583,8 @@
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">␣\t\n\r</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -585,8 +601,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;test&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;test&gt;
    &lt;oridinary-text-node&gt;
       &lt;same&gt;same&lt;/same&gt;
       &lt;diff&gt;actual&lt;/diff&gt;
@@ -595,8 +611,11 @@
       &lt;same xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;diff xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -614,8 +633,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result contains an element, the report HTML must serialize nodes in its opening
-                     tag with aligned indentation. (xspec/xspec#689) So...
-                  </th>
+                     tag with aligned indentation. (xspec/xspec#689) So...</th>
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
@@ -663,8 +681,7 @@
          <div id="scenario5-scenario1-scenario1">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several namespaces in x:result,
-            </h3>
+               an element with several namespaces in x:result,</h3>
             <div id="scenario5-scenario1-scenario1-expect1">
                <h4>[Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -677,16 +694,19 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -703,16 +723,19 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -721,8 +744,7 @@
          <div id="scenario5-scenario1-scenario2">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several namespaces in x:expect,
-            </h3>
+               an element with several namespaces in x:expect,</h3>
             <div id="scenario5-scenario1-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -734,17 +756,20 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -753,8 +778,7 @@
          <div id="scenario5-scenario2-scenario1">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several attributes in x:result,
-            </h3>
+               an element with several attributes in x:result,</h3>
             <div id="scenario5-scenario2-scenario1-expect1">
                <h4>[Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -767,15 +791,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>=<span class="diff">"val1"</span>
          <span class="diff">attr2</span>=<span class="diff">"val2"</span>
          <span class="diff">attr3</span>=<span class="diff">"val3"</span>&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -792,15 +819,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test attr1="val1"
          attr2="val2"
          attr3="val3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -809,8 +839,7 @@
          <div id="scenario5-scenario2-scenario2">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several attributes in x:expect,
-            </h3>
+               an element with several attributes in x:expect,</h3>
             <div id="scenario5-scenario2-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -822,16 +851,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>=<span class="diff">"val1"</span>
          <span class="diff">attr2</span>=<span class="diff">"val2"</span>
          <span class="diff">attr3</span>=<span class="diff">"val3"</span>&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -875,8 +907,7 @@
             <div id="scenario6-scenario1-expect1">
                <h4>The exact-match (taking '...' into account) attributes must be serialized as green="green".
                   The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                  must be serialized as solidPink="solidPink" regardless of their values.
-               </h4>
+                  must be serialized as solidPink="solidPink" regardless of their values.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -887,8 +918,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
              <span class="same">attr2</span>=<span class="same">"value2"</span>
              <span class="same">attr3</span>=<span class="same">""</span>
              <span class="same">attr4</span>=<span class="same">""</span> /&gt;
@@ -898,10 +929,11 @@
             <span class="inner-diff">attr4</span>=<span class="diff">"..."</span> /&gt;
 &lt;<span class="inner-diff">orphan</span> <span class="diff">attr1</span>=<span class="diff">"value1"</span>
         <span class="diff">attr2</span>=<span class="diff">""</span>
-        <span class="diff">attr3</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+        <span class="diff">attr3</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
              <span class="same">attr2</span>=<span class="same">"..."</span>
              <span class="same">attr3</span>=<span class="same">""</span>
              <span class="same">attr4</span>=<span class="same">"..."</span> /&gt;
@@ -911,7 +943,8 @@
             <span class="inner-diff">attr4</span>=<span class="diff">"value4"</span> /&gt;
 &lt;<span class="inner-diff">orphan</span> <span class="diff">attr4</span>=<span class="diff">"value4"</span>
         <span class="diff">attr5</span>=<span class="diff">""</span>
-        <span class="diff">attr6</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+        <span class="diff">attr6</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -931,8 +964,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;exact-match attr1="value1"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;exact-match attr1="value1"
              attr2="value2"
              attr3=""
              attr4="" /&gt;
@@ -942,8 +975,11 @@
             attr4="..." /&gt;
 &lt;orphan attr1="value1"
         attr2=""
-        attr3="..." /&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+        attr3="..." /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -986,15 +1022,13 @@
          </table>
          <div id="scenario7-scenario1">
             <h3>When the result contains processing instructions, both in [Result] and [Expected Result]
-               with diff,
-            </h3>
+               with diff,</h3>
             <div id="scenario7-scenario1-expect1">
                <h4>The exact-match (taking '...' into account) processing instructions must be serialized
                   as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
                   solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
                   be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.
-               </h4>
+                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1005,8 +1039,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same"></span>?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same"></span>?&gt;&lt;/exact-match&gt;
 &lt;<span class="inner-diff">name-match</span>&gt;&lt;?<span class="inner-diff">node1</span> <span class="diff">value1</span>?&gt;&lt;?<span class="inner-diff">node2</span> <span class="diff">value2</span>?&gt;&lt;?<span class="inner-diff">node3</span> <span class="diff"></span>?&gt;&lt;?<span class="inner-diff">node4</span> <span class="diff">...</span>?&gt;&lt;/name-match&gt;
 &lt;<span class="inner-diff">value-match</span>&gt;&lt;?<span class="diff">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="diff">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="diff">node3</span> <span class="same"></span>?&gt;&lt;?<span class="diff">node4</span> <span class="same"></span>?&gt;&lt;/value-match&gt;
 &lt;<span class="inner-diff">no-match</span>&gt;
@@ -1020,10 +1054,11 @@
       &lt;<span class="inner-diff">node1</span>&gt;&lt;?<span class="diff">node1-1</span> <span class="diff">value1-1</span>?&gt;&lt;?<span class="diff">node1-2</span> <span class="diff"></span>?&gt;&lt;?<span class="diff">node1-3</span> <span class="diff">...</span>?&gt;&lt;/node1&gt;
       &lt;<span class="inner-diff">node2</span> /&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">...</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same">...</span>?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">...</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same">...</span>?&gt;&lt;/exact-match&gt;
 &lt;<span class="inner-diff">name-match</span>&gt;&lt;?<span class="inner-diff">node1</span> <span class="diff">VALUE1</span>?&gt;&lt;?<span class="inner-diff">node2</span> <span class="diff"></span>?&gt;&lt;?<span class="inner-diff">node3</span> <span class="diff">value3</span>?&gt;&lt;?<span class="inner-diff">node4</span> <span class="diff">value4</span>?&gt;&lt;/name-match&gt;
 &lt;<span class="inner-diff">value-match</span>&gt;&lt;?<span class="diff">NODE1</span> <span class="same">value1</span>?&gt;&lt;?<span class="diff">NODE2</span> <span class="same">...</span>?&gt;&lt;?<span class="diff">NODE3</span> <span class="same"></span>?&gt;&lt;?<span class="diff">NODE4</span> <span class="same">...</span>?&gt;&lt;/value-match&gt;
 &lt;<span class="inner-diff">no-match</span>&gt;
@@ -1038,7 +1073,8 @@
       &lt;<span class="inner-diff">node1</span> /&gt;
       &lt;<span class="inner-diff">node2</span>&gt;&lt;?<span class="diff">node2-1</span> <span class="diff">value2-1</span>?&gt;&lt;?<span class="diff">node2-2</span> <span class="diff"></span>?&gt;&lt;?<span class="diff">node2-3</span> <span class="diff">...</span>?&gt;&lt;/node2&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1058,8 +1094,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;exact-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;exact-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/exact-match&gt;
 &lt;name-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ...?&gt;&lt;/name-match&gt;
 &lt;value-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/value-match&gt;
 &lt;no-match&gt;
@@ -1073,8 +1109,11 @@
       &lt;node1&gt;&lt;?node1-1 value1-1?&gt;&lt;?node1-2 ?&gt;&lt;?node1-3 ...?&gt;&lt;/node1&gt;
       &lt;node2 /&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 6 / pending: 0 / failed: 0 / total:
-         6)
-      </title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -75,8 +73,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>
@@ -96,8 +93,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>
@@ -144,8 +140,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -154,8 +149,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>

--- a/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:xspec-three-dots (passed: 44 / pending: 0 / failed: 28
-         / total: 72)
-      </title>
+      <title>Test Report for x-urn:test:xspec-three-dots (passed: 44 / pending: 0 / failed: 28 / total: 72)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -192,11 +190,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -216,11 +216,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">text</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">text</span>&lt;/elem&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -271,11 +273,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -338,14 +342,16 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">outer</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">outer</span>&gt;
    &lt;<span class="same">inner</span> /&gt;
-&lt;/outer&gt;</pre></td>
+&lt;/outer&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">outer</span>&gt;<span class="same">...</span>&lt;<span class="diff">inner</span> /&gt;
-&lt;/outer&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">outer</span>&gt;<span class="same">...</span>&lt;<span class="diff">inner</span> /&gt;
+&lt;/outer&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -416,11 +422,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/@*</code> from:
-                           </p><pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/@*</code> from:
-                           </p><pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -507,9 +515,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -529,11 +540,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff whitespace">\t\n\r␣</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff whitespace">\t\n\r␣</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -553,11 +566,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff whitespace"></span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff whitespace"></span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -577,11 +592,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -598,9 +615,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -671,11 +691,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--...--&gt;</span></pre></td>
+                           <p>XPath <code class="same">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--...--&gt;</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment--&gt;</span></pre></td>
+                           <p>XPath <code class="same">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment--&gt;</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -746,11 +768,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">...</span>?&gt;</pre></td>
+                           <p>XPath <code class="same">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">...</span>?&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">data</span>?&gt;</pre></td>
+                           <p>XPath <code class="same">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">data</span>?&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -813,8 +837,7 @@
          </table>
          <div id="scenario8-scenario1">
             <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt;
-            </h3>
+               /&gt;&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario1-expect1">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -827,12 +850,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
-&lt;<span class="diff">elem</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
+&lt;<span class="diff">elem</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="same">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="same">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -852,11 +877,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -876,11 +903,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -955,11 +984,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="..." /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="..." /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="namespace-uri" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="namespace-uri" /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1006,8 +1037,7 @@
          </table>
          <div id="scenario10-scenario1">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
-               /&gt;
-            </h3>
+               /&gt;</h3>
             <div id="scenario10-scenario1-expect3">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
@@ -1020,12 +1050,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="same">...</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="same">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1042,12 +1074,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">......</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">......</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1064,12 +1098,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">.........</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">.........</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1107,10 +1143,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>()</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>()</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1176,10 +1215,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'string'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>'string'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1195,8 +1237,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'string'</pre></td>
-                        <td><pre>'...'</pre></td>
+                        <td>
+                           <pre>'string'</pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1215,10 +1261,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'...'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>'...'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1234,8 +1283,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'...'</pre></td>
-                        <td><pre>'string'</pre></td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
+                        <td>
+                           <pre>'string'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1286,11 +1339,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">....</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">....</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1307,11 +1362,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">...x</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">...x</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1328,11 +1385,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff"> ...</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff"> ...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1349,9 +1408,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/query/xspec-three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-three-dots-result.xml
@@ -577,14 +577,14 @@
             <x:param select="'namespace-uri'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
+            <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:result>
          <x:test id="scenario9-scenario1-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario1-expect2" successful="true">
@@ -625,14 +625,14 @@
             <x:param select="'...'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+            <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:result>
          <x:test id="scenario9-scenario3-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario3-expect2" successful="true">
@@ -644,7 +644,7 @@
 					  xmlns:prefix="namespace-uri"
 					should be Failure</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
+               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
       </x:scenario>

--- a/test/end-to-end/cases/expected/schematron/import-demo-02-PhaseB-result.html
+++ b/test/end-to-end/cases/expected/schematron/import-demo-02-PhaseB-result.html
@@ -94,8 +94,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                         xmlns:local="local"
                         xmlns:saxon="http://saxon.sf.net/"
                         xmlns:schold="http://www.ascc.net/xml/schematron"
@@ -163,8 +163,11 @@
             &lt;/svrl:text&gt;
    &lt;/svrl:successful-report&gt;
    &lt;svrl:fired-rule context="sec" /&gt;
-&lt;/svrl:schematron-output&gt;</pre></td>
-                        <td><pre>boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 't1-1'])</pre></td>
+&lt;/svrl:schematron-output&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 't1-1'])</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -102,8 +102,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                         xmlns:saxon="http://saxon.sf.net/"
                         xmlns:schold="http://www.ascc.net/xml/schematron"
                         xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -132,8 +132,11 @@
                 title should not be all upper case
             &lt;/svrl:text&gt;
    &lt;/svrl:failed-assert&gt;
-&lt;/svrl:schematron-output&gt;</pre></td>
-                        <td><pre>boolean(svrl:schematron-output[svrl:fired-rule]) and                 not(boolean((svrl:schematron-output/svrl:failed-assert union svrl:schematron-output/svrl:successful-report)[                 not(@role) or lower-case(@role) = ('error','fatal')]))</pre></td>
+&lt;/svrl:schematron-output&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>boolean(svrl:schematron-output[svrl:fired-rule]) and                 not(boolean((svrl:schematron-output/svrl:failed-assert union svrl:schematron-output/svrl:successful-report)[                 not(@role) or lower-case(@role) = ('error','fatal')]))</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -172,8 +175,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                         xmlns:saxon="http://saxon.sf.net/"
                         xmlns:schold="http://www.ascc.net/xml/schematron"
                         xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -193,8 +196,11 @@
                 root element must be document
             &lt;/svrl:text&gt;
    &lt;/svrl:failed-assert&gt;
-&lt;/svrl:schematron-output&gt;</pre></td>
-                        <td><pre>boolean(svrl:schematron-output[svrl:fired-rule]) and                 not(boolean((svrl:schematron-output/svrl:failed-assert union svrl:schematron-output/svrl:successful-report)[                 not(@role) or lower-case(@role) = ('error','fatal')]))</pre></td>
+&lt;/svrl:schematron-output&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>boolean(svrl:schematron-output[svrl:fired-rule]) and                 not(boolean((svrl:schematron-output/svrl:failed-assert union svrl:schematron-output/svrl:successful-report)[                 not(@role) or lower-case(@role) = ('error','fatal')]))</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/schematron/xspec-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-result.html
@@ -64,8 +64,7 @@
             <h3>Using user-content (not @href) in x:context should work</h3>
             <div id="scenario1-expect2">
                <h4>This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[.
-                  = ''] report baz-exists
-               </h4>
+                  = ''] report baz-exists</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -76,8 +75,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                         xmlns:saxon="http://saxon.sf.net/"
                         xmlns:schold="http://www.ascc.net/xml/schematron"
                         xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -94,8 +93,11 @@
                            location="/foo[1]"&gt;
       &lt;svrl:text&gt;Found bar&lt;/svrl:text&gt;
    &lt;/svrl:successful-report&gt;
-&lt;/svrl:schematron-output&gt;</pre></td>
-                        <td><pre>exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'baz-exists'])</pre></td>
+&lt;/svrl:schematron-output&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>exists(svrl:schematron-output/svrl:successful-report[(@id, preceding-sibling::svrl:fired-rule[1]/@id, preceding-sibling::svrl:active-pattern[1]/@id)[1] = 'baz-exists'])</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-coverage.html
@@ -7,7 +7,8 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../../../../tutorial/coverage/demo.xsl">demo.xsl</a></p>
-      <h2>module: demo.xsl; 28 lines</h2><pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+      <h2>module: demo.xsl; 28 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
 02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
 03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
 04: <span class="ignored"></span>
@@ -34,7 +35,9 @@
 25: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
 26: <span class="ignored"></span>
 27: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-28: <span class="ignored"></span></pre><h2>module: demo-imported.xsl; 25 lines</h2><pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+28: <span class="ignored"></span></pre>
+      <h2>module: demo-imported.xsl; 25 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
 02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
 03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
 04: <span class="ignored"></span>
@@ -58,5 +61,6 @@
 22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
 23: <span class="ignored"></span>
 24: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-25: <span class="ignored"></span></pre></body>
+25: <span class="ignored"></span></pre>
+   </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -86,10 +86,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'Caught by #all mode'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                           <pre>'Caught by #all mode'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">expected-element</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -131,10 +134,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'Returned from function'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                           <pre>'Returned from function'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">expected-element</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -176,10 +182,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'Returned from named template'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">expected-element</span> /&gt;</pre></td>
+                           <pre>'Returned from named template'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">expected-element</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-151-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-151-result.html
@@ -69,14 +69,17 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/*</code> from:
-                           </p><pre>&lt;pseudo-element xmlns:test-mix="x-urn:test-mix"&gt;
+                           <p>XPath <code>/*</code> from:</p>
+                           <pre>&lt;pseudo-element xmlns:test-mix="x-urn:test-mix"&gt;
    &lt;test-mix:fooElement&gt;
       &lt;test-mix:barElement /&gt;
    &lt;/test-mix:fooElement&gt;
 &lt;/pseudo-element&gt;
-&lt;pseudo-atomic-value xmlns:test-mix="x-urn:test-mix"&gt;'string'&lt;/pseudo-atomic-value&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;pseudo-atomic-value xmlns:test-mix="x-urn:test-mix"&gt;'string'&lt;/pseudo-atomic-value&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-153-result.html
@@ -72,8 +72,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:dateTime('2000-01-01T12:00:00+12:00')</pre></td>
-                        <td><pre>xs:dateTime('1234-01-01T00:00:00Z')</pre></td>
+                        <td>
+                           <pre>xs:dateTime('2000-01-01T12:00:00+12:00')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:dateTime('1234-01-01T00:00:00Z')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-177-result.html
@@ -68,8 +68,7 @@
             <div id="scenario1-expect1">
                <h4>When @test is "empty($x:result/self::element(foo))" (i.e. boolean), then the HTML
                   report should be "Result" = "&lt;foo /&gt;" and "Expecting" = "empty($x:result/self::element(foo))"
-                  without diff.
-               </h4>
+                  without diff.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -80,9 +79,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;foo /&gt;</pre></td>
-                        <td><pre>empty($x:result/self::element(foo))</pre></td>
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;foo /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>empty($x:result/self::element(foo))</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -90,8 +92,7 @@
             <div id="scenario1-expect2">
                <h4>When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non
                   boolean), then the HTML report should be "Result" = "&lt;foo /&gt;" and "Expected Result"
-                  = "&lt;bar /&gt;" with diff.
-               </h4>
+                  = "&lt;bar /&gt;" with diff.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -102,11 +103,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">bar</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">bar</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-214-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-214-coverage.html
@@ -7,7 +7,8 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xspec-214.xsl">xspec-214.xsl</a></p>
-      <h2>module: xspec-214.xsl; 9 lines</h2><pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+      <h2>module: xspec-214.xsl; 9 lines</h2>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
 2: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
 3: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored"></span>
 4: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
@@ -15,5 +16,6 @@
 6: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
 7: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
 8: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-9: <span class="ignored"></span></pre></body>
+9: <span class="ignored"></span></pre>
+   </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
@@ -69,13 +69,15 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
-     <span class="inner-diff">bar</span>=<span class="diff">"true"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
+     <span class="inner-diff">bar</span>=<span class="diff">"true"</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
-     <span class="inner-diff">bar</span>=<span class="diff">"false"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">foo</span> xmlns="x-urn:test"
+     <span class="inner-diff">bar</span>=<span class="diff">"false"</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
@@ -69,18 +69,20 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">p</span>&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    <span class="diff whitespace">␣</span>
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
-&lt;/p&gt;</pre></td>
+&lt;/p&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">p</span>&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
-&lt;/p&gt;</pre></td>
+&lt;/p&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
@@ -90,9 +90,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">t</span></pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">t</span></pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -131,9 +134,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--c--&gt;</span></pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--c--&gt;</span></pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -172,9 +178,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;</pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -213,9 +222,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
@@ -69,8 +69,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -78,10 +78,11 @@
          &lt;<span class="diff">e4</span> /&gt;
       &lt;/ns3:e3&gt;
    &lt;/e2&gt;
-&lt;/e1&gt;</pre></td>
+&lt;/e1&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2!"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -89,7 +90,8 @@
          &lt;<span class="diff">e4</span> xmlns="" /&gt;
       &lt;/ns3:e3&gt;
    &lt;/e2&gt;
-&lt;/e1&gt;</pre></td>
+&lt;/e1&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-50-result.html
@@ -60,8 +60,7 @@
             <h3>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</h3>
             <div id="scenario1-expect1">
                <h4>must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
-                  and [Expected Result] = "xs:hexBinary('0123')"
-               </h4>
+                  and [Expected Result] = "xs:hexBinary('0123')"</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -71,8 +70,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:untypedAtomic('0123')</pre></td>
-                        <td><pre>xs:hexBinary('0123')</pre></td>
+                        <td>
+                           <pre>xs:untypedAtomic('0123')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:hexBinary('0123')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
@@ -46,23 +46,19 @@
             </colgroup>
             <tbody>
                <tr class="pending">
-                  <th>(<strong>Focus on 1-2</strong>) Scenario 1
-                  </th>
+                  <th>(<strong>Focus on 1-2</strong>) Scenario 1</th>
                   <th>passed: 0 / pending: 2 / failed: 1 / total: 3</th>
                </tr>
                <tr class="pending">
-                  <td>(<strong>Focus on 1-2</strong>) should be skipped (otherwise should fail)
-                  </td>
+                  <td>(<strong>Focus on 1-2</strong>) should be skipped (otherwise should fail)</td>
                   <td>Pending</td>
                </tr>
                <tr class="pending">
-                  <th>(<strong>Focus on 1-2</strong>) Scenario 1-1
-                  </th>
+                  <th>(<strong>Focus on 1-2</strong>) Scenario 1-1</th>
                   <th>passed: 0 / pending: 1 / failed: 0 / total: 1</th>
                </tr>
                <tr class="pending">
-                  <td>(<strong>Focus on 1-2</strong>) should be skipped (otherwise should fail)
-                  </td>
+                  <td>(<strong>Focus on 1-2</strong>) should be skipped (otherwise should fail)</td>
                   <td>Pending</td>
                </tr>
                <tr class="failed">
@@ -88,8 +84,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>xs:boolean('false')</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
@@ -77,16 +77,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>1.0</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>1.0</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
             </div>
             <div id="scenario1-expect2">
                <h4>[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
-                  double)
-               </h4>
+                  double)</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -96,8 +99,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>xs:double('1')</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>xs:double('1')</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -113,8 +120,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>1</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>1</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-67-result.html
@@ -121,11 +121,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:namespace-name="namespace-text" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:namespace-name="namespace-text" /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:another-namespace-name="another-namespace-text" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:another-namespace-name="another-namespace-text" /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-67-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-67-result.xml
@@ -12,14 +12,14 @@
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                xmlns:namespace-name="namespace-text"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>must be Success</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                   xmlns:namespace-name="namespace-text"/>
+            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:expect>
       </x:test>
    </x:scenario>
@@ -46,14 +46,14 @@
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                xmlns:namespace-name="namespace-text"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
+                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>must be Failure</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
-                                   xmlns:another-namespace-name="another-namespace-text"/>
+            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
+                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:expect>
       </x:test>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
@@ -98,10 +98,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -147,8 +150,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
-                        <td><pre>$x:result treat as xs:boolean</pre></td>
+                        <td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>$x:result treat as xs:boolean</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -183,8 +190,7 @@
          </table>
          <div id="scenario3-scenario1">
             <h3>Scenario for verifying that boolean @test precedes child node When function returns
-               true,
-            </h3>
+               true,</h3>
             <div id="scenario3-scenario1-expect1">
                <h4>Expecting element(foo) via child node should be Failure</h4>
                <table class="xspecResult">
@@ -196,10 +202,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -217,8 +226,7 @@
             <tbody>
                <tr class="successful">
                   <th>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select
-                     or child node)
-                  </th>
+                     or child node)</th>
                   <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
                </tr>
                <tr class="failed">
@@ -235,8 +243,7 @@
                </tr>
                <tr class="successful">
                   <td>Expecting empty sequence (no @href, @select or child node) along with @test=$x:result
-                     should be Success
-                  </td>
+                     should be Success</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -247,8 +254,7 @@
          </table>
          <div id="scenario4-scenario1">
             <h3>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select
-               or child node) When function returns true,
-            </h3>
+               or child node) When function returns true,</h3>
             <div id="scenario4-scenario1-expect1">
                <h4>Expecting empty sequence (no @href, @select or child node) should be Failure</h4>
                <table class="xspecResult">
@@ -260,8 +266,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -277,8 +287,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('true')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-focus-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-focus-1-result.html
@@ -108,8 +108,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-function-result.html
@@ -102,8 +102,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -119,8 +123,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-import-result.html
@@ -112,8 +112,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -170,8 +174,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-imported-result.html
@@ -94,8 +94,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>42</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>42</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-pending-result.html
@@ -122,8 +122,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>4</pre></td>
-                        <td><pre>$t:result instance of xs:string</pre></td>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -108,8 +108,7 @@
             <h3>Function (xspec/xspec#355) Array</h3>
             <div id="scenario1-scenario1-expect1">
                <h4>Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
-                  upon failure
-               </h4>
+                  upon failure</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -120,9 +119,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">["foo",1,[2,"bar"]]</span>&lt;/pseudo-function&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">["foo",1,[2,"bar"]]</span>&lt;/pseudo-function&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -132,8 +134,7 @@
             <h3>Function (xspec/xspec#355) Map</h3>
             <div id="scenario1-scenario2-expect1">
                <h4>Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
-                  upon failure
-               </h4>
+                  upon failure</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -144,9 +145,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">map{2:"bar","foo":1}</span>&lt;/pseudo-function&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">map{2:"bar","foo":1}</span>&lt;/pseudo-function&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -185,12 +189,15 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/(@* | node())</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-element</span>&gt;
+                           <p>XPath <code class="diff">/*/(@* | node())</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-element</span>&gt;
    &lt;<span class="diff">elem1</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem1&gt;
 &lt;/pseudo-element&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"attr-val"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"attr-val"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -229,10 +236,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/@*</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"foo"</span> /&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"bar"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"foo"</span> /&gt;
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr</span>=<span class="diff">"bar"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -271,13 +281,16 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/*/(@* | node())</code> from:
-                           </p><pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr1</span>=<span class="diff">"attr1-val"</span> /&gt;
+                           <p>XPath <code class="diff">/*/(@* | node())</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr1</span>=<span class="diff">"attr1-val"</span> /&gt;
 &lt;<span class="diff">pseudo-element</span>&gt;
    &lt;<span class="diff">elem2</span> xmlns=""&gt;<span class="diff">text</span>&lt;/elem2&gt;
 &lt;/pseudo-element&gt;
-&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>=<span class="diff">"attr3-val"</span> /&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;<span class="diff">pseudo-attribute</span> <span class="diff">attr3</span>=<span class="diff">"attr3-val"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -316,9 +329,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre></pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre></pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -357,8 +373,7 @@
          </table>
          <div id="scenario6-scenario1">
             <h3>XPath is different, but serialized node looks as if same [Result] = document node,
-               [Expected Result] = element
-            </h3>
+               [Expected Result] = element</h3>
             <div id="scenario6-scenario1-expect1">
                <h4>XPath should be colored as different. Serialized node should be colored as same.</h4>
                <table class="xspecResult">
@@ -371,11 +386,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -383,8 +400,7 @@
          </div>
          <div id="scenario6-scenario2">
             <h3>XPath is different, but serialized node looks as if same [Result] = element, [Expected
-               Result] = document node.
-            </h3>
+               Result] = document node.</h3>
             <div id="scenario6-scenario2-expect1">
                <h4>XPath should be colored as different. Serialized node should be colored as same.</h4>
                <table class="xspecResult">
@@ -397,11 +413,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/self::document-node()</code> from:
-                           </p><pre>&lt;<span class="same">test</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/self::document-node()</code> from:</p>
+                           <pre>&lt;<span class="same">test</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report_schema-aware-result.html
@@ -232,8 +232,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:ID('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:ID('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -252,8 +256,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:IDREF('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:IDREF('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -272,8 +280,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:ENTITY('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:ENTITY('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -292,8 +304,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:NCName('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:NCName('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -312,8 +328,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:language('en')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:language('en')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -332,8 +352,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:Name('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:Name('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -352,8 +376,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:NMTOKEN('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:NMTOKEN('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -372,8 +400,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:token('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:token('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -392,8 +424,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:normalizedString('foo')</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:normalizedString('foo')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -412,8 +448,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:negativeInteger(-1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:negativeInteger(-1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -432,8 +472,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:nonPositiveInteger(0)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:nonPositiveInteger(0)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -452,8 +496,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:byte(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:byte(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -472,8 +520,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:short(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:short(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -492,8 +544,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:int(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:int(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -512,8 +568,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:long(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:long(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -532,8 +592,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:unsignedByte(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:unsignedByte(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -552,8 +616,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:unsignedShort(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:unsignedShort(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -572,8 +640,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:unsignedInt(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:unsignedInt(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -592,8 +664,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:unsignedLong(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:unsignedLong(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -612,8 +688,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:positiveInteger(1)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:positiveInteger(1)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -632,8 +712,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:nonNegativeInteger(0)</pre></td>
-                        <td><pre>()</pre></td>
+                        <td>
+                           <pre>xs:nonNegativeInteger(0)</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-result-naming-collision-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-result-naming-collision-result.html
@@ -128,8 +128,9 @@
                            <p><a href="HREF-3">HREF-3</a></p>
                         </td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-rule-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-rule-result.html
@@ -95,11 +95,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">transformed</span> xmlns:my="http://example.org/ns/my" /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">transformed</span> xmlns:my="http://example.org/ns/my" /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">erroneous</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">erroneous</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
@@ -93,8 +93,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-                     (xspec/xspec#356) So...
-                  </th>
+                     (xspec/xspec#356) So...</th>
                   <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
                </tr>
                <tr class="failed">
@@ -121,8 +120,7 @@
          </table>
          <div id="scenario1-scenario1">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-               (xspec/xspec#356) So... When x:result in the report XML contains a comment node,
-            </h3>
+               (xspec/xspec#356) So... When x:result in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario1-expect1">
                <h4>[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
@@ -135,9 +133,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment-text--&gt;</span></pre></td>
-                        <td><pre>()</pre></td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment-text--&gt;</span></pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -154,9 +155,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/comment()</code> from:
-                           </p><pre>&lt;!--comment-text--&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+                           <p>XPath <code>/comment()</code> from:</p>
+                           <pre>&lt;!--comment-text--&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -164,8 +168,7 @@
          </div>
          <div id="scenario1-scenario2">
             <h3>When the result is a comment node, the report HTML must serialize it as &lt;!-- --&gt;.
-               (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,
-            </h3>
+               (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
                <table class="xspecResult">
@@ -177,10 +180,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment-text--&gt;</span></pre></td>
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment-text--&gt;</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -198,8 +204,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result is indented in the report XML file, the report HTML must serialize
-                     it with indentation.
-                  </th>
+                     it with indentation.</th>
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
@@ -260,8 +265,7 @@
          <div id="scenario2-scenario1-scenario1">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:result in the report XML file
-               is a sequence of simple nested elements serialized with indentation,
-            </h3>
+               is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario1-expect1">
                <h4>all elements in [Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
@@ -274,15 +278,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;
 &lt;<span class="diff">bar</span>&gt;
    &lt;<span class="diff">baz</span> /&gt;
 &lt;/bar&gt;
 &lt;<span class="diff">qux</span>&gt;
    &lt;<span class="diff">quux</span> /&gt;
-&lt;/qux&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -299,15 +306,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;foo /&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;foo /&gt;
 &lt;bar&gt;
    &lt;baz /&gt;
 &lt;/bar&gt;
 &lt;qux&gt;
    &lt;quux /&gt;
-&lt;/qux&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -316,8 +326,7 @@
          <div id="scenario2-scenario1-scenario2">
             <h3>When the result is indented in the report XML file, the report HTML must serialize
                it with indentation. So... (xspec/xspec#359) When x:expect in the report XML file
-               is a sequence of simple nested elements serialized with indentation,
-            </h3>
+               is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario2-expect1">
                <h4>all elements in [Expected Result] with diff must be serialized with indentation.</h4>
                <table class="xspecResult">
@@ -329,16 +338,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">foo</span> /&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> /&gt;
 &lt;<span class="diff">bar</span>&gt;
    &lt;<span class="diff">baz</span> /&gt;
 &lt;/bar&gt;
 &lt;<span class="diff">qux</span>&gt;
    &lt;<span class="diff">quux</span> /&gt;
-&lt;/qux&gt;</pre></td>
+&lt;/qux&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -349,8 +361,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
-               XML file,
-            </h3>
+               XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
@@ -363,20 +374,22 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>
       &lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">foo</span>&lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">foo</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -387,8 +400,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a node is indented, the diff of the indented node itself must not be affected. (xspec/xspec#367)
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
-               XML file,
-            </h3>
+               XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1">
                <h4>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
                <table class="xspecResult">
@@ -401,20 +413,22 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">foo</span>&lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">foo</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">elem1</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>
       &lt;<span class="same">bar</span> /&gt;
    &lt;/elem1&gt;
    &lt;<span class="inner-diff">elem2</span>&gt;<span class="diff">&lt;!--foo--&gt;</span>&lt;?<span class="same">bar</span> <span class="same"></span>?&gt;&lt;/elem2&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -425,8 +439,7 @@
                it with indentation. But the diff must not be affected by indentation. So... When
                a child node of an element is indented, the diff of the element must not be affected.
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
-               XML file with different indentation length,
-            </h3>
+               XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1">
                <h4>&lt;foo&gt; must be green.</h4>
                <table class="xspecResult">
@@ -439,21 +452,23 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="same">foo</span>&gt;
       &lt;<span class="same">bar</span> /&gt;
    &lt;/foo&gt;
    &lt;<span class="diff">baz</span> /&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="same">foo</span>&gt;
       &lt;<span class="same">bar</span> /&gt;
    &lt;/foo&gt;
    &lt;<span class="diff">qux</span> /&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -492,12 +507,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">foo</span>&gt;<span class="same ellipsis">...</span>&lt;/foo&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">foo</span>&gt;<span class="same ellipsis">...</span>&lt;/foo&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">foo</span>&gt;<span class="same">...</span>&lt;/foo&gt;
-&lt;<span class="diff">qux</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">foo</span>&gt;<span class="same">...</span>&lt;/foo&gt;
+&lt;<span class="diff">qux</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -531,8 +548,7 @@
             <h3>When the result contains significant text nodes,</h3>
             <div id="scenario4-expect1">
                <h4>both in [Result] and [Expected Result] with diff, the significant text nodes must
-                  be serialized with color. (xspec/xspec#386)
-               </h4>
+                  be serialized with color. (xspec/xspec#386)</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -543,8 +559,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">actual</span>&lt;/diff&gt;
@@ -553,10 +569,11 @@
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">\t\n\r␣</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">test</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">test</span>&gt;
    &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">expect</span>&lt;/diff&gt;
@@ -565,7 +582,8 @@
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">␣\t\n\r</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -582,8 +600,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;test&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;test&gt;
    &lt;oridinary-text-node&gt;
       &lt;same&gt;same&lt;/same&gt;
       &lt;diff&gt;actual&lt;/diff&gt;
@@ -592,8 +610,11 @@
       &lt;same xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;diff xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/diff&gt;
    &lt;/significant-whitespace-only-text-node&gt;
-&lt;/test&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/test&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -611,8 +632,7 @@
             <tbody>
                <tr class="successful">
                   <th>When the result contains an element, the report HTML must serialize nodes in its opening
-                     tag with aligned indentation. (xspec/xspec#689) So...
-                  </th>
+                     tag with aligned indentation. (xspec/xspec#689) So...</th>
                   <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
@@ -660,8 +680,7 @@
          <div id="scenario5-scenario1-scenario1">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several namespaces in x:result,
-            </h3>
+               an element with several namespaces in x:result,</h3>
             <div id="scenario5-scenario1-scenario1-expect1">
                <h4>[Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -674,16 +693,19 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -700,16 +722,19 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -718,8 +743,7 @@
          <div id="scenario5-scenario1-scenario2">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several namespaces in x:expect,
-            </h3>
+               an element with several namespaces in x:expect,</h3>
             <div id="scenario5-scenario1-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -731,17 +755,20 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> xmlns="ns"
          xmlns:ns1="ns1"
          xmlns:ns2="ns2"
          xmlns:ns3="ns3"&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -750,8 +777,7 @@
          <div id="scenario5-scenario2-scenario1">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several attributes in x:result,
-            </h3>
+               an element with several attributes in x:result,</h3>
             <div id="scenario5-scenario2-scenario1-expect1">
                <h4>[Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -764,15 +790,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>=<span class="diff">"val1"</span>
          <span class="diff">attr2</span>=<span class="diff">"val2"</span>
          <span class="diff">attr3</span>=<span class="diff">"val3"</span>&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -789,15 +818,18 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;looooooooooooooooooooooooooooooooooong&gt;
    &lt;test attr1="val1"
          attr2="val2"
          attr3="val3"&gt;
       &lt;a /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -806,8 +838,7 @@
          <div id="scenario5-scenario2-scenario2">
             <h3>When the result contains an element, the report HTML must serialize nodes in its opening
                tag with aligned indentation. (xspec/xspec#689) So... When the report XML contains
-               an element with several attributes in x:expect,
-            </h3>
+               an element with several attributes in x:expect,</h3>
             <div id="scenario5-scenario2-scenario2-expect1">
                <h4>[Expected Result] with diff must be serialized with aligned indentation.</h4>
                <table class="xspecResult">
@@ -819,16 +850,19 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>xs:boolean('false')</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
+                           <pre>xs:boolean('false')</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">looooooooooooooooooooooooooooooooooong</span>&gt;
    &lt;<span class="diff">test</span> <span class="diff">attr1</span>=<span class="diff">"val1"</span>
          <span class="diff">attr2</span>=<span class="diff">"val2"</span>
          <span class="diff">attr3</span>=<span class="diff">"val3"</span>&gt;
       &lt;<span class="diff">a</span> /&gt;
    &lt;/test&gt;
-&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre></td>
+&lt;/looooooooooooooooooooooooooooooooooong&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -872,8 +906,7 @@
             <div id="scenario6-scenario1-expect1">
                <h4>The exact-match (taking '...' into account) attributes must be serialized as green="green".
                   The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                  must be serialized as solidPink="solidPink" regardless of their values.
-               </h4>
+                  must be serialized as solidPink="solidPink" regardless of their values.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -884,8 +917,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
              <span class="same">attr2</span>=<span class="same">"value2"</span>
              <span class="same">attr3</span>=<span class="same">""</span>
              <span class="same">attr4</span>=<span class="same">""</span> /&gt;
@@ -895,10 +928,11 @@
             <span class="inner-diff">attr4</span>=<span class="diff">"..."</span> /&gt;
 &lt;<span class="inner-diff">orphan</span> <span class="diff">attr1</span>=<span class="diff">"value1"</span>
         <span class="diff">attr2</span>=<span class="diff">""</span>
-        <span class="diff">attr3</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+        <span class="diff">attr3</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span> <span class="same">attr1</span>=<span class="same">"value1"</span>
              <span class="same">attr2</span>=<span class="same">"..."</span>
              <span class="same">attr3</span>=<span class="same">""</span>
              <span class="same">attr4</span>=<span class="same">"..."</span> /&gt;
@@ -908,7 +942,8 @@
             <span class="inner-diff">attr4</span>=<span class="diff">"value4"</span> /&gt;
 &lt;<span class="inner-diff">orphan</span> <span class="diff">attr4</span>=<span class="diff">"value4"</span>
         <span class="diff">attr5</span>=<span class="diff">""</span>
-        <span class="diff">attr6</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+        <span class="diff">attr6</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -928,8 +963,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;exact-match attr1="value1"
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;exact-match attr1="value1"
              attr2="value2"
              attr3=""
              attr4="" /&gt;
@@ -939,8 +974,11 @@
             attr4="..." /&gt;
 &lt;orphan attr1="value1"
         attr2=""
-        attr3="..." /&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+        attr3="..." /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -983,15 +1021,13 @@
          </table>
          <div id="scenario7-scenario1">
             <h3>When the result contains processing instructions, both in [Result] and [Expected Result]
-               with diff,
-            </h3>
+               with diff,</h3>
             <div id="scenario7-scenario1-expect1">
                <h4>The exact-match (taking '...' into account) processing instructions must be serialized
                   as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
                   solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
                   be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.
-               </h4>
+                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1002,8 +1038,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same"></span>?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same"></span>?&gt;&lt;/exact-match&gt;
 &lt;<span class="inner-diff">name-match</span>&gt;&lt;?<span class="inner-diff">node1</span> <span class="diff">value1</span>?&gt;&lt;?<span class="inner-diff">node2</span> <span class="diff">value2</span>?&gt;&lt;?<span class="inner-diff">node3</span> <span class="diff"></span>?&gt;&lt;?<span class="inner-diff">node4</span> <span class="diff">...</span>?&gt;&lt;/name-match&gt;
 &lt;<span class="inner-diff">value-match</span>&gt;&lt;?<span class="diff">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="diff">node2</span> <span class="same">value2</span>?&gt;&lt;?<span class="diff">node3</span> <span class="same"></span>?&gt;&lt;?<span class="diff">node4</span> <span class="same"></span>?&gt;&lt;/value-match&gt;
 &lt;<span class="inner-diff">no-match</span>&gt;
@@ -1017,10 +1053,11 @@
       &lt;<span class="inner-diff">node1</span>&gt;&lt;?<span class="diff">node1-1</span> <span class="diff">value1-1</span>?&gt;&lt;?<span class="diff">node1-2</span> <span class="diff"></span>?&gt;&lt;?<span class="diff">node1-3</span> <span class="diff">...</span>?&gt;&lt;/node1&gt;
       &lt;<span class="inner-diff">node2</span> /&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">...</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same">...</span>?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">exact-match</span>&gt;&lt;?<span class="same">node1</span> <span class="same">value1</span>?&gt;&lt;?<span class="same">node2</span> <span class="same">...</span>?&gt;&lt;?<span class="same">node3</span> <span class="same"></span>?&gt;&lt;?<span class="same">node4</span> <span class="same">...</span>?&gt;&lt;/exact-match&gt;
 &lt;<span class="inner-diff">name-match</span>&gt;&lt;?<span class="inner-diff">node1</span> <span class="diff">VALUE1</span>?&gt;&lt;?<span class="inner-diff">node2</span> <span class="diff"></span>?&gt;&lt;?<span class="inner-diff">node3</span> <span class="diff">value3</span>?&gt;&lt;?<span class="inner-diff">node4</span> <span class="diff">value4</span>?&gt;&lt;/name-match&gt;
 &lt;<span class="inner-diff">value-match</span>&gt;&lt;?<span class="diff">NODE1</span> <span class="same">value1</span>?&gt;&lt;?<span class="diff">NODE2</span> <span class="same">...</span>?&gt;&lt;?<span class="diff">NODE3</span> <span class="same"></span>?&gt;&lt;?<span class="diff">NODE4</span> <span class="same">...</span>?&gt;&lt;/value-match&gt;
 &lt;<span class="inner-diff">no-match</span>&gt;
@@ -1035,7 +1072,8 @@
       &lt;<span class="inner-diff">node1</span> /&gt;
       &lt;<span class="inner-diff">node2</span>&gt;&lt;?<span class="diff">node2-1</span> <span class="diff">value2-1</span>?&gt;&lt;?<span class="diff">node2-2</span> <span class="diff"></span>?&gt;&lt;?<span class="diff">node2-3</span> <span class="diff">...</span>?&gt;&lt;/node2&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1055,8 +1093,8 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code>/element()</code> from:
-                           </p><pre>&lt;exact-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/exact-match&gt;
+                           <p>XPath <code>/element()</code> from:</p>
+                           <pre>&lt;exact-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/exact-match&gt;
 &lt;name-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ...?&gt;&lt;/name-match&gt;
 &lt;value-match&gt;&lt;?node1 value1?&gt;&lt;?node2 value2?&gt;&lt;?node3 ?&gt;&lt;?node4 ?&gt;&lt;/value-match&gt;
 &lt;no-match&gt;
@@ -1070,8 +1108,11 @@
       &lt;node1&gt;&lt;?node1-1 value1-1?&gt;&lt;?node1-2 ?&gt;&lt;?node1-3 ...?&gt;&lt;/node1&gt;
       &lt;node2 /&gt;
    &lt;/orphan&gt;
-&lt;/no-match&gt;</pre></td>
-                        <td><pre>false()</pre></td>
+&lt;/no-match&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
@@ -72,8 +72,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>
@@ -93,8 +92,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>
@@ -141,8 +139,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and explicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -151,8 +148,7 @@
                </tr>
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
-                     x:scenario and x:like
-                  </td>
+                     x:scenario and x:like</td>
                   <td>Success</td>
                </tr>
             </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for xspec-three-dots.xsl (passed: 44 / pending: 0 / failed: 28 / total:
-         72)
-      </title>
+      <title>Test Report for xspec-three-dots.xsl (passed: 44 / pending: 0 / failed: 28 / total: 72)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -191,11 +189,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -215,11 +215,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">text</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">text</span>&lt;/elem&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -270,11 +272,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span> <span class="diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">elem</span>&gt;<span class="diff">...</span>&lt;/elem&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -337,14 +341,16 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">outer</span>&gt;
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">outer</span>&gt;
    &lt;<span class="same">inner</span> /&gt;
-&lt;/outer&gt;</pre></td>
+&lt;/outer&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/element()</code> from:
-                           </p><pre>&lt;<span class="inner-diff">outer</span>&gt;<span class="same">...</span>&lt;<span class="diff">inner</span> /&gt;
-&lt;/outer&gt;</pre></td>
+                           <p>XPath <code class="same">/element()</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">outer</span>&gt;<span class="same">...</span>&lt;<span class="diff">inner</span> /&gt;
+&lt;/outer&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -415,11 +421,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/@*</code> from:
-                           </p><pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"..."</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/@*</code> from:
-                           </p><pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/@*</code> from:</p>
+                           <pre>&lt;<span class="inner-diff">pseudo-attribute</span> <span class="inner-diff">attrib</span>=<span class="diff">"val"</span> /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -506,9 +514,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -528,11 +539,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff whitespace">\t\n\r␣</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff whitespace">\t\n\r␣</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -552,11 +565,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff whitespace"></span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff whitespace"></span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -576,11 +591,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -597,9 +614,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -670,11 +690,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--...--&gt;</span></pre></td>
+                           <p>XPath <code class="same">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--...--&gt;</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/comment()</code> from:
-                           </p><pre><span class="diff">&lt;!--comment--&gt;</span></pre></td>
+                           <p>XPath <code class="same">/comment()</code> from:</p>
+                           <pre><span class="diff">&lt;!--comment--&gt;</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -745,11 +767,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">...</span>?&gt;</pre></td>
+                           <p>XPath <code class="same">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">...</span>?&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/processing-instruction()</code> from:
-                           </p><pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">data</span>?&gt;</pre></td>
+                           <p>XPath <code class="same">/processing-instruction()</code> from:</p>
+                           <pre>&lt;?<span class="inner-diff">pi</span> <span class="diff">data</span>?&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -812,8 +836,7 @@
          </table>
          <div id="scenario8-scenario1">
             <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt;
-            </h3>
+               /&gt;&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario1-expect1">
                <h4>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
                <table class="xspecResult">
@@ -826,12 +849,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
-&lt;<span class="diff">elem</span> /&gt;</pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
+&lt;<span class="diff">elem</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="same">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="same">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -851,11 +876,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -875,11 +902,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/self::document-node()</code> from:
-                           </p><pre><span class="diff">text</span></pre></td>
+                           <p>XPath <code class="same">/self::document-node()</code> from:</p>
+                           <pre><span class="diff">text</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -954,11 +983,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="..." /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="..." /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/*/namespace::*</code> from:
-                           </p><pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="namespace-uri" /&gt;</pre></td>
+                           <p>XPath <code class="same">/*/namespace::*</code> from:</p>
+                           <pre>&lt;<span class="same">pseudo-namespace-node</span> xmlns:prefix="namespace-uri" /&gt;</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1005,8 +1036,7 @@
          </table>
          <div id="scenario10-scenario1">
             <h3>For resultant sequence of multiple nodes When result is sequence of &lt;elem1 /&gt;&lt;elem2
-               /&gt;
-            </h3>
+               /&gt;</h3>
             <div id="scenario10-scenario1-expect3">
                <h4>expecting ... should be Failure</h4>
                <table class="xspecResult">
@@ -1019,12 +1049,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="same">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="same">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="same">...</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="same">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1041,12 +1073,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">......</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">......</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1063,12 +1097,14 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/element()</code> from:
-                           </p><pre>&lt;<span class="diff">elem1</span> /&gt;
-&lt;<span class="diff">elem2</span> /&gt;</pre></td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">elem1</span> /&gt;
+&lt;<span class="diff">elem2</span> /&gt;</pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">.........</span></pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">.........</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1106,10 +1142,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>()</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>()</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1175,10 +1214,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'string'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>'string'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1194,8 +1236,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'string'</pre></td>
-                        <td><pre>'...'</pre></td>
+                        <td>
+                           <pre>'string'</pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1214,10 +1260,13 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'...'</pre></td>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">...</span></pre></td>
+                           <pre>'...'</pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1233,8 +1282,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'...'</pre></td>
-                        <td><pre>'string'</pre></td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
+                        <td>
+                           <pre>'string'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1285,11 +1338,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">....</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">....</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1306,11 +1361,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">...x</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">...x</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1327,11 +1384,13 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
                         <td>
-                           <p>XPath <code class="same">/text()</code> from:
-                           </p><pre><span class="diff"> ...</span></pre></td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff"> ...</span></pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -1348,9 +1407,12 @@
                   <tbody>
                      <tr>
                         <td>
-                           <p>XPath <code class="diff">/text()</code> from:
-                           </p><pre><span class="diff">item</span></pre></td>
-                        <td><pre>'...'</pre></td>
+                           <p>XPath <code class="diff">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <pre>'...'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.xml
@@ -569,14 +569,14 @@
             <x:param select="'namespace-uri'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
+            <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:result>
          <x:test id="scenario9-scenario1-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario1-expect2" successful="true">
@@ -617,14 +617,14 @@
             <x:param select="'...'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+            <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
          </x:result>
          <x:test id="scenario9-scenario3-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
+               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario3-expect2" successful="true">
@@ -636,7 +636,7 @@
 					  xmlns:prefix="namespace-uri"
 					should be Failure</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
+               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
             </x:expect>
          </x:test>
       </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-xslt2-result.html
@@ -64,8 +64,7 @@
                <tr class="successful">
                   <th>xslt-version=1.0 in this XSpec file should always make all of the tests in this scenario
                      Success, even when this XSpec file is imported to another XSpec file which has xslt-version=2.0
-                     or higher.
-                  </th>
+                     or higher.</th>
                   <th>passed: 4 / pending: 0 / failed: 0 / total: 4</th>
                </tr>
                <tr class="successful">
@@ -100,8 +99,7 @@
             <h3>With 2 text nodes xslt-version=1.0 in this XSpec file should make this scenario Success
                when this XSpec file is executed independently. On the other hand, the result should
                be Failure when this XSpec file is imported to another XSpec file which has xslt-version=2.0
-               or higher.
-            </h3>
+               or higher.</h3>
             <div id="scenario1-scenario3-expect1">
                <h4>Expecting the compiled stylesheet to have version=1.0</h4>
                <table class="xspecResult">
@@ -113,8 +111,12 @@
                   </thead>
                   <tbody>
                      <tr>
-                        <td><pre>'2.0'</pre></td>
-                        <td><pre>'1.0'</pre></td>
+                        <td>
+                           <pre>'2.0'</pre>
+                        </td>
+                        <td>
+                           <pre>'1.0'</pre>
+                        </td>
                      </tr>
                   </tbody>
                </table>


### PR DESCRIPTION
Closes #588 

This pull request updates `test/end-to-end/ant/generate-expected/` to reject Saxon 9.8 or less (and 9.9.0.1 where XSpec crashes).

`test/end-to-end/cases/expected/` has been regenerated by Saxon-EE 9.9.0.2 (also tested on EE 9.9.1.5, EE 9.9.1.6 and HE 9.9.1.6). All the changes there reflect just how Saxon serializes HTML (and XML namespaces in a couple of cases).

`test/end-to-end/ant/run-e2e-tests/` is not affected and is still available on Saxon 9.8 and 9.7 as demonstrated on CI. The (ad hoc) [normalizer](https://github.com/xspec/xspec/blob/27731c941fcb14fdfafb9b74f3013d53a671f1a6/test/end-to-end/processor/html/_deserializer.xsl#L11-L28) absorbs the difference among Saxon versions.