### PR TITLE
ci(deps): bump Saxon from 9.9.1.6 to 9.9.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
         #   * BaseX test requires XML Calabash.
 
         # latest Saxon 9.9 and Jing
-        - SAXON_VERSION=9.9.1-6
+        - SAXON_VERSION=9.9.1-7
           JING_VERSION=20181222
           XMLCALABASH_VERSION=1.1.30-99
           DO_CODESPELL=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     #   * BaseX test requires XML Calabash.
 
     # latest Saxon 9.9 and Jing
-    - SAXON_VERSION: 9.9.1-6
+    - SAXON_VERSION: 9.9.1-7
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.30-99
       DO_CODESPELL: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
 
     variables:
       # latest Saxon and Jing
-      SAXON_VERSION: 9.9.1-6
+      SAXON_VERSION: 9.9.1-7
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.30-99
 

--- a/test/ant/build.xml
+++ b/test/ant/build.xml
@@ -75,9 +75,14 @@
 
 	<!-- Generates the worker -->
 	<target depends="get-processor-caps" name="generate-worker">
+		<property location="${run-xspec-tests.basedir}/worker/config.xml" name="saxon.config" />
+
 		<xslt force="true" in="worker/build-worker_template.xml" out="${build.worker}"
 			style="worker/generate.xsl">
-			<factory name="net.sf.saxon.TransformerFactoryImpl" />
+			<factory name="net.sf.saxon.TransformerFactoryImpl">
+				<attribute name="http://saxon.sf.net/feature/configuration-file"
+					value="${saxon.config}" />
+			</factory>
 			<param expression="${xspecfiles.dir.url}" name="XSPECFILES-DIR-URI" />
 			<param expression="${xspecfiles.dir.url.query}" name="XSPECFILES-DIR-URI-QUERY" />
 			<param expression="${xslt.supports.schema}" name="XSLT-SUPPORTS-SCHEMA" type="BOOLEAN" />

--- a/test/ant/worker/config.xml
+++ b/test/ant/worker/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns="http://saxon.sf.net/ns/configuration">
+	<resources>
+		<!-- Without this <fileExtension>, Saxon 9.9.1.7 does not recognize .xspec files as XML.
+			Maybe the design change by https://saxonica.plan.io/issues/4382 -->
+		<fileExtension extension="xspec" mediaType="text/xml" />
+	</resources>
+</configuration>

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -20,7 +20,7 @@ jobs:
 
         # latest Saxon and Jing
         Saxon-9-9:
-          SAXON_VERSION: 9.9.1-6
+          SAXON_VERSION: 9.9.1-7
           JING_VERSION: 20181222
           XMLCALABASH_VERSION: 1.1.30-99
           DO_CODESPELL: true


### PR DESCRIPTION
This pull request updates the Saxon version used for testing.

9.9.1.7 changed the behavior of `collection()` (probably https://saxonica.plan.io/issues/4382).
In response to it, this pull request modifies `test/ant/build.xml`. This modification has no impact on XSpec itself.