### PR TITLE
build(maven): bump pom.xml to 2.0.0-SNAPSHOT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ You are also encouraged to use a scope to highlight which functionality is affec
 | `report` | Test result reports | 
 | `xproc` | XProc | 
 | `schema` | Schema for .xspec files | 
+| `maven` | Maven |
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
  

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
Following our [workflow](https://github.com/xspec/xspec/wiki/Release-Workflow#updating-pomxml), this pull request increases the version of the XSpec release and adds the snapshot suffix. 

As usual, this should be the first pull request to be merged into `master` in order to start the development of XSpec v2.0.0.

Considering this kind of commits, this pull request adds `maven` to the commit scope list in `CONTRIBUTING.md`.