### PR TITLE
build(oxygen): add-on v0.0.6

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v1.6.0-SNAPSHOT.2</h3>
+				<ul>
+					<li>feat(schema): add Schematron schema for XSpec (<a
+							href="https://github.com/xspec/xspec/pull/742">#742</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v1.6.0-SNAPSHOT.1</h3>
 				<ul>
 					<li>Support Oxygen 22.0 (<a href="https://github.com/xspec/xspec/pull/780"

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -10,7 +10,7 @@
 		<!-- To publish a new version, update this @href to a specific commit archive and increment
 			<xt:version>. -->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/4f11f0cb3a8458774c49c84249aa8d280bcf56fd.zip" />
+			href="https://github.com/xspec/xspec/archive/c0c1c224dbaac47718260c15ebc8534293d18e00.zip" />
 
 		<!-- The version of this add-on. Increment only the last numeric part ('z' of "0.0.z")
 			whenever we publish a new version of this add-on.
@@ -18,7 +18,7 @@
 			by this add-on. But <xt:version> consists of only three numeric parts ("x.y.z") which
 			doesn't accommodate pre-release versions of XSpec ("x.y.z-SNAPSHOT.1" or something like
 			that). Use "0.0.z" until we find a better way. -->
-		<xt:version>0.0.5</xt:version>
+		<xt:version>0.0.6</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
Following #742, this pull request publishes the latest master via Oxygen add-on channel.

#795 is a new feature, but it doesn't help Oxygen users who already have in-app Saxon-PE+ license. That's why I didn't include it in the [changelog](https://github.com/xspec/xspec/pull/800/files#diff-0bbbd2c604be5224d8c4002e3df89307).

I tested this add-on version on Oxygen 22.0 build 2020021016 using `https://github.com/AirQuick/xspec/raw/oxy-addon_0-0-6/oxygen-addon.xml` and verified that
* SQF for XSpec worked
* **XSLT Code Coverage** transformation scenario worked with `test/end-to-end/cases/xspec-793-cr.xspec`
* **Run XSpec Test** transformation scenario worked with XSLT, XQuery and Schematron tutorial files