### PR TITLE
refactor: stub function of x:line-number()

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -371,6 +371,21 @@
 	</xsl:function>
 
 	<!--
+		Stub function for helping development on IDE without loading ../../java/
+	-->
+	<xsl:function as="xs:integer" name="x:line-number" override-extension-function="no"
+		use-when="
+			function-available('saxon:line-number')
+			and
+			(: Saxon 9.7 doesn't accept @override-extension-function when /xsl:stylesheet/@version
+				isn't 3.0 :) (xs:decimal(system-property('xsl:version')) ge 3.0)"
+		xmlns:saxon="http://saxon.sf.net/">
+		<xsl:param as="node()" name="node" />
+
+		<xsl:sequence select="saxon:line-number($node)" />
+	</xsl:function>
+
+	<!--
 		Resolves URIQualifiedName to xs:QName
 	-->
 	<xsl:function as="xs:QName" name="x:resolve-URIQualifiedName">


### PR DESCRIPTION
This pull request adds a stub function of `x:line-number()` so that without integrating its Java extension function, IDE such as Oxygen does not complain about the missing function and also `coverage-report.xsl` works on IDE.

Besides the automated tests on our CI, I manually ran the tests on Saxon-EE 9.9.1.7, 9.8.0.15, 9.7.0.21.