### PR TITLE
feat: specify CLI HTML reporter via environment variable

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -539,11 +539,13 @@ rem ## format the report #######################################################
 rem ##
 rem
 
+if not defined HTML_REPORTER_XSL set "HTML_REPORTER_XSL=%XSPEC_HOME%\src\reporter\format-xspec-report.xsl"
+
 echo:
 echo Formatting Report...
 call :xslt -o:"%HTML%" ^
     -s:"%RESULT%" ^
-    -a ^
+    -xsl:"%HTML_REPORTER_XSL%" ^
     inline-css=true ^
     || ( call :die "Error formatting the report" & goto :win_main_error_exit )
 

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -432,11 +432,15 @@ fi
 ## format the report #########################################################
 ##
 
+if [ -z "${HTML_REPORTER_XSL}" ]; then
+    HTML_REPORTER_XSL="${XSPEC_HOME}/src/reporter/format-xspec-report.xsl"
+fi
+
 echo
 echo "Formatting Report..."
 xslt -o:"$HTML" \
     -s:"$RESULT" \
-    -a \
+    -xsl:"${HTML_REPORTER_XSL}" \
     inline-css=true \
     || die "Error formatting the report"
 if test -n "$COVERAGE"; then

--- a/test/format-xspec-report-messaging.xsl
+++ b/test/format-xspec-report-messaging.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--
+		Hooks the default HTML reporter and emits some messages for each failed test.
+		Only for testing purposes. Not intended to be used in a production environment.
+	-->
+
+	<xsl:import href="../src/reporter/format-xspec-report.xsl" />
+
+	<xsl:template as="element(xhtml:div)" match="x:test[x:is-failed-test(.)]" mode="x:html-report">
+		<!--
+			Capture the original HTML report and output it
+		-->
+		<xsl:variable as="element(xhtml:div)" name="html-report">
+			<xsl:apply-imports />
+		</xsl:variable>
+		<xsl:sequence select="$html-report" />
+
+		<!--
+			Message
+		-->
+		<xsl:variable as="xs:string+" name="labels"
+			select="(ancestor::x:scenario | .)/x:label ! normalize-space()" />
+		<xsl:message select="'===', $labels, '==='" />
+		<xsl:for-each select="$html-report/xhtml:table/xhtml:tbody/xhtml:tr/xhtml:td">
+			<xsl:variable as="xs:integer" name="pos" select="position()" />
+			<xsl:message select="'--- ' || ('Actual', 'Expected')[$pos] || ' Result ---'" />
+			<xsl:for-each select="xhtml:p">
+				<xsl:message select="string()" />
+			</xsl:for-each>
+			<xsl:for-each select="xhtml:pre">
+				<xsl:message select="string() => parse-xml-fragment()" />
+			</xsl:for-each>
+		</xsl:for-each>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1501,4 +1501,28 @@
     call :verify_line * r "..*x:overridden-expect-id-"
 	</case>
 
+	<!--
+		Custom HTML reporter
+	-->
+
+	<case name="Custom HTML reporter (CLI)">
+    set HTML_REPORTER_XSL=format-xspec-report-messaging.xsl
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :verify_retval 0
+    call :verify_line -16 x "--- Actual Result ---"
+    call :verify_line  -9 x "--- Expected Result ---"
+	</case>
+
+	<case name="Custom HTML reporter (Ant)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.fail=false ^
+        -Dxspec.html.reporter.xsl="%CD%\format-xspec-report-messaging.xsl" ^
+        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
+    call :verify_retval 0
+    call :verify_line -21 x "     [xslt] --- Actual Result ---"
+    call :verify_line -14 x "     [xslt] --- Expected Result ---"
+	</case>
+
 </collection>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1742,4 +1742,30 @@ teardown() {
     [[ "${output}" =~ "x:overridden-expect-id" ]]
 }
 
+#
+# Custom HTML reporter
+#
+
+@test "Custom HTML reporter (CLI)" {
+    export HTML_REPORTER_XSL=format-xspec-report-messaging.xsl
+    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]}-16]}" = "--- Actual Result ---" ]
+    [ "${lines[${#lines[@]}-9]}"  = "--- Expected Result ---" ]
+}
+
+@test "Custom HTML reporter (Ant)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.fail=false \
+        -Dxspec.html.reporter.xsl="${PWD}/format-xspec-report-messaging.xsl" \
+        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]}-21]}" = "     [xslt] --- Actual Result ---" ]
+    [ "${lines[${#lines[@]}-14]}" = "     [xslt] --- Expected Result ---" ]
+}
+
 


### PR DESCRIPTION
In `bin/xspec.*`, the path of `format-xspec-report.xsl` is hardcoded.
This pull request replaces it with an environment variable (`HTML_REPORTER_XSL`), just like Ant `xspec.html.reporter.xsl` property.