### PR TITLE
ci: set cmarchand as pom.xml owner in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/pom.xml    @cmarchand


### PR DESCRIPTION
I thought it would be nice to set @cmarchand in [`CODEOWNERS`](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) as the owner of `/pom.xml`.

Based on its [commit history](https://github.com/xspec/xspec/commits/master/pom.xml), the primary responsibility of the owner would be reviewing and approving these changes in `pom.xml`:

* Update of dependencies submitted by *dependabot*
* Manipulation of the version number regarding the releases
* And, of course, any significant changes

@cmarchand 
Is this fine with you?