### PR TITLE
fix(report): fix tokenizing stylesheet CR lines on code coverage

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -91,7 +91,7 @@
   <xsl:variable name="stylesheet-string" as="xs:string"
     select="unparsed-text($stylesheet-uri)" />
   <xsl:variable name="stylesheet-lines" as="xs:string+" 
-    select="tokenize($stylesheet-string, '\n')" />
+    select="test:split-lines($stylesheet-string)" />
   <xsl:variable name="number-of-lines" as="xs:integer"
     select="count($stylesheet-lines)" />
   <xsl:variable name="number-width" as="xs:integer"
@@ -203,7 +203,7 @@
         <xsl:variable name="construct" as="xs:string" select="regex-group(1)" />
         <xsl:variable name="rest" as="xs:string" select="regex-group(20)" />
         <xsl:variable name="construct-lines" as="xs:string+"
-          select="tokenize($construct, '\n')" />
+          select="test:split-lines($construct)" />
         <xsl:variable name="endTag" as="xs:boolean" select="regex-group(9) != ''" />
         <xsl:variable name="emptyTag" as="xs:boolean" select="regex-group(19) != ''" />
         <xsl:variable name="startTag" as="xs:boolean" select="not($emptyTag) and regex-group(11) != ''" />
@@ -367,6 +367,13 @@
     select="for $l in $line-numbers
             return concat($module, ':', $l)" />
   <xsl:sequence select="key('coverage', $keys, $trace)" />
+</xsl:function>
+
+<xsl:function name="test:split-lines" as="xs:string+">
+  <xsl:param name="input" as="xs:string" />
+
+  <!-- Regular expression is based on http://www.w3.org/TR/xpath-functions-31/#func-unparsed-text-lines -->
+  <xsl:sequence select="tokenize($input, '\r\n|\r|\n')" />
 </xsl:function>
 
 </xsl:stylesheet>

--- a/test/end-to-end/cases/.gitattributes
+++ b/test/end-to-end/cases/.gitattributes
@@ -1,0 +1,3 @@
+/xspec-793-cr.xsl   binary
+/xspec-793-crlf.xsl eol=crlf
+/xspec-793-lf.xsl   eol=lf

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-coverage.html
@@ -7,7 +7,16 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xspec-793-cr.xsl">xspec-793-cr.xsl</a></p>
-      <h2>module: xspec-793-cr.xsl; 1 lines</h2>
-      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;!-- This file must be saved with CR line ending --&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">&#xD;	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored">&#xD;		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[&#xD;test&#xD;]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored">&#xD;	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored">&#xD;</span></pre>
+      <h2>module: xspec-793-cr.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR line ending --&gt;</span><span class="ignored"></span>
+03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored"></span>
+05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
+06: <span class="hit">test</span>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
+09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
+10: <span class="ignored"></span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-coverage.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xspec-793-cr.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xspec-793-cr.xsl">xspec-793-cr.xsl</a></p>
+      <h2>module: xspec-793-cr.xsl; 1 lines</h2>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;!-- This file must be saved with CR line ending --&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">&#xD;	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored">&#xD;		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[&#xD;test&#xD;]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored">&#xD;	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored">&#xD;</span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored">&#xD;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-793-cr.xspec">
+   <testsuite name="input" tests="1" failures="0">
+      <testcase name="output" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-793-cr.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../xspec-793-cr.xsl">xspec-793-cr.xsl</a></p>
+      <p>XSpec: <a href="../../xspec-793-cr.xspec">xspec-793-cr.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">input</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">input<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>input</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>output</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-result.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../xspec-793-cr.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../xspec-793-cr.xspec">
+   <x:scenario id="scenario1" xspec="../../xspec-793-cr.xspec">
+      <x:label>input</x:label>
+      <x:context>
+         <input/>
+      </x:context>
+      <x:result select="/element()">
+         <output>
+test
+</output>
+      </x:result>
+      <x:test id="scenario1-expect1" successful="true">
+         <x:label>output</x:label>
+         <x:expect select="/element()">
+            <output>
+test
+</output>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-coverage.html
@@ -8,15 +8,15 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xspec-793-crlf.xsl">xspec-793-crlf.xsl</a></p>
       <h2>module: xspec-793-crlf.xsl; 10 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored">&#xD;</span>
-02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR LF line ending --&gt;</span><span class="ignored">&#xD;</span>
-03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">&#xD;</span>
-04: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored">&#xD;</span>
-05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[&#xD;</span>
-06: <span class="hit">test&#xD;</span>
-07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored">&#xD;</span>
-08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored">&#xD;</span>
-09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored">&#xD;</span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR LF line ending --&gt;</span><span class="ignored"></span>
+03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored"></span>
+05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
+06: <span class="hit">test</span>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
+09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
 10: <span class="ignored"></span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-coverage.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xspec-793-crlf.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xspec-793-crlf.xsl">xspec-793-crlf.xsl</a></p>
+      <h2>module: xspec-793-crlf.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored">&#xD;</span>
+02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR LF line ending --&gt;</span><span class="ignored">&#xD;</span>
+03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">&#xD;</span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored">&#xD;</span>
+05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[&#xD;</span>
+06: <span class="hit">test&#xD;</span>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored">&#xD;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored">&#xD;</span>
+09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored">&#xD;</span>
+10: <span class="ignored"></span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-793-crlf.xspec">
+   <testsuite name="input" tests="1" failures="0">
+      <testcase name="output" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-793-crlf.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../xspec-793-crlf.xsl">xspec-793-crlf.xsl</a></p>
+      <p>XSpec: <a href="../../xspec-793-crlf.xspec">xspec-793-crlf.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">input</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">input<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>input</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>output</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-result.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../xspec-793-crlf.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../xspec-793-crlf.xspec">
+   <x:scenario id="scenario1" xspec="../../xspec-793-crlf.xspec">
+      <x:label>input</x:label>
+      <x:context>
+         <input/>
+      </x:context>
+      <x:result select="/element()">
+         <output>
+test
+</output>
+      </x:result>
+      <x:test id="scenario1-expect1" successful="true">
+         <x:label>output</x:label>
+         <x:expect select="/element()">
+            <output>
+test
+</output>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-coverage.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xspec-793-lf.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xspec-793-lf.xsl">xspec-793-lf.xsl</a></p>
+      <h2>module: xspec-793-lf.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with LF line ending --&gt;</span><span class="ignored"></span>
+03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template match="input"&gt;</span><span class="ignored"></span>
+05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
+06: <span class="hit">test</span>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
+09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
+10: <span class="ignored"></span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-793-lf.xspec">
+   <testsuite name="input" tests="1" failures="0">
+      <testcase name="output" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-793-lf.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../xspec-793-lf.xsl">xspec-793-lf.xsl</a></p>
+      <p>XSpec: <a href="../../xspec-793-lf.xspec">xspec-793-lf.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">input</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">input<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>input</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>output</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-793-lf-result.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../xspec-793-lf.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../xspec-793-lf.xspec">
+   <x:scenario id="scenario1" xspec="../../xspec-793-lf.xspec">
+      <x:label>input</x:label>
+      <x:context>
+         <input/>
+      </x:context>
+      <x:result select="/element()">
+         <output>
+test
+</output>
+      </x:result>
+      <x:test id="scenario1-expect1" successful="true">
+         <x:label>output</x:label>
+         <x:expect select="/element()">
+            <output>
+test
+</output>
+         </x:expect>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/xspec-793-cr.xsl
+++ b/test/end-to-end/cases/xspec-793-cr.xsl
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- This file must be saved with CR line ending --><xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">	<xsl:template match="input">		<output><![CDATA[test]]></output>	</xsl:template></xsl:stylesheet>

--- a/test/end-to-end/cases/xspec-793-cr.xspec
+++ b/test/end-to-end/cases/xspec-793-cr.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="xspec-793-cr.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="input">
+		<x:context>
+			<input />
+		</x:context>
+		<x:expect label="output">
+			<output><![CDATA[
+test
+]]></output>
+		</x:expect>
+	</x:scenario>
+</x:description>

--- a/test/end-to-end/cases/xspec-793-crlf.xsl
+++ b/test/end-to-end/cases/xspec-793-crlf.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file must be saved with CR LF line ending -->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template match="input">
+		<output><![CDATA[
+test
+]]></output>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases/xspec-793-crlf.xspec
+++ b/test/end-to-end/cases/xspec-793-crlf.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="xspec-793-crlf.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="input">
+		<x:context>
+			<input />
+		</x:context>
+		<x:expect label="output">
+			<output><![CDATA[
+test
+]]></output>
+		</x:expect>
+	</x:scenario>
+</x:description>

--- a/test/end-to-end/cases/xspec-793-lf.xsl
+++ b/test/end-to-end/cases/xspec-793-lf.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file must be saved with LF line ending -->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template match="input">
+		<output><![CDATA[
+test
+]]></output>
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases/xspec-793-lf.xspec
+++ b/test/end-to-end/cases/xspec-793-lf.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="xspec-793-lf.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="input">
+		<x:context>
+			<input />
+		</x:context>
+		<x:expect label="output">
+			<output><![CDATA[
+test
+]]></output>
+		</x:expect>
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
Fixes #793

Before fixing the issue, CR lines were reported [as one line](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/65052b4ddd18e7400178ffe119131817fc079b42/test/end-to-end/cases/expected/stylesheet/xspec-793-cr-coverage.html) and CR LF lines were reported [with `&#xD;`](https://github.com/xspec/xspec/blob/65052b4ddd18e7400178ffe119131817fc079b42/test/end-to-end/cases/expected/stylesheet/xspec-793-crlf-coverage.html), as demonstrated in an intermediate commit.

The test files (`test/end-to-end/cases/xspec-793-*.*`) were created by copying `test/end-to-end/cases/xspec-214.*` and saved with different line endings. See [`test/end-to-end/cases/.gitattributes`](https://github.com/xspec/xspec/blob/bdb517f4c4a9d13933a735f68ca16524c0e1f714/test/end-to-end/cases/.gitattributes).