### PR TITLE
docs: fix CONTRIBUTING.md details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@
 
 ## How to contribute
 
-- [Report an issue](https://github.com/xspec/xspec/issues/new): whether you find a bug in XSpec or have a feature request, raise an issue to let us know. Please submit code examples to reproduce a bug and read the [wiki](https://github.com/xspec/xspec/wiki) to check how XSpec is supposed to work.  
-- [Raise a pull request](https://github.com/xspec/xspec/pulls): all code changes in XSpec are initiated via pull requests towards the `master` branch and are usually reviewed by a maintainer or another contributor before merging. Your pull request will be automatically scanned by our CI systems so you may want to [run the test suite locally](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to avoid surprises. If possible, add a test when submitting a bug fix or a new feature and consider writing some documentation in the pull request which could be later added to the wiki. Before implementing a large feature or fix, consider discussing it first with the maintainers via an issue, this usually speeds up the review process and avoids disappointment. 
-- [Improve the documentation](https://github.com/xspec/xspec/wiki): if you notice a gap in the documentation on the [wiki](https://github.com/xspec/xspec/wiki), raise an issue or discuss it within an existing issue or pull request. Changes in the wiki can only be made by maintainers and contributors with write permissions. 
+- [Report an issue](https://github.com/xspec/xspec/issues/new): whether you find a bug in XSpec or have a feature request, raise an issue to let us know. Please submit code examples to reproduce a bug and read the [wiki](https://github.com/xspec/xspec/wiki) to check how XSpec is supposed to work.
+- [Raise a pull request](https://github.com/xspec/xspec/pulls): all code changes in XSpec are initiated via pull requests towards the `master` branch and are usually reviewed by a maintainer or another contributor before merging. Your pull request will be automatically scanned by our CI systems so you may want to [run the test suite locally](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to avoid surprises. If possible, add a test when submitting a bug fix or a new feature and consider writing some documentation in the pull request which could be later added to the wiki. Before implementing a large feature or fix, consider discussing it first with the maintainers via an issue, this usually speeds up the review process and avoids disappointment.
+- [Improve the documentation](https://github.com/xspec/xspec/wiki): if you notice a gap in the documentation on the [wiki](https://github.com/xspec/xspec/wiki), raise an issue or discuss it within an existing issue or pull request. Changes in the wiki can only be made by maintainers and contributors with write permissions.
 
 All contributions are submitted under the [MIT License](https://github.com/xspec/xspec/blob/master/LICENSE).
 
-## Code Conventions 
+## Code Conventions
 
 ### Git commit messages
 
@@ -20,32 +20,32 @@ These are the valid prefixes for type (see also [the Angular documentation](http
 
 | Type | Description |
 | --- | --- |
-| `feat` | New feature or enhancement | 
-| `fix` | Bug fix | 
-| `test` | Test | 
-| `ci` | CI configuration (Travis, Azure Pipelines, AppVeyor) | 
-| `docs` | Documentation | 
-| `perf` | Performance improvement | 
-| `refactor` | Refactoring improvement (no new feature or bug fix) | 
-| `style` | Style change (white-space, formatting, etc.) | 
-| `build` | Build and release changes | 
+| `feat` | New feature or enhancement |
+| `fix` | Bug fix |
+| `test` | Test |
+| `ci` | CI configuration (Travis, Azure Pipelines, AppVeyor) |
+| `docs` | Documentation |
+| `perf` | Performance improvement |
+| `refactor` | Refactoring improvement (no new feature or bug fix) |
+| `style` | Style change (white-space, formatting, etc.) |
+| `build` | Build and release changes |
 
 You are also encouraged to use a scope to highlight which functionality is affected by your change:  
 
 | Scope | Description |
 | --- | --- |
-| `xslt` | XSLT | 
-| `xquery` | XQuery | 
-| `schematron` | Schematron | 
-| `oxygen` | Oxygen | 
-| `basex` | BaseX | 
-| `deps` | Dependencies | 
-| `report` | Test result reports | 
-| `xproc` | XProc | 
-| `schema` | Schema for .xspec files | 
+| `xslt` | XSLT |
+| `xquery` | XQuery |
+| `schematron` | Schematron |
+| `oxygen` | Oxygen |
+| `basex` | BaseX |
+| `deps` | Dependencies |
+| `report` | Test result reports |
+| `xproc` | XProc |
+| `schema` | Schema for .xspec files |
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
- 
+
 Here are some examples of valid commit message with type and scope:
 
 ```
@@ -53,7 +53,7 @@ feat(xslt): add XSLT code coverage transformation scenario
 fix(schematron): remove scenario
 fix: invalid col element in result HTML
 test(xslt): add test for mode="#all"
-ci: run tests with XML Calabash 1.1.30 
+ci: run tests with XML Calabash 1.1.30
 docs: document code coverage
 build: increment pom.xml
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you raise a pull request without using this format in its title, the automati
 
 This convention is enforced only in the pull request title. Each commit message in the pull request is not required to follow the convention, although you're still encouraged to apply the same convention to each commit message.
 
-### Type
+#### Type
 
 These are the valid prefixes for type (see also [the Angular documentation](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type)):
 
@@ -38,7 +38,7 @@ These are the valid prefixes for type (see also [the Angular documentation](http
 | `style` | Style change (white-space, formatting, etc.) |
 | `build` | Build and release changes |
 
-### Scope
+#### Scope
 
 You are also encouraged to use a scope to highlight which functionality is affected by your change:  
 
@@ -57,7 +57,7 @@ You are also encouraged to use a scope to highlight which functionality is affec
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
 
-### Example
+#### Example
 
 Here are some examples of valid pull request title with type and scope:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ These are the valid prefixes for type (see also [the Angular documentation](http
 | `feat` | New feature or enhancement |
 | `fix` | Bug fix |
 | `test` | Test |
-| `ci` | CI configuration (Travis, Azure Pipelines, AppVeyor) |
+| `ci` | CI configuration (GitHub Actions, Checks, etc.) |
 | `docs` | Documentation |
 | `perf` | Performance improvement |
 | `refactor` | Refactoring improvement (no new feature or bug fix) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 :+1::tada: Thanks for taking the time to contribute! :tada::+1:
 
-# How to contribute
+## How to contribute
 
 - [Report an issue](https://github.com/xspec/xspec/issues/new): whether you find a bug in XSpec or have a feature request, raise an issue to let us know. Please submit code examples to reproduce a bug and read the [wiki](https://github.com/xspec/xspec/wiki) to check how XSpec is supposed to work.  
 - [Raise a pull request](https://github.com/xspec/xspec/pulls): all code changes in XSpec are initiated via pull requests towards the `master` branch and are usually reviewed by a maintainer or another contributor before merging. Your pull request will be automatically scanned by our CI systems so you may want to [run the test suite locally](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to avoid surprises. If possible, add a test when submitting a bug fix or a new feature and consider writing some documentation in the pull request which could be later added to the wiki. Before implementing a large feature or fix, consider discussing it first with the maintainers via an issue, this usually speeds up the review process and avoids disappointment. 
@@ -10,9 +10,9 @@
 
 All contributions are submitted under the [MIT License](https://github.com/xspec/xspec/blob/master/LICENSE).
 
-# Code Conventions 
+## Code Conventions 
 
-## Git commit messages
+### Git commit messages
 
 We use [Commit Lint](https://www.commit-lint.com) to enforce conventions in commit messages and pull requests and we follow the [Angular Coding Conventions](https://www.commit-lint.com/conventions). If you raise a pull request without using one of the valid prefixes for type in your last commit, the automatic checks in the pull request will report an error.
 


### PR DESCRIPTION
* Trivial fixes
* Do not list every non GitHub CI system, because we sometimes switch CI systems depending on their performance/stability.