### PR TITLE
test: test with higher-order functions if possible

### DIFF
--- a/test/ant/build.xml
+++ b/test/ant/build.xml
@@ -40,6 +40,17 @@
 		</condition>
 		<echo message="xslt.supports.3-0=${xslt.supports.3-0}" />
 
+		<!-- Checks to see if XSLT processor supports higher-order functions -->
+		<java classname="net.sf.saxon.Transform" classpath="${java.class.path}" fork="true"
+			resultproperty="xslt.hof.compile.result">
+			<arg value="-nogo" />
+			<arg value="-xsl:${run-xspec-tests.basedir}/../caps/hof.xsl" />
+		</java>
+		<condition else="false" property="xslt.supports.hof">
+			<equals arg1="${xslt.hof.compile.result}" arg2="0" />
+		</condition>
+		<echo message="xslt.supports.hof=${xslt.supports.hof}" />
+
 		<!-- Checks to see if XQuery processor can be schema-aware ('-sa') -->
 		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
 			resultproperty="xquery.schema-aware.run.result">
@@ -71,6 +82,16 @@
 			<equals arg1="${xquery3-1.qversion.run.result}" arg2="0" />
 		</condition>
 		<echo message="xquery.supports.3-1.qversion=${xquery.supports.3-1.qversion}" />
+
+		<!-- Checks to see if XQuery processor supports higher-order functions -->
+		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
+			resultproperty="xquery.hof.run.result">
+			<arg value="-q:${run-xspec-tests.basedir}/../caps/hof.xquery" />
+		</java>
+		<condition else="false" property="xquery.supports.hof">
+			<equals arg1="${xquery.hof.run.result}" arg2="0" />
+		</condition>
+		<echo message="xquery.supports.hof=${xquery.supports.hof}" />
 	</target>
 
 	<!-- Generates the worker -->
@@ -87,12 +108,14 @@
 			<param expression="${xspecfiles.dir.url.query}" name="XSPECFILES-DIR-URI-QUERY" />
 			<param expression="${xslt.supports.schema}" name="XSLT-SUPPORTS-SCHEMA" type="BOOLEAN" />
 			<param expression="${xslt.supports.3-0}" name="XSLT-SUPPORTS-3-0" type="BOOLEAN" />
+			<param expression="${xslt.supports.hof}" name="XSLT-SUPPORTS-HOF" type="BOOLEAN" />
 			<param expression="${xquery.supports.schema}" name="XQUERY-SUPPORTS-SCHEMA"
 				type="BOOLEAN" />
 			<param expression="${xquery.supports.3-1.default}" name="XQUERY-SUPPORTS-3-1-DEFAULT"
 				type="BOOLEAN" />
 			<param expression="${xquery.supports.3-1.qversion}" name="XQUERY-SUPPORTS-3-1-QVERSION"
 				type="BOOLEAN" />
+			<param expression="${xquery.supports.hof}" name="XQUERY-SUPPORTS-HOF" type="BOOLEAN" />
 			<param expression="${run-xspec-tests.now}" if="run-xspec-tests.now" name="NOW" />
 			<param expression="${thread.count}" if="thread.count" name="THREAD-COUNT" type="INT" />
 		</xslt>

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -22,11 +22,13 @@
 	<!-- XSLT processor capabilities -->
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-SCHEMA" required="yes" />
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-3-0" required="yes" />
+	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-HOF" required="yes" />
 
 	<!-- XQuery processor capabilities -->
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-SCHEMA" required="yes" />
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-3-1-DEFAULT" required="yes" />
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-3-1-QVERSION" required="yes" />
+	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-HOF" required="yes" />
 
 	<!-- Saxon -now option -->
 	<xsl:param as="xs:string?" name="NOW" />
@@ -125,6 +127,14 @@
 
 					<xsl:when
 						test="
+							($test-type eq 't')
+							and ($pis = 'require-xslt-to-support-hof')
+							and not($XSLT-SUPPORTS-HOF)">
+						<xsl:text>Requires XSLT processor to support higher-order functions</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
 							($test-type eq 'q')
 							and ($pis = 'require-xquery-to-support-schema')
 							and not($XQUERY-SUPPORTS-SCHEMA)">
@@ -137,6 +147,14 @@
 							and $require-xquery-to-support-3-1
 							and not($XQUERY-SUPPORTS-3-1-DEFAULT or $XQUERY-SUPPORTS-3-1-QVERSION)">
 						<xsl:text>Requires XQuery 3.1 processor</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
+							($test-type eq 'q')
+							and ($pis = 'require-xquery-to-support-hof')
+							and not($XQUERY-SUPPORTS-HOF)">
+						<xsl:text>Requires XQuery processor to support higher-order functions</xsl:text>
 					</xsl:when>
 
 					<xsl:when

--- a/test/caps/hof.xquery
+++ b/test/caps/hof.xquery
@@ -1,0 +1,2 @@
+(: This file is just for checking to see if the XQuery processor supports higher-order functions :)
+function-lookup(xs:QName('xs:integer'), 1)(0)

--- a/test/caps/hof.xsl
+++ b/test/caps/hof.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file is just for checking to see if the XSLT processor supports higher-order functions -->
+<xsl:stylesheet version="3.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template name="xsl:initial-template">
+		<xsl:sequence select="function-lookup(xs:QName('xs:integer'), 1)(0)" />
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases/expected/query/xspec-355-junit.xml
+++ b/test/end-to-end/cases/expected/query/xspec-355-junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-355.xspec">
+   <testsuite name="Function" tests="1" failures="1">
+      <testcase name="Fail deliberately" status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-355-result.html
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: x-urn:test:mirror</p>
+      <p>Query-at: <a href="../../../../mirror.xquery">mirror.xquery</a></p>
+      <p>XSpec: <a href="../../xspec-355.xspec">xspec-355.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Function</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Function<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Function</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">Fail deliberately</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Function</h3>
+            <div id="scenario1-expect1">
+               <h4>Fail deliberately</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/xspec-355-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-355-result.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          date="2000-01-01T00:00:00Z"
+          query="x-urn:test:mirror"
+          query-at="../../../../mirror.xquery"
+          xspec="../../xspec-355.xspec">
+   <x:scenario id="scenario1" xspec="../../xspec-355.xspec">
+      <x:label>Function</x:label>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
+      </x:call>
+      <x:result select="/*">
+         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+      </x:result>
+      <x:test id="scenario1-expect1" successful="false">
+         <x:label>Fail deliberately</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="xspec-355.xspec">
+   <testsuite name="Function" tests="1" failures="1">
+      <testcase name="Fail deliberately" status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
+      <p>XSpec: <a href="../../xspec-355.xspec">xspec-355.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Function</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Function<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Function</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">Fail deliberately</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Function</h3>
+            <div id="scenario1-expect1">
+               <h4>Fail deliberately</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-result.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../../../mirror.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../xspec-355.xspec">
+   <x:scenario id="scenario1" xspec="../../xspec-355.xspec">
+      <x:label>Function</x:label>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
+      </x:call>
+      <x:result select="/*">
+         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+      </x:result>
+      <x:test id="scenario1-expect1" successful="false">
+         <x:label>Fail deliberately</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
+</x:report>

--- a/test/end-to-end/cases/xspec-355.xspec
+++ b/test/end-to-end/cases/xspec-355.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-xquery-to-support-hof?>
+<?xspec-test require-xslt-to-support-hof?>
+<x:description query="x-urn:test:mirror" query-at="../../mirror.xquery"
+	stylesheet="../../mirror.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xslt-version="3.0">
+
+	<!-- array(*) and map(*) are tested in xspec-report.xspec -->
+
+	<x:scenario label="Function">
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
+			<x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)" />
+		</x:call>
+		<x:expect label="Fail deliberately" />
+	</x:scenario>
+
+</x:description>

--- a/test/end-to-end/cases/xspec-report.xspec
+++ b/test/end-to-end/cases/xspec-report.xspec
@@ -4,7 +4,7 @@
 	xquery-version="3.1" xslt-version="3.0">
 
 	<x:scenario label="Function (xspec/xspec#355)">
-		<!-- function(*) (excluding array(*) and map(*)) requires Saxon-PE or EE -->
+		<!-- function(*) (excluding array(*) and map(*)) is tested in xspec-355.xspec -->
 
 		<x:scenario label="Array">
 			<x:call function="exactly-one">


### PR DESCRIPTION
Now that higher-order functions are available on Saxon-HE, this pull request enables [the automated test](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to handle XSpec files containing HOF.