### PR TITLE
ci: delegate Azure Pipelines condition to cmd

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.30-99
       DO_CODESPELL: true
+      DO_MAVEN_PACKAGE: true
 
     # latest Saxon 9.8
     # - SAXON_VERSION: 9.8.0-15
@@ -39,28 +40,28 @@ build: off
 
 test_script:
 - cmd: |
-    rem print versions and env vars
+    rem Print versions and env vars
     test\ci\print-env.cmd
 
-    rem spell check
+    rem Spell check
     test\ci\run-codespell.cmd
 
-    rem execute bats-like unit tests
+    rem Execute bats-like unit tests
     test\run-bats.cmd
 
-    rem execute XSpec unit tests
+    rem Execute XSpec unit tests
     test\run-xspec-tests-ant.cmd -silent
 
-    rem execute XSpec end-to-end tests
+    rem Execute XSpec end-to-end tests
     test\end-to-end\run-e2e-tests.cmd -silent
 
     rem Maven package
     test\ci\maven-package.cmd -q
 
-    rem compile java
+    rem Compile Java
     test\ci\compile-java.cmd -silent
 
-    rem check git status
+    rem Check git status
     test\ci\last-git-status.cmd
 
 deploy: off

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -76,11 +76,9 @@ jobs:
 
       - script: call test\ci\maven-package.cmd --no-transfer-progress
         displayName: Maven package
-        condition: and(succeeded(), variables['DO_MAVEN_PACKAGE'])
 
       - script: call test\ci\compile-java.cmd -verbose
-        displayName: Compile java
-        condition: and(succeeded(), eq(${{ parameters.javaVersion }}, 8))
+        displayName: Compile Java
 
       - script: call test\ci\last-git-status.cmd
         displayName: Check git status

--- a/test/ci/compile-java.cmd
+++ b/test/ci/compile-java.cmd
@@ -1,1 +1,9 @@
-call ant -buildfile "%~dp0build_java.xml" %*
+echo Compile Java
+
+javac -version 2>&1 | %SYSTEMROOT%\system32\find " 1.8."
+if errorlevel 1 (
+    echo Skip compiling Java
+    verify > NUL
+) else (
+    call ant -buildfile "%~dp0build_java.xml" %*
+)

--- a/test/ci/compile-java.sh
+++ b/test/ci/compile-java.sh
@@ -7,5 +7,5 @@ if javac -version 2>&1 | grep -F ' 1.8.'; then
 	mydir=$(cd -P -- $(dirname -- "${myname}"); pwd)
 	ant -buildfile "${mydir}/build_java.xml" "$@"
 else
-	echo "Skip compiling java"
+	echo "Skip compiling Java"
 fi

--- a/test/ci/maven-package.cmd
+++ b/test/ci/maven-package.cmd
@@ -1,1 +1,7 @@
-call mvn package -P release %*
+echo Maven package
+
+if "%DO_MAVEN_PACKAGE%"=="true" (
+    call mvn package -P release %*
+) else (
+    echo Skip Maven package
+)


### PR DESCRIPTION
This pull request moves some condition checks from `test/ci/azure-pipelines_windows.yml` to `test/ci/*.cmd` for reducing dependency on a specific CI.