### PR TITLE
fix: do not allow element in x:label element

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -209,7 +209,11 @@
    <xsl:template match="text()[not(normalize-space())]" as="text()?" mode="x:gather-specs">
       <xsl:param name="preserve-space" as="xs:QName*" tunnel="yes" select="()"/>
 
-      <xsl:if test="x:is-ws-only-text-node-significant(., $preserve-space)">
+      <xsl:if test="x:is-ws-only-text-node-significant(., $preserve-space)
+         or
+         (: TODO: The specification of @label and x:label is not clear about whitespace.
+            Preserve it for now. :)
+         (parent::x:label and not(x:is-user-content(.)))">
          <xsl:sequence select="." />
       </xsl:if>
    </xsl:template>

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -97,7 +97,7 @@ label =
 	## the word "with"; it should make sense if the labels of ancestor scenarios are 
 	## concatenated with this one. For example "with a Type attribute".
 	attribute label { text } |
-	element label { user-content }
+	element label { text }
 
 variable =
 	## A test file can define global variables. A scenario can define local variables.

--- a/test/end-to-end/cases/expected/query/label-element-junit.xml
+++ b/test/end-to-end/cases/expected/query/label-element-junit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="label-element.xspec">
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: x-urn:test:do-nothing</p>
+      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 3</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario3"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario1-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario2-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario3">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario3">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario3-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario3">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario3-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/label-element-result.xml
+++ b/test/end-to-end/cases/expected/query/label-element-result.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          date="2000-01-01T00:00:00Z"
+          query="x-urn:test:do-nothing"
+          query-at="../../../../do-nothing.xquery"
+          xspec="../../label-element.xspec">
+   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario1-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario2-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario3-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/expected/schematron/label-element-junit.xml
+++ b/test/end-to-end/cases/expected/schematron/label-element-junit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="label-element.xspec">
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
+      <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 3</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario3"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario1-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario2-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario3">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario3">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario3-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario3">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario3-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.xml
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="label-element-sch-preprocessed.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../label-element.xspec"
+          schematron="../../../../do-nothing.sch">
+   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario1-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario2-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario3-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-junit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="label-element.xspec">
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Scenario&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " tests="1" failures="1">
+      <testcase name="&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; My&#x9;&#xA;&#xD; Expectation&#x9;&#xA;&#xD; &#x9;&#xA;&#xD; " status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 3</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario3"> &#xD; &#xD; My &#xD; Scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario1-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario2-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario3">
+         <h2 class="failed"> &#xD; &#xD; My &#xD; Scenario<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario3">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th> &#xD; &#xD; My &#xD; Scenario</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario3-expect1"> &#xD; &#xD; My &#xD; Expectation</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario3">
+            <h3> &#xD; &#xD; My &#xD; Scenario</h3>
+            <div id="scenario3-expect1">
+               <h4> &#xD; &#xD; My &#xD; Expectation</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>xs:boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>false()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../src/reporter/format-xspec-report.xsl"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../../../do-nothing.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../label-element.xspec">
+   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario1-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario2-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+      <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Scenario	
+&#xD; 	
+&#xD; </x:label>
+      <x:call function="true"/>
+      <x:result select="xs:boolean('true')"/>
+      <x:test id="scenario3-expect1" successful="false">
+         <x:label>	
+&#xD; 	
+&#xD; My	
+&#xD; Expectation	
+&#xD; 	
+&#xD; </x:label>
+         <x:expect test="false()" select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/label-element.xspec
+++ b/test/end-to-end/cases/label-element.xspec
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
+	schematron="../../do-nothing.sch" stylesheet="../../do-nothing.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		* '&#x09;&#x0A;&#x0D;&#x20;' is inserted deliberately to see what will happen.
+		  * In particular, //x:label/text()[position() = (1, 3, last())] are deliberately made as
+		    whitespace-only text nodes.
+		
+		* Comments and processing instructions inserted deliberately to verify these:
+		  * XSpec schema allows them.
+		  * XSpec compiler ignores them.
+	-->
+
+	<x:scenario>
+		<x:label>&#x09;&#x0A;&#x0D;&#x20;<!--test-->&#x09;&#x0A;&#x0D;&#x20;My<?test test?>&#x09;&#x0A;&#x0D;&#x20;<!--test-->Scenario&#x09;&#x0A;&#x0D;&#x20;<?test test?>&#x09;&#x0A;&#x0D;&#x20;</x:label>
+		<x:call function="true" />
+		<x:expect test="false()">
+			<x:label>&#x09;&#x0A;&#x0D;&#x20;<!--test-->&#x09;&#x0A;&#x0D;&#x20;My<?test test?>&#x09;&#x0A;&#x0D;&#x20;<!--test-->Expectation&#x09;&#x0A;&#x0D;&#x20;<?test test?>&#x09;&#x0A;&#x0D;&#x20;</x:label>
+		</x:expect>
+	</x:scenario>
+
+	<x:scenario label="Test with x:like/@label">
+		<x:like
+			label="&#x09;&#x0A;&#x0D;&#x20;&#x09;&#x0A;&#x0D;&#x20;My&#x09;&#x0A;&#x0D;&#x20;Scenario&#x09;&#x0A;&#x0D;&#x20;&#x09;&#x0A;&#x0D;&#x20;"
+		 />
+	</x:scenario>
+
+	<x:scenario label="Test with x:like/x:label">
+		<x:like>
+			<!-- This x:label is exactly the same as /x:description/x:scenario[1]/x:label -->
+			<x:label>&#x09;&#x0A;&#x0D;&#x20;<!--test-->&#x09;&#x0A;&#x0D;&#x20;My<?test test?>&#x09;&#x0A;&#x0D;&#x20;<!--test-->Scenario&#x09;&#x0A;&#x0D;&#x20;<?test test?>&#x09;&#x0A;&#x0D;&#x20;</x:label>
+		</x:like>
+	</x:scenario>
+
+</x:description>

--- a/test/end-to-end/cases/label-element.xspec
+++ b/test/end-to-end/cases/label-element.xspec
@@ -4,6 +4,11 @@
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!--
+		xspec-utils_stylesheet.xspec uses this file for testing x:is-user-content().
+		When modifying this file, check whether xspec-utils_stylesheet.xspec needs any additions or updates.
+	-->
+
+	<!--
 		* '&#x09;&#x0A;&#x0D;&#x20;' is inserted deliberately to see what will happen.
 		  * In particular, //x:label/text()[position() = (1, 3, last())] are deliberately made as
 		    whitespace-only text nodes.

--- a/test/end-to-end/cases/label-element.xspec
+++ b/test/end-to-end/cases/label-element.xspec
@@ -34,8 +34,10 @@
 
 	<x:scenario label="Test with x:like/x:label">
 		<x:like>
-			<!-- This x:label is exactly the same as /x:description/x:scenario[1]/x:label -->
-			<x:label>&#x09;&#x0A;&#x0D;&#x20;<!--test-->&#x09;&#x0A;&#x0D;&#x20;My<?test test?>&#x09;&#x0A;&#x0D;&#x20;<!--test-->Scenario&#x09;&#x0A;&#x0D;&#x20;<?test test?>&#x09;&#x0A;&#x0D;&#x20;</x:label>
+			<!-- This x:label is exactly the same as /x:description/x:scenario[1]/x:label,
+				except that comments and processing instructions have different text, which ensures
+				that the XSpec compiler ignores them when matching x:like/x:label to x:scenario/x:label. -->
+			<x:label>&#x09;&#x0A;&#x0D;&#x20;<!--like-->&#x09;&#x0A;&#x0D;&#x20;My<?like like?>&#x09;&#x0A;&#x0D;&#x20;<!--like-->Scenario&#x09;&#x0A;&#x0D;&#x20;<?like like?>&#x09;&#x0A;&#x0D;&#x20;</x:label>
 		</x:like>
 	</x:scenario>
 

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -448,6 +448,62 @@
 			</x:scenario>
 		</x:scenario>
 
+		<x:scenario label="label">
+			<x:scenario label="scenario label">
+				<x:scenario label="x:label element">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="//x:scenario/x:label" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+
+				<x:scenario label="child text">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="(//x:scenario/x:label/text())[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+			</x:scenario>
+
+			<x:scenario label="assertion label">
+				<x:scenario label="x:label element">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="//x:expect/x:label" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+
+				<x:scenario label="child text">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="(//x:expect/x:label/text())[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+			</x:scenario>
+
+			<x:scenario label="like label">
+				<x:scenario label="x:label element">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="//x:like/x:label" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+
+				<x:scenario label="child text">
+					<x:call function="x:is-user-content">
+						<x:param href="end-to-end/cases/label-element.xspec"
+							select="(//x:like/x:label/text())[1]" />
+					</x:call>
+					<x:expect label="False" select="false()" />
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function pack-version">


### PR DESCRIPTION
Fixes #801 

This pull request changes the schema of `x:label` to disallow child elements.

Also,
* `mode="x:gather-specs"` is updated to always preserve whitespace-only text nodes in `x:label`.
* Some tests are added for `x:is-user-content()`, which ensures that `x:label//node()` is not handled in the same way as nodes under `x:param`, `x:context` etc.