### PR TITLE
test: do not pollute repository dir in Bats test

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -153,49 +153,54 @@
 	<case name="invoking xspec without TEST_DIR set externally (XSLT)">
     set TEST_DIR=
 
-    rem Delete default output dir if exists, to make the line numbers predictable
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to make the message line numbers predictable
+    rem and to avoid a residue of output files
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\escape-for-regex.* "%TUTORIAL_COPY%"
 
     rem Run
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :run ..\bin\xspec.bat "%TUTORIAL_COPY%\escape-for-regex.xspec"
     call :verify_retval 0
 
     rem Verify message
     call :verify_line 20 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
-    call :verify_line 21 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\escape-for-regex-result.html"
+    call :verify_line 21 x "Report available at %TUTORIAL_COPY%\xspec\escape-for-regex-result.html"
 
     rem Verify report files
     rem * XML report file is created
     rem * HTML report file is created
     rem * Coverage is disabled by default
     rem * JUnit is disabled by default
-    call :run dir /b /o:n ..\tutorial\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 3
     call :verify_line 1 x escape-for-regex-compiled.xsl
     call :verify_line 2 x escape-for-regex-result.html
     call :verify_line 3 x escape-for-regex-result.xml
 
     rem HTML report file contains CSS inline #135
-    call :run java -jar "%SAXON_JAR%" -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
+    call :run java -jar "%SAXON_JAR%" ^
+        -s:"%TUTORIAL_COPY%\xspec\escape-for-regex-result.html" ^
+        -xsl:html-css.xsl
     call :verify_line 1 x "true"
-
-    rem Cleanup
-    call :rmdir ..\tutorial\xspec
 	</case>
 
 	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="invoking xspec -c without TEST_DIR set externally">
     set TEST_DIR=
 
-    rem Delete default output dir if exists, to make the line numbers predictable
-    call :rmdir-if-exist ..\tutorial\coverage\xspec
+    rem Use a fresh dir, to make the message line numbers predictable
+    rem and to avoid a residue of output files
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\coverage\demo* "%TUTORIAL_COPY%"
 
     rem Run
-    call :run ..\bin\xspec.bat -c ..\tutorial\coverage\demo.xspec
+    call :run ..\bin\xspec.bat -c "%TUTORIAL_COPY%\demo.xspec"
     call :verify_retval 0
 
     rem Verify message
     call :verify_line 13 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-    call :verify_line 15 x "Report available at %PARENT_DIR_ABS%\tutorial\coverage\xspec\demo-coverage.html"
+    call :verify_line 15 x "Report available at %TUTORIAL_COPY%\xspec\demo-coverage.html"
 
     rem Verify report files
     rem * XML report file is created
@@ -203,75 +208,72 @@
     rem * Coverage XML report is created
     rem * Coverage HTML report is created
     rem * JUnit is disabled by default
-    call :run dir /b /o:n ..\tutorial\coverage\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 5
     call :verify_line 1 x demo-compiled.xsl
     call :verify_line 2 x demo-coverage.html
     call :verify_line 3 x demo-coverage.xml
     call :verify_line 4 x demo-result.html
     call :verify_line 5 x demo-result.xml
-
-    rem Cleanup
-    call :rmdir ..\tutorial\coverage\xspec
 	</case>
 
 	<case name="invoking xspec without TEST_DIR set externally (XQuery)">
     set TEST_DIR=
 
-    rem Delete default output dir if exists, to make the line numbers predictable
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to make the message line numbers predictable
+    rem and to avoid a residue of output files
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\xquery-tutorial.* "%TUTORIAL_COPY%"
 
     rem Run
-    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :run ..\bin\xspec.bat -q "%TUTORIAL_COPY%\xquery-tutorial.xspec"
     call :verify_retval 0
 
     rem Verify message
     call :verify_line 7 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-    call :verify_line 8 x "Report available at %PARENT_DIR_ABS%\tutorial\xspec\xquery-tutorial-result.html"
+    call :verify_line 8 x "Report available at %TUTORIAL_COPY%\xspec\xquery-tutorial-result.html"
 
     rem Verify report files
     rem * XML report file is created
     rem * HTML report file is created
     rem * JUnit is disabled by default
-    call :run dir /b /o:n ..\tutorial\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 3
     call :verify_line 1 x xquery-tutorial-compiled.xq
     call :verify_line 2 x xquery-tutorial-result.html
     call :verify_line 3 x xquery-tutorial-result.xml
-
-    rem Cleanup
-    call :rmdir ..\tutorial\xspec
 	</case>
 
 	<case name="invoking xspec without TEST_DIR set externally (Schematron)">
     set TEST_DIR=
 
-    rem Delete default output dir if exists, to make the line numbers predictable
-    call :rmdir-if-exist ..\tutorial\schematron\xspec
+    rem Use a fresh dir, to make the message line numbers predictable
+    rem and to avoid a residue of output files
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\schematron\demo-03* "%TUTORIAL_COPY%"
 
     rem Run
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-03.xspec
+    call :run ..\bin\xspec.bat -s "%TUTORIAL_COPY%\demo-03.xspec"
     call :verify_retval 0
 
     rem Verify message
     rem * No Schematron warnings #129 #131
     call :verify_line  5 x "Converting Schematron XSpec into XSLT XSpec..."
     call :verify_line 32 x "passed: 10 / pending: 1 / failed: 0 / total: 11"
-    call :verify_line 33 x "Report available at %PARENT_DIR_ABS%\tutorial\schematron\xspec\demo-03-result.html"
+    call :verify_line 33 x "Report available at %TUTORIAL_COPY%\xspec\demo-03-result.html"
 
     rem Verify report files
     rem * XML report file is created
     rem * HTML report file is created
     rem * JUnit is disabled by default
     rem * Schematron-specific temporary files are deleted
-    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 3
     call :verify_line 1 x demo-03-compiled.xsl
     call :verify_line 2 x demo-03-result.html
     call :verify_line 3 x demo-03-result.xml
-
-    rem Cleanup
-    call :rmdir ..\tutorial\schematron\xspec
 	</case>
 
 	<!--
@@ -482,11 +484,13 @@
 	-->
 
 	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (XSLT)">
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\escape-for-regex.* "%TUTORIAL_COPY%"
 
     rem Run with absolute TEST_DIR
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :run ..\bin\xspec.bat "%TUTORIAL_COPY%\escape-for-regex.xspec"
     call :verify_retval 0
     call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
@@ -498,11 +502,12 @@
     call :verify_line 3 x escape-for-regex-result.xml
 
     rem Default output dir should not be created
-    call :verify_leaf_dir_not_exist ..\tutorial\xspec
+    call :verify_leaf_dir_not_exist "%TUTORIAL_COPY%\xspec"
 
     rem Run with relative TEST_DIR
-    set TEST_DIR=..\tutorial\xspec
-    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    cd /d "%WORK_DIR%"
+    set "TEST_DIR=relative-test-dir %RANDOM%"
+    call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" "%TUTORIAL_COPY%\escape-for-regex.xspec""
     call :verify_retval 0
     call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
@@ -512,17 +517,16 @@
     call :verify_line 1 x escape-for-regex-compiled.xsl
     call :verify_line 2 x escape-for-regex-result.html
     call :verify_line 3 x escape-for-regex-result.xml
-
-    rem Cleanup
-    call :rmdir "%TEST_DIR%"
 	</case>
 
 	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="invoking xspec -c with TEST_DIR creates files in TEST_DIR">
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\coverage\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\coverage\demo* "%TUTORIAL_COPY%"
 
     rem Run with absolute TEST_DIR
-    call :run ..\bin\xspec.bat -c ..\tutorial\coverage\demo.xspec
+    call :run ..\bin\xspec.bat -c "%TUTORIAL_COPY%\demo.xspec"
     call :verify_retval 0
     call :verify_line 15 x "Report available at %TEST_DIR%\demo-coverage.html"
 
@@ -536,11 +540,12 @@
     call :verify_line 5 x demo-result.xml
 
     rem Default output dir should not be created
-    call :verify_leaf_dir_not_exist ..\tutorial\coverage\xspec
+    call :verify_leaf_dir_not_exist "%TUTORIAL_COPY%\xspec"
 
     rem Run with relative TEST_DIR
-    set TEST_DIR=..\tutorial\coverage\xspec
-    call :run ..\bin\xspec.bat -c ..\tutorial\coverage\demo.xspec
+    cd /d "%WORK_DIR%"
+    set "TEST_DIR=relative-test-dir %RANDOM%"
+    call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -c "%TUTORIAL_COPY%\demo.xspec""
     call :verify_retval 0
     call :verify_line 15 x "Report available at %TEST_DIR%\demo-coverage.html"
 
@@ -552,17 +557,16 @@
     call :verify_line 3 x demo-coverage.xml
     call :verify_line 4 x demo-result.html
     call :verify_line 5 x demo-result.xml
-
-    rem Cleanup
-    call :rmdir "%TEST_DIR%"
 	</case>
 
 	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (XQuery)">
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\xquery-tutorial.* "%TUTORIAL_COPY%"
 
     rem Run with absolute TEST_DIR
-    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    call :run ..\bin\xspec.bat -q "%TUTORIAL_COPY%\xquery-tutorial.xspec"
     call :verify_retval 0
     call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
 
@@ -574,11 +578,12 @@
     call :verify_line 3 x xquery-tutorial-result.xml
 
     rem Default output dir should not be created
-    call :verify_leaf_dir_not_exist ..\tutorial\xspec
+    call :verify_leaf_dir_not_exist "%TUTORIAL_COPY%\xspec"
 
     rem Run with relative TEST_DIR
-    set TEST_DIR=..\tutorial\xspec
-    call :run ..\bin\xspec.bat -q ..\tutorial\xquery-tutorial.xspec
+    cd /d "%WORK_DIR%"
+    set "TEST_DIR=relative-test-dir %RANDOM%"
+    call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -q "%TUTORIAL_COPY%\xquery-tutorial.xspec""
     call :verify_retval 0
     call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
 
@@ -588,45 +593,44 @@
     call :verify_line 1 x xquery-tutorial-compiled.xq
     call :verify_line 2 x xquery-tutorial-result.html
     call :verify_line 3 x xquery-tutorial-result.xml
-
-    rem Cleanup
-    call :rmdir "%TEST_DIR%"
 	</case>
 
 	<case name="invoking xspec with TEST_DIR creates files in TEST_DIR (Schematron)">
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\test\xspec
+    rem Test with x:context[node()] #322
+
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\schematron\demo-03* "%TUTORIAL_COPY%"
 
     rem Run with absolute TEST_DIR
-    call :run ..\bin\xspec.bat -s schematron-017.xspec
+    call :run ..\bin\xspec.bat -s "%TUTORIAL_COPY%\demo-03.xspec"
     call :verify_retval 0
-    call :verify_line 17 x "Report available at %TEST_DIR%\schematron-017-result.html"
+    call :verify_line 33 x "Report available at %TEST_DIR%\demo-03-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017-compiled.xsl
-    call :verify_line 2 x schematron-017-result.html
-    call :verify_line 3 x schematron-017-result.xml
+    call :verify_line 1 x demo-03-compiled.xsl
+    call :verify_line 2 x demo-03-result.html
+    call :verify_line 3 x demo-03-result.xml
 
     rem Default output dir should not be created
-    call :verify_leaf_dir_not_exist xspec
+    call :verify_leaf_dir_not_exist "%TUTORIAL_COPY%\xspec"
 
     rem Run with relative TEST_DIR
-    set TEST_DIR=..\test\xspec
-    call :run ..\bin\xspec.bat -s schematron-017.xspec
+    cd /d "%WORK_DIR%"
+    set "TEST_DIR=relative-test-dir %RANDOM%"
+    call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -s "%TUTORIAL_COPY%\demo-03.xspec""
     call :verify_retval 0
-    call :verify_line 17 x "Report available at %TEST_DIR%\schematron-017-result.html"
+    call :verify_line 33 x "Report available at %TEST_DIR%\demo-03-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
     call :verify_line_count 3
-    call :verify_line 1 x schematron-017-compiled.xsl
-    call :verify_line 2 x schematron-017-result.html
-    call :verify_line 3 x schematron-017-result.xml
-
-    rem Cleanup
-    call :rmdir "%TEST_DIR%"
+    call :verify_line 1 x demo-03-compiled.xsl
+    call :verify_line 2 x demo-03-result.html
+    call :verify_line 3 x demo-03-result.xml
 	</case>
 
 	<!--
@@ -701,14 +705,16 @@
     rem Unset any preset args
     set ANT_ARGS=
 
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\escape-for-regex.* "%TUTORIAL_COPY%"
 
     rem Run
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
+        -Dxspec.xml="%TUTORIAL_COPY%\escape-for-regex.xspec"
 
     rem Default xspec.fail is true
     call :verify_retval 1
@@ -719,7 +725,7 @@
     rem * Default clean.output.dir is false
     rem * Default xspec.coverage.enabled is false
     rem * Default xspec.junit.enabled is false
-    call :run dir /b /o:n ..\tutorial\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 4
     call :verify_line 1 x escape-for-regex_xml-to-properties.xml
     call :verify_line 2 x escape-for-regex-compiled.xsl
@@ -727,26 +733,27 @@
     call :verify_line 4 x escape-for-regex-result.xml
 
     rem HTML report file contains CSS inline
-    call :run java -jar "%SAXON_JAR%" -s:..\tutorial\xspec\escape-for-regex-result.html -xsl:html-css.xsl
+    call :run java -jar "%SAXON_JAR%" ^
+        -s:"%TUTORIAL_COPY%\xspec\escape-for-regex-result.html" ^
+        -xsl:html-css.xsl
     call :verify_line 1 x "true"
-
-    rem Cleanup
-    call :rmdir ..\tutorial\xspec
 	</case>
 
 	<case name="Ant with minimum properties (XQuery)">
     rem Unset any preset args
     set ANT_ARGS=
 
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\xquery-tutorial.* "%TUTORIAL_COPY%"
 
     rem Run
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
         -Dtest.type=q ^
-        -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec"
+        -Dxspec.xml="%TUTORIAL_COPY%\xquery-tutorial.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
     call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -754,23 +761,22 @@
     rem Verify default output dir
     rem * Default clean.output.dir is false
     rem * Default xspec.junit.enabled is false
-    call :run dir /b /o:n ..\tutorial\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 4
     call :verify_line 1 x xquery-tutorial_xml-to-properties.xml
     call :verify_line 2 x xquery-tutorial-compiled.xq
     call :verify_line 3 x xquery-tutorial-result.html
     call :verify_line 4 x xquery-tutorial-result.xml
-
-    rem Cleanup
-    call :rmdir ..\tutorial\xspec
 	</case>
 
 	<case name="Ant with minimum properties (Schematron)">
     rem Unset any preset args
     set ANT_ARGS=
 
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\schematron\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\schematron\demo-03* "%TUTORIAL_COPY%"
 
     rem Run
     rem * Should work without phase #168
@@ -778,7 +784,7 @@
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
         -Dtest.type=s ^
-        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
+        -Dxspec.xml="%TUTORIAL_COPY%\demo-03.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
     call :verify_line -2 x "BUILD SUCCESSFUL"
@@ -786,7 +792,7 @@
     rem Verify default output dir
     rem * Default clean.output.dir is false
     rem * Default xspec.junit.enabled is false
-    call :run dir /b /o:n ..\tutorial\schematron\xspec
+    call :run dir /b /o:n "%TUTORIAL_COPY%\xspec"
     call :verify_line_count 9
     call :verify_line 1 x demo-03_xml-to-properties.xml
     call :verify_line 2 x demo-03-compiled.xsl
@@ -797,9 +803,6 @@
     call :verify_line 7 x demo-03-sch-step3-wrapper.xsl
     call :verify_line 8 x demo-03-step1.sch
     call :verify_line 9 x demo-03-step2.sch
-
-    rem Cleanup
-    call :rmdir ..\tutorial\schematron\xspec
 	</case>
 
 	<!--
@@ -918,8 +921,10 @@
     rem For testing -Dxspec.project.dir
     call :copy ..\build.xml "%BUILD_XML%"
 
-    rem Delete default output dir if exists
-    call :rmdir-if-exist ..\tutorial\schematron\xspec
+    rem Use a fresh dir, to avoid a residue of default output dir
+    set "TUTORIAL_COPY=%WORK_DIR%\tutorial %RANDOM%"
+    call :mkdir "%TUTORIAL_COPY%"
+    call :copy ..\tutorial\schematron\demo-03* "%TUTORIAL_COPY%"
 
     rem Run
     call :run ant ^
@@ -928,13 +933,13 @@
         -Dclean.output.dir=true ^
         -Dxspec.project.dir="%CD%\.." ^
         -Dxspec.properties="%CD%\schematron.properties" ^
-        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-03.xspec"
+        -Dxspec.xml="%TUTORIAL_COPY%\demo-03.xspec"
     call :verify_retval 0
     call :verify_line  * x "     [xslt] passed: 10 / pending: 1 / failed: 0 / total: 11"
     call :verify_line -2 x "BUILD SUCCESSFUL"
 
     rem Verify that -Dxspec.dir was honored and the default output dir was not created
-    call :verify_leaf_dir_not_exist ..\tutorial\schematron\xspec
+    call :verify_leaf_dir_not_exist "%TUTORIAL_COPY%\xspec"
 
     rem Verify clean.output.dir=true
     call :verify_leaf_dir_not_exist "%TEST_DIR%"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -219,24 +219,27 @@ load bats-helper
 @test "invoking xspec without TEST_DIR set externally (XSLT)" {
     unset TEST_DIR
 
-    # Delete default output dir if exists, to make the line numbers predictable
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/escape-for-regex.* "${tutorial_copy}"
 
     # Run
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    run ../bin/xspec.sh "${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
 
     # Verify message
     [ "${lines[19]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
-    [ "${lines[20]}" = "Report available at ../tutorial/xspec/escape-for-regex-result.html" ]
+    [ "${lines[20]}" = "Report available at ${tutorial_copy}/xspec/escape-for-regex-result.html" ]
 
     # Verify report files
     # * XML report file is created
     # * HTML report file is created
     # * Coverage is disabled by default
     # * JUnit is disabled by default
-    run ls ../tutorial/xspec
+    run ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
@@ -244,12 +247,11 @@ load bats-helper
     [ "${lines[2]}" = "escape-for-regex-result.xml" ]
 
     # HTML report file contains CSS inline #135
-    run java -jar "${SAXON_JAR}" -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
+    run java -jar "${SAXON_JAR}" \
+        -s:"${tutorial_copy}/xspec/escape-for-regex-result.html" \
+        -xsl:html-css.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
-
-    # Cleanup
-    rm -r ../tutorial/xspec
 }
 
 @test "invoking xspec -c without TEST_DIR set externally" {
@@ -259,18 +261,21 @@ load bats-helper
 
     unset TEST_DIR
 
-    # Delete default output dir if exists, to make the line numbers predictable
-    rm -rf ../tutorial/coverage/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/coverage/demo* "${tutorial_copy}"
 
     # Run
-    run ../bin/xspec.sh -c ../tutorial/coverage/demo.xspec
+    run ../bin/xspec.sh -c "${tutorial_copy}/demo.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
 
     # Verify message
     # Bats bug inserts garbages into $lines: bats-core/bats-core#151
     assert_regex "${output}" $'\n''passed: 1 / pending: 0 / failed: 0 / total: 1'$'\n'
-    assert_regex "${output}" $'\n''Report available at ../tutorial/coverage/xspec/demo-coverage\.html'$'\n'
+    assert_regex "${output}" $'\n''Report available at '"${tutorial_copy}"'/xspec/demo-coverage\.html'$'\n'
 
     # Verify report files
     # * XML report file is created
@@ -278,7 +283,7 @@ load bats-helper
     # * Coverage XML report is created
     # * Coverage HTML report is created
     # * JUnit is disabled by default
-    run ls ../tutorial/coverage/xspec
+    run ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "5" ]
     [ "${lines[0]}" = "demo-compiled.xsl" ]
@@ -286,49 +291,49 @@ load bats-helper
     [ "${lines[2]}" = "demo-coverage.xml" ]
     [ "${lines[3]}" = "demo-result.html" ]
     [ "${lines[4]}" = "demo-result.xml" ]
-
-    # Cleanup
-    rm -r ../tutorial/coverage/xspec
 }
 
 @test "invoking xspec without TEST_DIR set externally (XQuery)" {
     unset TEST_DIR
 
-    # Delete default output dir if exists, to make the line numbers predictable
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/xquery-tutorial.* "${tutorial_copy}"
 
     # Run
-    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+    run ../bin/xspec.sh -q "${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
 
     # Verify message
     [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-    [ "${lines[7]}" = "Report available at ../tutorial/xspec/xquery-tutorial-result.html" ]
+    [ "${lines[7]}" = "Report available at ${tutorial_copy}/xspec/xquery-tutorial-result.html" ]
 
     # Verify report files
     # * XML report file is created
     # * HTML report file is created
     # * JUnit is disabled by default
-    run ls ../tutorial/xspec
+    run ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
     [ "${lines[1]}" = "xquery-tutorial-result.html" ]
     [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
-
-    # Cleanup
-    rm -r ../tutorial/xspec
 }
 
 @test "invoking xspec without TEST_DIR set externally (Schematron)" {
     unset TEST_DIR
 
-    # Delete default output dir if exists, to make the line numbers predictable
-    rm -rf ../tutorial/schematron/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/schematron/demo-03* "${tutorial_copy}"
 
     # Run
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-03.xspec
+    run ../bin/xspec.sh -s "${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -336,22 +341,19 @@ load bats-helper
     # * No Schematron warnings #129 #131
     [ "${lines[4]}"  = "Converting Schematron XSpec into XSLT XSpec..." ]
     [ "${lines[31]}" = "passed: 10 / pending: 1 / failed: 0 / total: 11" ]
-    [ "${lines[32]}" = "Report available at ../tutorial/schematron/xspec/demo-03-result.html" ]
+    [ "${lines[32]}" = "Report available at ${tutorial_copy}/xspec/demo-03-result.html" ]
 
     # Verify report files
     # * XML report file is created
     # * HTML report file is created
     # * JUnit is disabled by default
     # * Schematron-specific temporary files are deleted
-    run ls ../tutorial/schematron/xspec
+    run ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
     [ "${lines[0]}" = "demo-03-compiled.xsl" ]
     [ "${lines[1]}" = "demo-03-result.html" ]
     [ "${lines[2]}" = "demo-03-result.xml" ]
-
-    # Cleanup
-    rm -r ../tutorial/schematron/xspec
 }
 
 #
@@ -585,11 +587,14 @@ load bats-helper
 #
 
 @test "invoking xspec with TEST_DIR creates files in TEST_DIR (XSLT)" {
-    # Delete default output dir if exists
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/escape-for-regex.* "${tutorial_copy}"
 
     # Run with absolute TEST_DIR
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    run ../bin/xspec.sh "${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
@@ -603,11 +608,12 @@ load bats-helper
     [ "${lines[2]}" = "escape-for-regex-result.xml" ]
 
     # Default output dir should not be created
-    assert_leaf_dir_not_exist ../tutorial/xspec
+    assert_leaf_dir_not_exist "${tutorial_copy}/xspec"
 
     # Run with relative TEST_DIR
-    export TEST_DIR=../tutorial/xspec
-    run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    cd "${work_dir}"
+    export TEST_DIR="relative-test-dir ${RANDOM}"
+    run "${parent_dir_abs}/bin/xspec.sh" "${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
@@ -619,9 +625,6 @@ load bats-helper
     [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
     [ "${lines[1]}" = "escape-for-regex-result.html" ]
     [ "${lines[2]}" = "escape-for-regex-result.xml" ]
-
-    # Cleanup
-    rm -r "${TEST_DIR}"
 }
 
 @test "invoking xspec -c with TEST_DIR creates files in TEST_DIR" {
@@ -629,11 +632,14 @@ load bats-helper
         skip "XSLT_SUPPORTS_COVERAGE is not defined"
     fi
 
-    # Delete default output dir if exists
-    rm -rf ../tutorial/coverage/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/coverage/demo* "${tutorial_copy}"
 
     # Run with absolute TEST_DIR
-    run ../bin/xspec.sh -c ../tutorial/coverage/demo.xspec
+    run ../bin/xspec.sh -c "${tutorial_copy}/demo.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     # Bats bug inserts garbages into $lines: bats-core/bats-core#151
@@ -650,11 +656,12 @@ load bats-helper
     [ "${lines[4]}" = "demo-result.xml" ]
 
     # Default output dir should not be created
-    assert_leaf_dir_not_exist ../tutorial/coverage/xspec
+    assert_leaf_dir_not_exist "${tutorial_copy}/xspec"
 
     # Run with relative TEST_DIR
-    export TEST_DIR=../tutorial/coverage/xspec
-    run ../bin/xspec.sh -c ../tutorial/coverage/demo.xspec
+    cd "${work_dir}"
+    export TEST_DIR="relative-test-dir ${RANDOM}"
+    run "${parent_dir_abs}/bin/xspec.sh" -c "${tutorial_copy}/demo.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     # Bats bug inserts garbages into $lines: bats-core/bats-core#151
@@ -669,17 +676,17 @@ load bats-helper
     [ "${lines[2]}" = "demo-coverage.xml" ]
     [ "${lines[3]}" = "demo-result.html" ]
     [ "${lines[4]}" = "demo-result.xml" ]
-
-    # Cleanup
-    rm -r "${TEST_DIR}"
 }
 
 @test "invoking xspec with TEST_DIR creates files in TEST_DIR (XQuery)" {
-    # Delete default output dir if exists
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/xquery-tutorial.* "${tutorial_copy}"
 
     # Run with absolute TEST_DIR
-    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+    run ../bin/xspec.sh -q "${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
@@ -693,11 +700,12 @@ load bats-helper
     [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
 
     # Default output dir should not be created
-    assert_leaf_dir_not_exist ../tutorial/xspec
+    assert_leaf_dir_not_exist "${tutorial_copy}/xspec"
 
     # Run with relative TEST_DIR
-    export TEST_DIR=../tutorial/xspec
-    run ../bin/xspec.sh -q ../tutorial/xquery-tutorial.xspec
+    cd "${work_dir}"
+    export TEST_DIR="relative-test-dir ${RANDOM}"
+    run "${parent_dir_abs}/bin/xspec.sh" -q "${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
@@ -709,49 +717,49 @@ load bats-helper
     [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
     [ "${lines[1]}" = "xquery-tutorial-result.html" ]
     [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
-
-    # Cleanup
-    rm -r "${TEST_DIR}"
 }
 
 @test "invoking xspec with TEST_DIR creates files in TEST_DIR (Schematron)" {
-    # Delete default output dir if exists
-    rm -rf ../test/xspec
+    # Test with x:context[node()] #322
+
+    # Use a fresh dir, to make the message line numbers predictable
+    # and to avoid a residue of output files
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/schematron/demo-03* "${tutorial_copy}"
 
     # Run with absolute TEST_DIR
-    run ../bin/xspec.sh -s schematron-017.xspec
+    run ../bin/xspec.sh -s "${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[16]}" = "Report available at ${TEST_DIR}/schematron-017-result.html" ]
+    [ "${lines[32]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
-    [ "${lines[1]}" = "schematron-017-result.html" ]
-    [ "${lines[2]}" = "schematron-017-result.xml" ]
+    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
+    [ "${lines[1]}" = "demo-03-result.html" ]
+    [ "${lines[2]}" = "demo-03-result.xml" ]
 
     # Default output dir should not be created
-    assert_leaf_dir_not_exist xspec
+    assert_leaf_dir_not_exist "${tutorial_copy}/xspec"
 
     # Run with relative TEST_DIR
-    export TEST_DIR=../test/xspec
-    run ../bin/xspec.sh -s schematron-017.xspec
+    cd "${work_dir}"
+    export TEST_DIR="relative-test-dir ${RANDOM}"
+    run "${parent_dir_abs}/bin/xspec.sh" -s "${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[16]}" = "Report available at ${TEST_DIR}/schematron-017-result.html" ]
+    [ "${lines[32]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
     echo "$output"
     [ "${#lines[@]}" = "3" ]
-    [ "${lines[0]}" = "schematron-017-compiled.xsl" ]
-    [ "${lines[1]}" = "schematron-017-result.html" ]
-    [ "${lines[2]}" = "schematron-017-result.xml" ]
-
-    # Cleanup
-    rm -r "${TEST_DIR}"
+    [ "${lines[0]}" = "demo-03-compiled.xsl" ]
+    [ "${lines[1]}" = "demo-03-result.html" ]
+    [ "${lines[2]}" = "demo-03-result.xml" ]
 }
 
 #
@@ -840,14 +848,16 @@ load bats-helper
     # Unset any preset args
     unset ANT_ARGS
 
-    # Delete default output dir if exists
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to avoid a residue of default output dir
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/escape-for-regex.* "${tutorial_copy}"
 
     # Run
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
+        -Dxspec.xml="${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
 
     # Default xspec.fail is true
@@ -859,7 +869,7 @@ load bats-helper
     # * Default clean.output.dir is false
     # * Default xspec.coverage.enabled is false
     # * Default xspec.junit.enabled is false
-    run env LC_ALL=C ls ../tutorial/xspec
+    run env LC_ALL=C ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "4" ]
     [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
@@ -868,27 +878,28 @@ load bats-helper
     [ "${lines[3]}" = "escape-for-regex_xml-to-properties.xml" ]
 
     # HTML report file contains CSS inline
-    run java -jar "${SAXON_JAR}" -s:../tutorial/xspec/escape-for-regex-result.html -xsl:html-css.xsl
+    run java -jar "${SAXON_JAR}" \
+        -s:"${tutorial_copy}/xspec/escape-for-regex-result.html" \
+        -xsl:html-css.xsl
     echo "$output"
     [ "${lines[0]}" = "true" ]
-
-    # Cleanup
-    rm -r ../tutorial/xspec
 }
 
 @test "Ant with minimum properties (XQuery)" {
     # Unset any preset args
     unset ANT_ARGS
 
-    # Delete default output dir if exists
-    rm -rf ../tutorial/xspec
+    # Use a fresh dir, to avoid a residue of default output dir
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/xquery-tutorial.* "${tutorial_copy}"
 
     # Run
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
         -Dtest.type=q \
-        -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec"
+        -Dxspec.xml="${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     assert_regex "${output}" $'\n''     \[xslt\] passed: 1 / pending: 0 / failed: 0 / total: 1'$'\n'
@@ -897,24 +908,23 @@ load bats-helper
     # Verify default output dir
     # * Default clean.output.dir is false
     # * Default xspec.junit.enabled is false
-    run env LC_ALL=C ls ../tutorial/xspec
+    run env LC_ALL=C ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "4" ]
     [ "${lines[0]}" = "xquery-tutorial-compiled.xq" ]
     [ "${lines[1]}" = "xquery-tutorial-result.html" ]
     [ "${lines[2]}" = "xquery-tutorial-result.xml" ]
     [ "${lines[3]}" = "xquery-tutorial_xml-to-properties.xml" ]
-
-    # Cleanup
-    rm -r ../tutorial/xspec
 }
 
 @test "Ant with minimum properties (Schematron)" {
     # Unset any preset args
     unset ANT_ARGS
 
-    # Delete default output dir if exists
-    rm -rf ../tutorial/schematron/xspec
+    # Use a fresh dir, to avoid a residue of default output dir
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/schematron/demo-03* "${tutorial_copy}"
 
     # Run
     # * Should work without phase #168
@@ -922,7 +932,7 @@ load bats-helper
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
         -Dtest.type=s \
-        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-03.xspec"
+        -Dxspec.xml="${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     assert_regex "${output}" $'\n''     \[xslt\] passed: 10 / pending: 1 / failed: 0 / total: 11'$'\n'
@@ -931,7 +941,7 @@ load bats-helper
     # Verify default output dir
     # * Default clean.output.dir is false
     # * Default xspec.junit.enabled is false
-    run env LC_ALL=C ls ../tutorial/schematron/xspec
+    run env LC_ALL=C ls "${tutorial_copy}/xspec"
     echo "$output"
     [ "${#lines[@]}" = "9" ]
     [ "${lines[0]}" = "demo-03-compiled.xsl" ]
@@ -943,9 +953,6 @@ load bats-helper
     [ "${lines[6]}" = "demo-03-step1.sch" ]
     [ "${lines[7]}" = "demo-03-step2.sch" ]
     [ "${lines[8]}" = "demo-03_xml-to-properties.xml" ]
-
-    # Cleanup
-    rm -r ../tutorial/schematron/xspec
 }
 
 #
@@ -1085,8 +1092,10 @@ load bats-helper
     # For testing -Dxspec.project.dir
     cp ../build.xml "${build_xml}"
 
-    # Delete default output dir if exists
-    rm -rf ../tutorial/schematron/xspec
+    # Use a fresh dir, to avoid a residue of default output dir
+    tutorial_copy="${work_dir}/tutorial ${RANDOM}"
+    mkdir "${tutorial_copy}"
+    cp ../tutorial/schematron/demo-03* "${tutorial_copy}"
 
     # Run
     run ant \
@@ -1095,14 +1104,14 @@ load bats-helper
         -Dclean.output.dir=true \
         -Dxspec.project.dir="${PWD}/.." \
         -Dxspec.properties="${PWD}/schematron.properties" \
-        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-03.xspec"
+        -Dxspec.xml="${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     assert_regex "${output}" $'\n''     \[xslt\] passed: 10 / pending: 1 / failed: 0 / total: 11'$'\n'
     [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
 
     # Verify that -Dxspec.dir was honored and the default output dir was not created
-    assert_leaf_dir_not_exist ../tutorial/schematron/xspec
+    assert_leaf_dir_not_exist "${tutorial_copy}/xspec"
 
     # Verify clean.output.dir=true
     assert_leaf_dir_not_exist "${TEST_DIR}"


### PR DESCRIPTION
Some Bats tests unset `TEST_DIR` (CLI) or `xspec.dir` (Ant), or set relative `TEST_DIR`. They pollute `tutorial/` and `test/` directories.
This pull request copies `tutorial/` to the work directory and runs the tests there so that they do not pollute the repository directories.