### PR TITLE
refactor: remove deprecated coverage option from CLI

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -47,7 +47,7 @@ rem ##
         call :win_echo %1
         echo:
     )
-    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog file^|-h] file [coverage]
+    echo Usage: xspec [-t^|-q^|-s^|-c^|-j^|-catalog file^|-h] file
     echo:
     echo   file           the XSpec document
     echo   -t             test an XSLT stylesheet (the default)
@@ -57,7 +57,6 @@ rem ##
     echo   -j             output JUnit report
     echo   -catalog file  use XML Catalog file to locate resources
     echo   -h             display this help message
-    echo   coverage       deprecated, use -c instead
     goto :EOF
 
 :die
@@ -93,7 +92,6 @@ rem ##
     set JUNIT=
     set WIN_HELP=
     set WIN_UNKNOWN_OPTION=
-    set WIN_DEPRECATED_COVERAGE=
     set WIN_EXTRA_OPTION=
     set XSPEC=
     set CATALOG=
@@ -122,12 +120,8 @@ rem ##
     ) else if "%WIN_ARGV:~0,1%"=="-" (
         set "WIN_UNKNOWN_OPTION=%WIN_ARGV%"
     ) else if defined XSPEC (
-        if "%WIN_ARGV%"=="coverage" (
-            set WIN_DEPRECATED_COVERAGE=1
-        ) else (
-            set "WIN_EXTRA_OPTION=%WIN_ARGV%"
-            goto :EOF
-        )
+        set "WIN_EXTRA_OPTION=%WIN_ARGV%"
+        goto :EOF
     ) else (
         set "XSPEC=%WIN_ARGV%"
     )
@@ -428,14 +422,6 @@ rem
 if defined WIN_EXTRA_OPTION (
     call :usage "Error: Extra option: %WIN_EXTRA_OPTION%"
     exit /b 1
-)
-
-rem
-rem Deprecated 'coverage' option
-rem
-if defined WIN_DEPRECATED_COVERAGE (
-    echo Long-form option 'coverage' deprecated, use '-c' instead.
-    set COVERAGE=1
 )
 
 rem

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -36,7 +36,7 @@ usage() {
         echo "$1"
         echo;
     fi
-    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]"
+    echo "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file"
     echo
     echo "  file           the XSpec document"
     echo "  -t             test an XSLT stylesheet (the default)"
@@ -46,7 +46,6 @@ usage() {
     echo "  -j             output JUnit report"
     echo "  -catalog file  use XML Catalog file to locate resources"
     echo "  -h             display this help message"
-    echo "  coverage       deprecated, use -c instead"
 }
 
 die() {
@@ -257,16 +256,8 @@ if [ ! -f "$XSPEC" ]; then
 fi
 
 if [ -n "$2" ]; then
-    if [ "$2" != coverage ]; then
-        usage "Error: Extra option: $2"
-        exit 1
-    fi
-	echo "Long-form option 'coverage' deprecated, use '-c' instead."
-	COVERAGE=1
-    if [ -n "$3" ]; then
-        usage "Error: Extra option: $3"
-        exit 1
-    fi
+    usage "Error: Extra option: $2"
+    exit 1
 fi
 
 ##

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -9,7 +9,7 @@
 	<case name="invoking xspec without arguments prints usage">
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]"
+    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file"
 	</case>
 
 	<case name="invoking xspec without arguments prints usage even if Saxon environment variables are not defined">

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -41,7 +41,7 @@ teardown() {
     run ../bin/xspec.sh
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file [coverage]" ]
+    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-h] file" ]
 }
 
 @test "invoking xspec without arguments prints usage even if Saxon environment variables are not defined" {


### PR DESCRIPTION
`coverage` option has been explicitly deprecated for more than 9 years (since 8829adaf).

This pull request removes it.
