### PR TITLE
test: test x:resolve-URIQualifiedName() without using xs:QName()

### DIFF
--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -848,17 +848,18 @@
 
 	<x:scenario label="Scenario for testing function resolve-URIQualifiedName">
 		<x:scenario label="With URI">
+			<x:variable as="xs:anyURI" name="ridiculous-uri">'">&lt;#,|%7D&#x20;%7B][$^</x:variable>
 			<x:call function="x:resolve-URIQualifiedName">
-				<x:param select="'Q{http://www.jenitennison.com/xslt/xspec}foo'" />
+				<x:param select="concat('Q{', $ridiculous-uri, '}foo')" />
 			</x:call>
-			<x:expect label="Resolved" select="xs:QName('x:foo')" />
+			<x:expect label="Resolved" select="QName($ridiculous-uri, 'foo')" />
 		</x:scenario>
 
 		<x:scenario label="Without URI">
 			<x:call function="x:resolve-URIQualifiedName">
 				<x:param select="'Q{}foo'" />
 			</x:call>
-			<x:expect label="Resolved as no namespace" select="xs:QName('foo')" />
+			<x:expect label="Resolved as no namespace" select="QName('', 'foo')" />
 		</x:scenario>
 	</x:scenario>
 


### PR DESCRIPTION
This pull request just replaces `xs:QName()` in a test with `QName()` which is more context-independent.