### PR TITLE
ci: run codespell only in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - run: test/ci/run-codespell.sh
-        env:
-          DO_CODESPELL: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
         - SAXON_VERSION=9.9.1-7
           JING_VERSION=20181222
           XMLCALABASH_VERSION=1.1.30-99
-          DO_CODESPELL=true
           DO_MAVEN_PACKAGE=true
 
         # latest Saxon 9.8
@@ -46,7 +45,6 @@ install:
 
 script: >
   ./test/ci/print-env.sh
-  && ./test/ci/run-codespell.sh
   && ./test/ci/run-core-tests.sh
   && ./test/ci/maven-package.sh -q
   && ./test/ci/compile-java.sh -silent

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ environment:
     - SAXON_VERSION: 9.9.1-7
       JING_VERSION: 20181222
       XMLCALABASH_VERSION: 1.1.30-99
-      DO_CODESPELL: true
       DO_MAVEN_PACKAGE: true
 
     # latest Saxon 9.8
@@ -45,9 +44,6 @@ test_script:
 - cmd: |
     rem Print versions and env vars
     test\ci\print-env.cmd
-
-    rem Spell check
-    test\ci\run-codespell.cmd
 
     rem Execute bats-like unit tests
     test\run-bats.cmd

--- a/test/README
+++ b/test/README
@@ -1,5 +1,5 @@
 Those test suites try to cover all features of XSpec, and are aimed to
 be run as any other suites to test a specific implementation of XSpec.
 This is NOT an automated test set, as which test must pass and which
-test must fail is not automatically checked.  We need something better,
+test must fail is not autmatically checked.  We need something better,
 but this is better than nothing.

--- a/test/README
+++ b/test/README
@@ -1,5 +1,5 @@
 Those test suites try to cover all features of XSpec, and are aimed to
 be run as any other suites to test a specific implementation of XSpec.
 This is NOT an automated test set, as which test must pass and which
-test must fail is not autmatically checked.  We need something better,
+test must fail is not automatically checked.  We need something better,
 but this is better than nothing.

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -27,7 +27,6 @@ jobs:
           SAXON_VERSION: 9.9.1-7
           JING_VERSION: 20181222
           XMLCALABASH_VERSION: 1.1.30-99
-          DO_CODESPELL: true
           DO_MAVEN_PACKAGE: true
 
         # latest Saxon 9.8
@@ -64,10 +63,6 @@ jobs:
 
       - script: call test\ci\print-env.cmd
         displayName: Print versions and env vars
-
-      - script: call test\ci\run-codespell.cmd
-        displayName: Spell check
-        condition: and(succeeded(), variables['DO_CODESPELL'])
 
       - script: call test\run-bats.cmd
         displayName: Execute bats-like unit tests

--- a/test/ci/run-codespell.cmd
+++ b/test/ci/run-codespell.cmd
@@ -1,3 +1,5 @@
+echo Run codespell
+
 pip install ^
     --disable-pip-version-check ^
     --quiet ^

--- a/test/ci/run-codespell.sh
+++ b/test/ci/run-codespell.sh
@@ -1,23 +1,17 @@
 #!/bin/bash
-# This script runs codespell to find spelling mistakes in the source code
-# it ignores specific directory and binary files
 
-echo "find spelling mistakes in source code"
+echo "Run codespell"
 
-if [ "${DO_CODESPELL}" = true ] ; then
-    pip install \
-        --disable-pip-version-check \
-        --quiet \
-        --user \
-        codespell
+pip install \
+    --disable-pip-version-check \
+    --quiet \
+    --user \
+    codespell
 
-    # ".git" dir is not skipped by default: codespell-project/codespell#783
-    # Skipping nested dirs needs "./": codespell-project/codespell#99
-    ~/.local/bin/codespell \
-        --check-filenames \
-        --check-hidden \
-        --quiet-level 6 \
-        --skip=".git,./src/schematron/iso-schematron"
-else
-    echo "Skip codespell"
-fi
+# ".git" dir is not skipped by default: codespell-project/codespell#783
+# Skipping nested dirs needs "./": codespell-project/codespell#99
+~/.local/bin/codespell \
+    --check-filenames \
+    --check-hidden \
+    --quiet-level 6 \
+    --skip=".git,./src/schematron/iso-schematron"


### PR DESCRIPTION
Following #864, this pull request removes *codespell* from AppVeyor, Azure Pipelines and Travis CI.

By this change, we lose redundancy of the spellcheck test, which I think is ok, because it isn't a critical part of CI.

`test/ci/run-codespell.cmd` is no longer necessary, but this pull request doesn't delete it, because it can be used in *git* pre-commit hook or possible future migration to another CI.

e17c6e16d0fc1bc5a68dd72028e1e9c07e177b22 is a temporary commit to verify this change.

### Further work

* Add *codespell* GitHub Actions workflow to the `master` branch protection rule
