### PR TITLE
fix: trim names while gathering specs

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -371,4 +371,31 @@
 		<xsl:sequence select="x:resolve-xml-uri-with-catalog($schematron-uri)" />
 	</xsl:function>
 
+	<!--
+		Removes leading whitespace
+	-->
+	<xsl:function as="xs:string" name="x:left-trim">
+		<xsl:param as="xs:string" name="input" />
+
+		<xsl:sequence select="replace($input, '^\s+', '')" />
+	</xsl:function>
+
+	<!--
+		Removes trailing whitespace
+	-->
+	<xsl:function as="xs:string" name="x:right-trim">
+		<xsl:param as="xs:string" name="input" />
+
+		<xsl:sequence select="replace($input, '\s+$', '')" />
+	</xsl:function>
+
+	<!--
+		Removes leading and trailing whitespace
+	-->
+	<xsl:function as="xs:string" name="x:trim">
+		<xsl:param as="xs:string" name="input" />
+
+		<xsl:sequence select="x:left-trim(x:right-trim($input))" />
+	</xsl:function>
+
 </xsl:stylesheet>

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -779,7 +779,7 @@
       <xsl:variable name="msg" as="xs:string"
          select="concat('User-defined XSpec variable, ',@name,', must not use the XSpec namespace.')"/>
       <xsl:choose>
-         <xsl:when test="starts-with(normalize-space(@name),'Q{')">
+         <xsl:when test="starts-with(x:left-trim(@name),'Q{')">
             <!-- URI-qualified name -->
             <xsl:if test="replace(@name,'(^\s*Q\{)|(\}.*$)','') eq $xspec-namespace">
                <xsl:sequence select="error(xs:QName('x:XSPEC008'), $msg)"/>
@@ -801,7 +801,7 @@
       <!-- Create sequence of xs:QName values, so we can use distinct-values to compare them all. -->
       <xsl:variable name="qnames" as="xs:QName*"
          select="for $thisvar in $vars return
-         if (starts-with(normalize-space($thisvar/@name),'Q{'))
+         if (starts-with(x:left-trim($thisvar/@name),'Q{'))
          then QName(replace($thisvar/@name,'(^\s*Q\{)|(\}.*$)',''), substring-after($thisvar/@name,'}'))
          else QName($thisvar/@namespace-uri, $thisvar/@name)
          "/>

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -185,7 +185,7 @@
    </xsl:template>
 
    <xsl:template match="x:*/@as | x:*/@function | x:*/@mode | x:*/@name" as="attribute()"
-       mode="x:gather-specs">
+      mode="x:gather-specs">
       <xsl:attribute name="{local-name()}" namespace="{namespace-uri()}" select="x:trim(.)" />
    </xsl:template>
 

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -184,8 +184,8 @@
          select="resolve-uri(., x:base-uri(.))" />
    </xsl:template>
 
-   <xsl:template match="x:*/@as | x:*/@function | x:*/@mode | x:*/@name" as="attribute()"
-      mode="x:gather-specs">
+   <xsl:template match="x:*/@as | x:*/@function | x:*/@mode | x:*/@name | x:*/@template"
+      as="attribute()" mode="x:gather-specs">
       <xsl:attribute name="{local-name()}" namespace="{namespace-uri()}" select="x:trim(.)" />
    </xsl:template>
 

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -372,7 +372,7 @@
 <xsl:template match="x:label" as="text()" mode="x:html-report">
   <!-- TODO: Consider doing more whitespace normalization or normalizing
     at an earlier stage (the compiler or the XML report) -->
-  <xsl:value-of select=" replace(., '\s+$', '')" />
+  <xsl:value-of select="x:right-trim(.)" />
 </xsl:template>
 
 <!-- Formats the Actual Result or the Expected Result in HTML -->

--- a/test/variable/reserved-eqname.xspec
+++ b/test/variable/reserved-eqname.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="../do-nothing.xsl">
+
+   <x:scenario label="URIQualifiedName in local variable">
+      <x:variable
+         name="Q{http://www.jenitennison.com/xslt/xspec}foo"
+         select="'str'" />
+      <x:call function="exactly-one">
+         <x:param select="$x:foo" />
+      </x:call>
+      <x:expect label="takes effect" select="'str'" />
+   </x:scenario>
+
+</x:description>

--- a/test/variable/reserved-eqname.xspec
+++ b/test/variable/reserved-eqname.xspec
@@ -3,8 +3,12 @@
                stylesheet="../do-nothing.xsl">
 
    <x:scenario label="URIQualifiedName in local variable">
+      <!-- Leading and trailing &#x09;&#x0A;&#x0D;&#x20; inserted deliberately -->
       <x:variable
-         name="Q{http://www.jenitennison.com/xslt/xspec}foo"
+         name="
+            &#x09;&#x0A;&#x0D;&#x20;
+            Q{http://www.jenitennison.com/xslt/xspec}foo
+            &#x09;&#x0A;&#x0D;&#x20;"
          select="'str'" />
       <x:call function="exactly-one">
          <x:param select="$x:foo" />

--- a/test/variable/reserved-name.xspec
+++ b/test/variable/reserved-name.xspec
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<x:description xmlns:u="http://www.jenitennison.com/xslt/xspec"
+               xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="../do-nothing.xsl">
 
-   <x:variable name="x:foo" />
+   <x:variable name="u:foo"
+               select="'str'" />
+
+   <x:scenario label="QName in global variable">
+      <x:call function="exactly-one">
+         <x:param select="$u:foo" />
+      </x:call>
+      <x:expect label="takes effect" select="'str'" />
+   </x:scenario>
 
 </x:description>

--- a/test/variable/reserved-name.xspec
+++ b/test/variable/reserved-name.xspec
@@ -3,7 +3,11 @@
                xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="../do-nothing.xsl">
 
-   <x:variable name="u:foo"
+   <!-- Leading and trailing &#x09;&#x0A;&#x0D;&#x20; inserted deliberately -->
+   <x:variable name="
+                  &#x09;&#x0A;&#x0D;&#x20;
+                  u:foo
+                  &#x09;&#x0A;&#x0D;&#x20;"
                select="'str'" />
 
    <x:scenario label="QName in global variable">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1256,10 +1256,17 @@
 		User-defined variable in XSpec namespace
 	-->
 
-	<case name="Error on user-defined variable in XSpec namespace">
+	<case name="Error on user-defined variable in XSpec namespace (URIQualifiedName in local variable)">
+    call :run ..\bin\xspec.bat variable\reserved-eqname.xspec
+    call :verify_retval 2
+    call :verify_line 6 x "  x:XSPEC008: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo,"
+    call :verify_line 7 x "  must not use the XSpec namespace."
+	</case>
+
+	<case name="Error on user-defined variable in XSpec namespace (QName in global variable)">
     call :run ..\bin\xspec.bat variable\reserved-name.xspec
     call :verify_retval 2
-    call :verify_line 6 r ".*x:XSPEC008:"
+    call :verify_line 6 x "  x:XSPEC008: User-defined XSpec variable, u:foo, must not use the XSpec namespace."
 	</case>
 
 	<!--

--- a/test/xspec-eqname.xspec
+++ b/test/xspec-eqname.xspec
@@ -6,9 +6,19 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xslt-version="3.0">
 
+	<!-- Leading and trailing &#x09;&#x0A;&#x0D;&#x20; inserted to names deliberately -->
+
 	<x:scenario label="Using EQName in function-call @function and function-param @name">
-		<x:call function="Q{x-urn:test:xspec-eqname}param-mirror-function">
-			<x:param name="Q{x-urn:test:xspec-eqname}param-items">
+		<x:call
+			function="
+				&#x09;&#x0A;&#x0D;&#x20;
+				Q{x-urn:test:xspec-eqname}param-mirror-function
+				&#x09;&#x0A;&#x0D;&#x20;">
+			<x:param
+				name="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{x-urn:test:xspec-eqname}param-items
+					&#x09;&#x0A;&#x0D;&#x20;">
 				<function-param-child />
 			</x:param>
 		</x:call>
@@ -19,13 +29,23 @@
 
 	<x:scenario label="Using EQName in function-param @as">
 		<x:call function="Q{x-urn:test:xspec-eqname}param-mirror-function">
-			<x:param name="Q{x-urn:test:xspec-eqname}param-items" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+			<x:param
+				name="Q{x-urn:test:xspec-eqname}param-items"
+				as="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{http://www.w3.org/2001/XMLSchema}string
+					&#x09;&#x0A;&#x0D;&#x20;"
+				select="'xyz'"/>
 		</x:call>
 		<x:expect label="should be possible" test="$x:result treat as xs:string"
 			select="$x:result treat as xs:string"/>
 	</x:scenario>
 
-	<x:param name="Q{x-urn:test:xspec-eqname}global-param">
+	<x:param
+		name="
+			&#x09;&#x0A;&#x0D;&#x20;
+			Q{x-urn:test:xspec-eqname}global-param
+			&#x09;&#x0A;&#x0D;&#x20;">
 		<global-param-child />
 	</x:param>
 	<x:scenario label="Using EQName in global-param @name">
@@ -38,7 +58,13 @@
 		 />
 	</x:scenario>
 
-	<x:param name="Q{x-urn:test:xspec-eqname}global-string-param" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+	<x:param
+		name="Q{x-urn:test:xspec-eqname}global-string-param"
+		as="
+			&#x09;&#x0A;&#x0D;&#x20;
+			Q{http://www.w3.org/2001/XMLSchema}string
+			&#x09;&#x0A;&#x0D;&#x20;"
+		select="'xyz'"/>
 	<x:scenario label="Using EQName in global-param @as">
 		<x:call function="false" />
 		<x:expect label="should be possible"
@@ -46,7 +72,13 @@
 			select="$Q{x-urn:test:xspec-eqname}global-string-param treat as xs:string"/>
 	</x:scenario>
 
-	<x:variable name="Q{http://example.org/ns/my/variable}global-var" select="/Q{}global-var-child" as="element(global-var-child)">
+	<x:variable
+		name="
+			&#x09;&#x0A;&#x0D;&#x20;
+			Q{http://example.org/ns/my/variable}global-var
+			&#x09;&#x0A;&#x0D;&#x20;"
+		select="/Q{}global-var-child"
+		as="element(global-var-child)">
 		<global-var-child />
 	</x:variable>
 	<x:scenario label="Using EQName in global variable @name and @select">
@@ -58,7 +90,13 @@
 			test="$Q{http://example.org/ns/my/variable}global-var instance of element(Q{}global-var-child)"
 		/>
 	</x:scenario>
-	<x:variable name="Q{http://example.org/ns/my/variable}global-string-var" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+	<x:variable
+		name="Q{http://example.org/ns/my/variable}global-string-var"
+		as="
+			&#x09;&#x0A;&#x0D;&#x20;
+			Q{http://www.w3.org/2001/XMLSchema}string
+			&#x09;&#x0A;&#x0D;&#x20;"
+		select="'xyz'"/>
 	<x:scenario label="Using EQName in global variable @as">
 		<x:call function="false" />
 		<x:expect label="should be possible"
@@ -67,7 +105,12 @@
 	</x:scenario>
 
 	<x:scenario label="Using EQName in local variable @name and @select">
-		<x:variable name="Q{http://example.org/ns/my/variable}var" as="element(variable-child)"
+		<x:variable
+			name="
+				&#x09;&#x0A;&#x0D;&#x20;
+				Q{http://example.org/ns/my/variable}var
+				&#x09;&#x0A;&#x0D;&#x20;"
+			as="element(variable-child)"
 			select="/Q{}variable-child"><variable-child /></x:variable>
 		<!-- The following definition illustrates redefining a variable and mixing notations
 			for its name. The file xspec-variable.xspec would be a good place to test that,
@@ -103,7 +146,13 @@
 	</x:scenario>
 
 	<x:scenario label="Using EQName in local variable @as">
-		<x:variable name="Q{http://example.org/ns/my/variable}string-var" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+		<x:variable
+			name="Q{http://example.org/ns/my/variable}string-var"
+			as="
+				&#x09;&#x0A;&#x0D;&#x20;
+				Q{http://www.w3.org/2001/XMLSchema}string
+				&#x09;&#x0A;&#x0D;&#x20;"
+			select="'xyz'"/>
 		<x:call function="false" />
 		<x:expect label="should be possible"
 			test="$Q{http://example.org/ns/my/variable}string-var treat as xs:string"

--- a/test/xspec-eqname_stylesheet.xspec
+++ b/test/xspec-eqname_stylesheet.xspec
@@ -5,10 +5,20 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xslt-version="3.0">
 
+	<!-- Leading and trailing &#x09;&#x0A;&#x0D;&#x20; inserted to names deliberately -->
+
 	<x:scenario label="Using EQName in">
 		<x:scenario label="context @mode and template-param @name">
-			<x:context mode="Q{x-urn:test:xspec-eqname}param-mirror-mode">
-				<x:param name="Q{x-urn:test:xspec-eqname}param-items">
+			<x:context
+				mode="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{x-urn:test:xspec-eqname}param-mirror-mode
+					&#x09;&#x0A;&#x0D;&#x20;">
+				<x:param
+					name="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{x-urn:test:xspec-eqname}param-items
+						&#x09;&#x0A;&#x0D;&#x20;">
 					<template-param-child />
 				</x:param>
 				<context-child />
@@ -32,8 +42,16 @@
 		</x:scenario>
 
 		<x:scenario label="template-call @template and template-param @name">
-			<x:call template="Q{x-urn:test:xspec-eqname}param-mirror-template">
-				<x:param name="Q{x-urn:test:xspec-eqname}param-items">
+			<x:call
+				template="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{x-urn:test:xspec-eqname}param-mirror-template
+					&#x09;&#x0A;&#x0D;&#x20;">
+				<x:param
+					name="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{x-urn:test:xspec-eqname}param-items
+						&#x09;&#x0A;&#x0D;&#x20;">
 					<template-param-child />
 				</x:param>
 			</x:call>
@@ -44,7 +62,13 @@
 
 		<x:scenario label="template-param @as">
 			<x:call template="Q{x-urn:test:xspec-eqname}param-mirror-template">
-				<x:param name="Q{x-urn:test:xspec-eqname}param-items" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+				<x:param
+					name="Q{x-urn:test:xspec-eqname}param-items"
+					as="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{http://www.w3.org/2001/XMLSchema}string
+						&#x09;&#x0A;&#x0D;&#x20;"
+					select="'xyz'"/>
 			</x:call>
 			<x:expect label="should be possible" select="$x:result treat as xs:string"
 				test="$x:result treat as xs:string" />

--- a/test/xspec-no-prefix_stylesheet.xspec
+++ b/test/xspec-no-prefix_stylesheet.xspec
@@ -7,10 +7,20 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xslt-version="3.0">
 
+	<!-- Leading and trailing &#x09;&#x0A;&#x0D;&#x20; inserted to names deliberately -->
+
 	<scenario label="Using EQName in">
 		<scenario label="context @mode and template-param @name">
-			<context mode="Q{x-urn:test:xspec-eqname}param-mirror-mode">
-				<param name="Q{x-urn:test:xspec-eqname}param-items">
+			<context
+				mode="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{x-urn:test:xspec-eqname}param-mirror-mode
+					&#x09;&#x0A;&#x0D;&#x20;">
+				<param
+					name="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{x-urn:test:xspec-eqname}param-items
+						&#x09;&#x0A;&#x0D;&#x20;">
 					<template-param-child xmlns="" />
 				</param>
 				<context-child xmlns="" />
@@ -34,8 +44,16 @@
 		</scenario>
 
 		<scenario label="template-call @template and template-param @name">
-			<call template="Q{x-urn:test:xspec-eqname}param-mirror-template">
-				<param name="Q{x-urn:test:xspec-eqname}param-items">
+			<call
+				template="
+					&#x09;&#x0A;&#x0D;&#x20;
+					Q{x-urn:test:xspec-eqname}param-mirror-template
+					&#x09;&#x0A;&#x0D;&#x20;">
+				<param
+					name="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{x-urn:test:xspec-eqname}param-items
+						&#x09;&#x0A;&#x0D;&#x20;">
 					<template-param-child xmlns="" />
 				</param>
 			</call>
@@ -46,7 +64,13 @@
 
 		<scenario label="template-param @as">
 			<call template="Q{x-urn:test:xspec-eqname}param-mirror-template">
-				<param name="Q{x-urn:test:xspec-eqname}param-items" as="Q{http://www.w3.org/2001/XMLSchema}string" select="'xyz'"/>
+				<param
+					name="Q{x-urn:test:xspec-eqname}param-items"
+					as="
+						&#x09;&#x0A;&#x0D;&#x20;
+						Q{http://www.w3.org/2001/XMLSchema}string
+						&#x09;&#x0A;&#x0D;&#x20;"
+					select="'xyz'"/>
 			</call>
 			<expect label="should be possible" select="$Q{http://www.jenitennison.com/xslt/xspec}result treat as xs:string"
 				test="$Q{http://www.jenitennison.com/xslt/xspec}result treat as xs:string" />

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -847,4 +847,34 @@
 		<x:expect label="reachable" test="doc-available($x:result)" />
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing function left-trim">
+		<x:call function="x:left-trim">
+			<x:param
+				select="'&#x09;&#x0A;&#x0D;&#x20;foo&#x09;&#x0A;&#x0D;&#x20;bar&#x09;&#x0A;&#x0D;&#x20;'"
+			 />
+		</x:call>
+		<x:expect label="Leading trimmed. In-between and trailing intact."
+			select="'foo&#x09;&#x0A;&#x0D;&#x20;bar&#x09;&#x0A;&#x0D;&#x20;'" />
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function right-trim">
+		<x:call function="x:right-trim">
+			<x:param
+				select="'&#x09;&#x0A;&#x0D;&#x20;foo&#x09;&#x0A;&#x0D;&#x20;bar&#x09;&#x0A;&#x0D;&#x20;'"
+			 />
+		</x:call>
+		<x:expect label="Trailing trimmed. Leading and in-between intact."
+			select="'&#x09;&#x0A;&#x0D;&#x20;foo&#x09;&#x0A;&#x0D;&#x20;bar'" />
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function trim">
+		<x:call function="x:trim">
+			<x:param
+				select="'&#x09;&#x0A;&#x0D;&#x20;foo&#x09;&#x0A;&#x0D;&#x20;bar&#x09;&#x0A;&#x0D;&#x20;'"
+			 />
+		</x:call>
+		<x:expect label="Leading and trailing trimmed. In-between intact."
+			select="'foo&#x09;&#x0A;&#x0D;&#x20;bar'" />
+	</x:scenario>
+
 </x:description>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1465,11 +1465,19 @@ teardown() {
 # User-defined variable in XSpec namespace
 #
 
-@test "Error on user-defined variable in XSpec namespace" {
+@test "Error on user-defined variable in XSpec namespace (URIQualifiedName in local variable)" {
+    run ../bin/xspec.sh variable/reserved-eqname.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[5]}" = "  x:XSPEC008: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo," ]
+    [ "${lines[6]}" = "  must not use the XSpec namespace." ]
+}
+
+@test "Error on user-defined variable in XSpec namespace (QName in global variable)" {
     run ../bin/xspec.sh variable/reserved-name.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${lines[5]}" =~ "x:XSPEC008:" ]]
+    [ "${lines[5]}" = "  x:XSPEC008: User-defined XSpec variable, u:foo, must not use the XSpec namespace." ]
 }
 
 #


### PR DESCRIPTION
https://www.w3.org/TR/xslt-30/#qname (bold by me)
> [Definition: An EQName is a string representing an expanded QName where the string, **after removing leading and trailing whitespace**, is in the form defined by the EQName...
> [Definition: A lexical QName is a string representing an expanded QName where the string, **after removing leading and trailing whitespace**, is within the lexical space of the xs:QName datatype as defined in XML Schema...

XSpec does not perform the bold part. Names with leading or trailing whitespace sometimes work, sometimes crash XSpec. Inconsistent, at least.
This pull request fixes it by trimming names while gathering specs. Tests are incorporated into `test/xspec-eqname*.xspec`.