### PR TITLE
refactor: make x.y.z part optional in x:pack-version()

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -54,7 +54,7 @@
          use-when="element-available('xsl:context-item')" />
 
       <xsl:variable name="deprecation-warning" as="xs:string?" select="
-         if (x:saxon-version() lt x:pack-version(9,8,0,0))
+         if (x:saxon-version() lt x:pack-version((9, 8)))
          then 'Saxon version 9.7 or less is deprecated. XSpec will stop supporting it in the near future.'
          else ()" />
       <xsl:message select="

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -142,44 +142,44 @@
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-3543-fixed')
-							and (x:saxon-version() lt x:pack-version(9, 8, 0, 7))">
+							and (x:saxon-version() lt x:pack-version((9, 8, 0, 7)))">
 						<xsl:text>Requires Saxon bug #3543 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-3838-fixed')
-							and (x:saxon-version() ge x:pack-version(9, 8, 0, 0))
-							and (x:saxon-version() lt x:pack-version(9, 9, 0, 0))">
+							and (x:saxon-version() ge x:pack-version((9, 8)))
+							and (x:saxon-version() lt x:pack-version((9, 9)))">
 						<xsl:text>Requires Saxon bug #3838 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-3889-fixed')
-							and (x:saxon-version() lt x:pack-version(9, 8, 0, 15))">
+							and (x:saxon-version() lt x:pack-version((9, 8, 0, 15)))">
 						<xsl:text>Requires Saxon bug #3889 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-4315-fixed')
-							and (x:saxon-version() ge x:pack-version(9, 9, 0, 0))
-							and (x:saxon-version() le x:pack-version(9, 9, 1, 6))">
+							and (x:saxon-version() ge x:pack-version((9, 9)))
+							and (x:saxon-version() le x:pack-version((9, 9, 1, 6)))">
 						<xsl:text>Requires Saxon bug #4315 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-4376-fixed')
-							and (x:saxon-version() le x:pack-version(9, 9, 1, 5))">
+							and (x:saxon-version() le x:pack-version((9, 9, 1, 5)))">
 						<xsl:text>Requires Saxon bug #4376 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when
 						test="
 							($pis = 'require-xspec-issue-720-fixed')
-							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
+							and (x:saxon-version() lt x:pack-version((9, 8)))">
 						<xsl:text>Requires xspec/xspec#720 to have been fixed</xsl:text>
 					</xsl:when>
 
@@ -187,7 +187,7 @@
 						test="
 							($test-type eq 't')
 							and ($pis = 'require-type-available-in-use-when')
-							and (x:saxon-version() lt x:pack-version(9, 8, 0, 0))">
+							and (x:saxon-version() lt x:pack-version((9, 8)))">
 						<xsl:text>Requires type-available() to be reliable in @use-when</xsl:text>
 					</xsl:when>
 				</xsl:choose>

--- a/test/end-to-end/ant/generate-expected/worker/generate.xsl
+++ b/test/end-to-end/ant/generate-expected/worker/generate.xsl
@@ -19,7 +19,7 @@
 		Rejects specific Saxon versions
 	-->
 	<xsl:template as="document-node(element(project))" match="document-node()">
-		<xsl:if test="x:saxon-version() lt x:pack-version(9, 9, 0, 2)">
+		<xsl:if test="x:saxon-version() lt x:pack-version((9, 9, 0, 2))">
 			<xsl:message terminate="yes">
 				<xsl:text>Saxon version is </xsl:text>
 				<xsl:value-of select="system-property('xsl:product-version')" />

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -507,14 +507,60 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function pack-version">
-		<x:scenario label="76.0.3809.132">
-			<x:call function="x:pack-version">
-				<x:param select="76" />
-				<x:param select="0" />
-				<x:param select="3809" />
-				<x:param select="132" />
-			</x:call>
-			<x:expect label="0x004C00000EE10084" select="21392098479636612" />
+		<x:scenario label="Valid parameter">
+			<x:scenario label="76.0.3809.132">
+				<x:call function="x:pack-version">
+					<x:param select="76, 0, 3809, 132" />
+				</x:call>
+				<x:expect label="0x004C00000EE10084" select="21392098479636612" />
+			</x:scenario>
+
+			<x:scenario label="1.2.3">
+				<x:call function="x:pack-version">
+					<x:param select="1, 2, 3" />
+				</x:call>
+				<x:expect label="0x0001000200030000" select="281483566841856" />
+			</x:scenario>
+
+			<x:scenario label="10.11">
+				<x:call function="x:pack-version">
+					<x:param select="10, 11" />
+				</x:call>
+				<x:expect label="0x000A000B00000000" select="2814797011746816" />
+			</x:scenario>
+
+			<x:scenario label="9">
+				<x:call function="x:pack-version">
+					<x:param select="9" />
+				</x:call>
+				<x:expect label="0x0009000000000000" select="2533274790395904" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario catch="true" label="Invalid parameter">
+			<x:scenario label="5 components">
+				<x:call function="x:pack-version">
+					<x:param select="1, 2, 3, 4, 5" />
+				</x:call>
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
+					test="$x:result?err?code treat as xs:QName" />
+			</x:scenario>
+
+			<x:scenario label="Greater than uint16">
+				<x:call function="x:pack-version">
+					<x:param select="65536" />
+				</x:call>
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
+					test="$x:result?err?code treat as xs:QName" />
+			</x:scenario>
+
+			<x:scenario label="Less than uint16">
+				<x:call function="x:pack-version">
+					<x:param select="-1" />
+				</x:call>
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
+					test="$x:result?err?code treat as xs:QName" />
+			</x:scenario>
 		</x:scenario>
 	</x:scenario>
 
@@ -594,9 +640,9 @@
 		<x:scenario label="Assume we test this on Saxon versions from 9.7 to 9.9">
 			<x:call function="x:saxon-version" />
 			<x:expect label="Greater than or equal to 9.7.0.0"
-				test="$x:result treat as xs:integer ge x:pack-version(9,7,0,0)" />
+				test="$x:result treat as xs:integer ge x:pack-version((9, 7))" />
 			<x:expect label="Less than 10.0"
-				test="$x:result treat as xs:integer lt x:pack-version(10,0,0,0)" />
+				test="$x:result treat as xs:integer lt x:pack-version(10)" />
 		</x:scenario>
 	</x:scenario>
 


### PR DESCRIPTION
Saxon 10 changed the version number scheme. Reflecting it, this pull request makes x.y.z part optional in `x:pack-version()`.