### PR TITLE
test: test format-xspec-report-folding.xsl in end-to-end test

### DIFF
--- a/test/ant/worker/build-worker_util.xml
+++ b/test/ant/worker/build-worker_util.xml
@@ -43,6 +43,7 @@
 		<attribute default="" name="enable-coverage" />
 		<attribute default="" name="saxon-custom-options" />
 		<attribute default="" name="additional-classpath" />
+		<attribute default="" name="html-reporter" />
 		<attribute default="" name="output-xml-url" />
 		<attribute default="" name="output-html-url" />
 		<attribute default="" name="output-coverage-url" />
@@ -105,6 +106,8 @@
 					value="@{saxon-custom-options}" />
 				<param name="xspec.additional.classpath" unless:blank="@{additional-classpath}"
 					value="@{additional-classpath}" />
+				<param name="xspec.html.reporter.xsl" unless:blank="@{html-reporter}"
+					value="@{html-reporter}" />
 
 				<param if:set="output-xml-path" location="${output-xml-path}"
 					name="xspec.result.xml" />

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -283,6 +283,11 @@
 								select="substring-after(., 'additional-classpath=')" />
 						</xsl:for-each>
 
+						<xsl:for-each select="$pis[starts-with(., 'html-reporter=')]">
+							<xsl:attribute name="html-reporter"
+								select="substring-after(., 'html-reporter=')" />
+						</xsl:for-each>
+
 						<xsl:call-template name="on-run-xspec">
 							<xsl:with-param name="coverage-enabled" select="$enable-coverage" />
 						</xsl:call-template>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-junit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="format-xspec-report-folding.xspec">
+   <testsuite name="an unfocused correct scenario must be Pending"
+              tests="1"
+              failures="0">
+      <testcase name="it would return Success if it were not Pending" status="skipped">
+         <skipped>testing @focus of a correct scenario</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="an unfocused incorrect scenario must be Pending"
+              tests="1"
+              failures="0">
+      <testcase name="it would return Failure if it were not Pending" status="skipped">
+         <skipped>testing @focus of a correct scenario</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="a focused correct scenario" tests="1" failures="0">
+      <testcase name="must execute the test and return Success" status="passed"/>
+   </testsuite>
+   <testsuite name="a focused incorrect scenario" tests="1" failures="1">
+      <testcase name="must execute the test and return Failure" status="failed">
+         <failure message="expect assertion failed">Expected: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for xspec-tested.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" /><script language="javascript" type="text/javascript">
+function toggle(scenarioID) {
+  table = document.getElementById("table_"+scenarioID);
+  icon = document.getElementById("icon_"+scenarioID)
+  // need to:
+  //   switch table.style.display between 'none' and 'block'
+  //   switch between collapse and expand icons
+
+   if (table.style.display == "none") {
+    // This try/catch is to handle IE 7.  It doesn't support table.style.display = "table"
+    try {
+      table.style.display = "table";
+    } catch(err) {
+      table.style.display = "block";
+    }
+    icon.src = "../../../../../graphics/3angle-down.gif" ;
+    icon.alt = "collapse" ;
+    icon.title = "collapse" ;
+  }
+  else {
+    table.style.display = "none";
+    icon.src = "../../../../../graphics/3angle-right.gif" ;
+    icon.alt = "expand" ;
+    icon.title = "expand" ;
+  };
+
+  return;
+}
+</script></head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../xspec-tested.xsl">xspec-tested.xsl</a></p>
+      <p>XSpec: <a href="../../format-xspec-report-folding.xspec">format-xspec-report-folding.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 2</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 4</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="pending">
+               <th>(<strong>testing @focus of a correct scenario</strong>) <a>an unfocused correct scenario must be Pending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="pending">
+               <th>(<strong>testing @focus of a correct scenario</strong>) <a>an unfocused incorrect scenario must be Pending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario3">a focused correct scenario</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario4">a focused incorrect scenario</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario3">
+         <h2 class="successful"><a href="javascript:toggle('scenario3')"><img src="../../../../../graphics/3angle-right.gif" alt="expand" id="icon_scenario3" /></a>a focused correct scenario<span class="scenario-totals">1/0/0/1</span></h2>
+         <table class="xspec" id="table_scenario3" style="display: none">
+            <colgroup>
+               <col style="width:85%" />
+               <col style="width:15%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>a focused correct scenario</th>
+                  <th>1/0/0/1</th>
+               </tr>
+               <tr class="successful">
+                  <td>must execute the test and return Success</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario4">
+         <h2 class="failed"><a href="javascript:toggle('scenario4')"><img src="../../../../../graphics/3angle-down.gif" alt="collapse" id="icon_scenario4" /></a>a focused incorrect scenario<span class="scenario-totals">0/0/1/1</span></h2>
+         <table class="xspec" id="table_scenario4" style="display: table">
+            <colgroup>
+               <col style="width:85%" />
+               <col style="width:15%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>a focused incorrect scenario</th>
+                  <th>0/0/1/1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario4-expect1">must execute the test and return Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario4">
+            <h3>a focused incorrect scenario</h3>
+            <div id="scenario4-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:report xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          stylesheet="../../../../xspec-tested.xsl"
+          date="2000-01-01T00:00:00Z"
+          xspec="../../format-xspec-report-folding.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:my="http://example.org/ns/my"
+               id="scenario1"
+               xspec="../../xspec-focus-1.xspec"
+               pending="testing @focus of a correct scenario">
+      <t:label>an unfocused correct scenario must be Pending</t:label>
+      <t:call function="my:square">
+         <t:param select="3"/>
+      </t:call>
+      <t:test id="scenario1-expect1" pending="testing @focus of a correct scenario">
+         <t:label>it would return Success if it were not Pending</t:label>
+      </t:test>
+   </t:scenario>
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:my="http://example.org/ns/my"
+               id="scenario2"
+               xspec="../../xspec-focus-1.xspec"
+               pending="testing @focus of a correct scenario">
+      <t:label>an unfocused incorrect scenario must be Pending</t:label>
+      <t:call function="my:square">
+         <t:param select="2"/>
+      </t:call>
+      <t:test id="scenario2-expect1" pending="testing @focus of a correct scenario">
+         <t:label>it would return Failure if it were not Pending</t:label>
+      </t:test>
+   </t:scenario>
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:my="http://example.org/ns/my"
+               id="scenario3"
+               xspec="../../xspec-focus-1.xspec">
+      <t:label>a focused correct scenario</t:label>
+      <t:call function="my:square">
+         <t:param select="3"/>
+      </t:call>
+      <t:result select="9"/>
+      <t:test id="scenario3-expect1" successful="true">
+         <t:label>must execute the test and return Success</t:label>
+         <t:expect select="9"/>
+      </t:test>
+   </t:scenario>
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:my="http://example.org/ns/my"
+               id="scenario4"
+               xspec="../../xspec-focus-1.xspec">
+      <t:label>a focused incorrect scenario</t:label>
+      <t:call function="my:square">
+         <t:param select="2"/>
+      </t:call>
+      <t:result select="4"/>
+      <t:test id="scenario4-expect1" successful="false">
+         <t:label>must execute the test and return Failure</t:label>
+         <t:expect test="$t:result instance of xs:string" select="()"/>
+      </t:test>
+   </t:scenario>
+</x:report>

--- a/test/end-to-end/cases/format-xspec-report-folding.xspec
+++ b/test/end-to-end/cases/format-xspec-report-folding.xspec
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test html-reporter=${xspec.project.dir}/src/reporter/format-xspec-report-folding.xsl?>
+<x:description stylesheet="../../xspec-tested.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="xspec-focus-1.xspec" />
+</x:description>

--- a/test/end-to-end/processor/html/_deserializer.xsl
+++ b/test/end-to-end/processor/html/_deserializer.xsl
@@ -12,7 +12,14 @@
 		Removes insignificant whitespace (artifact of serialization indent) from text node
 			This is an ad hoc implementation only suitable for the test result HTML.
 	-->
-	<xsl:template as="text()?" match="text()[not(parent::pre or parent::span/parent::pre)]"
+	<xsl:template as="text()?"
+		match="
+			text()[not(
+			parent::pre
+			or
+			parent::script
+			or
+			parent::span/parent::pre)]"
 		mode="deserializer:unindent">
 		<xsl:choose>
 			<xsl:when test="normalize-space()">

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -181,4 +181,43 @@
 		<xsl:sequence select="$doc/html/body/starts-with(p[1], 'Schematron:')" />
 	</xsl:function>
 
+	<!--
+		Templates for format-xspec-report-folding.xsl
+	-->
+
+	<!--
+		Normalizes image URI in script
+	-->
+	<xsl:template as="text()" match="script/text()" mode="normalizer:normalize">
+		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
+
+		<xsl:variable name="regex"><![CDATA[^( +icon\.src = ")(.+?)(" ;)$]]></xsl:variable>
+
+		<xsl:value-of>
+			<xsl:analyze-string flags="m" regex="{$regex}" select=".">
+				<xsl:matching-substring>
+					<xsl:sequence
+						select="
+							regex-group(1),
+							normalizer:relative-uri(regex-group(2), $tunnel_document-uri),
+							regex-group(3)"
+					 />
+				</xsl:matching-substring>
+				<xsl:non-matching-substring>
+					<xsl:copy />
+				</xsl:non-matching-substring>
+			</xsl:analyze-string>
+		</xsl:value-of>
+	</xsl:template>
+
+	<!--
+		Normalizes image URI
+	-->
+	<xsl:template as="attribute(src)" match="img/@src" mode="normalizer:normalize">
+		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
+
+		<xsl:attribute name="{local-name()}" namespace="{namespace-uri()}"
+			select="normalizer:relative-uri(., $tunnel_document-uri)" />
+	</xsl:template>
+
 </xsl:stylesheet>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1578,7 +1578,9 @@
 	</case>
 
 	<!--
-		Custom HTML reporter
+		Custom HTML reporter (CLI)
+		
+			Ant is tested by XSPEC_HOME/test/end-to-end/cases/format-xspec-report-folding.xspec
 	-->
 
 	<case name="Custom HTML reporter (CLI)">
@@ -1587,18 +1589,6 @@
     call :verify_retval 0
     call :verify_line -16 x "--- Actual Result ---"
     call :verify_line  -9 x "--- Expected Result ---"
-	</case>
-
-	<case name="Custom HTML reporter (Ant)">
-    call :run ant ^
-        -buildfile ..\build.xml ^
-        -lib "%SAXON_JAR%" ^
-        -Dxspec.fail=false ^
-        -Dxspec.html.reporter.xsl="%CD%\format-xspec-report-messaging.xsl" ^
-        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
-    call :verify_retval 0
-    call :verify_line -21 x "     [xslt] --- Actual Result ---"
-    call :verify_line -14 x "     [xslt] --- Expected Result ---"
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1867,7 +1867,9 @@ load bats-helper
 }
 
 #
-# Custom HTML reporter
+# Custom HTML reporter (CLI)
+#
+#     Ant is tested by XSPEC_HOME/test/end-to-end/cases/format-xspec-report-folding.xspec
 #
 
 @test "Custom HTML reporter (CLI)" {
@@ -1877,19 +1879,6 @@ load bats-helper
     [ "$status" -eq 0 ]
     [ "${lines[${#lines[@]}-16]}" = "--- Actual Result ---" ]
     [ "${lines[${#lines[@]}-9]}"  = "--- Expected Result ---" ]
-}
-
-@test "Custom HTML reporter (Ant)" {
-    run ant \
-        -buildfile ../build.xml \
-        -lib "${SAXON_JAR}" \
-        -Dxspec.fail=false \
-        -Dxspec.html.reporter.xsl="${PWD}/format-xspec-report-messaging.xsl" \
-        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]}-21]}" = "     [xslt] --- Actual Result ---" ]
-    [ "${lines[${#lines[@]}-14]}" = "     [xslt] --- Expected Result ---" ]
 }
 
 #


### PR DESCRIPTION
`src/reporter/format-xspec-report-folding.xsl` is not tested at all.

This pull request tests it in the end-to-end test. ([Live expected result](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/ccc36c276fb8d1ae72d518d97b49d0b9feedd17b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html))