### PR TITLE
ci: specify all trigger branches in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,10 @@
-# Workaround for https://developercommunity.visualstudio.com/content/problem/947762/github-pull-request-not-triggering-azure-pipelines.html
+# Workaround for https://status.dev.azure.com/_event/179641421
+trigger:
+  branches:
+    include:
+      - '*'
+
+# Workaround for https://status.dev.azure.com/_event/179641421
 pr:
   branches:
     include:


### PR DESCRIPTION
#832 made Azure Pipelines triggered on PR branches, but it's still not triggered by pushing commits.
This pull request adds a workaround per https://status.dev.azure.com/_event/179641421.