### PR TITLE
ci: run codespell in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: test/ci/run-codespell.sh
+        env:
+          DO_CODESPELL: true
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
-name: lint
+name: Lint
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   codespell:

--- a/test/README
+++ b/test/README
@@ -1,5 +1,5 @@
 Those test suites try to cover all features of XSpec, and are aimed to
 be run as any other suites to test a specific implementation of XSpec.
 This is NOT an automated test set, as which test must pass and which
-test must fail is not automatically checked.  We need something better,
+test must fail is not autmatically checked.  We need something better,
 but this is better than nothing.

--- a/test/README
+++ b/test/README
@@ -1,5 +1,5 @@
 Those test suites try to cover all features of XSpec, and are aimed to
 be run as any other suites to test a specific implementation of XSpec.
 This is NOT an automated test set, as which test must pass and which
-test must fail is not autmatically checked.  We need something better,
+test must fail is not automatically checked.  We need something better,
 but this is better than nothing.

--- a/test/ci/run-codespell.sh
+++ b/test/ci/run-codespell.sh
@@ -13,7 +13,7 @@ if [ "${DO_CODESPELL}" = true ] ; then
 
     # ".git" dir is not skipped by default: codespell-project/codespell#783
     # Skipping nested dirs needs "./": codespell-project/codespell#99
-    codespell \
+    ~/.local/bin/codespell \
         --check-filenames \
         --check-hidden \
         --quiet-level 6 \


### PR DESCRIPTION
This pull request just adds a static code analysis workflow (only *codespell* at the moment) to GitHub Actions.

be26e85fca0a41a79da9df5dae052ec026b72c5b is a temporary commit to test misspelling.