### PR TITLE
test: refactor expressions in test/**/*.xsl with XPath 3

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -212,7 +212,7 @@
 
 						<xsl:variable as="xs:string*" name="saxon-custom-options">
 							<xsl:if test="$NOW">
-								<xsl:sequence select="concat('-now:', $NOW)" />
+								<xsl:sequence select="'-now:' || $NOW" />
 							</xsl:if>
 
 							<xsl:sequence

--- a/test/end-to-end/ant/base/worker/generate.xsl
+++ b/test/end-to-end/ant/base/worker/generate.xsl
@@ -30,9 +30,9 @@
 
 		<!-- Directory URIs where the XSpec report files are put -->
 		<xsl:variable as="xs:anyURI" name="actual-reports-dir-uri"
-			select="resolve-uri(concat('actual__/', name(), '/'), $XSPECFILES-DIR-URI)" />
+			select="resolve-uri(('actual__/' || name() || '/'), $XSPECFILES-DIR-URI)" />
 		<xsl:variable as="xs:anyURI" name="expected-reports-dir-uri"
-			select="resolve-uri(concat('expected/', name(), '/'), $XSPECFILES-DIR-URI)" />
+			select="resolve-uri(('expected/' || name() || '/'), $XSPECFILES-DIR-URI)" />
 
 		<!-- Get the file name without extension. i.e. Get "foo" from "scheme://host/dir/foo.xspec" -->
 		<xsl:variable as="xs:string" name="xspec-file-name-without-extension"
@@ -43,14 +43,14 @@
 			<reports>
 				<!-- XML -->
 				<xsl:variable as="xs:string" name="xml-file-name"
-					select="concat($xspec-file-name-without-extension, '-result.xml')" />
+					select="$xspec-file-name-without-extension || '-result.xml'" />
 				<xml actual="{resolve-uri($xml-file-name, $actual-reports-dir-uri)}"
 					expected="{resolve-uri($xml-file-name, $expected-reports-dir-uri)}"
 					processor-dir="{resolve-uri('xml/', $processor-dir-uri)}" />
 
 				<!-- HTML -->
 				<xsl:variable as="xs:string" name="html-file-name"
-					select="concat($xspec-file-name-without-extension, '-result.html')" />
+					select="$xspec-file-name-without-extension || '-result.html'" />
 				<html actual="{resolve-uri($html-file-name, $actual-reports-dir-uri)}"
 					expected="{resolve-uri($html-file-name, $expected-reports-dir-uri)}"
 					processor-dir="{resolve-uri('html/', $processor-dir-uri)}" />
@@ -58,7 +58,7 @@
 				<!-- Coverage -->
 				<xsl:if test="$coverage-enabled">
 					<xsl:variable as="xs:string" name="coverage-file-name"
-						select="concat($xspec-file-name-without-extension, '-coverage.html')" />
+						select="$xspec-file-name-without-extension || '-coverage.html'" />
 					<coverage actual="{resolve-uri($coverage-file-name, $actual-reports-dir-uri)}"
 						expected="{resolve-uri($coverage-file-name, $expected-reports-dir-uri)}"
 						processor-dir="{resolve-uri('coverage/', $processor-dir-uri)}" />
@@ -66,7 +66,7 @@
 
 				<!-- JUnit -->
 				<xsl:variable as="xs:string" name="junit-file-name"
-					select="concat($xspec-file-name-without-extension, '-junit.xml')" />
+					select="$xspec-file-name-without-extension || '-junit.xml'" />
 				<junit actual="{resolve-uri($junit-file-name, $actual-reports-dir-uri)}"
 					expected="{resolve-uri($junit-file-name, $expected-reports-dir-uri)}"
 					processor-dir="{resolve-uri('junit/', $processor-dir-uri)}" />

--- a/test/end-to-end/ant/base/worker/generate.xsl
+++ b/test/end-to-end/ant/base/worker/generate.xsl
@@ -30,9 +30,13 @@
 
 		<!-- Directory URIs where the XSpec report files are put -->
 		<xsl:variable as="xs:anyURI" name="actual-reports-dir-uri"
-			select="resolve-uri(('actual__/' || name() || '/'), $XSPECFILES-DIR-URI)" />
+			select="
+				('actual__/' || name() || '/')
+				=> resolve-uri($XSPECFILES-DIR-URI)" />
 		<xsl:variable as="xs:anyURI" name="expected-reports-dir-uri"
-			select="resolve-uri(('expected/' || name() || '/'), $XSPECFILES-DIR-URI)" />
+			select="
+				('expected/' || name() || '/')
+				=> resolve-uri($XSPECFILES-DIR-URI)" />
 
 		<!-- Get the file name without extension. i.e. Get "foo" from "scheme://host/dir/foo.xspec" -->
 		<xsl:variable as="xs:string" name="xspec-file-name-without-extension"

--- a/test/end-to-end/processor/base/_normalizer.xsl
+++ b/test/end-to-end/processor/base/_normalizer.xsl
@@ -78,7 +78,7 @@
 		<xsl:variable as="xs:integer" name="first-index" select="index-of($uris, $this-uri)[1]" />
 
 		<xsl:attribute name="{local-name()}" namespace="{namespace-uri()}"
-			select="concat(upper-case(local-name()), '-', $first-index)" />
+			select="upper-case(local-name()) || '-' || $first-index" />
 	</xsl:template>
 
 	<!--

--- a/test/end-to-end/processor/base/compare.xsl
+++ b/test/end-to-end/processor/base/compare.xsl
@@ -64,9 +64,8 @@
 			<!-- Save the normalized input document -->
 			<xsl:variable as="xs:anyURI" name="save-normalized-input-uri"
 				select="
-					resolve-uri(
-					(x:filename-without-extension($input-doc-uri) || '-norm' || x:extension-without-filename($input-doc-uri)),
-					$input-doc-uri)" />
+					(x:filename-without-extension($input-doc-uri) || '-norm' || x:extension-without-filename($input-doc-uri))
+					=> resolve-uri($input-doc-uri)" />
 			<xsl:result-document format="serializer:output" href="{$save-normalized-input-uri}">
 				<xsl:sequence select="$normalized-input-doc" />
 			</xsl:result-document>

--- a/test/end-to-end/processor/base/compare.xsl
+++ b/test/end-to-end/processor/base/compare.xsl
@@ -65,7 +65,7 @@
 			<xsl:variable as="xs:anyURI" name="save-normalized-input-uri"
 				select="
 					resolve-uri(
-					concat(x:filename-without-extension($input-doc-uri), '-norm', x:extension-without-filename($input-doc-uri)),
+					(x:filename-without-extension($input-doc-uri) || '-norm' || x:extension-without-filename($input-doc-uri)),
 					$input-doc-uri)" />
 			<xsl:result-document format="serializer:output" href="{$save-normalized-input-uri}">
 				<xsl:sequence select="$normalized-input-doc" />

--- a/test/override-id/generate-xspec-tests.xsl
+++ b/test/override-id/generate-xspec-tests.xsl
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<xsl:import href="../../src/compiler/generate-xspec-tests.xsl" />
 
 	<xsl:template match="x:scenario" as="xs:string" mode="x:generate-id">
-		<xsl:sequence select="concat('overridden-scenario-id-', generate-id())" />
+		<xsl:sequence select="'overridden-scenario-id-' || generate-id()" />
 	</xsl:template>
 
 	<xsl:template match="x:expect" as="xs:string" mode="x:generate-id">
-		<xsl:sequence select="concat('overridden-expect-id-', generate-id())" />
+		<xsl:sequence select="'overridden-expect-id-' || generate-id()" />
 	</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This pull request just simplifies some expressions in `test/**/*.xsl`.