### PR TITLE
fix: detect broken x:import

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -107,7 +107,7 @@
       <!-- "document($imports/@href)" without sorting -->
       <xsl:variable name="docs" as="document-node(element(x:description))*">
         <xsl:for-each select="$imports">
-          <xsl:sequence select="document(@href)" />
+          <xsl:sequence select="document(@href) treat as document-node(element(x:description))" />
         </xsl:for-each>
       </xsl:variable>
       <xsl:variable name="docs" as="document-node(element(x:description))*"

--- a/test/import/file-not-found.xspec
+++ b/test/import/file-not-found.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:import href="this.file.never.exists" />
+
+	<x:scenario label="Dummy scenario">
+		<x:context />
+		<x:expect label="always successful" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/import/no-href.xspec
+++ b/test/import/no-href.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:import />
+
+	<x:scenario label="Dummy scenario">
+		<x:context />
+		<x:expect label="always successful" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schema/build.xml
+++ b/test/schema/build.xml
@@ -25,6 +25,8 @@
 			<exclude name="test/xspec-node-selection.xspec" />
 			<exclude name="test/xspec-node-selection_stylesheet.xspec" />
 
+			<!-- Tests x:import without @href -->
+			<exclude name="test/import/no-href.xspec" />
 		</fileset>
 
 		<!-- Jing is silent when all files are valid.

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -923,14 +923,14 @@
         xspec-node-selection.xspec ^
         xspec-node-selection_stylesheet.xspec
     call :verify_retval 1
-    call :verify_line 1 r ".*-child-not-allowed"
-    call :verify_line 2 r ".*-child-not-allowed"
-    call :verify_line 3 r ".*-child-not-allowed"
-    call :verify_line 4 r ".*-child-not-allowed"
-    call :verify_line 5 r ".*-child-not-allowed"
-    call :verify_line 6 r ".*-child-not-allowed"
-    call :verify_line 7 r ".*-child-not-allowed"
-    call :verify_line 8 r "Elapsed time"
+    call :verify_line 1 r "..*: error: element \"function-param-child-not-allowed\" not allowed here;"
+    call :verify_line 2 r "..*: error: element \"global-param-child-not-allowed\" not allowed here;"
+    call :verify_line 3 r "..*: error: element \"global-variable-child-not-allowed\" not allowed here;"
+    call :verify_line 4 r "..*: error: element \"assertion-child-not-allowed\" not allowed here;"
+    call :verify_line 5 r "..*: error: element \"variable-child-not-allowed\" not allowed here;"
+    call :verify_line 6 r "..*: error: element \"template-param-child-not-allowed\" not allowed here;"
+    call :verify_line 7 r "..*: error: element \"template-param-child-not-allowed\" not allowed here;"
+    call :verify_line 8 r "Elapsed time "
 	</case>
 
 	<case ifdef="JING_JAR" name="Schema detects missing @href in x:import">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1553,4 +1553,22 @@
     call :verify_line * r "..*--Customized coverage report--..*"
 	</case>
 
+	<!--
+		Broken x:import
+	-->
+
+	<case name="x:import with unreachable @href">
+    call :run ..\bin\xspec.bat import\file-not-found.xspec
+    call :verify_retval 2
+    call :verify_line  * r "  FODC0002[: ] I/O error reported by XML parser processing$"
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+
+	<case name="x:import without @href">
+    call :run ..\bin\xspec.bat import\no-href.xspec
+    call :verify_retval 2
+    call :verify_line  * r "  XPDY0050[: ] An empty sequence is not allowed as the value in 'treat as' expression$"
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+
 </collection>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -933,6 +933,14 @@
     call :verify_line 8 r "Elapsed time"
 	</case>
 
+	<case ifdef="JING_JAR" name="Schema detects missing @href in x:import">
+    rem '-t' for identifying the last line
+    call :run java -jar "%JING_JAR%" -c -t ..\src\schemas\xspec.rnc import\no-href.xspec
+    call :verify_retval 1
+    call :verify_line 1 r "..*: error: element \"x:import\" missing required attribute \"href\"$"
+    call :verify_line 2 r "Elapsed time "
+	</case>
+
 	<!--
 		saxon.custom.options (Ant)
 	-->

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1113,14 +1113,14 @@ assert_regex() {
         xspec-node-selection_stylesheet.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [[ "${lines[0]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[1]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[2]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[3]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[4]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[5]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[6]}" =~ "-child-not-allowed" ]]
-    [[ "${lines[7]}" =~ "Elapsed time" ]]
+    assert_regex "${lines[0]}" '.+: error: element "function-param-child-not-allowed" not allowed here;'
+    assert_regex "${lines[1]}" '.+: error: element "global-param-child-not-allowed" not allowed here;'
+    assert_regex "${lines[2]}" '.+: error: element "global-variable-child-not-allowed" not allowed here;'
+    assert_regex "${lines[3]}" '.+: error: element "assertion-child-not-allowed" not allowed here;'
+    assert_regex "${lines[4]}" '.+: error: element "variable-child-not-allowed" not allowed here;'
+    assert_regex "${lines[5]}" '.+: error: element "template-param-child-not-allowed" not allowed here;'
+    assert_regex "${lines[6]}" '.+: error: element "template-param-child-not-allowed" not allowed here;'
+    assert_regex "${lines[7]}" '^Elapsed time '
 }
 
 @test "Schema detects missing @href in x:import" {

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1123,6 +1123,19 @@ assert_regex() {
     [[ "${lines[7]}" =~ "Elapsed time" ]]
 }
 
+@test "Schema detects missing @href in x:import" {
+    if [ -z "${JING_JAR}" ]; then
+        skip "JING_JAR is not defined"
+    fi
+
+    # '-t' for identifying the last line
+    run java -jar "${JING_JAR}" -c -t ../src/schemas/xspec.rnc import/no-href.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${lines[0]}" '.+: error: element "x:import" missing required attribute "href"$'
+    assert_regex "${lines[1]}" '^Elapsed time '
+}
+
 #
 # saxon.custom.options (Ant)
 #

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1847,4 +1847,24 @@ assert_regex() {
     [[ "${output}" =~ "--Customized coverage report--" ]]
 }
 
+#
+# Broken x:import
+#
+
+@test "x:import with unreachable @href" {
+    run ../bin/xspec.sh import/file-not-found.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  FODC0002[: ] I/O error reported by XML parser processing'$'\n'
+    [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
+}
+
+@test "x:import without @href" {
+    run ../bin/xspec.sh import/no-href.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] An empty sequence is not allowed as the value in '\''treat as'\'' expression'$'\n'
+    [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
+}
+
 


### PR DESCRIPTION
XSpec does not error out when `x:import/@href` is unreachable or the attribute does not exist.
This pull request fixes it.