### PR TITLE
ci: remove Saxon 9.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         java: [ 8, 11 ]
-        env: [ saxon-10, saxon-9-9, saxon-9-8, oxygen, saxon-9-7 ]
+        env: [ saxon-10, saxon-9-9, oxygen, saxon-9-8 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ jdk:
 
 env:
   jobs:
-    # saxon-9-7 is not included in favor of GitHub Actions
+    # saxon-9-8 is not included in favor of GitHub Actions
     - XSPEC_TEST_ENV=saxon-10
     - XSPEC_TEST_ENV=saxon-9-9
-    - XSPEC_TEST_ENV=saxon-9-8
     - XSPEC_TEST_ENV=oxygen
 
 script: >

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -20,14 +20,11 @@ jobs:
         Saxon-9-9:
           XSPEC_TEST_ENV: saxon-9-9
 
-        Saxon-9-8:
-          XSPEC_TEST_ENV: saxon-9-8
-
         Oxygen:
           XSPEC_TEST_ENV: oxygen
 
-        Saxon-9-7:
-          XSPEC_TEST_ENV: saxon-9-7
+        Saxon-9-8:
+          XSPEC_TEST_ENV: saxon-9-8
 
     steps:
       - task: BatchScript@1

--- a/test/ci/env/saxon-9-7.env
+++ b/test/ci/env/saxon-9-7.env
@@ -1,5 +1,0 @@
-#
-# Highest deprecated Saxon
-#
-BASEX_VERSION=
-SAXON_VERSION=9.7.0-21


### PR DESCRIPTION
This pull request removes Saxon 9.7 from the CI test matrix and retreats Saxon 9.8 to the lowest priority.

### Further work
Update [Wiki](https://github.com/xspec/xspec/wiki/Requirements#saxon)