### PR TITLE
test: parse failure element text in xspec-junit.xspec

### DIFF
--- a/test/xspec-junit.xspec
+++ b/test/xspec-junit.xspec
@@ -37,9 +37,15 @@
         <x:expect label="convert it to test case with status failed">
 			<testcase name="failing test"
 		        status="failed">
-				<failure message="expect assertion failed"><![CDATA[<x:expect xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:x="http://www.jenitennison.com/xslt/xspec"><p>Bar</p></x:expect>]]></failure>
+				<failure message="expect assertion failed">...</failure>
 			</testcase>
 		</x:expect>
+        <x:expect label="failure element holds a text node of serialized x:expect"
+            test="parse-xml($x:result/failure/text())" select="/">
+            <x:expect>
+                <p>Bar</p>
+            </x:expect>
+        </x:expect>
     </x:scenario>
 
 
@@ -69,9 +75,15 @@
 	      <testcase name="Successful test" status="passed"/>
 	     <testcase name="Failing test"
 		        status="failed">
-				<failure message="expect assertion failed"><![CDATA[<x:expect xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:x="http://www.jenitennison.com/xslt/xspec"><p>Bar</p></x:expect>]]></failure>
+				<failure message="expect assertion failed">...</failure>
 		</testcase>
 		</x:expect>
+        <x:expect label="failure element holds a text node of serialized x:expect"
+            test="parse-xml($x:result/failure/text())" select="/">
+            <x:expect>
+                <p>Bar</p>
+            </x:expect>
+        </x:expect>
     </x:scenario>
 
 


### PR DESCRIPTION
`test/xspec-junit.xspec` expects serialized element strings. Maintaining this fragile method has been a pain. Internal compiler changes or Saxon changes affect it.
This pull request replaces the expectation with `parse-xml()` so that we don't need to care about serialization.