### PR TITLE
refactor: rename x:compile-params to x:compile-global-params-and-vars

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -380,10 +380,9 @@
    </xsl:template>
 
    <!--
-       Drive the compilation of test suite params (aka global params
-       and variables).
+       Drive the compilation of global params and variables.
    -->
-   <xsl:template name="x:compile-params">
+   <xsl:template name="x:compile-global-params-and-vars">
       <xsl:context-item as="element(x:description)" use="required"
          use-when="element-available('xsl:context-item')" />
 

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -147,8 +147,8 @@
          </xsl:with-param>
       </xsl:call-template>
 
-      <!-- Compile the test suite params (aka global params). -->
-      <xsl:call-template name="x:compile-params"/>
+      <!-- Compile global params and global variables. -->
+      <xsl:call-template name="x:compile-global-params-and-vars" />
 
       <!-- Compile the top-level scenarios. -->
       <xsl:call-template name="x:compile-scenarios"/>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -75,8 +75,8 @@
       <xsl:value-of select="$xspec-master-uri" />
     </variable>
 
-    <!-- Compile the test suite params (aka global params). -->
-    <xsl:call-template name="x:compile-params"/>
+    <!-- Compile global params and global variables. -->
+    <xsl:call-template name="x:compile-global-params-and-vars" />
 
     <!-- The main compiled template. -->
     <template name="{x:xspec-name(.,'main')}">


### PR DESCRIPTION
The template name `x:compile-params` suggests it handles all `x:param`. Actually it handles global `x:param` and global `x:variable`.
This pull request just changes the template name to better reflect its responsibility. Also the term `test suite params` is removed, as it is not used elsewhere.