### PR TITLE
feat: specify CLI coverage reporter via environment variable

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -539,6 +539,8 @@ rem ## format the report #######################################################
 rem ##
 rem
 
+if not defined COVERAGE_REPORTER_XSL set "COVERAGE_REPORTER_XSL=%XSPEC_HOME%\src\reporter\coverage-report.xsl"
+
 echo:
 echo Formatting Report...
 call :xslt -o:"%HTML%" ^
@@ -553,7 +555,7 @@ if defined COVERAGE (
     call :xslt -config:"%XSPEC_HOME%\src\reporter\coverage-report-config.xml" ^
         -o:"%COVERAGE_HTML%" ^
         -s:"%COVERAGE_XML%" ^
-        -xsl:"%XSPEC_HOME%\src\reporter\coverage-report.xsl" ^
+        -xsl:"%COVERAGE_REPORTER_XSL%" ^
         inline-css=true ^
         || ( call :die "Error formatting the coverage report" & goto :win_main_error_exit )
     call :win_echo "Report available at %COVERAGE_HTML%"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -432,6 +432,10 @@ fi
 ## format the report #########################################################
 ##
 
+if [ -z "${COVERAGE_REPORTER_XSL}" ]; then
+    COVERAGE_REPORTER_XSL="$XSPEC_HOME/src/reporter/coverage-report.xsl"
+fi
+
 echo
 echo "Formatting Report..."
 xslt -o:"$HTML" \
@@ -445,7 +449,7 @@ if test -n "$COVERAGE"; then
     xslt -config:"${XSPEC_HOME}/src/reporter/coverage-report-config.xml" \
         -o:"$COVERAGE_HTML" \
         -s:"$COVERAGE_XML" \
-        -xsl:"$XSPEC_HOME/src/reporter/coverage-report.xsl" \
+        -xsl:"${COVERAGE_REPORTER_XSL}" \
         inline-css=true \
         || die "Error formatting the coverage report"
     echo "Report available at $COVERAGE_HTML"

--- a/test/custom-coverage-report.xsl
+++ b/test/custom-coverage-report.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:import href="../src/reporter/coverage-report.xsl" />
+
+	<xsl:template as="node()+" match="/">
+		<!-- Just insert a comment into the document -->
+		<xsl:comment>Customized coverage report</xsl:comment>
+
+		<xsl:apply-imports />
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1501,4 +1501,30 @@
     call :verify_line * r "..*x:overridden-expect-id-"
 	</case>
 
+	<!--
+		Custom coverage reporter
+	-->
+
+	<case name="Custom coverage reporter (CLI)">
+    set COVERAGE_REPORTER_XSL=custom-coverage-report.xsl
+    call :run ..\bin\xspec.bat -c ..\tutorial\coverage\demo.xspec
+    call :verify_retval 0
+
+    call :run type "%TEST_DIR%\demo-coverage.html"
+    call :verify_line * r "..*--Customized coverage report--..*"
+	</case>
+
+	<case name="Custom coverage reporter (Ant)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dxspec.coverage.enabled=true ^
+        -Dxspec.coverage.reporter.xsl="%CD%\custom-coverage-report.xsl" ^
+        -Dxspec.xml="%CD%\..\tutorial\coverage\demo.xspec"
+    call :verify_retval 0
+
+    call :run type "%TEST_DIR%\demo-coverage.html"
+    call :verify_line * r "..*--Customized coverage report--..*"
+	</case>
+
 </collection>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1742,4 +1742,34 @@ teardown() {
     [[ "${output}" =~ "x:overridden-expect-id" ]]
 }
 
+#
+# Custom coverage reporter
+#
+
+@test "Custom coverage reporter (CLI)" {
+    export COVERAGE_REPORTER_XSL=custom-coverage-report.xsl
+    run ../bin/xspec.sh -c ../tutorial/coverage/demo.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run cat "${TEST_DIR}/demo-coverage.html"
+    echo "$output"
+    [[ "${output}" =~ "--Customized coverage report--" ]]
+}
+
+@test "Custom coverage reporter (Ant)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dxspec.coverage.enabled=true \
+        -Dxspec.coverage.reporter.xsl="${PWD}/custom-coverage-report.xsl" \
+        -Dxspec.xml="${PWD}/../tutorial/coverage/demo.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run cat "${TEST_DIR}/demo-coverage.html"
+    echo "$output"
+    [[ "${output}" =~ "--Customized coverage report--" ]]
+}
+
 


### PR DESCRIPTION
In `bin/xspec.*`, the path of `coverage-report.xsl` is hardcoded.
This pull request replaces it with an environment variable (`COVERAGE_REPORTER_XSL`), just like Ant `xspec.coverage.reporter.xsl` property.
