### PR TITLE
test(schematron): test external XSLT file chain

### DIFF
--- a/test/schematron/schematron-xslt-compile.xsl
+++ b/test/schematron/schematron-xslt-compile.xsl
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<xsl:stylesheet xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
     <xsl:import href="../../src/schematron/iso-schematron/iso_svrl_for_xslt2.xsl" />
 
-    <xsl:include href="../../src/common/xspec-utils.xsl" />
-
-    <xsl:template match="/">
-        <xsl:message>I am <xsl:value-of select="x:filename-and-extension(static-base-uri())" />!</xsl:message>
-        <xsl:apply-imports />
+    <xsl:template match="sch:let[@name eq 'hook-me']" as="element(xsl:variable)">
+        <xsl:element name="xsl:variable">
+            <xsl:attribute name="name">verify-me</xsl:attribute>
+            <xsl:attribute name="select">12345</xsl:attribute>
+        </xsl:element>
     </xsl:template>
 </xsl:stylesheet>

--- a/test/schematron/schematron-xslt-expand.xsl
+++ b/test/schematron/schematron-xslt-expand.xsl
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<xsl:stylesheet xmlns:iae="http://www.schematron.com/namespace/iae"
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
     <xsl:import href="../../src/schematron/iso-schematron/iso_abstract_expand.xsl" />
 
-    <xsl:include href="../../src/common/xspec-utils.xsl" />
-
-    <xsl:template match="/">
-        <xsl:message>I am <xsl:value-of select="x:filename-and-extension(static-base-uri())" />!</xsl:message>
-        <xsl:apply-imports />
+    <xsl:template match="sch:pattern[@is-a eq 'hook-me']" as="element(sch:let)" mode="iae:go">
+        <sch:let name="hook-me" />
     </xsl:template>
 </xsl:stylesheet>

--- a/test/schematron/schematron-xslt-include.xsl
+++ b/test/schematron/schematron-xslt-include.xsl
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<xsl:stylesheet xmlns:dsdl="http://www.schematron.com/namespace/dsdl"
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
     <xsl:import href="../../src/schematron/iso-schematron/iso_dsdl_include.xsl" />
 
-    <xsl:include href="../../src/common/xspec-utils.xsl" />
-
-    <xsl:template match="/">
-        <xsl:message>I am <xsl:value-of select="x:filename-and-extension(static-base-uri())" />!</xsl:message>
-        <xsl:apply-imports />
+    <xsl:template match="sch:include[@href eq 'hook-me']" as="element(sch:pattern)" mode="dsdl:go">
+        <sch:pattern is-a="hook-me" />
     </xsl:template>
 </xsl:stylesheet>

--- a/test/schematron/schematron-xslt.sch
+++ b/test/schematron/schematron-xslt.sch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+	xmlns:sqf="http://www.schematron-quickfix.com/validator/process">
+
+	<sch:include href="hook-me" />
+
+	<sch:pattern>
+		<sch:rule context="e">
+			<sch:report id="hook-chain-verified" test="$verify-me eq 12345">Good</sch:report>
+		</sch:rule>
+	</sch:pattern>
+
+</sch:schema>

--- a/test/schematron/schematron-xslt.xspec
+++ b/test/schematron/schematron-xslt.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="schematron-xslt.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="Scenario for verifying the hook chain">
+		<x:context>
+			<e />
+		</x:context>
+		<x:expect-report id="hook-chain-verified" />
+	</x:scenario>
+</x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -454,12 +454,9 @@
     set SCHEMATRON_XSLT_EXPAND=schematron\schematron-xslt-expand.xsl
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt-compile.xsl
 
-    call :run ..\bin\xspec.bat -s ..\tutorial\schematron\demo-01.xspec
+    call :run ..\bin\xspec.bat -s schematron\schematron-xslt.xspec
     call :verify_retval 0
-    call :verify_line  5 x "I am schematron-xslt-include.xsl!"
-    call :verify_line  6 x "I am schematron-xslt-expand.xsl!"
-    call :verify_line  7 x "I am schematron-xslt-compile.xsl!"
-    call :verify_line 20 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
+    call :verify_line 13 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
 
 	<case name="invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)">
@@ -470,13 +467,10 @@
         -Dxspec.schematron.preprocessor.step1="%CD%\schematron\schematron-xslt-include.xsl" ^
         -Dxspec.schematron.preprocessor.step2="%CD%\schematron\schematron-xslt-expand.xsl" ^
         -Dxspec.schematron.preprocessor.step3="%CD%\schematron\schematron-xslt-compile.xsl" ^
-        -Dxspec.xml="%CD%\..\tutorial\schematron\demo-01.xspec"
+        -Dxspec.xml="%CD%\schematron\schematron-xslt.xspec"
     call :verify_retval 0
-    call :verify_line  * x "     [xslt] I am schematron-xslt-include.xsl!"
-    call :verify_line  * x "     [xslt] I am schematron-xslt-expand.xsl!"
-    call :verify_line  * x "     [xslt] I am schematron-xslt-compile.xsl!"
-    call :verify_line  * x "     [xslt] passed: 3 / pending: 0 / failed: 0 / total: 3"
-    call :verify_line -2 x "BUILD SUCCESSFUL"
+    call :verify_line -10 x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line -2  x "BUILD SUCCESSFUL"
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -555,13 +555,10 @@ load bats-helper
     export SCHEMATRON_XSLT_EXPAND=schematron/schematron-xslt-expand.xsl
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt-compile.xsl
 
-    run ../bin/xspec.sh -s ../tutorial/schematron/demo-01.xspec
+    run ../bin/xspec.sh -s schematron/schematron-xslt.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[4]}"  = "I am schematron-xslt-include.xsl!" ]
-    [ "${lines[5]}"  = "I am schematron-xslt-expand.xsl!" ]
-    [ "${lines[6]}"  = "I am schematron-xslt-compile.xsl!" ]
-    [ "${lines[19]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
+    [ "${lines[12]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
 @test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)" {
@@ -572,14 +569,11 @@ load bats-helper
         -Dxspec.schematron.preprocessor.step1="${PWD}/schematron/schematron-xslt-include.xsl" \
         -Dxspec.schematron.preprocessor.step2="${PWD}/schematron/schematron-xslt-expand.xsl" \
         -Dxspec.schematron.preprocessor.step3="${PWD}/schematron/schematron-xslt-compile.xsl" \
-        -Dxspec.xml="${PWD}/../tutorial/schematron/demo-01.xspec"
+        -Dxspec.xml="${PWD}/schematron/schematron-xslt.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    assert_regex "${output}" $'\n''     \[xslt\] I am schematron-xslt-include.xsl!'$'\n'
-    assert_regex "${output}" $'\n''     \[xslt\] I am schematron-xslt-expand.xsl!'$'\n'
-    assert_regex "${output}" $'\n''     \[xslt\] I am schematron-xslt-compile.xsl!'$'\n'
-    assert_regex "${output}" $'\n''     \[xslt\] passed: 3 / pending: 0 / failed: 0 / total: 3'$'\n'
-    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+    [ "${lines[${#lines[@]}-10]}" = "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[${#lines[@]}-2]}"  = "BUILD SUCCESSFUL" ]
 }
 
 #


### PR DESCRIPTION
While the tests for `SCHEMATRON_XSLT_*` (CLI) and `xspec.schematron.preprocessor.step?` (Ant) ensures that the specified XSLT files are invoked in order, they do not ensure that the transformation results are chained in order. This pr ensures it.