### PR TITLE
refactor: resolve lexical QName using a util function

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -393,4 +393,24 @@
 		</xsl:analyze-string>
 	</xsl:function>
 
+	<!--
+		Resolves lexical QName to xs:QName without using the default namespace.
+		
+		Unlike fn:resolve-QName(), this function can handle XSLT names in many cases. See
+		"Notes" in https://www.w3.org/TR/xpath-functions-31/#func-resolve-QName or more
+		specifically p.866 of XSLT 2.0 and XPath 2.0 Programmer's Reference, 4th Edition.
+	-->
+	<xsl:function as="xs:QName" name="x:resolve-QName-ignoring-default-ns">
+		<xsl:param as="xs:string" name="lexical-qname" />
+		<xsl:param as="element()" name="element" />
+
+		<xsl:sequence
+			select="
+				if (contains($lexical-qname, ':')) then
+					resolve-QName($lexical-qname, $element)
+				else
+					QName('', $lexical-qname)"
+		 />
+	</xsl:function>
+
 </xsl:stylesheet>

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -775,18 +775,10 @@
       <xsl:context-item as="element(x:variable)" use="required"
          use-when="element-available('xsl:context-item')" />
 
-      <xsl:variable name="qname" as="xs:QName">
-         <xsl:choose>
-            <xsl:when test="starts-with(normalize-space(@name), 'Q{')">
-               <xsl:sequence select="x:resolve-URIQualifiedName(@name)" />
-            </xsl:when>
-            <xsl:otherwise>
-               <xsl:sequence select="if (contains(@name, ':'))
-                                     then resolve-QName(@name, .)
-                                     else QName('', @name)" />
-            </xsl:otherwise>
-         </xsl:choose>
-      </xsl:variable>
+      <xsl:variable name="qname" as="xs:QName"
+         select="if (starts-with(normalize-space(@name), 'Q{'))
+                 then x:resolve-URIQualifiedName(@name)
+                 else x:resolve-QName-ignoring-default-ns(@name, .)" />
 
       <xsl:if test="namespace-uri-from-QName($qname) eq $xspec-namespace">
          <xsl:variable name="msg" as="xs:string"

--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -25,9 +25,7 @@
 
    <xsl:key name="named-templates" 
             match="xsl:template[@name]"
-            use="if (contains(@name, ':'))
-                 then resolve-QName(@name, .)
-                 else QName('', @name)" />
+            use="x:resolve-QName-ignoring-default-ns(@name, .)" />
 
    <xsl:key name="matching-templates" 
             match="xsl:template[@match]" 

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -25,9 +25,7 @@
 
    <xsl:key name="named-templates" 
             match="xsl:template[@name]"
-            use="if (contains(@name, ':'))
-                 then resolve-QName(@name, .)
-                 else QName('', @name)" />
+            use="x:resolve-QName-ignoring-default-ns(@name, .)" />
 
    <xsl:key name="matching-templates" 
             match="xsl:template[@match]" 

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -862,4 +862,39 @@
 		</x:scenario>
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing function resolve-QName-ignoring-default-ns">
+		<x:scenario label="With prefix">
+			<x:call function="x:resolve-QName-ignoring-default-ns">
+				<x:param select="'prefix:foo'" />
+				<x:param>
+					<e xmlns:prefix="prefixed-ns" />
+				</x:param>
+			</x:call>
+			<x:expect label="Resolved" select="QName('prefixed-ns', 'prefix:foo')" />
+		</x:scenario>
+
+		<x:scenario label="Without prefix">
+			<x:scenario label="With default namespace">
+				<x:call function="x:resolve-QName-ignoring-default-ns">
+					<x:param select="'foo'" />
+					<x:param>
+						<e xmlns="default-ns" />
+					</x:param>
+				</x:call>
+				<x:expect label="Resolved without using the default namespace"
+					select="QName('', 'foo')" />
+			</x:scenario>
+
+			<x:scenario label="Without default namespace">
+				<x:call function="x:resolve-QName-ignoring-default-ns">
+					<x:param select="'foo'" />
+					<x:param>
+						<e xmlns="" />
+					</x:param>
+				</x:call>
+				<x:expect label="Resolved" select="QName('', 'foo')" />
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
 </x:description>


### PR DESCRIPTION
There are multiple places where a lexical QName needs to be resolved without using the default namespace. This pull request sets up a utility function for it.