### PR TITLE
refactor: remove CLI code for stale Saxon versions

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -285,41 +285,26 @@ rem
 rem # set SAXON_CP (either it has been by the user, or set it from SAXON_HOME)
 rem
 
-rem
-rem # Set this variable in your environment or here, if you don't set SAXON_CP
-rem # set SAXON_HOME=C:\path\to\saxon\dir
-rem
-rem Since we don't use the delayed environment variable expansion,
-rem SAXON_HOME must be set outside 'if' scope.
-rem
+set USE_SAXON_HOME=
 
 if not defined SAXON_CP (
     if not defined SAXON_HOME (
         echo SAXON_CP and SAXON_HOME both not set!
-    )
-    if        exist "%SAXON_HOME%\saxon9ee.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon9ee.jar"
-    ) else if exist "%SAXON_HOME%\saxon9pe.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon9pe.jar"
-    ) else if exist "%SAXON_HOME%\saxon9he.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon9he.jar"
-    ) else if exist "%SAXON_HOME%\saxon9sa.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon9sa.jar"
-    ) else if exist "%SAXON_HOME%\saxon9.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon9.jar"
-    ) else if exist "%SAXON_HOME%\saxonb9-1-0-8.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxonb9-1-0-8.jar"
-    ) else if exist "%SAXON_HOME%\saxon8sa.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon8sa.jar"
-    ) else if exist "%SAXON_HOME%\saxon8.jar" (
-        set "SAXON_CP=%SAXON_HOME%\saxon8.jar"
     ) else (
-        call :win_echo "Saxon jar cannot be found in SAXON_HOME: %SAXON_HOME%"
+        set USE_SAXON_HOME=1
+        for %%I in ( ^
+            "%SAXON_HOME%\saxon9?e.jar" ^
+        ) do set "SAXON_CP=%%~I"
     )
 )
-if defined SAXON_HOME (
-    if exist "%SAXON_HOME%\xml-resolver-1.2.jar" (
-        set "SAXON_CP=%SAXON_CP%;%SAXON_HOME%\xml-resolver-1.2.jar"
+
+if defined USE_SAXON_HOME (
+    if not defined SAXON_CP (
+        call :win_echo "Saxon jar cannot be found in SAXON_HOME: %SAXON_HOME%"
+    ) else (
+        if exist "%SAXON_HOME%\xml-resolver-1.2.jar" (
+            set "SAXON_CP=%SAXON_CP%;%SAXON_HOME%\xml-resolver-1.2.jar"
+        )
     )
 )
 
@@ -330,13 +315,6 @@ rem ##
 rem ## options ###################################################################
 rem ##
 rem
-
-rem
-rem Saxon jar filename
-rem
-set WIN_SAXON_CP=%SAXON_CP%;
-for %%I in ("%WIN_SAXON_CP:;=";"%") do if /i "%%~xI"==".jar" if /i "%%~nI" GEQ "saxon8" if /i "%%~nI" LSS "saxonb9a" set "WIN_SAXON_JAR_N=%%~nI"
-set WIN_SAXON_CP=
 
 rem
 rem Parse command line
@@ -369,16 +347,6 @@ rem
 if defined XSLT if defined XQUERY (
     call :usage "-t and -q are mutually exclusive"
     exit /b 1
-)
-
-rem
-rem # JUnit report
-rem
-if defined JUNIT (
-    if /i "%WIN_SAXON_JAR_N:~0,6%"=="saxon8" (
-        echo Saxon8 detected. JUnit report requires Saxon9.
-        exit /b 1
-    )
 )
 
 rem
@@ -437,11 +405,6 @@ if defined WIN_DEPRECATED_COVERAGE (
     echo Long-form option 'coverage' deprecated, use '-c' instead.
     set COVERAGE=1
 )
-
-rem
-rem Env var no longer necessary
-rem
-set WIN_SAXON_JAR_N=
 
 rem
 rem ##

--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -286,8 +286,8 @@ if not defined SAXON_CP (
         echo SAXON_CP and SAXON_HOME both not set!
     ) else (
         set USE_SAXON_HOME=1
-        for %%I in ( ^
-            "%SAXON_HOME%\saxon9?e.jar" ^
+        for %%I in (
+            "%SAXON_HOME%\saxon9?e.jar"
         ) do set "SAXON_CP=%%~I"
     )
 )

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -133,36 +133,31 @@ fi
 
 # set SAXON_CP (either it has been by the user, or set it from SAXON_HOME)
 
+unset USE_SAXON_HOME
+
 if test -z "$SAXON_CP"; then
-    # Set this variable in your environment or here, if you don't set SAXON_CP
-    # SAXON_HOME=/path/to/saxon/dir
     if test -z "$SAXON_HOME"; then
-    	echo "SAXON_CP and SAXON_HOME both not set!"
+        echo "SAXON_CP and SAXON_HOME both not set!"
 #        die "SAXON_CP and SAXON_HOME both not set!"
-    fi
-    if test -f "${SAXON_HOME}/saxon9ee.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9ee.jar";
-    elif test -f "${SAXON_HOME}/saxon9pe.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9pe.jar";
-    elif test -f "${SAXON_HOME}/saxon9he.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9he.jar";
-    elif test -f "${SAXON_HOME}/saxon9sa.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9sa.jar";
-    elif test -f "${SAXON_HOME}/saxon9.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9.jar";
-    elif test -f "${SAXON_HOME}/saxonb9-1-0-8.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxonb9-1-0-8.jar";
-    elif test -f "${SAXON_HOME}/saxon8sa.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon8sa.jar";
-    elif test -f "${SAXON_HOME}/saxon8.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon8.jar";
     else
-    	echo "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
-#        die "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
+        USE_SAXON_HOME=1
+        for f in \
+            "${SAXON_HOME}"/saxon9?e.jar
+        do
+            [ -f "${f}" ] && SAXON_CP="${f}"
+        done
     fi
-    if test -f "${SAXON_HOME}/xml-resolver-1.2.jar"; then
-	   SAXON_CP="${SAXON_CP}${CP_DELIM}${SAXON_HOME}/xml-resolver-1.2.jar";
-	fi
+fi
+
+if [ -n "${USE_SAXON_HOME}" ]; then
+    if [ -z "${SAXON_CP}" ]; then
+        echo "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
+#        die "Saxon jar cannot be found in SAXON_HOME: $SAXON_HOME"
+    else
+        if test -f "${SAXON_HOME}/xml-resolver-1.2.jar"; then
+           SAXON_CP="${SAXON_CP}${CP_DELIM}${SAXON_HOME}/xml-resolver-1.2.jar";
+        fi
+    fi
 fi
 
 CP="${SAXON_CP}${CP_DELIM}${XSPEC_HOME}/java/"
@@ -211,10 +206,6 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
             COVERAGE=1;;
         # JUnit report
         -j)
-			if [[ ${SAXON_CP} == *"saxon8"* || ${SAXON_CP} == *"saxon8sa"* ]]; then
-				echo "Saxon8 detected. JUnit report requires Saxon9."
-			    exit 1
-			fi
             JUNIT=1;;
         # Catalog
         -catalog)

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -17,7 +17,7 @@
     call :run ..\bin\xspec.bat
     call :verify_retval 1
     call :verify_line 2 x "SAXON_CP and SAXON_HOME both not set!"
-    call :verify_line 5 r "Usage: xspec "
+    call :verify_line 4 r "Usage: xspec "
 	</case>
 
 	<case name="invoking xspec with -h prints usage and does so even when it is 11th argument">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -186,24 +186,6 @@
 	</case>
 
 	<!--
-		JUnit and Saxon versions (CLI)
-	-->
-
-	<case name="invoking xspec with -j option with Saxon8 returns error message">
-    set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8.jar
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 1
-    call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
-	</case>
-
-	<case name="invoking xspec with -j option with Saxon8-SA returns error message">
-    set SAXON_CP=%SYSTEMDRIVE%\path\to\saxon8sa.jar
-    call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 1
-    call :verify_line 2 x "Saxon8 detected. JUnit report requires Saxon9."
-	</case>
-
-	<!--
 		JUnit (CLI)
 	-->
 
@@ -220,17 +202,6 @@
 
     rem JUnit report file
     call :verify_exist "%TEST_DIR%\escape-for-regex-junit.xml"
-	</case>
-
-	<!--
-		Saxon-B (CLI)
-	-->
-
-	<case name="invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet">
-    set SAXON_CP=%SYSTEMDRIVE%\path\to\saxonb9-1-0-8.jar
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
-    call :verify_retval 1
-    call :verify_line 3 x "Creating Test Stylesheet..."
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -235,26 +235,6 @@ teardown() {
 }
 
 #
-# JUnit and Saxon versions (CLI)
-#
-
-@test "invoking xspec with -j option with Saxon8 returns error message" {
-    export SAXON_CP=/path/to/saxon8.jar
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-    echo "$output"
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-}
-
-@test "invoking xspec with -j option with Saxon8-SA returns error message" {
-    export SAXON_CP=/path/to/saxon8sa.jar
-    run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
-    echo "$output"
-    [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
-}
-
-#
 # JUnit (CLI)
 #
 
@@ -272,18 +252,6 @@ teardown() {
 
     # JUnit report file
     [ -f "${TEST_DIR}/escape-for-regex-junit.xml" ]
-}
-
-#
-# Saxon-B (CLI)
-#
-
-@test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
-    export SAXON_CP=/path/to/saxonb9-1-0-8.jar
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
-    echo "$output"
-    [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Creating Test Stylesheet..." ]
 }
 
 #

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -50,7 +50,7 @@ teardown() {
     echo "$output"
     [ "$status" -eq 1 ]
     [ "${lines[1]}" = "SAXON_CP and SAXON_HOME both not set!" ]
-    [[ "${lines[4]}" =~ "Usage: xspec " ]]
+    [[ "${lines[3]}" =~ "Usage: xspec " ]]
 }
 
 @test "invoking xspec with -h prints usage and does so even when it is 11th argument" {


### PR DESCRIPTION
CLI contains some code for very old Saxon versions including Saxon 8.

This pull request removes it.
