### PR TITLE
test: fix nonexistent call rmdir-if-exists

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -719,7 +719,7 @@
     set ANT_ARGS=
 
     rem Delete default output dir if exists
-    call :rmdir-if-exists ..\tutorial\schematron\xspec
+    call :rmdir-if-exist ..\tutorial\schematron\xspec
 
     rem Run
     rem * Should work without phase #168


### PR DESCRIPTION
There is an [error](https://xspec.visualstudio.com/xspec/_build/results?buildId=806&view=logs&j=166b8c02-95cc-5502-dd2b-44f9c8527e72&t=31cacdea-a5fc-5a98-b796-b9d255e3ef7e&l=321) in a Bats test for Windows:

```console
CASE #42: Ant with minimum properties (Schematron)
The system cannot find the batch label specified - rmdir-if-exists
...
```

This pull request [fixes](https://xspec.visualstudio.com/xspec/_build/results?buildId=808&view=logs&j=166b8c02-95cc-5502-dd2b-44f9c8527e72&t=31cacdea-a5fc-5a98-b796-b9d255e3ef7e&l=320) it.
