### PR TITLE
test(xslt): overriding global param and variable

### DIFF
--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="global.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:param name="global-param" select="'global param overridden by XSpec'" />
+
+	<x:variable name="global-variable" select="'global variable overridden by XSpec'" />
+
+	<x:scenario label="Regardless of x:context">
+		<x:context>
+			<context-child />
+		</x:context>
+
+		<x:scenario label="global x:param in XSpec">
+			<x:call template="get-global-param" />
+			<x:expect label="overrides xsl:param in SUT" select="'global param overridden by XSpec'"
+			 />
+		</x:scenario>
+
+		<x:scenario label="global x:variable in XSpec">
+			<x:call template="get-global-variable" />
+			<x:expect label="overrides xsl:variable in SUT"
+				select="'global variable overridden by XSpec'" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/global.xsl
+++ b/test/global.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:param as="xs:string" name="global-param" select="'global param defined in SUT'" />
+
+	<xsl:variable as="xs:string" name="global-variable" select="'global variable defined in SUT'" />
+
+	<!-- Returns the global parameter intact -->
+	<xsl:template as="xs:string" name="get-global-param">
+		<xsl:sequence select="$global-param" />
+	</xsl:template>
+
+	<!-- Returns the global variable intact -->
+	<xsl:template as="xs:string" name="get-global-variable">
+		<xsl:sequence select="$global-variable" />
+	</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This pull request just adds a test which checks to see if `x:param` and `x:variable` override `xsl:param` and `xsl:variable`.