### PR TITLE
style: fix indent in x:decimal-string()

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -250,8 +250,7 @@
 		<xsl:variable as="xs:string" name="decimal-string" select="string($decimal)" />
 		<xsl:sequence
 			select="
-				if (contains($decimal-string, '.'))
-				then
+				if (contains($decimal-string, '.')) then
 					$decimal-string
 				else
 					concat($decimal-string, '.0')"


### PR DESCRIPTION
This pull request just aligns an indent in `x:decimal-string()` with the other lines in the same file.