### PR TITLE
feat(report): report non-array non-map function(*)

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -157,6 +157,52 @@
 	</xsl:function>
 
 	<!--
+		Returns true if item is function (including map and array).
+		
+		Alternative to "instance of function(*)" which is not widely available.
+	-->
+	<xsl:function as="xs:boolean" name="x:instance-of-function">
+		<xsl:param as="item()" name="item" />
+
+		<xsl:choose>
+			<xsl:when test="($item instance of array(*)) or ($item instance of map(*))"
+				use-when="number(system-property('xsl:version')) ge 3">
+				<xsl:sequence select="true()" />
+			</xsl:when>
+
+			<xsl:when test="$item instance of function(*)"
+				use-when="
+					((: for Saxon-EE 9.7 :) number(system-property('xsl:version')) ge 3)
+					and
+					((: for Saxon 9.x :) function-available('function-lookup'))">
+				<xsl:sequence select="true()" />
+			</xsl:when>
+
+			<xsl:when test="true()">
+				<xsl:sequence select="false()" />
+			</xsl:when>
+		</xsl:choose>
+	</xsl:function>
+
+	<!--
+		Returns type of function (including map and array).
+		
+		$function must be an instance of function(*).
+	-->
+	<xsl:function as="xs:string" name="x:function-type"
+		use-when="number(system-property('xsl:version')) ge 3">
+
+		<!-- TODO: @as="function(*)" -->
+		<xsl:param as="item()" name="function" />
+
+		<xsl:choose>
+			<xsl:when test="$function instance of array(*)">array</xsl:when>
+			<xsl:when test="$function instance of map(*)">map</xsl:when>
+			<xsl:otherwise>function</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
+
+	<!--
 		Returns true if node is user-content
 	-->
 	<xsl:function as="xs:boolean" name="x:is-user-content">

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -441,10 +441,8 @@
       </xsl:element>
     </xsl:when>
 
-    <!-- "instance of function(*)" requires Saxon-PE or higher -->
-    <xsl:when test="($item instance of array(*)) or ($item instance of map(*))"
-      use-when="function-available('serialize', 2)">
-      <xsl:element name="{$local-name-prefix}function" namespace="{$wrapper-ns}">
+    <xsl:when test="x:instance-of-function($item)" use-when="function-available('serialize', 2)">
+      <xsl:element name="{$local-name-prefix}{x:function-type($item)}" namespace="{$wrapper-ns}">
         <xsl:value-of select="serialize($item, map { 'method': 'adaptive' })" />
       </xsl:element>
     </xsl:when>

--- a/test/end-to-end/cases/expected/query/xspec-355-junit.xml
+++ b/test/end-to-end/cases/expected/query/xspec-355-junit.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="xspec-355.xspec">
-   <testsuite name="Function" tests="1" failures="1">
+   <testsuite name="xs:integer()" tests="1" failures="1">
+      <testcase name="Fail deliberately" status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="Anonymous" tests="1" failures="1">
       <testcase name="Fail deliberately" status="failed">
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>

--- a/test/end-to-end/cases/expected/query/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-355-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -24,13 +24,20 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 1</th>
-               <th class="totals">total: 1</th>
+               <th class="totals">failed: 2</th>
+               <th class="totals">total: 2</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#top_scenario1">Function</a></th>
+               <th><a href="#top_scenario1">xs:integer()</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">Anonymous</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -39,7 +46,7 @@
          </tbody>
       </table>
       <div id="top_scenario1">
-         <h2 class="failed">Function<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <h2 class="failed">xs:integer()<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
          <table class="xspec" id="table_scenario1">
             <colgroup>
                <col style="width:75%" />
@@ -47,7 +54,7 @@
             </colgroup>
             <tbody>
                <tr class="failed">
-                  <th>Function</th>
+                  <th>xs:integer()</th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
@@ -57,8 +64,52 @@
             </tbody>
          </table>
          <div id="scenario1">
-            <h3>Function</h3>
+            <h3>xs:integer()</h3>
             <div id="scenario1-expect1">
+               <h4>Fail deliberately</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">Anonymous<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Anonymous</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">Fail deliberately</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>Anonymous</h3>
+            <div id="scenario2-expect1">
                <h4>Fail deliberately</h4>
                <table class="xspecResult">
                   <thead>

--- a/test/end-to-end/cases/expected/query/xspec-355-result.xml
+++ b/test/end-to-end/cases/expected/query/xspec-355-result.xml
@@ -5,7 +5,7 @@
           query-at="../../../../mirror.xquery"
           xspec="../../xspec-355.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-355.xspec">
-      <x:label>Function</x:label>
+      <x:label>xs:integer()</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
       </x:call>
@@ -13,6 +13,19 @@
          <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
+         <x:label>Fail deliberately</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario2" xspec="../../xspec-355.xspec">
+      <x:label>Anonymous</x:label>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param as="function(*)" select="function($x){$x+1}"/>
+      </x:call>
+      <x:result select="/*">
+         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+      </x:result>
+      <x:test id="scenario2-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-junit.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="xspec-355.xspec">
-   <testsuite name="Function" tests="1" failures="1">
+   <testsuite name="xs:integer()" tests="1" failures="1">
+      <testcase name="Fail deliberately" status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="Anonymous" tests="1" failures="1">
       <testcase name="Fail deliberately" status="failed">
          <failure message="expect assertion failed">Expected: ()</failure>
       </testcase>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,13 +23,20 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 1</th>
-               <th class="totals">total: 1</th>
+               <th class="totals">failed: 2</th>
+               <th class="totals">total: 2</th>
             </tr>
          </thead>
          <tbody>
             <tr class="failed">
-               <th><a href="#top_scenario1">Function</a></th>
+               <th><a href="#top_scenario1">xs:integer()</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">Anonymous</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -38,7 +45,7 @@
          </tbody>
       </table>
       <div id="top_scenario1">
-         <h2 class="failed">Function<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <h2 class="failed">xs:integer()<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
          <table class="xspec" id="table_scenario1">
             <colgroup>
                <col style="width:75%" />
@@ -46,7 +53,7 @@
             </colgroup>
             <tbody>
                <tr class="failed">
-                  <th>Function</th>
+                  <th>xs:integer()</th>
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
@@ -56,7 +63,7 @@
             </tbody>
          </table>
          <div id="scenario1">
-            <h3>Function</h3>
+            <h3>xs:integer()</h3>
             <div id="scenario1-expect1">
                <h4>Fail deliberately</h4>
                <table class="xspecResult">
@@ -70,7 +77,51 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-other</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">xs:integer#1</span>&lt;/pseudo-function&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">Anonymous<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Anonymous</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">Fail deliberately</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>Anonymous</h3>
+            <div id="scenario2-expect1">
+               <h4>Fail deliberately</h4>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">(anonymous-function)#1</span>&lt;/pseudo-function&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-result.xml
@@ -6,14 +6,27 @@
           date="2000-01-01T00:00:00Z"
           xspec="../../xspec-355.xspec">
    <x:scenario id="scenario1" xspec="../../xspec-355.xspec">
-      <x:label>Function</x:label>
+      <x:label>xs:integer()</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
       </x:call>
       <x:result select="/*">
-         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">xs:integer#1</pseudo-function>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
+         <x:label>Fail deliberately</x:label>
+         <x:expect select="()"/>
+      </x:test>
+   </x:scenario>
+   <x:scenario id="scenario2" xspec="../../xspec-355.xspec">
+      <x:label>Anonymous</x:label>
+      <x:call function="Q{x-urn:test:mirror}param-mirror">
+         <x:param as="function(*)" select="function($x){$x+1}"/>
+      </x:call>
+      <x:result select="/*">
+         <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">(anonymous-function)#1</pseudo-function>
+      </x:result>
+      <x:test id="scenario2-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -120,7 +120,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">["foo",1,[2,"bar"]]</span>&lt;/pseudo-function&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-array</span>&gt;<span class="diff">["foo",1,[2,"bar"]]</span>&lt;/pseudo-array&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>
@@ -146,7 +146,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-function</span>&gt;<span class="diff">map{2:"bar","foo":1}</span>&lt;/pseudo-function&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-map</span>&gt;<span class="diff">map{2:"bar","foo":1}</span>&lt;/pseudo-map&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.xml
@@ -13,7 +13,7 @@
             <x:param as="array(*)" select="['foo', 1, [2, 'bar']]"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">["foo",1,[2,"bar"]]</pseudo-function>
+            <pseudo-array xmlns="http://www.jenitennison.com/xslt/xspec">["foo",1,[2,"bar"]]</pseudo-array>
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported upon failure</x:label>
@@ -26,7 +26,7 @@
             <x:param as="map(*)" select="      map {       'foo': 1,       2: 'bar'      }"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">map{2:"bar","foo":1}</pseudo-function>
+            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{2:"bar","foo":1}</pseudo-map>
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="false">
             <x:label>Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported upon failure</x:label>

--- a/test/end-to-end/cases/xspec-355.xspec
+++ b/test/end-to-end/cases/xspec-355.xspec
@@ -7,9 +7,16 @@
 
 	<!-- array(*) and map(*) are tested in xspec-report.xspec -->
 
-	<x:scenario label="Function">
+	<x:scenario label="xs:integer()">
 		<x:call function="Q{x-urn:test:mirror}param-mirror">
 			<x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)" />
+		</x:call>
+		<x:expect label="Fail deliberately" />
+	</x:scenario>
+
+	<x:scenario label="Anonymous">
+		<x:call function="Q{x-urn:test:mirror}param-mirror">
+			<x:param as="function(*)" select="function($x){$x+1}" />
 		</x:call>
 		<x:expect label="Fail deliberately" />
 	</x:scenario>

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -151,6 +151,60 @@
 			test="$x:result[name() eq 'wrapper-prefix']/string()" />
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing function instance-of-function">
+		<x:scenario label="Node">
+			<x:call function="x:instance-of-function">
+				<x:param>
+					<e />
+				</x:param>
+			</x:call>
+			<x:expect label="False" select="false()" />
+		</x:scenario>
+
+		<x:scenario label="Atomic value">
+			<x:call function="x:instance-of-function">
+				<x:param select="1" />
+			</x:call>
+			<x:expect label="False" select="false()" />
+		</x:scenario>
+
+		<x:scenario label="function(*)">
+			<x:scenario label="Array">
+				<x:call function="x:instance-of-function">
+					<x:param select="[ 0, 1 ]" />
+				</x:call>
+				<x:expect label="True" select="true()" />
+			</x:scenario>
+
+			<x:scenario label="Map">
+				<x:call function="x:instance-of-function">
+					<x:param select="map { 0: 1 }" />
+				</x:call>
+				<x:expect label="True" select="true()" />
+			</x:scenario>
+
+			<!-- Function (excluding map and array) is tested in xspec-utils_stylesheet_hof.xspec -->
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function function-type">
+		<x:scenario label="Array">
+			<x:call function="x:function-type">
+				<x:param select="[ 0, 1 ]" />
+			</x:call>
+			<x:expect label="array" select="'array'" />
+		</x:scenario>
+
+		<x:scenario label="Map">
+			<x:call function="x:function-type">
+				<x:param select="map { 0: 1 }" />
+			</x:call>
+			<x:expect label="map" select="'map'" />
+		</x:scenario>
+
+		<!-- Function (excluding map and array) is tested in xspec-utils_stylesheet_hof.xspec -->
+	</x:scenario>
+
 	<x:scenario label="Scenario for testing function is-user-content">
 
 		<x:scenario label="function-param">

--- a/test/xspec-utils_stylesheet_hof.xspec
+++ b/test/xspec-utils_stylesheet_hof.xspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-xslt-to-support-hof?>
+<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xslt-version="3.0">
+
+	<!--
+		The test target (../src/common/xspec-utils.xsl) is included
+		implicitly by the XSpec compiler. You don't need to specify it in
+		/x:description/@stylesheet.
+	-->
+
+	<x:scenario label="Scenario for testing function instance-of-function">
+		<!-- array(*) and map(*) are tested in xspec-utils_stylesheet.xspec -->
+
+		<x:scenario label="Function (excluding map and array)">
+			<x:call function="x:instance-of-function">
+				<x:param select="function-lookup(xs:QName('xs:integer'), 1)" />
+			</x:call>
+			<x:expect label="True" select="true()" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function function-type">
+		<!-- array(*) and map(*) are tested in xspec-utils_stylesheet.xspec -->
+
+		<x:scenario label="Function (excluding map and array)">
+			<x:call function="x:function-type">
+				<x:param select="function-lookup(xs:QName('xs:integer'), 1)" />
+			</x:call>
+			<x:expect label="function" select="'function'" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Now that `function(*)` is available on Saxon-HE, this pull request enables `test:report-sequence` to handle it in a bit more details.

Current `master`:
* [XSLT](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/b75f426f0a35010927194c0b08c15294782208eb/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html)
* [XQuery](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/b75f426f0a35010927194c0b08c15294782208eb/test/end-to-end/cases/expected/query/xspec-355-result.html)

After this change:
* [XSLT](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/e2555099ab084dc3fc96a9bcc82a1ec95bae29e1/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html)
* [XQuery](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/e2555099ab084dc3fc96a9bcc82a1ec95bae29e1/test/end-to-end/cases/expected/query/xspec-355-result.html)

Not implemented for XQuery, for I don't know an alternative to `@use-when`.

In addition to the automated tests on our CI systems, I ran them on Saxon-EE 10.0, 9.9.1.7, 9.8.0.15 and 9.7.0.21.