### PR TITLE
fix: #826 (SXWN9000 when resolving QName with non-empty prefix)

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -462,12 +462,17 @@
 		<xsl:param as="xs:string" name="lexical-qname" />
 		<xsl:param as="element()" name="element" />
 
+		<!-- To suppress "SXWN9000: ... QName has null namespace but non-empty prefix",
+			do not pass the lexical QName directly to fn:QName(). (xspec/xspec#826) -->
+		<xsl:variable as="xs:QName" name="qname-taking-default-ns"
+			select="resolve-QName($lexical-qname, $element)" />
+
 		<xsl:sequence
 			select="
-				if (contains($lexical-qname, ':')) then
-					resolve-QName($lexical-qname, $element)
+				if (prefix-from-QName($qname-taking-default-ns)) then
+					$qname-taking-default-ns
 				else
-					QName('', $lexical-qname)"
+					QName('', local-name-from-QName($qname-taking-default-ns))"
 		 />
 	</xsl:function>
 

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -234,13 +234,19 @@
 	</case>
 
 	<!--
-		#46
+		Runtime warning
 	-->
 
 	<case name="invoking xspec that passes a non xs:boolean does not raise a warning #46">
     call :run ..\bin\xspec.bat xspec-46.xspec
     call :verify_retval 0
-    call :verify_line 6 r "Testing with"
+    call :verify_line 6 r "Testing with "
+	</case>
+
+	<case name="x:resolve-QName-ignoring-default-ns() with non-empty prefix does not raise a warning #826">
+    call :run ..\bin\xspec.bat xspec-826.xspec
+    call :verify_retval 0
+    call :verify_line 6 r "Testing with "
 	</case>
 
 	<!--

--- a/test/xspec-826.xspec
+++ b/test/xspec-826.xspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Resolve QName With prefix">
+		<x:call function="x:resolve-QName-ignoring-default-ns">
+			<x:param select="'prefix:foo'" />
+			<x:param>
+				<e xmlns:prefix="prefixed-ns" />
+			</x:param>
+		</x:call>
+		<x:expect label="Resolved" select="QName('prefixed-ns', 'prefix:foo')" />
+	</x:scenario>
+</x:description>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -287,14 +287,21 @@ teardown() {
 }
 
 #
-# #46
+# Runtime warning
 #
 
 @test "invoking xspec that passes a non xs:boolean does not raise a warning #46" {
     run ../bin/xspec.sh xspec-46.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "${lines[5]}" =~ "Testing with" ]]
+    [[ "${lines[5]}" =~ "Testing with " ]]
+}
+
+@test "x:resolve-QName-ignoring-default-ns() with non-empty prefix does not raise a warning #826" {
+    run ../bin/xspec.sh xspec-826.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "${lines[5]}" =~ "Testing with " ]]
 }
 
 #


### PR DESCRIPTION
Fixes #826 

This pull request pleases Saxon by not passing the lexical QName directly to `fn:QName()`.

Tested on Saxon-EE 9.9.1.7 (Windows) and 9.9.1.5 (Linux).