### PR TITLE
build(oxygen): add-on v0.0.9

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,12 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v1.6.0</h3>
+				<ul>
+					<li>Official release of v1.6.0</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v1.6.0-SNAPSHOT.4</h3>
 				<ul>
 					<li>Minor bug fixes</li>
@@ -41,34 +47,6 @@
 				<ul>
 					<li>Support Oxygen 22.0 (<a href="https://github.com/xspec/xspec/pull/780"
 							>#780</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.5.0</h3>
-				<ul>
-					<li>Official release of v1.5.0</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.5.0-SNAPSHOT.3</h3>
-				<ul>
-					<li>Add XSLT Code Coverage transformation scenario (<a
-							href="https://github.com/xspec/xspec/pull/738">#738</a>)</li>
-					<li>Support XQuery in Run XSpec Test transformation scenario (<a
-							href="https://github.com/xspec/xspec/pull/739">#739</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.5.0-SNAPSHOT.2</h3>
-				<ul>
-					<li>Add Oxygen XQuery XProc transformation scenario (<a
-							href="https://github.com/xspec/xspec/pull/736">#736</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.5.0-SNAPSHOT.1</h3>
-				<ul>
-					<li>Initial integration of XSpec framework</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -10,7 +10,7 @@
 		<!-- To publish a new version, update this @href to a specific commit archive and increment
 			<xt:version>. -->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/2d35fe33febdf8e9390fb9c85cd0a0bb6b61cb63.zip" />
+			href="https://github.com/xspec/xspec/archive/v1.6.0.zip" />
 
 		<!-- The version of this add-on. Increment only the last numeric part ('z' of "0.0.z")
 			whenever we publish a new version of this add-on.
@@ -18,7 +18,7 @@
 			by this add-on. But <xt:version> consists of only three numeric parts ("x.y.z") which
 			doesn't accommodate pre-release versions of XSpec ("x.y.z-SNAPSHOT.1" or something like
 			that). Use "0.0.z" until we find a better way. -->
-		<xt:version>0.0.8</xt:version>
+		<xt:version>0.0.9</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
Following our [workflow](https://github.com/xspec/xspec/wiki/Release-Workflow#updating-oxygen-add-on), this pull request publishes XSpec v1.6.0 final via Oxygen add-on channel. 

As usual, this should be the 2nd pull request to be merged into `master` in order to start the development of XSpec v2.0.0. (The 1st one should be #902.)

I will test this change on Oxygen 22.1 build 2020030607 using `https://github.com/AirQuick/xspec/raw/oxy-addon_0-0-9/oxygen-addon.xml`