### PR TITLE
ci(deps): bump BaseX from 9.3.1 to 9.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         - ANT_VERSION=1.10.7
 
         # latest BaseX
-        - BASEX_VERSION=9.3.1
+        - BASEX_VERSION=9.3.2
 
     jobs:
         # Note

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
     ANT_VERSION: 1.10.7
 
     # latest BaseX
-    BASEX_VERSION: 9.3.1
+    BASEX_VERSION: 9.3.2
 
   matrix:
     # Non-mainstream jobs are disabled in favor of Azure Pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   ANT_VERSION: 1.10.7
 
   # latest BaseX
-  BASEX_VERSION: 9.3.1
+  BASEX_VERSION: 9.3.2
 
 jobs:
   - template: test/ci/azure-pipelines_windows.yml


### PR DESCRIPTION
https://raw.githubusercontent.com/BaseXdb/basex/master/CHANGELOG
> VERSION 9.3.2 (March 10, 2020) -----------------------------------------
>  - Minor bug fixes, numerous performance tweaks