### PR TITLE
test(xslt): remove unused item.xsl from xspec-utils_stylesheet.xspec

### DIFF
--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description stylesheet="items.xsl" xmlns:items="x-urn:test:xspec-items"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!--
 		The test target (../src/common/xspec-utils.xsl) is included


### PR DESCRIPTION
This pull request just removes unused stylesheet reference from `xspec-utils_stylesheet.xspec`.