### PR TITLE
test: add xsl:mode to xspec-tested.xsl

### DIFF
--- a/test/xspec-tested.xsl
+++ b/test/xspec-tested.xsl
@@ -18,6 +18,8 @@
       <xsl:sequence select="$n * $n"/>
    </xsl:function>
 
+   <xsl:mode on-no-match="fail" use-when="element-available('xsl:mode')" />
+
    <xsl:template match="rule">
       <xsl:param name="p"/>
       <transformed/>


### PR DESCRIPTION
This pull request just adds `xsl:mode` to `xspec-tested.xsl` so that it can be easily included in XSLT pacakges.