### PR TITLE
test(xslt): multiple context items

### DIFF
--- a/test/mirror.xsl
+++ b/test/mirror.xsl
@@ -10,7 +10,13 @@
 		use-when="element-available('xsl:mode')" />
 
 	<xsl:template as="node()" match="attribute() | node() | document-node()"
-		mode="mirror:context-mirror" name="mirror:context-mirror">
+		mode="mirror:context-mirror" name="mirror:context-mirror"
+		use-when="number(system-property('xsl:version')) lt 3">
+		<xsl:sequence select="." />
+	</xsl:template>
+
+	<xsl:template as="item()" match="." mode="mirror:context-mirror" name="mirror:context-mirror"
+		use-when="number(system-property('xsl:version')) ge 3">
 		<xsl:sequence select="." />
 	</xsl:template>
 

--- a/test/multiple-context-items.xspec
+++ b/test/multiple-context-items.xspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xslt-version="3.0">
+
+	<x:variable as="item()+" name="multiple-mixed-items" select="node(), 'str', 2">
+		<element />
+		<x:text>text</x:text>
+	</x:variable>
+	<x:scenario label="Make sure">
+		<x:call function="mirror:false" />
+		<x:expect label="the test variable contains a node"
+			test="exists($multiple-mixed-items[. instance of node()])" />
+		<x:expect label="the test variable contains an atomic value"
+			test="exists($multiple-mixed-items[. instance of xs:anyAtomicType])" />
+	</x:scenario>
+
+	<x:scenario label="With multiple context items containing both node and atomic value">
+		<x:context select="$multiple-mixed-items" />
+
+		<x:scenario label="Calling a named template">
+			<x:call template="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-mixed-items" />
+		</x:scenario>
+
+		<x:scenario label="Applying templates">
+			<x:context mode="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-mixed-items" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/multiple-context-nodes.xspec
+++ b/test/multiple-context-nodes.xspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:variable as="node()+" name="multiple-nodes">
+		<element />
+		<x:text>text</x:text>
+	</x:variable>
+	<x:scenario label="Make sure">
+		<x:call function="mirror:false" />
+		<x:expect label="the test variable consists of 2+ nodes"
+			test="count($multiple-nodes treat as node()+) ge 2" />
+	</x:scenario>
+
+	<x:scenario label="With multiple context nodes">
+		<x:context select="$multiple-nodes" />
+
+		<x:scenario label="Calling a named template">
+			<x:call template="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-nodes" />
+		</x:scenario>
+
+		<x:scenario label="Applying templates">
+			<x:context mode="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-nodes" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/multiple-context-values.xspec
+++ b/test/multiple-context-values.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xslt-version="3.0">
+
+	<x:variable as="xs:anyAtomicType+" name="multiple-atomic-values" select="'str', 2" />
+	<x:scenario label="Make sure">
+		<x:call function="mirror:false" />
+		<x:expect label="the test variable consists of 2+ atomic values"
+			test="count($multiple-atomic-values treat as xs:anyAtomicType+) ge 2" />
+	</x:scenario>
+
+	<x:scenario label="With multiple context atomic values">
+		<x:context select="$multiple-atomic-values" />
+
+		<x:scenario label="Calling a named template">
+			<x:call template="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-atomic-values" />
+		</x:scenario>
+
+		<x:scenario label="Applying templates">
+			<x:context mode="mirror:context-mirror" />
+			<x:expect label="should work" select="$multiple-atomic-values" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
This branch is not tested with multiple items stored in the variable of `${test:variable-name($context)}`:

https://github.com/xspec/xspec/blob/7e673316b510b3bd5315be3fe63e7331c3df227a/src/compiler/generate-xspec-tests.xsl#L325-L330

This pull request adds some tests for it.