### PR TITLE
test: use mirror.* in end-to-end test

### DIFF
--- a/test/end-to-end/cases/expected/query/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-346-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-346.xspec">xspec-346.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -71,7 +71,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <pre>&lt;<span class="inner-diff">p</span> xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    <span class="diff whitespace">␣</span>
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
@@ -79,7 +79,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <pre>&lt;<span class="inner-diff">p</span> xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
 &lt;/p&gt;</pre>

--- a/test/end-to-end/cases/expected/query/xspec-346-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-346-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-346.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param as="element(p)" href="../../xspec-346.xml" select="element(p)"/>
       </x:call>
       <x:result select="/element()">

--- a/test/end-to-end/cases/expected/query/xspec-447_1-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_1-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-447_1.xspec">xspec-447_1.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-447_1-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-447_1-result.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-447_1.xspec">
    <x:scenario id="scenario1"
                xspec="../../xspec-447_1.xspec"
                pending="x:pending/x:label containing }{">
       <x:label>should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="x:pending/x:label containing }{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/query/xspec-447_2-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_2-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-447_2.xspec">xspec-447_2.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-447_2-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-447_2-result.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-447_2.xspec">
    <x:scenario id="scenario1"
                xspec="../../xspec-447_2.xspec"
                pending="x:pending/@label containing }{">
       <x:label>should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="x:pending/@label containing }{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/query/xspec-447_3-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-447_3-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-447_3.xspec">xspec-447_3.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-447_3-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-447_3-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-447_3.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-447_3.xspec" pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="}{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/query/xspec-448-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-448-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-448.xspec">xspec-448.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-448-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-448-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-448.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-448.xspec">
          <x:label>x:label containing }{ should not affect test</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>(This x:expect doesn't matter)</x:label>
@@ -18,7 +19,7 @@
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../xspec-448.xspec">
          <x:label>@label containing }{ should not affect test</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario1-scenario2-expect1" successful="true">
             <x:label>(This x:expect doesn't matter)</x:label>

--- a/test/end-to-end/cases/expected/query/xspec-449-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-449-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-449.xspec">xspec-449.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-449-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-449-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-449.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-449.xspec">
       <x:label>x:expect/</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>x:label containing }{ should not affect test</x:label>

--- a/test/end-to-end/cases/expected/query/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-452-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-452.xspec">xspec-452.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -224,7 +224,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/element()</code> from:</p>
-                           <pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
+                           <pre>&lt;<span class="diff">elem</span> xmlns:mirror="x-urn:test:mirror"&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
                         </td>
                         <td>
                            <pre>xs:boolean('false')</pre>

--- a/test/end-to-end/cases/expected/query/xspec-452-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-452-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-452.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-452.xspec">
       <x:label>Text</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>t</x:param>
       </x:call>
       <x:result select="/text()">t</x:result>
@@ -17,7 +18,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-452.xspec">
       <x:label>Comment</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param><!--c--></x:param>
       </x:call>
       <x:result select="/comment()"><!--c--></x:result>
@@ -28,7 +29,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-452.xspec">
       <x:label>Processing instruction</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param><?p?></x:param>
       </x:call>
       <x:result select="/processing-instruction()"><?p?></x:result>
@@ -39,7 +40,7 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../xspec-452.xspec">
       <x:label>In element</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>
             <elem>t<!--c--><?p?></elem>
          </x:param>

--- a/test/end-to-end/cases/expected/query/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-467-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-467.xspec">xspec-467.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -71,7 +71,8 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"
+    xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -83,7 +84,8 @@
                         </td>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"
+    xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2!"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;

--- a/test/end-to-end/cases/expected/query/xspec-467-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-467-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-467.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-467.xspec">
       <x:label>Testing namespace differences</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>
             <e1 xmlns="ns1">
                <e2 xmlns:ns4="ns4" xmlns:ns3="ns3" xmlns="ns2">

--- a/test/end-to-end/cases/expected/query/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-55-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-55.xspec">xspec-55.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-55-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-55-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-55.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-55.xspec">
       <x:label>In a failure report HTML</x:label>
-      <x:call function="true"/>
+      <x:call function="mirror:true"/>
       <x:result select="xs:boolean('true')"/>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of

--- a/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 5 / pending: 0 / failed: 5 / total: 10)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 5 / pending: 0 / failed: 5 / total: 10)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-ambiguous-expect.xspec">xspec-ambiguous-expect.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -104,7 +104,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="diff">/self::document-node()</code> from:</p>
-                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">foo</span> xmlns:mirror="x-urn:test:mirror" /&gt;</pre>
                         </td>
                      </tr>
                   </tbody>
@@ -208,7 +208,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="diff">/element()</code> from:</p>
-                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">foo</span> xmlns:mirror="x-urn:test:mirror" /&gt;</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-ambiguous-expect.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Expecting document node via @href should be Failure</x:label>
@@ -30,7 +31,7 @@
       <x:result select="()"/>
       <x:scenario id="scenario2-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns false,</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario2-scenario1-expect1" successful="true">
             <x:label>Expecting false via @select should be Success</x:label>
@@ -47,7 +48,7 @@
       <x:result select="()"/>
       <x:scenario id="scenario3-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario3-scenario1-expect1" successful="false">
             <x:label>Expecting element(foo) via child node should be Failure</x:label>
@@ -68,7 +69,7 @@
       <x:result select="()"/>
       <x:scenario id="scenario4-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario4-scenario1-expect1" successful="false">
             <x:label>Expecting empty sequence (no @href, @select or child node) should be Failure</x:label>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 8 / total: 8)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 8 / total: 8)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-report.xspec">xspec-report.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-report.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-report.xspec">
          <x:label>Array</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="array(*)" select="['foo', 1, [2, 'bar']]"/>
          </x:call>
          <x:result select="/*">
@@ -22,7 +22,7 @@
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../xspec-report.xspec">
          <x:label>Map</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="map(*)" select="      map {       'foo': 1,       2: 'bar'      }"/>
          </x:call>
          <x:result select="/*">
@@ -36,7 +36,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-report.xspec">
       <x:label>Element, attribute (xspec/xspec#357)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="elem1 | elem2/attribute()">
             <elem1>text</elem1>
             <elem2 attr="attr-val"/>
@@ -55,7 +55,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-report.xspec">
       <x:label>Attributes of the same name (xspec/xspec#358)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="attribute()+" select="element()/attribute()">
             <elem1 attr="foo"/>
             <elem2 attr="bar"/>
@@ -72,7 +72,7 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../xspec-report.xspec">
       <x:label>Attribute, element, attribute (xspec/xspec#360)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="element()/attribute() | elem2">
             <elem1 attr1="attr1-val"/>
             <elem2>text</elem2>
@@ -93,8 +93,8 @@
    </x:scenario>
    <x:scenario id="scenario5" xspec="../../xspec-report.xspec">
       <x:label>Document node with no children (xspec/xspec#697)</x:label>
-      <x:call function="parse-xml-fragment">
-         <x:param select="''"/>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param select="parse-xml-fragment('')"/>
       </x:call>
       <x:result select="/self::document-node()"/>
       <x:test id="scenario5-expect1" successful="false">
@@ -107,7 +107,7 @@
       <x:result select="()"/>
       <x:scenario id="scenario6-scenario1" xspec="../../xspec-report.xspec">
          <x:label>[Result] = document node, [Expected Result] = element</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="document-node()" select="/">
                <test/>
             </x:param>
@@ -124,7 +124,7 @@
       </x:scenario>
       <x:scenario id="scenario6-scenario2" xspec="../../xspec-report.xspec">
          <x:label>[Result] = element, [Expected Result] = document node.</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element()">
                <test/>
             </x:param>

--- a/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-result.html
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Query: x-urn:test:do-nothing</p>
-      <p>Query-at: <a href="../../../../do-nothing.xquery">do-nothing.xquery</a></p>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
       <p>XSpec: <a href="../../xspec-shared-like.xspec">xspec-shared-like.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/query/xspec-shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-shared-like-result.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xmlns:mirror="x-urn:test:mirror"
           date="2000-01-01T00:00:00Z"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xquery"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
           xspec="../../xspec-shared-like.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -15,7 +16,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-shared-like.xspec">
       <x:label>Referenced and implicitly unshared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -24,7 +25,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-shared-like.xspec">
       <x:label>Scenario for testing x:like which references a shared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>This nested shared x:expect should fire only at nested x:like</x:label>
@@ -40,7 +41,7 @@
       <x:result select="()"/>
       <x:scenario id="scenario4-scenario1" xspec="../../xspec-shared-like.xspec">
          <x:label>explicit one</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -49,7 +50,7 @@
       </x:scenario>
       <x:scenario id="scenario4-scenario2" xspec="../../xspec-shared-like.xspec">
          <x:label>implicit one</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-346.xspec">xspec-346.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -70,7 +70,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <pre>&lt;<span class="inner-diff">p</span> xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    <span class="diff whitespace">␣</span>
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
@@ -78,7 +78,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">p</span>&gt;
+                           <pre>&lt;<span class="inner-diff">p</span> xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="same">span</span>&gt;<span class="same">foo</span>&lt;/span&gt;
    &lt;<span class="diff">span</span>&gt;<span class="diff">bar</span>&lt;/span&gt;
 &lt;/p&gt;</pre>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-346-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-346-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-346.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param as="element(p)" href="../../xspec-346.xml" select="element(p)"/>
       </x:call>
       <x:result select="/element()">

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_1-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-447_1.xspec">xspec-447_1.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_1-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-447_1.xspec">
    <x:scenario id="scenario1"
                xspec="../../xspec-447_1.xspec"
                pending="x:pending/x:label containing }{">
       <x:label>should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="x:pending/x:label containing }{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_2-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-447_2.xspec">xspec-447_2.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_2-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-447_2.xspec">
    <x:scenario id="scenario1"
                xspec="../../xspec-447_2.xspec"
                pending="x:pending/@label containing }{">
       <x:label>should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="x:pending/@label containing }{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_3-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-447_3.xspec">xspec-447_3.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-447_3-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-447_3-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-447_3.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-447_3.xspec" pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="}{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-448-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-448-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-448.xspec">xspec-448.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-448-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-448-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-448.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-448.xspec">
          <x:label>x:label containing }{ should not affect test</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>(This x:expect doesn't matter)</x:label>
@@ -18,7 +19,7 @@
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../xspec-448.xspec">
          <x:label>@label containing }{ should not affect test</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario1-scenario2-expect1" successful="true">
             <x:label>(This x:expect doesn't matter)</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-449-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-449-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-449.xspec">xspec-449.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-449-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-449-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-449.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-449.xspec">
       <x:label>x:expect/</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>x:label containing }{ should not affect test</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-452.xspec">xspec-452.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -223,7 +223,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/element()</code> from:</p>
-                           <pre>&lt;<span class="diff">elem</span>&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
+                           <pre>&lt;<span class="diff">elem</span> xmlns:mirror="x-urn:test:mirror"&gt;<span class="diff">t</span><span class="diff">&lt;!--c--&gt;</span>&lt;?<span class="diff">p</span> <span class="diff"></span>?&gt;&lt;/elem&gt;</pre>
                         </td>
                         <td>
                            <pre>xs:boolean('false')</pre>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-452-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-452-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-452.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-452.xspec">
       <x:label>Text</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>t</x:param>
       </x:call>
       <x:result select="/text()">t</x:result>
@@ -18,7 +19,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-452.xspec">
       <x:label>Comment</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param><!--c--></x:param>
       </x:call>
       <x:result select="/comment()"><!--c--></x:result>
@@ -29,7 +30,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-452.xspec">
       <x:label>Processing instruction</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param><?p?></x:param>
       </x:call>
       <x:result select="/processing-instruction()"><?p?></x:result>
@@ -40,7 +41,7 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../xspec-452.xspec">
       <x:label>In element</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>
             <elem>t<!--c--><?p?></elem>
          </x:param>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-467.xspec">xspec-467.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -70,7 +70,8 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"
+    xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;
@@ -82,7 +83,8 @@
                         </td>
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"&gt;
+                           <pre>&lt;<span class="inner-diff">e1</span> xmlns="ns1"
+    xmlns:mirror="x-urn:test:mirror"&gt;
    &lt;<span class="diff">e2</span> xmlns="ns2!"
        xmlns:ns3="ns3"
        xmlns:ns4="ns4"&gt;

--- a/test/end-to-end/cases/expected/stylesheet/xspec-467-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-467-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-467.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-467.xspec">
       <x:label>Testing namespace differences</x:label>
-      <x:call function="exactly-one">
+      <x:call function="mirror:param-mirror">
          <x:param>
             <e1 xmlns="ns1">
                <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">

--- a/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-528.xspec">xspec-528.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-528-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-528-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-528.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-528.xspec" pending="Focus on 1-2">
       <x:label>Scenario 1</x:label>
-      <x:call function="true"/>
+      <x:call function="mirror:true"/>
       <x:test id="scenario1-expect1" pending="Focus on 1-2">
          <x:label>should be skipped (otherwise should fail)</x:label>
       </x:test>
@@ -15,14 +16,14 @@
                   xspec="../../xspec-528.xspec"
                   pending="Focus on 1-2">
          <x:label>Scenario 1-1</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:test id="scenario1-scenario1-expect1" pending="Focus on 1-2">
             <x:label>should be skipped (otherwise should fail)</x:label>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../xspec-528.xspec">
          <x:label>Scenario 1-2</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario1-scenario2-expect1" successful="false">
             <x:label>should fail</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-55.xspec">xspec-55.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-55-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-55-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-55.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-55.xspec">
       <x:label>In a failure report HTML</x:label>
-      <x:call function="true"/>
+      <x:call function="mirror:true"/>
       <x:result select="xs:boolean('true')"/>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of

--- a/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 5 / pending: 0 / failed: 5 / total: 10)</title>
+      <title>Test Report for mirror.xsl (passed: 5 / pending: 0 / failed: 5 / total: 10)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-ambiguous-expect.xspec">xspec-ambiguous-expect.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>
@@ -103,7 +103,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="diff">/self::document-node()</code> from:</p>
-                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">foo</span> xmlns:mirror="x-urn:test:mirror" /&gt;</pre>
                         </td>
                      </tr>
                   </tbody>
@@ -207,7 +207,7 @@
                         </td>
                         <td>
                            <p>XPath <code class="diff">/element()</code> from:</p>
-                           <pre>&lt;<span class="diff">foo</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">foo</span> xmlns:mirror="x-urn:test:mirror" /&gt;</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-ambiguous-expect.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Expecting document node via @href should be Failure</x:label>
@@ -29,7 +30,7 @@
       <x:label>Scenario for verifying that boolean @test precedes @select</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns false,</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario2-scenario1-expect1" successful="true">
             <x:label>Expecting false via @select should be Success</x:label>
@@ -45,7 +46,7 @@
       <x:label>Scenario for verifying that boolean @test precedes child node</x:label>
       <x:scenario id="scenario3-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario3-scenario1-expect1" successful="false">
             <x:label>Expecting element(foo) via child node should be Failure</x:label>
@@ -65,7 +66,7 @@
       <x:label>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select or child node)</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../xspec-ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
-         <x:call function="true"/>
+         <x:call function="mirror:true"/>
          <x:result select="xs:boolean('true')"/>
          <x:test id="scenario4-scenario1-expect1" successful="false">
             <x:label>Expecting empty sequence (no @href, @select or child node) should be Failure</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 8 / total: 8)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 8 / total: 8)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-report.xspec">xspec-report.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
@@ -2,14 +2,14 @@
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-report.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../xspec-report.xspec">
          <x:label>Array</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="array(*)" select="['foo', 1, [2, 'bar']]"/>
          </x:call>
          <x:result select="/*">
@@ -22,7 +22,7 @@
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../xspec-report.xspec">
          <x:label>Map</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="map(*)" select="      map {       'foo': 1,       2: 'bar'      }"/>
          </x:call>
          <x:result select="/*">
@@ -36,7 +36,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-report.xspec">
       <x:label>Element, attribute (xspec/xspec#357)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="elem1 | elem2/attribute()">
             <elem1>text</elem1>
             <elem2 attr="attr-val"/>
@@ -55,7 +55,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-report.xspec">
       <x:label>Attributes of the same name (xspec/xspec#358)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="attribute()+" select="element()/attribute()">
             <elem1 attr="foo"/>
             <elem2 attr="bar"/>
@@ -72,7 +72,7 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../xspec-report.xspec">
       <x:label>Attribute, element, attribute (xspec/xspec#360)</x:label>
-      <x:call function="one-or-more">
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="element()/attribute() | elem2">
             <elem1 attr1="attr1-val"/>
             <elem2>text</elem2>
@@ -93,8 +93,8 @@
    </x:scenario>
    <x:scenario id="scenario5" xspec="../../xspec-report.xspec">
       <x:label>Document node with no children (xspec/xspec#697)</x:label>
-      <x:call function="parse-xml-fragment">
-         <x:param select="''"/>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param select="parse-xml-fragment('')"/>
       </x:call>
       <x:result select="/self::document-node()"/>
       <x:test id="scenario5-expect1" successful="false">
@@ -106,7 +106,7 @@
       <x:label>XPath is different, but serialized node looks as if same</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../xspec-report.xspec">
          <x:label>[Result] = document node, [Expected Result] = element</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="document-node()" select="/">
                <test/>
             </x:param>
@@ -123,7 +123,7 @@
       </x:scenario>
       <x:scenario id="scenario6-scenario2" xspec="../../xspec-report.xspec">
          <x:label>[Result] = element, [Expected Result] = document node.</x:label>
-         <x:call function="exactly-one">
+         <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element()">
                <test/>
             </x:param>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <title>Test Report for mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
       <h1>Test Report</h1>
-      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xspec-shared-like.xspec">xspec-shared-like.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
       <h2>Contents</h2>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-shared-like-result.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          stylesheet="../../../../do-nothing.xsl"
+          stylesheet="../../../../mirror.xsl"
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-shared-like.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -16,7 +17,7 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../xspec-shared-like.xspec">
       <x:label>Referenced and implicitly unshared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -25,7 +26,7 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../xspec-shared-like.xspec">
       <x:label>Scenario for testing x:like which references a shared scenario</x:label>
-      <x:call function="false"/>
+      <x:call function="mirror:false"/>
       <x:result select="xs:boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>This nested shared x:expect should fire only at nested x:like</x:label>
@@ -40,7 +41,7 @@
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../xspec-shared-like.xspec">
          <x:label>explicit one</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
@@ -49,7 +50,7 @@
       </x:scenario>
       <x:scenario id="scenario4-scenario2" xspec="../../xspec-shared-like.xspec">
          <x:label>implicit one</x:label>
-         <x:call function="false"/>
+         <x:call function="mirror:false"/>
          <x:result select="xs:boolean('false')"/>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>

--- a/test/end-to-end/cases/xspec-346.xspec
+++ b/test/end-to-end/cases/xspec-346.xspec
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="When a function returns a node containing a space">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param as="element(p)" href="xspec-346.xml" select="element(p)" />
 		</x:call>
 		<x:expect label="Expecting no space should be Failure">

--- a/test/end-to-end/cases/xspec-447_1.xspec
+++ b/test/end-to-end/cases/xspec-447_1.xspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:pending>
 		<x:label>x:pending/x:label containing }{</x:label>
 		<x:scenario label="should not affect test">
-			<x:call function="false" />
+			<x:call function="mirror:false" />
 			<x:expect label="(This x:expect doesn't matter)" select="false()" />
 		</x:scenario>
 	</x:pending>

--- a/test/end-to-end/cases/xspec-447_2.xspec
+++ b/test/end-to-end/cases/xspec-447_2.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:pending label="x:pending/@label containing }{">
 		<x:scenario label="should not affect test">
-			<x:call function="false" />
+			<x:call function="mirror:false" />
 			<x:expect label="(This x:expect doesn't matter)" select="false()" />
 		</x:scenario>
 	</x:pending>

--- a/test/end-to-end/cases/xspec-447_3.xspec
+++ b/test/end-to-end/cases/xspec-447_3.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="x:scenario/@pending containing curly brackets should not affect test"
 		pending="}{">
-		<x:call function="false" />
+		<x:call function="mirror:false" />
 		<x:expect label="(This x:expect doesn't matter)" select="false()" />
 	</x:scenario>
 </x:description>

--- a/test/end-to-end/cases/xspec-448.xspec
+++ b/test/end-to-end/cases/xspec-448.xspec
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="x:scenario/">
 		<x:scenario>
 			<x:label>x:label containing }{ should not affect test</x:label>
-			<x:call function="false" />
+			<x:call function="mirror:false" />
 			<x:expect label="(This x:expect doesn't matter)" select="false()" />
 		</x:scenario>
 
 		<x:scenario label="@label containing }{ should not affect test">
-			<x:call function="false" />
+			<x:call function="mirror:false" />
 			<x:expect label="(This x:expect doesn't matter)" select="false()" />
 		</x:scenario>
 	</x:scenario>

--- a/test/end-to-end/cases/xspec-449.xspec
+++ b/test/end-to-end/cases/xspec-449.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="x:expect/">
-		<x:call function="false" />
+		<x:call function="mirror:false" />
 		<x:expect select="false()">
 			<x:label>x:label containing }{ should not affect test</x:label>
 		</x:expect>

--- a/test/end-to-end/cases/xspec-452.xspec
+++ b/test/end-to-end/cases/xspec-452.xspec
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="Text">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param>t</x:param>
 		</x:call>
 		<x:expect label="Expect" select="false()" />
 	</x:scenario>
 
 	<x:scenario label="Comment">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param><!--c--></x:param>
 		</x:call>
 		<x:expect label="Expect" select="false()" />
 	</x:scenario>
 
 	<x:scenario label="Processing instruction">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param><?p?></x:param>
 		</x:call>
 		<x:expect label="Expect" select="false()" />
 	</x:scenario>
 
 	<x:scenario label="In element">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param>
 				<elem>t<!--c--><?p?></elem>
 			</x:param>

--- a/test/end-to-end/cases/xspec-467.xspec
+++ b/test/end-to-end/cases/xspec-467.xspec
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="Testing namespace differences">
-		<x:call function="exactly-one">
+		<x:call function="mirror:param-mirror">
 			<x:param>
 				<e1 xmlns="ns1">
 					<e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">

--- a/test/end-to-end/cases/xspec-528.xspec
+++ b/test/end-to-end/cases/xspec-528.xspec
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!-- XSpec fails to run this file on XQuery. Maybe a variant of #446? -->
 
 	<x:scenario label="Scenario 1">
-		<x:call function="true" />
+		<x:call function="mirror:true" />
 		<x:expect label="should be skipped (otherwise should fail)" select="false()" />
 
 		<x:scenario label="Scenario 1-1">
-			<x:call function="true" />
+			<x:call function="mirror:true" />
 			<x:expect label="should be skipped (otherwise should fail)" select="false()" />
 		</x:scenario>
 
 		<x:scenario focus="Focus on 1-2" label="Scenario 1-2">
-			<x:call function="true" />
+			<x:call function="mirror:true" />
 			<x:expect label="should fail" select="false()" />
 		</x:scenario>
 	</x:scenario>

--- a/test/end-to-end/cases/xspec-55.xspec
+++ b/test/end-to-end/cases/xspec-55.xspec
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="In a failure report HTML">
-		<x:call function="true" />
+		<x:call function="mirror:true" />
 		<x:expect select="xs:decimal(1)">
 			<x:label>[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of
 				decimal)</x:label>

--- a/test/end-to-end/cases/xspec-ambiguous-expect.xspec
+++ b/test/end-to-end/cases/xspec-ambiguous-expect.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="Scenario for verifying that boolean @test precedes @href">
 		<x:scenario label="When function returns true,">
-			<x:call function="true" />
+			<x:call function="mirror:true" />
 
 			<x:expect href="xspec-ambiguous-expect.xml"
 				label="Expecting document node via @href should be Failure" />
@@ -16,7 +17,7 @@
 
 	<x:scenario label="Scenario for verifying that boolean @test precedes @select">
 		<x:scenario label="When function returns false,">
-			<x:call function="false" />
+			<x:call function="mirror:false" />
 
 			<x:expect label="Expecting false via @select should be Success" select="false()" />
 
@@ -28,7 +29,7 @@
 
 	<x:scenario label="Scenario for verifying that boolean @test precedes child node">
 		<x:scenario label="When function returns true,">
-			<x:call function="true" />
+			<x:call function="mirror:true" />
 
 			<x:expect label="Expecting element(foo) via child node should be Failure">
 				<foo />
@@ -45,7 +46,7 @@
 	<x:scenario
 		label="Scenario for verifying that boolean @test precedes empty sequence (no @href, @select or child node)">
 		<x:scenario label="When function returns true,">
-			<x:call function="true" />
+			<x:call function="mirror:true" />
 
 			<x:expect
 				label="Expecting empty sequence (no @href, @select or child node) should be Failure" />

--- a/test/end-to-end/cases/xspec-report.xspec
+++ b/test/end-to-end/cases/xspec-report.xspec
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
 	xquery-version="3.1" xslt-version="3.0">
 
 	<x:scenario label="Function (xspec/xspec#355)">
 		<!-- function(*) (excluding array(*) and map(*)) requires Saxon-PE or EE -->
 
 		<x:scenario label="Array">
-			<x:call function="exactly-one">
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
 				<x:param as="array(*)" select="['foo', 1, [2, 'bar']]" />
 			</x:call>
 			<x:expect
@@ -16,7 +16,7 @@
 		</x:scenario>
 
 		<x:scenario label="Map">
-			<x:call function="exactly-one">
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
 				<x:param as="map(*)" select="
 					map {
 						'foo': 1,
@@ -30,7 +30,7 @@
 	</x:scenario>
 
 	<x:scenario label="Element, attribute (xspec/xspec#357)">
-		<x:call function="one-or-more">
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
 			<x:param as="node()+" select="elem1 | elem2/attribute()">
 				<elem1>text</elem1>
 				<elem2 attr="attr-val" />
@@ -40,7 +40,7 @@
 	</x:scenario>
 
 	<x:scenario label="Attributes of the same name (xspec/xspec#358)">
-		<x:call function="one-or-more">
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
 			<x:param as="attribute()+" select="element()/attribute()">
 				<elem1 attr="foo" />
 				<elem2 attr="bar" />
@@ -50,7 +50,7 @@
 	</x:scenario>
 
 	<x:scenario label="Attribute, element, attribute (xspec/xspec#360)">
-		<x:call function="one-or-more">
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
 			<x:param as="node()+" select="element()/attribute() | elem2">
 				<elem1 attr1="attr1-val" />
 				<elem2>text</elem2>
@@ -61,15 +61,15 @@
 	</x:scenario>
 
 	<x:scenario label="Document node with no children (xspec/xspec#697)">
-		<x:call function="parse-xml-fragment">
-			<x:param select="''" />
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
+			<x:param select="parse-xml-fragment('')" />
 		</x:call>
 		<x:expect label="XPath should be reported between Result title and box" />
 	</x:scenario>
 
 	<x:scenario label="XPath is different, but serialized node looks as if same">
 		<x:scenario label="[Result] = document node, [Expected Result] = element">
-			<x:call function="exactly-one">
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
 				<x:param as="document-node()" select="/">
 					<test />
 				</x:param>
@@ -82,7 +82,7 @@
 		</x:scenario>
 
 		<x:scenario label="[Result] = element, [Expected Result] = document node.">
-			<x:call function="exactly-one">
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
 				<x:param as="element()">
 					<test />
 				</x:param>

--- a/test/end-to-end/cases/xspec-shared-like.xspec
+++ b/test/end-to-end/cases/xspec-shared-like.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xquery"
-	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="Unreferenced shared scenario" shared="yes">
 		<x:expect label="This unreferenced shared x:expect should not fire at all" test="true()" />
@@ -15,14 +16,14 @@
 	</x:scenario>
 
 	<x:scenario label="Referenced and explicitly unshared scenario" shared="no">
-		<x:call function="false" />
+		<x:call function="mirror:false" />
 		<x:expect
 			label="This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like"
 			test="true()" />
 	</x:scenario>
 
 	<x:scenario label="Referenced and implicitly unshared scenario">
-		<x:call function="false" />
+		<x:call function="mirror:false" />
 		<x:expect
 			label="This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
 			test="true()" />
@@ -34,7 +35,7 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing x:like which references a shared scenario">
-		<x:call function="false" />
+		<x:call function="mirror:false" />
 		<x:like label="Referenced shared scenario" />
 	</x:scenario>
 


### PR DESCRIPTION
Following #822, this pull request applies `test/mirror.xquery` and `test/mirror.xsl` to `test/end-to-end/`.