### PR TITLE
refactor: x:yes-no-synonym() with default value

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -275,6 +275,22 @@
 	</xsl:function>
 
 	<!--
+		x:yes-no-synonym#1 plus default value
+	-->
+	<xsl:function as="xs:boolean" name="x:yes-no-synonym">
+		<xsl:param as="xs:string?" name="input" />
+		<xsl:param as="xs:boolean" name="default" />
+
+		<xsl:sequence
+			select="
+				if (exists($input)) then
+					x:yes-no-synonym($input)
+				else
+					$default"
+		 />
+	</xsl:function>
+
+	<!--
 		Returns a semi-formatted string of URI
 	-->
 	<xsl:function as="xs:string" name="x:format-uri">

--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -275,7 +275,7 @@
 	</xsl:function>
 
 	<!--
-		x:yes-no-synonym#1 plus default value
+		x:yes-no-synonym#1 plus default value in case of empty sequence
 	-->
 	<xsl:function as="xs:boolean" name="x:yes-no-synonym">
 		<xsl:param as="xs:string?" name="input" />

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -708,11 +708,8 @@
 
       <xsl:param name="instruction" as="node()+" required="yes" />
 
-      <xsl:variable name="catch-flag" as="xs:string"
-         select="(ancestor-or-self::*[@catch][1]/@catch, 'no')[1]" />
-
       <xsl:choose>
-         <xsl:when test="x:yes-no-synonym($catch-flag)">
+         <xsl:when test="x:yes-no-synonym(ancestor-or-self::*[@catch][1]/@catch, false())">
             <xsl:call-template name="x:output-try-catch">
                <xsl:with-param name="instruction" select="$instruction" />
             </xsl:call-template>

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -516,7 +516,7 @@
 		</x:scenario>
 	</x:scenario>
 
-	<x:scenario label="Scenario for testing function yes-no-synonym">
+	<x:scenario label="Scenario for testing function yes-no-synonym#1">
 		<x:scenario label="Valid strings">
 			<x:scenario label="Base (yes or no)">
 				<x:scenario label="'yes'">
@@ -564,6 +564,62 @@
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function yes-no-synonym#2">
+		<x:scenario label="Input true">
+			<x:scenario label="Default true">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="'true'" />
+					<x:param select="true()" />
+				</x:call>
+				<x:expect label="True" select="true()" />
+			</x:scenario>
+
+			<x:scenario label="Default false">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="'true'" />
+					<x:param select="false()" />
+				</x:call>
+				<x:expect label="True" select="true()" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Input false">
+			<x:scenario label="Default true">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="'false'" />
+					<x:param select="true()" />
+				</x:call>
+				<x:expect label="False" select="false()" />
+			</x:scenario>
+
+			<x:scenario label="Default false">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="'false'" />
+					<x:param select="false()" />
+				</x:call>
+				<x:expect label="False" select="false()" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Input empty">
+			<x:scenario label="Default true">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="()" />
+					<x:param select="true()" />
+				</x:call>
+				<x:expect label="True" select="true()" />
+			</x:scenario>
+
+			<x:scenario label="Default false">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="()" />
+					<x:param select="false()" />
+				</x:call>
+				<x:expect label="False" select="false()" />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="do-nothing.xsl" xmlns:err="http://www.w3.org/2005/xqt-errors"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xslt-version="3.0">
 
 	<!--
 		The test target (../src/common/xspec-utils.xsl) is included

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -634,7 +634,7 @@
 					select="xs:QName('err:XTTE0780')" test="$x:result?err?code treat as xs:QName" />
 			</x:scenario>
 
-			<x:scenario catch="true" label="Bogus">
+			<x:scenario label="Bogus">
 				<x:call function="x:yes-no-synonym">
 					<x:param select="'bogus'" />
 					<x:param select="true()" />

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description stylesheet="do-nothing.xsl" xmlns:err="http://www.w3.org/2005/xqt-errors"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!--
 		The test target (../src/common/xspec-utils.xsl) is included
@@ -620,6 +621,26 @@
 					<x:param select="false()" />
 				</x:call>
 				<x:expect label="False" select="false()" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario catch="true" label="Unexpected input">
+			<x:scenario label="Zero-length string">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="''" />
+					<x:param select="true()" />
+				</x:call>
+				<x:expect label="Error without falling back on the default value"
+					select="xs:QName('err:XTTE0780')" test="$x:result?err?code treat as xs:QName" />
+			</x:scenario>
+
+			<x:scenario catch="true" label="Bogus">
+				<x:call function="x:yes-no-synonym">
+					<x:param select="'bogus'" />
+					<x:param select="true()" />
+				</x:call>
+				<x:expect label="Error without falling back on the default value"
+					select="xs:QName('err:XTTE0780')" test="$x:result?err?code treat as xs:QName" />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>


### PR DESCRIPTION
This pull request adds the second parameter to `x:yes-no-synonym()` so that its caller can provide the default boolean value.