### PR TITLE
test: skip xspec-serialize.xspec on Saxon 10.0

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -178,6 +178,13 @@
 
 					<xsl:when
 						test="
+							($pis = 'require-saxon-bug-4483-fixed')
+							and (x:saxon-version() eq x:pack-version(10, 0, 0, 0))">
+						<xsl:text>Requires Saxon bug #4483 to have been fixed</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
 							($pis = 'require-xspec-issue-720-fixed')
 							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
 						<xsl:text>Requires xspec/xspec#720 to have been fixed</xsl:text>

--- a/test/end-to-end/cases/xspec-serialize.xspec
+++ b/test/end-to-end/cases/xspec-serialize.xspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-saxon-bug-4483-fixed?>
 <x:description query="x-urn:test:xspec-items" query-at="../../items.xquery"
 	stylesheet="../../items.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec" xslt-version="3.0">
 	<x:scenario>


### PR DESCRIPTION
This pull request skips `test/end-to-end/cases/xspec-serialize.xspec` on Saxon 10.0 because of a Saxon [bug](https://saxonica.plan.io/issues/4483).

I verified that the test was skipped on Saxon 10.0 on my local machine.