### PR TITLE
refactor(schema): xslt-version default value

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -3,6 +3,7 @@
 # of an XSLT application. They are similar to the RSpec documents used in RoR
 # testing, but for XSLT
 default namespace x = "http://www.jenitennison.com/xslt/xspec"
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 start = description
 
@@ -21,6 +22,7 @@ description =
 		## XSLT version which will be declared in the compiled master stylesheet.
 		## This version may also activate a certain compatibility mode when
 		## evaluating expressions and comparing sequences.
+		[ a:defaultValue = "2.0" ]
 		attribute xslt-version { xsd:decimal }?,
 
 		attribute query-at { xsd:anyURI }?,


### PR DESCRIPTION
When `x:description/@xslt-version` is not set, XSpec processes it as if it were `2.0`.
This pull request reflects it in the schema. In the near future, we'll update it to `3.0`.

I verified that Oxygen 22.0 picked up this default value in **Attributes** pane.

XSpec compiler for XQuery does not assume the default `@xquery-version`. So this pull request doesn't touch it.