### PR TITLE
test: test template context in global-override.xspec

### DIFF
--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -5,9 +5,11 @@
 
 	<x:variable name="global-variable" select="'global variable overridden by XSpec'" />
 
-	<x:scenario label="Regardless of x:context">
-		<x:context>
-			<context-child />
+	<x:scenario label="With x:context">
+		<x:context select="//context-grandchild">
+			<context-child>
+				<context-grandchild />
+			</context-child>
 		</x:context>
 
 		<x:scenario label="global x:param in XSpec">
@@ -20,6 +22,13 @@
 			<x:call template="get-global-variable" />
 			<x:expect label="overrides xsl:variable in SUT"
 				select="'global variable overridden by XSpec'" />
+		</x:scenario>
+
+		<x:scenario label="template context">
+			<x:call template="get-template-context" />
+			<x:expect label="x:context/@select">
+				<context-grandchild />
+			</x:expect>
 		</x:scenario>
 	</x:scenario>
 

--- a/test/global.xsl
+++ b/test/global.xsl
@@ -16,4 +16,9 @@
 		<xsl:sequence select="$global-variable" />
 	</xsl:template>
 
+	<!-- Returns the context item intact -->
+	<xsl:template as="item()?" name="get-template-context">
+		<xsl:sequence select="." />
+	</xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
This pull request just adds a test to `global-override.xspec` for verifying the template context.