### PR TITLE
test(xslt): add apply-templates invocation to template context test

### DIFF
--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -26,10 +26,19 @@
 		</x:scenario>
 
 		<x:scenario label="template context">
-			<x:call template="mirror:context-mirror" />
-			<x:expect label="x:context/@select">
-				<context-grandchild />
-			</x:expect>
+			<x:scenario label="apply-templates invocation">
+				<x:context mode="mirror:context-mirror" />
+				<x:expect label="x:context/@select">
+					<context-grandchild />
+				</x:expect>
+			</x:scenario>
+
+			<x:scenario label="call-template invocation">
+				<x:call template="mirror:context-mirror" />
+				<x:expect label="x:context/@select">
+					<context-grandchild />
+				</x:expect>
+			</x:scenario>
 		</x:scenario>
 	</x:scenario>
 

--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description stylesheet="global.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description stylesheet="global.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:param name="global-param" select="'global param overridden by XSpec'" />
 
@@ -25,7 +26,7 @@
 		</x:scenario>
 
 		<x:scenario label="template context">
-			<x:call template="get-template-context" />
+			<x:call template="mirror:context-mirror" />
 			<x:expect label="x:context/@select">
 				<context-grandchild />
 			</x:expect>

--- a/test/global.xsl
+++ b/test/global.xsl
@@ -16,9 +16,7 @@
 		<xsl:sequence select="$global-variable" />
 	</xsl:template>
 
-	<!-- Returns the context item intact -->
-	<xsl:template as="item()?" name="get-template-context">
-		<xsl:sequence select="." />
-	</xsl:template>
+	<!-- Mirror -->
+	<xsl:include href="mirror.xsl" />
 
 </xsl:stylesheet>


### PR DESCRIPTION
This pull request adds a test for *apply-templates* invocation to the template context test in `global-override.xspec`.

The template context and the global context item are somewhat entangled in `fn:transform()`. That's why the template context inspection is added to `global-override.xspec`.