### PR TITLE
ci: add Saxon 10.0 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.
 
+        # latest Saxon 10
+        - SAXON_VERSION=10.0
+
         # latest Saxon 9.9 and Jing
         - SAXON_VERSION=9.9.1-7
           JING_VERSION=20181222

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ environment:
     #   * XML Calabash will use Saxon jar in its own lib directory.
     #   * BaseX test requires XML Calabash.
 
+    # latest Saxon 10
+    # - SAXON_VERSION: 10.0
+
     # latest Saxon 9.9 and Jing
     - SAXON_VERSION: 9.9.1-7
       JING_VERSION: 20181222

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       vmImage: macOS-latest
 
     variables:
-      # latest Saxon and Jing
+      # latest Saxon 9.9 and Jing
       SAXON_VERSION: 9.9.1-7
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.30-99

--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -242,6 +242,7 @@
 			Example:
 				"EE 9.9.1.5"  -> 2533313445167109 (0x0009000900010005)
 				"HE 9.3.0.11" -> 2533287675297809 (0x0009000300000011)
+				"HE 10.0"     -> 2814749767106560 (0x000A000000000000)
 	-->
 	<xsl:function as="xs:integer?" name="x:saxon-version">
 		<xsl:if test="system-property('xsl:product-name') eq 'SAXON'">

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -18,7 +18,11 @@ jobs:
         #   * XML Calabash will use Saxon jar in its own lib directory.
         #   * BaseX test requires XML Calabash.
 
-        # latest Saxon and Jing
+        # latest Saxon 10
+        Saxon-10:
+          SAXON_VERSION: 10.0
+
+        # latest Saxon 9.9 and Jing
         Saxon-9-9:
           SAXON_VERSION: 9.9.1-7
           JING_VERSION: 20181222

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -11,7 +11,7 @@ jobs:
       vmImage: windows-latest
 
     strategy:
-      maxParallel: 4
+      maxParallel: 5
 
       matrix:
         # Note

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -637,12 +637,12 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function saxon-version">
-		<x:scenario label="Assume we test this on Saxon versions from 9.7 to 9.9">
+		<x:scenario label="Assume we test this on Saxon versions from 9.7 to 10.x">
 			<x:call function="x:saxon-version" />
 			<x:expect label="Greater than or equal to 9.7.0.0"
 				test="$x:result treat as xs:integer ge x:pack-version((9, 7))" />
-			<x:expect label="Less than 10.0"
-				test="$x:result treat as xs:integer lt x:pack-version(10)" />
+			<x:expect label="Less than 11.0"
+				test="$x:result treat as xs:integer lt x:pack-version(11)" />
 		</x:scenario>
 	</x:scenario>
 


### PR DESCRIPTION
This pull request adds Saxon 10.0 to Azure Pipelines (Windows) and Travis CI (Linux).
AppVeyor (Windows) and macOS (Azure Pipelines) remain 9.9, because 10 is not considered as mainstream.

### Further work
Add 10 to [Wiki](https://github.com/xspec/xspec/wiki/Requirements#saxon).