### PR TITLE
ci: remove dist from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 language: java
-dist: trusty
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ os: linux
 language: java
 
 jdk:
-  - oraclejdk8
+  # 'oraclejdk8' needs 'dist: trusty' (xspec/xspec#585)
+  - openjdk8
   - openjdk11
 
 env:


### PR DESCRIPTION
This pull request stops specifying an old version of Ubuntu in `.travis.yml`