### PR TITLE
docs: update "Compilation" doc

### DIFF
--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -88,6 +88,7 @@
       <xsl:text>";&#x0A;</xsl:text>
 
       <!-- Import module to be tested -->
+      <xsl:text>(: the tested library module :)&#10;</xsl:text>
       <xsl:text>import module </xsl:text>
       <xsl:if test="exists($prefix)">
          <xsl:text>namespace </xsl:text>
@@ -103,6 +104,7 @@
       <xsl:text>";&#10;</xsl:text>
 
       <!-- Import 'test' utils -->
+      <xsl:text>(: an XSpec library module providing tools :)&#10;</xsl:text>
       <xsl:text>import module namespace test = </xsl:text>
       <xsl:text>"http://www.jenitennison.com/xslt/unit-test"</xsl:text>
       <xsl:if test="not($utils-library-at eq '#none')">
@@ -152,6 +154,8 @@
       <xsl:call-template name="x:compile-scenarios"/>
       <xsl:text>&#10;</xsl:text>
 
+      <xsl:text>(: the query body of this main module, to run the suite :)&#10;</xsl:text>
+      <xsl:text>(: set up the result document (the report) :)&#10;</xsl:text>
       <xsl:text>document {&#x0A;</xsl:text>
 
       <xsl:element name="{x:xspec-name($this,'report')}" namespace="{$xspec-namespace}">
@@ -166,6 +170,7 @@
 
          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
+         <xsl:text>      (: a call instruction for each top-level scenario :)&#10;</xsl:text>
          <xsl:call-template name="x:call-scenarios"/>
          <xsl:text>&#10;}&#10;</xsl:text>
       </xsl:element>
@@ -256,6 +261,7 @@
         declare function local:...(...)
         {
       -->
+      <xsl:text>&#10;(: generated from the x:scenario element :)</xsl:text>
       <xsl:text>&#10;declare function local:</xsl:text>
       <xsl:value-of select="$scenario-id" />
       <xsl:text>(</xsl:text>
@@ -321,6 +327,7 @@
                <xsl:text>, '</xsl:text>
                <xsl:value-of select="x:xspec-name(.,'result')" />
                <xsl:text>'),&#10;</xsl:text>
+               <xsl:text>      (: a call instruction for each x:expect element :)&#10;</xsl:text>
             </xsl:when>
             <xsl:otherwise>
                <!--
@@ -396,6 +403,7 @@
         declare function local:...($t:result as item()*)
         {
       -->
+      <xsl:text>&#10;(: generated from the x:expect element :)</xsl:text>
       <xsl:text>&#10;declare function local:</xsl:text>
       <xsl:value-of select="$expect-id" />
       <xsl:text>(</xsl:text>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -83,7 +83,7 @@
     <!-- The main compiled template. -->
     <xsl:comment> the main template to run the suite </xsl:comment>
     <template name="{x:xspec-name(.,'main')}">
-      <xsl:text>&#10;   </xsl:text><xsl:comment> info message </xsl:comment>
+      <xsl:text>&#10;      </xsl:text><xsl:comment> info message </xsl:comment>
       <message>
         <text>Testing with </text>
         <value-of select="system-property('xsl:product-name')" />

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -57,7 +57,9 @@
 
     <xsl:sequence select="x:copy-namespaces(.)" />
 
+    <xsl:text>&#10;   </xsl:text><xsl:comment> the tested stylesheet </xsl:comment>
     <import href="{$stylesheet-uri}" />
+    <xsl:comment> an XSpec stylesheet providing tools </xsl:comment>
     <import href="{resolve-uri('generate-tests-utils.xsl')}"/>
     <xsl:if test="$is-schematron">
       <import href="{resolve-uri('../schematron/sch-location-compare.xsl')}"/>
@@ -79,7 +81,9 @@
     <xsl:call-template name="x:compile-global-params-and-vars" />
 
     <!-- The main compiled template. -->
+    <xsl:comment> the main template to run the suite </xsl:comment>
     <template name="{x:xspec-name(.,'main')}">
+      <xsl:text>&#10;   </xsl:text><xsl:comment> info message </xsl:comment>
       <message>
         <text>Testing with </text>
         <value-of select="system-property('xsl:product-name')" />
@@ -89,6 +93,7 @@
 
       <!-- Use <xsl:result-document> to avoid clashes with <xsl:output> in the stylesheet
         being tested which would otherwise govern the output of the report XML. -->
+      <xsl:comment> set up the result document (the report) </xsl:comment>
       <result-document format="{x:xspec-name(.,'report')}">
         <xsl:element name="{x:xspec-name(.,'report')}" namespace="{$xspec-namespace}">
           <!-- This bit of jiggery-pokery with the $stylesheet-uri variable is so
@@ -107,6 +112,7 @@
           </xsl:if>
 
           <!-- Generate calls to the compiled top-level scenarios. -->
+          <xsl:text>&#10;            </xsl:text><xsl:comment> a call instruction for each top-level scenario </xsl:comment>
           <xsl:call-template name="x:call-scenarios"/>
         </xsl:element>
       </result-document>
@@ -401,6 +407,7 @@
             <xsl:value-of select="x:xspec-name(.,'result')" />
           </with-param>
         </call-template>
+        <xsl:comment> a call instruction for each x:expect element </xsl:comment>
       </xsl:if>
       <xsl:call-template name="x:call-scenarios"/>
     </xsl:element>

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -171,20 +171,21 @@ result as parameter.
 ```xml
 <!-- generated from the x:scenario element -->
 <xsl:template name="x:scenario1">
-  <xsl:message>scenario</xsl:message>
-  <x:scenario id="scenario1"
-              xspec=".../compilation-simple-suite.xspec">
-     <x:label>scenario</x:label>
-     <x:call>
-        <xsl:attribute name="function">my:f</xsl:attribute>
-     </x:call>
-     <xsl:variable name="x:result" as="item()*">
-        <xsl:sequence select="my:f()"/>
-     </xsl:variable>
-   ... generate scenario data in the report ...
-     <xsl:call-template name="x:scenario1-expect1">
-        <xsl:with-param name="x:result" select="$x:result"/>
-     </xsl:call-template>
+   <xsl:message>scenario</xsl:message>
+   <x:scenario id="scenario1"
+               xspec=".../compilation-simple-suite.xspec">
+      <x:label>scenario</x:label>
+      <x:call>
+         <xsl:attribute name="function">my:f</xsl:attribute>
+      </x:call>
+      <xsl:variable name="x:result" as="item()*">
+         <xsl:sequence select="my:f()"/>
+      </xsl:variable>
+      ... generate scenario data in the report ...
+      <xsl:call-template name="x:scenario1-expect1">
+         <xsl:with-param name="x:result" select="$x:result"/>
+      </xsl:call-template>
+   </x:scenario>
 </xsl:template>
 
 <!-- generated from the x:expect element -->
@@ -192,32 +193,32 @@ result as parameter.
    <xsl:param name="x:result" required="yes"/>
    <!-- expected result -->
    <xsl:variable name="impl:expect-d6e4" select="()"/>
-   <!-- wrap $x:result into a doc node if node()+ -->
-      <xsl:variable name="impl:test-items" as="item()*">
-         <xsl:choose>
-            <xsl:when test="exists($x:result) and test:wrappable-sequence($x:result)">
-               <xsl:sequence select="test:wrap-nodes($x:result)"/>
-            </xsl:when>
-            <xsl:otherwise>
-               <xsl:sequence select="$x:result"/>
-            </xsl:otherwise>
-         </xsl:choose>
-      </xsl:variable>
+   <!-- wrap $x:result into a doc node if possible -->
+   <xsl:variable name="impl:test-items" as="item()*">
+      <xsl:choose>
+         <xsl:when test="exists($x:result) and test:wrappable-sequence($x:result)">
+            <xsl:sequence select="test:wrap-nodes($x:result)"/>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:sequence select="$x:result"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:variable>
    <!-- evaluate the predicate with $x:result as context
         node if $x:result is a single node; if not, just
         evaluate the predicate -->
    <xsl:variable name="impl:test-result" as="item()*">
-     <xsl:choose>
-        <xsl:when test="count($impl:test-items) eq 1">
-           <xsl:for-each select="$impl:test-items">
-              <xsl:sequence select="$x:result = 1" version="2"/>
-           </xsl:for-each>
-        </xsl:when>
-        <xsl:otherwise>
-           <xsl:sequence select="$x:result = 1" version="2"/>
-        </xsl:otherwise>
-     </xsl:choose>
-  </xsl:variable>
+      <xsl:choose>
+         <xsl:when test="count($impl:test-items) eq 1">
+            <xsl:for-each select="$impl:test-items">
+               <xsl:sequence select="$x:result = 1" version="2"/>
+            </xsl:for-each>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:sequence select="$x:result = 1" version="2"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:variable>
    <!-- did the test pass? -->
    <xsl:variable name="impl:boolean-test"
                  as="xs:boolean"

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -25,14 +25,17 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
 ### Test suite
 
 ```xml
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-               xmlns:q="http://example.org/ns/query"
-               query="http://example.org/ns/query"
-               stylesheet="http://example.org/ns/stylesheet.xsl">
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+   xmlns:my="http://example.org/ns/my"
+   xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   stylesheet="compilation-simple-suite.xsl"
+   query="http://example.org/ns/my"
+   query-at="compilation-simple-suite.xquery">
 
    <x:scenario label="scenario">
-      <x:call function="f"/>
-      <x:expect label="expectations" test="predicate"/>
+      <x:call function="my:f"/>
+      <x:expect label="expectations" test="$x:result = 1"/>
    </x:scenario>
 
 </x:description>
@@ -41,28 +44,22 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
 ### Stylesheet
 
 ```xml
-<xsl:stylesheet xmlns:test="http://www.jenitennison.com/xslt/unit-test"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                xmlns:__x="http://www.w3.org/1999/XSL/TransformAliasAlias"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:impl="urn:x-xspec:compile:xslt:impl"
-                xmlns:q="http://example.org/ns/query"
-                version="2.0">
-
+                xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                xmlns:my="http://example.org/ns/my"
+                version="2.0"
+                exclude-result-prefixes="impl">
    <!-- the tested stylesheet -->
-   <xsl:import href="http://example.org/ns/stylesheet.xsl"/>
+   <xsl:import href=".../compilation-simple-suite.xsl"/>
    <!-- an XSpec stylesheet providing tools -->
-   <xsl:import href=".../generate-tests-utils.xsl"/>
-
-   <xsl:namespace-alias stylesheet-prefix="__x" result-prefix="xsl"/>
-
+   <xsl:import href=".../xspec/src/compiler/generate-tests-utils.xsl"/>
+   <xsl:include href=".../xspec/src/common/xspec-utils.xsl"/>
    <xsl:output name="x:report" method="xml" indent="yes"/>
-
-   <!-- the tested stylesheet -->
-   <xsl:variable name="x:stylesheet-uri" as="xs:string"
-                 select="'http://example.org/ns/stylesheet.xsl'"/>
-
+   <xsl:variable name="x:xspec-uri" as="xs:anyURI">.../compilation-simple-suite.xspec</xsl:variable>
    <!-- the main template to run the suite -->
    <xsl:template name="x:main">
       <!-- info message -->
@@ -72,29 +69,28 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
          <xsl:text> </xsl:text>
          <xsl:value-of select="system-property('xsl:product-version')"/>
       </xsl:message>
-      <!-- setup the result document (the report) -->
+      <!-- set up the result document (the report) -->
       <xsl:result-document format="x:report">
-         <xsl:processing-instruction name="xml-stylesheet">
-            <xsl:text>type="text/xsl" href=".../format-xspec-report.xsl"</xsl:text>
-         </xsl:processing-instruction>
-         <x:report stylesheet="{ $x:stylesheet-uri }" date="{ current-dateTime() }">
+         <x:report stylesheet=".../compilation-simple-suite.xsl"
+                   date="{current-dateTime()}"
+                   xspec=".../compilation-simple-suite.xspec">
             <!-- a call instruction for each top-level scenario -->
-            <xsl:call-template name="x:d4e2"/>
+            <xsl:call-template name="x:scenario1"/>
          </x:report>
       </xsl:result-document>
    </xsl:template>
 
    <!-- generated from the x:scenario element -->
-   <xsl:template name="x:d4e2">
+   <xsl:template name="x:scenario1">
       ...
       <!-- a call instruction for each x:expect element -->
-      <xsl:call-template name="x:d4e4">
+      <xsl:call-template name="x:scenario1-expect1">
          ...
       </xsl:call-template>
    </xsl:template>
 
    <!-- generated from the x:expect element -->
-   <xsl:template name="x:d4e4">
+   <xsl:template name="x:scenario1-expect1">
       ...
    </xsl:template>
 
@@ -105,36 +101,48 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
 
 ```xquery
 (: the tested library module :)
-import module namespace q = "http://example.org/ns/query";
+import module namespace my = "http://example.org/ns/my"
+  at ".../compilation-simple-suite.xquery";
 (: an XSpec library module providing tools :)
 import module namespace test = "http://www.jenitennison.com/xslt/unit-test"
-  at ".../generate-query-utils.xql";
+  at ".../src/compiler/generate-query-utils.xql";
+import module "http://www.jenitennison.com/xslt/xspec"
+  at ".../src/common/xspec-utils.xquery";
 
 declare namespace x = "http://www.jenitennison.com/xslt/xspec";
 
 (: generated from the x:scenario element :)
-declare function local:d4e2()
+declare function local:scenario1()
 {
   ...
   (: a call instruction for each x:expect element :)
-  local:d4e4($x:result)
+  let $x:tmp := local:scenario1-expect1($x:result) return (
+    $x:tmp
+  )
+
   ...
 };
 
 (: generated from the x:expect element :)
-declare function local:d4e4($x:result as item()*)
+declare function local:scenario1-expect1($x:result)
 {
   ...
 };
 
 (: the query body of this main module, to run the suite :)
-(: setup the result document (the report) :)
+(: set up the result document (the report) :)
+document {
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2010-01-28T22:45:03.649+01:00"
-          query="http://example.org/ns/query">
-{
-  (: a call instruction for each top-level scenario :)
-  local:d4e2()
+          xmlns:my="http://example.org/ns/my"
+          date="{current-dateTime()}"
+          query="http://example.org/ns/my"
+          query-at=".../compilation-simple-suite.xquery"
+          xspec=".../compilation-simple-suite.xspec"> {
+      (: a call instruction for each top-level scenario :)
+      let $x:tmp := local:scenario1() return (
+        $x:tmp
+      )
+
 }
 </x:report>
 ```
@@ -153,8 +161,8 @@ result as parameter.
 
 ```xml
 <x:scenario label="scenario">
-   <x:call function="f"/>
-   <x:expect label="expectations" test="predicate"/>
+   <x:call function="my:f"/>
+   <x:expect label="expectations" test="$x:result = 1"/>
 </x:scenario>
 ```
 
@@ -162,58 +170,61 @@ result as parameter.
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template name="x:d4e2">
-   <x:call function="f"/>
-   <xsl:variable name="x:result" as="item()*">
-      <xsl:sequence select="f()"/>
-   </xsl:variable>
+<xsl:template name="x:scenario1">
+  <xsl:message>scenario</xsl:message>
+  <x:scenario id="scenario1"
+              xspec=".../compilation-simple-suite.xspec">
+     <x:label>scenario</x:label>
+     <x:call>
+        <xsl:attribute name="function">my:f</xsl:attribute>
+     </x:call>
+     <xsl:variable name="x:result" as="item()*">
+        <xsl:sequence select="my:f()"/>
+     </xsl:variable>
    ... generate scenario data in the report ...
-   <xsl:call-template name="x:d4e4">
-      <xsl:with-param name="x:result" select="$x:result"/>
-   </xsl:call-template>
+     <xsl:call-template name="x:scenario1-expect1">
+        <xsl:with-param name="x:result" select="$x:result"/>
+     </xsl:call-template>
 </xsl:template>
 
 <!-- generated from the x:expect element -->
-<xsl:template name="x:d4e4">
+<xsl:template name="x:scenario1-expect1">
    <xsl:param name="x:result" required="yes"/>
-   <!-- expected result (none here) -->
-   <xsl:variable name="impl:expected" select="()"/>
+   <!-- expected result -->
+   <xsl:variable name="impl:expect-d6e4" select="()"/>
    <!-- wrap $x:result into a doc node if node()+ -->
-   <xsl:variable name="impl:test-items" as="item()*">
-      <xsl:choose>
-         <xsl:when test="$x:result instance of node()+">
-            <xsl:document>
-               <xsl:copy-of select="$x:result"/>
-            </xsl:document>
-         </xsl:when>
-         <xsl:otherwise>
-            <xsl:sequence select="$x:result"/>
-         </xsl:otherwise>
-      </xsl:choose>
-   </xsl:variable>
+      <xsl:variable name="impl:test-items" as="item()*">
+         <xsl:choose>
+            <xsl:when test="exists($x:result) and test:wrappable-sequence($x:result)">
+               <xsl:sequence select="test:wrap-nodes($x:result)"/>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:sequence select="$x:result"/>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:variable>
    <!-- evaluate the predicate with $x:result as context
-        node if $x:result is a single node, if not just
+        node if $x:result is a single node; if not, just
         evaluate the predicate -->
    <xsl:variable name="impl:test-result" as="item()*">
-      <xsl:choose>
-         <xsl:when test="count($impl:test-items) eq 1">
-            <xsl:for-each select="$impl:test-items">
-               <xsl:sequence select="predicate" version="2"/>
-            </xsl:for-each>
-         </xsl:when>
-         <xsl:otherwise>
-            <xsl:sequence select="predicate" version="2"/>
-         </xsl:otherwise>
-      </xsl:choose>
-   </xsl:variable>
+     <xsl:choose>
+        <xsl:when test="count($impl:test-items) eq 1">
+           <xsl:for-each select="$impl:test-items">
+              <xsl:sequence select="$x:result = 1" version="2"/>
+           </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+           <xsl:sequence select="$x:result = 1" version="2"/>
+        </xsl:otherwise>
+     </xsl:choose>
+  </xsl:variable>
    <!-- did the test pass? -->
-   <xsl:variable name="impl:boolean-test" as="xs:boolean"
+   <xsl:variable name="impl:boolean-test"
+                 as="xs:boolean"
                  select="$impl:test-result instance of xs:boolean"/>
-   <xsl:variable name="impl:successful" as="xs:boolean" select="
-       if ( $impl:boolean-test ) then
-         $impl:test-result
-       else
-         test:deep-equal($impl:expected, $impl:test-result, 2)"/>
+   <xsl:variable name="impl:successful"
+                 as="xs:boolean"
+                 select="if ($impl:boolean-test) then  boolean($impl:test-result) else test:deep-equal($impl:expect-d6e4, $impl:test-result, '')"/>
    ... generate test result in the report ...
 </xsl:template>
 ```
@@ -222,30 +233,36 @@ result as parameter.
 
 ```xquery
 (: generated from the x:scenario element :)
-declare function local:d4e2()
+declare function local:scenario1()
 {
   ... generate scenario data in the report ...
-  let $x:result := f()
+  let $x:result := (
+    my:f()
+  )
     return (
-      local:d4e4($x:result)
+      test:report-sequence($x:result, 'x:result'),
+      let $x:tmp := local:scenario1-expect1($x:result) return (
+        $x:tmp
+      )
     )
 };
 
 (: generated from the x:expect element :)
-declare function local:d4e4($x:result as item()*)
+declare function local:scenario1-expect1($x:result)
 {
-  let $local:expected    :=                  (: expected result (none here) :)
-      (  )
-  let $local:test-result :=                  (: evaluate the predicate :)
-      if ( $x:result instance of node() ) then
-        $x:result/( predicate )
-      else
-        ( predicate )
-  let $local:successful  :=                  (: did the test pass?:)
-      if ( $local:test-result instance of xs:boolean ) then
-        $local:test-result
-      else
-        test:deep-equal($local:expected, $local:test-result)
+  let $local:expect-d6e4 := (: expected result (none here) :)
+      ( () )
+  let $local:test-items as item()* := $x:result
+  let $local:test-result as item()* := (: evaluate the predicate :)
+      ($x:result = 1)
+
+  let $local:boolean-test as xs:boolean :=
+    ($local:test-result instance of xs:boolean)
+  let $local:successful as xs:boolean := (: did the test pass? :) (
+    if ($local:boolean-test)
+    then boolean($local:test-result)
+    else test:deep-equal($local:expect-d6e4, $local:test-result, '')
+  )
     return
       ... generate test result in the report ...
 };
@@ -269,7 +286,7 @@ template or an XPath function. `x:context` also represents applying
 a template rule to a node, but in a different way than `x:apply`:
 the former represents more a full transform (e.g., the result is
 always one document node) where `x:apply` is exactly the result of a
-template rule (the result is the exact result sequence or the
+template rule (the result is the exact result sequence of the
 rule).
 
 Those examples show only what is related to the call of the SUT in
@@ -291,7 +308,7 @@ section "[Simple scenario](#simple-scenario)").
 </x:apply>
 
 <!-- call a function -->
-<x:call function="f">
+<x:call function="my:f">
    <x:param select="val1"/>
    <x:param name="p2" as="element()">
       <val2/>
@@ -300,7 +317,7 @@ section "[Simple scenario](#simple-scenario)").
 
 <!-- call a named template -->
 <x:call template="t">
-   <x:param name="p1" select="val"/>
+   <x:param name="p1" select="val1"/>
    <x:param name="p2">
       <val2/>
    </x:param>
@@ -331,18 +348,32 @@ section "[Simple scenario](#simple-scenario)").
 </xsl:variable>
 
 <xsl:variable name="x:result" as="item()*">
-   <xsl:variable name="..." select="val"/>
+   <xsl:variable name="..." select="val1"/>
+   <xsl:variable name="...-doc" as="document-node()">
+      <xsl:document>
+         <val2/>
+      </xsl:document>
+   </xsl:variable>
    <xsl:variable name="p2" as="element()">
-      <val2/>
-   </xsl:with-param>
-   <xsl:sequence select="f($..., $p2)"/>
+      <xsl:for-each select="$...-doc">
+         <xsl:sequence select="node()"/>
+      </xsl:for-each>
+   </xsl:variable>
+   <xsl:sequence select="my:f($..., $p2)"/>
 </xsl:variable>
 
 <xsl:variable name="x:result" as="item()*">
-   <xsl:variable name="p1" select="val"/>
+   <xsl:variable name="p1" select="val1"/>
+   <xsl:variable name="...-doc" as="document-node()">
+      <xsl:document>
+         <val2/>
+      </xsl:document>
+   </xsl:variable>
    <xsl:variable name="p2" as="item()*">
-      <val2/>
-   </xsl:with-param>
+      <xsl:for-each select="$...-doc">
+         <xsl:sequence select="node()"/>
+      </xsl:for-each>
+   </xsl:variable>
    <xsl:call-template name="t">
       <xsl:with-param name="p1" select="$p1"/>
       <xsl:with-param name="p2" select="$p2"/>
@@ -350,20 +381,30 @@ section "[Simple scenario](#simple-scenario)").
 </xsl:variable>
 
 <xsl:variable name="x:result" as="item()*">
-   <xsl:variable name="context-doc" as="document-node()">
+   <xsl:variable name="...-doc" as="document-node()">
       <xsl:document>
          <elem/>
       </xsl:document>
    </xsl:variable>
-   <xsl:variable name="context" select="$context-doc/node()"/>
-   <xsl:apply-templates select="$context"/>
+   <xsl:variable name="..." as="item()*">
+      <xsl:for-each select="$...-doc">
+         <xsl:sequence select="node()"/>
+      </xsl:for-each>
+   </xsl:variable>
+   <xsl:apply-templates select="$..."/>
 </xsl:variable>
 ```
 
 ### Query
 
 ```
-TODO: ...
+let $local:param-... := ( val1 )
+let $local:param-...-doc as document-node() := ( document { <val2 xmlns:my="http://example.org/ns/my">{ () }
+</val2> } )
+let $p2 as element() := ( $local:param-...-doc ! ( node() ) )
+let $x:result := (
+  my:f($local:param-..., $p2)
+)
 ```
 
 ## Variables
@@ -386,25 +427,25 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template name="x:d4e2">
+<xsl:template name="x:scenario1">
    <!-- the generated variable -->
    <xsl:variable name="myv:var" select="'value'"/>
    <xsl:variable name="x:result" as="item()*">
       ... exercise the SUT ...
    </xsl:variable>
    ...
-   <xsl:call-template name="x:d4e4">
+   <xsl:call-template name="x:scenario1-expect1">
       <xsl:with-param name="x:result" select="$x:result"/>
       <xsl:with-param name="myv:var" select="$myv:var"/>
    </xsl:call-template>
 </xsl:template>
 
 <!-- generated from the x:expect element -->
-<xsl:template name="x:d4e4">
+<xsl:template name="x:scenario1-expect1">
    <xsl:param name="x:result" required="yes"/>
    <xsl:param name="myv:var" required="yes"/>
    <!-- evaluate the expectation -->
-   <xsl:variable name="impl:expected" ...>
+   <xsl:variable name="impl:expect-d6e8" ...>
    <xsl:variable name="impl:test-items" ...>
    <xsl:variable name="impl:test-result" ...>
    <xsl:variable name="impl:boolean-test" ...>
@@ -418,14 +459,14 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 
 ```xquery
 (: generated from the x:scenario element :)
-declare function local:d4e2()
+declare function local:scenario1()
 {
   let $myv:var := ( 'value' )        (: the generated variable :)
   ...
   let $x:result := ... exercise the SUT ...
     return (
       ...,
-      let $x:tmp := local:d4e4($x:result, $myv:var) return (
+      let $x:tmp := local:scenario1-expect1($x:result, $myv:var) return (
         $x:tmp
       )
     )
@@ -433,9 +474,9 @@ declare function local:d4e2()
 };
 
 (: generated from the x:expect element :)
-declare function local:d4e4($x:result, $myv:var)
+declare function local:scenario1-expect1($x:result, $myv:var)
 {
-  let $local:expected    :=  ... (: expected result :)
+  let $local:expect-d6e8    :=  ... (: expected result :)
   let $local:test-items as item()* := ...
   let $local:test-result as item()* := ...
   let $local:boolean-test as xs:boolean :=  ...
@@ -472,21 +513,27 @@ this accessibility.
 
 ```xml
 <xsl:variable name="myv:select" select="'value'"/>
+
 <xsl:variable name="myv:href-doc"
               as="document-node()"
               select="doc('.../test-data.xml')"/>
+<xsl:variable name="impl:variable-d6e6-uri" as="xs:anyURI">.../test-data.xml</xsl:variable>
+<xsl:variable name="impl:variable-d6e6-doc"
+              as="document-node()"
+              select="doc($impl:variable-d6e6-uri)"/>
 <xsl:variable name="myv:href" as="item()*">
-   <xsl:for-each select="$myv:href-doc">
+   <xsl:for-each select="$impl:variable-d6e6-doc">
       <xsl:sequence select="."/>
    </xsl:for-each>
 </xsl:variable>
-<xsl:variable name="myv:content-doc" as="document-node()">
+
+<xsl:variable name="impl:variable-d6e7-doc" as="document-node()">
    <xsl:document>
       <elem/>
    </xsl:document>
 </xsl:variable>
 <xsl:variable name="myv:content" as="element()">
-   <xsl:for-each select="$myv:content-doc">
+   <xsl:for-each select="$impl:variable-d6e7-doc">
       <xsl:sequence select="node()"/>
    </xsl:for-each>
 </xsl:variable>
@@ -496,11 +543,12 @@ this accessibility.
 
 ```xquery
 let $myv:select := ( 'value' )
-let $myv:href-doc as document-node() := ( doc('.../test-data.xml') )
-let $myv:href := ( $myv:href-doc ! ( . ) )
-let $myv:content-doc as document-node() := ( document { <elem xmlns:...>{ () }
+let $local:variable-d6e6-uri as xs:anyURI := ( xs:anyURI(".../test-data.xml") )
+let $local:variable-d6e6-doc as document-node() := ( doc($local:variable-d6e6-uri) )
+let $myv:href := ( $local:variable-d6e6-doc ! ( . ) )
+let $local:variable-d6e7-doc as document-node() := ( document { <elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
 </elem> } )
-let $myv:content as element() := ( $myv:content-doc ! ( node() ) )
+let $myv:content as element() := ( $local:variable-d6e7-doc ! ( node() ) )
 ```
 
 ## Variables scope
@@ -529,7 +577,7 @@ and functions in XQuery).
    <x:variable name="myv:var-1" ...>
    <x:scenario label="inner">
       <x:variable name="myv:var-2" ...>
-      <x:call function="f"/>
+      <x:call function="my:f"/>
       <x:variable name="myv:var-3" ...>
       <x:expect label="expect one" ...>
       <x:variable name="myv:var-4" ...>
@@ -544,29 +592,29 @@ and functions in XQuery).
 <xsl:variable name="myv:global" ...>
 
 <!-- generated from the scenario outer -->
-<xsl:template name="x:d4e2">
+<xsl:template name="x:scenario1">
    <!-- the generated variable -->
    <xsl:variable name="myv:var-1" ...>
    ...
-   <xsl:call-template name="x:d4e3">
+   <xsl:call-template name="x:scenario1-scenario1">
       <!-- pass the variable to inner context -->
       <xsl:with-param name="myv:var-1" select="$myv:var-1"/>
    </xsl:call-template>
 </xsl:template>
 
 <!-- generated from the scenario inner -->
-<xsl:template name="x:d4e3">
+<xsl:template name="x:scenario1-scenario1">
    <!-- the variable is passed as param -->
    <xsl:param name="myv:var-1" required="yes" ...>
    <!-- the generated variable -->
    <xsl:variable name="myv:var-2" ...>
    <xsl:variable name="x:result" as="item()*">
-      <xsl:sequence select="f()"/>
+      <xsl:sequence select="my:f()"/>
    </xsl:variable>
    ...
    <!-- the generated variable -->
    <xsl:variable name="myv:var-3" ...>
-   <xsl:call-template name="x:d4e4">
+   <xsl:call-template name="x:scenario1-scenario1-expect1">
       <xsl:with-param name="x:result"  select="$x:result"/>
       <xsl:with-param name="myv:var-1" select="$myv:var-1"/>
       <xsl:with-param name="myv:var-2" select="$myv:var-2"/>
@@ -574,7 +622,7 @@ and functions in XQuery).
    </xsl:call-template>
    <!-- the generated variable -->
    <xsl:variable name="myv:var-4" ...>
-   <xsl:call-template name="x:d4e5">
+   <xsl:call-template name="x:scenario1-scenario1-expect2">
       <xsl:with-param name="x:result"  select="$x:result"/>
       <xsl:with-param name="myv:var-1" select="$myv:var-1"/>
       <xsl:with-param name="myv:var-2" select="$myv:var-2"/>
@@ -584,7 +632,7 @@ and functions in XQuery).
 </xsl:template>
 
 <!-- generated from the expect one -->
-<xsl:template name="x:d4e4">
+<xsl:template name="x:scenario1-scenario1-expect1">
    <xsl:param name="x:result" required="yes"/>
    <!-- the variables are passed as param -->
    <xsl:param name="myv:var-1" required="yes" ...>
@@ -594,7 +642,7 @@ and functions in XQuery).
 </xsl:template>
 
 <!-- generated from the expect two -->
-<xsl:template name="x:d4e5">
+<xsl:template name="x:scenario1-scenario1-expect2">
    <xsl:param name="x:result" required="yes"/>
    <!-- the variables are passed as param -->
    <xsl:param name="myv:var-1" required="yes" ...>
@@ -608,14 +656,14 @@ and functions in XQuery).
 ### Query
 
 ```xquery
-declare variable $global := ...;
+declare variable $myv:global := ...;
 
 (: generated from the scenario outer :)
-declare function local:d4e2()
+declare function local:scenario1()
 {
   ...
   let $myv:var-1 := ...
-  let $x:tmp := local:d4e3($myv:var-1)
+  let $x:tmp := local:scenario1-scenario1($myv:var-1)
     return (
       $x:tmp
     )
@@ -623,7 +671,7 @@ declare function local:d4e2()
 };
 
 (: generated from the scenario inner :)
-declare function local:d4e3($myv:var-1) (: $myv:var-1 can have an "as" clause :)
+declare function local:scenario1-scenario1($myv:var-1) (: $myv:var-1 can have an "as" clause :)
 {
   ...
   let $myv:var-2        := ...
@@ -632,10 +680,10 @@ declare function local:d4e3($myv:var-1) (: $myv:var-1 can have an "as" clause :)
     return (
       ...,
       let $myv:var-3 := ...
-      let $x:tmp := local:d4e4($x:result, $myv:var-1, $myv:var-2, $myv:var-3) return (
+      let $x:tmp := local:scenario1-scenario1-expect1($x:result, $myv:var-1, $myv:var-2, $myv:var-3) return (
         $x:tmp,
         let $myv:var-4 := ...
-        let $x:tmp := local:d4e5($x:result, $myv:var-1, $myv:var-2, $myv:var-3, $myv:var-4) return (
+        let $x:tmp := local:scenario1-scenario1-expect2($x:result, $myv:var-1, $myv:var-2, $myv:var-3, $myv:var-4) return (
           $x:tmp
         )
       )
@@ -643,13 +691,13 @@ declare function local:d4e3($myv:var-1) (: $myv:var-1 can have an "as" clause :)
 };
 
 (: generated from the expect one :)
-declare function local:d4e4($x:result as item()*, $myv:var-1, $myv:var-2, $myv:var-3)
+declare function local:scenario1-scenario1-expect1($x:result as item()*, $myv:var-1, $myv:var-2, $myv:var-3)
 {
   ...evaluate the expectations ...
 };
 
 (: generated from the expect two :)
-declare function local:d4e5($x:result as item()*, $myv:var-1, $myv:var-2, $myv:var-3, $myv:var-4)
+declare function local:scenario1-scenario1-expect2($x:result as item()*, $myv:var-1, $myv:var-2, $myv:var-3, $myv:var-4)
 {
   ...evaluate the expectations ...
 };

--- a/tutorial/under-the-hood/compilation-simple-suite.xquery
+++ b/tutorial/under-the-hood/compilation-simple-suite.xquery
@@ -1,0 +1,8 @@
+module namespace my = "http://example.org/ns/my";
+
+(: Example in Compilation.md, under "Simple suite" :)
+
+declare function my:f() as xs:integer
+{
+  xs:integer(1)
+};

--- a/tutorial/under-the-hood/compilation-simple-suite.xsl
+++ b/tutorial/under-the-hood/compilation-simple-suite.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:my="http://example.org/ns/my"
+  version="3.0">
+  <!-- Example in Compilation.md, under "Simple suite" -->
+
+  <xsl:function name="my:f">
+    <xsl:sequence select="1"/>
+  </xsl:function>
+</xsl:stylesheet>

--- a/tutorial/under-the-hood/compilation-simple-suite.xspec
+++ b/tutorial/under-the-hood/compilation-simple-suite.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+   xmlns:my="http://example.org/ns/my"
+   xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   stylesheet="compilation-simple-suite.xsl"
+   query="http://example.org/ns/my"
+   query-at="compilation-simple-suite.xquery">
+
+   <!-- Example in Compilation.md, under "Simple suite" -->
+   <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->
+
+   <x:scenario label="scenario">
+      <x:call function="my:f"/>
+      <x:expect label="expectations" test="$x:result = 1"/>
+   </x:scenario>
+
+</x:description>

--- a/tutorial/under-the-hood/compilation-sut.xquery
+++ b/tutorial/under-the-hood/compilation-sut.xquery
@@ -1,0 +1,7 @@
+module namespace my = "http://example.org/ns/my";
+
+(: Example in Compilation.md, under "SUT" :)
+declare function my:f($p1, $p2) as xs:boolean
+{
+  true()
+};

--- a/tutorial/under-the-hood/compilation-sut.xsl
+++ b/tutorial/under-the-hood/compilation-sut.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:my="http://example.org/ns/my"
+  version="3.0">
+   <!-- Example in Compilation.md, under "SUT" -->
+
+   <xsl:function name="my:f">
+      <xsl:param name="p1"/>
+      <xsl:param name="p2"/>
+      <xsl:sequence select="true()"/>
+   </xsl:function>
+
+   <xsl:template name="t">
+      <xsl:param name="p1"/>
+      <xsl:param name="p2"/>
+      <xsl:sequence select="true()"/>
+   </xsl:template>
+
+   <xsl:template match="elem">
+      <xsl:sequence select="true()"/>
+   </xsl:template>
+</xsl:stylesheet>

--- a/tutorial/under-the-hood/compilation-sut_query.xspec
+++ b/tutorial/under-the-hood/compilation-sut_query.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- galtm: NOT DONE YET -->
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   xmlns:my="http://example.org/ns/my"
+   query="http://example.org/ns/my"
+   query-at="compilation-sut.xquery">
+
+   <!-- Example in Compilation.md, under "SUT" -->
+   <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->
+
+   <x:scenario label="call a function">
+      <x:call function="my:f">
+         <x:param select="val1"/>
+         <x:param name="p2" as="element()">
+            <val2/>
+         </x:param>
+      </x:call>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+
+</x:description>

--- a/tutorial/under-the-hood/compilation-sut_stylesheet.xspec
+++ b/tutorial/under-the-hood/compilation-sut_stylesheet.xspec
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   xmlns:my="http://example.org/ns/my"
+   stylesheet="compilation-sut.xsl">
+
+   <!-- Example in Compilation.md, under "SUT" -->
+   <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->
+
+<!-- x:apply is not implemented or in the schema yet.
+   <x:scenario label="apply template rules on a node (with x:apply)">
+      <x:variable name="ctxt">
+         <elem/>
+      </x:variable>
+      <x:apply select="$ctxt" mode="mode">
+         <x:param name="p1" select="val1" tunnel="yes"/>
+         <x:param name="p2" as="element()">
+            <val2/>
+         </x:param>
+      </x:apply>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+-->
+
+   <x:scenario label="call a function">
+      <x:call function="my:f">
+         <x:param select="val1"/>
+         <x:param name="p2" as="element()">
+            <val2/>
+         </x:param>
+      </x:call>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+
+   <x:scenario label="call a named template">
+      <x:call template="t">
+         <x:param name="p1" select="val1"/>
+         <x:param name="p2">
+            <val2/>
+         </x:param>
+      </x:call>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+   
+   <x:scenario label="apply template rules on a node (with x:context)">
+      <x:context>
+         <elem/>
+      </x:context>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+   
+  
+
+</x:description>


### PR DESCRIPTION
As mentioned in #797 and #505, the Compilation wiki needed some updates. This pull request has these pieces:

- (738ffeb) Update sample code in Compilation wiki.
- (82b7eaa) Commit some code files that represent the sample code in the wiki. These files should make future updates easier.
- (4e52abf) Modify compiler so high-level comments in the Compilation wiki's sample code actually appear in the compiled stylesheet and query files.

Regarding the last piece: I didn't try to be comprehensive, because automating the wiki updates too much could be counterproductive. It's useful for a person to look over the code, decide where to replace code with "..." for clarity in the example, and make sure the comments are still accurate as the compiler evolves.
