### PR TITLE
test: comment in xspec-avt*.xspec about xspec-utils_stylesheet.xspec

### DIFF
--- a/test/xspec-avt.xspec
+++ b/test/xspec-avt.xspec
@@ -3,6 +3,12 @@
 	stylesheet="do-nothing.xsl"
 	xmlns:myv="http://example.org/ns/my/variable"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		xspec-utils_stylesheet.xspec uses this file for testing x:is-user-content().
+		When modifying this file, check whether xspec-utils_stylesheet.xspec needs any additions or updates.
+	-->
+
 	<x:scenario label="In function-param, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:call[@function]/x:param/node(),">
 			<x:call function="exactly-one">

--- a/test/xspec-avt_stylesheet.xspec
+++ b/test/xspec-avt_stylesheet.xspec
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="xspec-avt.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
+	<!--
+		xspec-utils_stylesheet.xspec uses this file for testing x:is-user-content().
+		When modifying this file, check whether xspec-utils_stylesheet.xspec needs any additions or updates.
+	-->
+
 	<x:scenario label="In context template-param, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:context/x:param/node(),">
 			<x:context mode="param-mirror-mode">


### PR DESCRIPTION
Following f1dab868210d47b858e10e5aff3a0615dcd1b495, this pull request just adds comments to `test/xspec-avt*.xspec` about their relationship to `test/xspec-utils_stylesheet.xspec`.
No code change.