### PR TITLE
test(xslt): skip coverage test on Saxon 10

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -110,6 +110,14 @@
 					<xsl:when
 						test="
 							($test-type eq 't')
+							and $enable-coverage
+							and (x:saxon-version() ge x:pack-version(10, 0, 0, 0))">
+						<xsl:text>XSLT Code Coverage requires Saxon version less than 10 (xspec/xspec#852)</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
+							($test-type eq 't')
 							and ($pis = 'require-xslt-to-support-schema')
 							and not($XSLT-SUPPORTS-SCHEMA)">
 						<xsl:text>Requires schema-aware XSLT processor</xsl:text>


### PR DESCRIPTION
This pull request skips Code Coverage in [the automated test](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) on Saxon 10 because it doesn't work (#852).