### PR TITLE
fix(report): plain report hint mark

### DIFF
--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -319,7 +319,7 @@
 
     <div class="xTestReportHint">
       <a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank"
-        title="What does this report mean?">&#x2754;</a>
+        title="What does this report mean?">[?]</a>
     </div>
 
     <!-- True if the expectation is boolean (i.e. x:expect/@test was an xs:boolean at runtime.) -->

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -541,7 +541,6 @@ span.scenario-totals {
 }
 .xTestReportHint {
 	grid-area: hint;
-	text-shadow: 1px 2px 3px gray;
 }
 .xspecResult {
 	grid-area: table;

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -74,7 +74,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -118,7 +118,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -162,7 +162,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-151-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-151-result.html
@@ -60,7 +60,7 @@
             <h3>When the result is a mixture of a typed element and a string</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] in the failure report HTML must wrap element and string separately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-153-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-153-result.html
@@ -64,7 +64,7 @@
             <h3>When a function returns a local date time string</h3>
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Comparing the function result with a different date time will report Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-177-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-177-result.html
@@ -70,7 +70,7 @@
                <h4 class="xTestReportTitle">When @test is "empty($x:result/self::element(foo))" (i.e. boolean), then the HTML
                   report should be "Result" = "&lt;foo /&gt;" and "Expecting" = "empty($x:result/self::element(foo))"
                   without diff.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -95,7 +95,7 @@
                <h4 class="xTestReportTitle">When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non
                   boolean), then the HTML report should be "Result" = "&lt;foo /&gt;" and "Expected Result"
                   = "&lt;bar /&gt;" with diff.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-346-result.html
@@ -60,7 +60,7 @@
             <h3>When a function returns a node containing a space</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting no space should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-355-result.html
@@ -67,7 +67,7 @@
             <h3>xs:integer()</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Fail deliberately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -112,7 +112,7 @@
             <h3>Anonymous</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Fail deliberately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-452-result.html
@@ -81,7 +81,7 @@
             <h3>Text</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -126,7 +126,7 @@
             <h3>Comment</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -171,7 +171,7 @@
             <h3>Processing instruction</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -216,7 +216,7 @@
             <h3>In element</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-467-result.html
@@ -60,7 +60,7 @@
             <h3>Testing namespace differences</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting the same structure but in different namespaces</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-50-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-50-result.html
@@ -62,7 +62,7 @@
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
                   and [Expected Result] = "xs:hexBinary('0123')"</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-55-result.html
@@ -69,7 +69,7 @@
             <h3>In a failure report HTML</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -92,7 +92,7 @@
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
                   double)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -114,7 +114,7 @@
             </div>
             <div id="scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-67-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-67-result.html
@@ -112,7 +112,7 @@
             <h3>Comparing different namespaces</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-ambiguous-expect-result.html
@@ -90,7 +90,7 @@
             <h3>Scenario for verifying that boolean @test precedes @href When function returns true,</h3>
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting document node via @href should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -143,7 +143,7 @@
             <h3>Scenario for verifying that boolean @test precedes @select When function returns false,</h3>
             <div id="scenario2-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting false via @select along with @test=$x:result should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -196,7 +196,7 @@
                true,</h3>
             <div id="scenario3-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting element(foo) via child node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -261,7 +261,7 @@
                or child node) When function returns true,</h3>
             <div id="scenario4-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting empty sequence (no @href, @select or child node) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -283,7 +283,7 @@
             </div>
             <div id="scenario4-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Ditto using x:label</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-focus-1-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-focus-1-result.html
@@ -100,7 +100,7 @@
             <h3>a focused incorrect scenario</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-function-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-function-result.html
@@ -94,7 +94,7 @@
             <h3>when calling a function and expecting incorrectly</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting an incorrect value must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -116,7 +116,7 @@
             </div>
             <div id="scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting an incorrect type must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-import-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-import-result.html
@@ -104,7 +104,7 @@
             <h3>when testing an incorrect scenario in an importing file</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">it must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -167,7 +167,7 @@
             <h3>an incorrect scenario in an imported file</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-imported-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-imported-result.html
@@ -86,7 +86,7 @@
             <h3>an incorrect scenario in an imported file</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-pending-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-pending-result.html
@@ -114,7 +114,7 @@
             <h3>a non-pending incorrect scenario alongside a pending scenario</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report-result.html
@@ -110,7 +110,7 @@
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -137,7 +137,7 @@
             <div id="scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -182,7 +182,7 @@
             <h3>Element, attribute (xspec/xspec#357)</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">@attr should be reported as an attribute</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -230,7 +230,7 @@
             <h3>Attributes of the same name (xspec/xspec#358)</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Both @attr=foo and @attr=bar should be reported</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -276,7 +276,7 @@
             <h3>Attribute, element, attribute (xspec/xspec#360)</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] should be reported</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -325,7 +325,7 @@
             <h3>Document node with no children (xspec/xspec#697)</h3>
             <div id="scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be reported between Result title and box</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -383,7 +383,7 @@
                [Expected Result] = element</h3>
             <div id="scenario6-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be colored as different. Serialized node should be colored as same.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -411,7 +411,7 @@
                Result] = document node.</h3>
             <div id="scenario6-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be colored as different. Serialized node should be colored as same.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-report_schema-aware-result.html
@@ -224,7 +224,7 @@
             <h3>In a failure report HTML Derived string types xs:ID</h3>
             <div id="scenario1-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:ID('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -249,7 +249,7 @@
             <h3>In a failure report HTML Derived string types xs:IDREF</h3>
             <div id="scenario1-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:IDREF('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -274,7 +274,7 @@
             <h3>In a failure report HTML Derived string types xs:ENTITY</h3>
             <div id="scenario1-scenario1-scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:ENTITY('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -299,7 +299,7 @@
             <h3>In a failure report HTML Derived string types xs:NCName</h3>
             <div id="scenario1-scenario1-scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:NCName('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -324,7 +324,7 @@
             <h3>In a failure report HTML Derived string types xs:language</h3>
             <div id="scenario1-scenario1-scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:language('en')" (XSLT) or "'en'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -349,7 +349,7 @@
             <h3>In a failure report HTML Derived string types xs:Name</h3>
             <div id="scenario1-scenario1-scenario6-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:Name('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -374,7 +374,7 @@
             <h3>In a failure report HTML Derived string types xs:NMTOKEN</h3>
             <div id="scenario1-scenario1-scenario7-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:NMTOKEN('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -399,7 +399,7 @@
             <h3>In a failure report HTML Derived string types xs:token</h3>
             <div id="scenario1-scenario1-scenario8-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:token('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -424,7 +424,7 @@
             <h3>In a failure report HTML Derived string types xs:normalizedString</h3>
             <div id="scenario1-scenario1-scenario9-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:normalizedString('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -449,7 +449,7 @@
             <h3>In a failure report HTML Derived numeric types xs:negativeInteger</h3>
             <div id="scenario1-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:negativeInteger(-1)" (XSLT) or "-1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -474,7 +474,7 @@
             <h3>In a failure report HTML Derived numeric types xs:nonPositiveInteger</h3>
             <div id="scenario1-scenario2-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:nonPositiveInteger(0)" (XSLT) or "0" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -499,7 +499,7 @@
             <h3>In a failure report HTML Derived numeric types xs:byte</h3>
             <div id="scenario1-scenario2-scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:byte(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -524,7 +524,7 @@
             <h3>In a failure report HTML Derived numeric types xs:short</h3>
             <div id="scenario1-scenario2-scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:short(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -549,7 +549,7 @@
             <h3>In a failure report HTML Derived numeric types xs:int</h3>
             <div id="scenario1-scenario2-scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:int(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -574,7 +574,7 @@
             <h3>In a failure report HTML Derived numeric types xs:long</h3>
             <div id="scenario1-scenario2-scenario6-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:long(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -599,7 +599,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedByte</h3>
             <div id="scenario1-scenario2-scenario7-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedByte(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -624,7 +624,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedShort</h3>
             <div id="scenario1-scenario2-scenario8-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedShort(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -649,7 +649,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedInt</h3>
             <div id="scenario1-scenario2-scenario9-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedInt(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -674,7 +674,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedLong</h3>
             <div id="scenario1-scenario2-scenario10-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedLong(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -699,7 +699,7 @@
             <h3>In a failure report HTML Derived numeric types xs:positiveInteger</h3>
             <div id="scenario1-scenario2-scenario11-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:positiveInteger(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -724,7 +724,7 @@
             <h3>In a failure report HTML Derived numeric types xs:nonNegativeInteger</h3>
             <div id="scenario1-scenario2-scenario12-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:nonNegativeInteger(0)" (XSLT) or "0" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-serialize-result.html
@@ -124,7 +124,7 @@
                (xspec/xspec#356) So... When x:result in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -147,7 +147,7 @@
             </div>
             <div id="scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -174,7 +174,7 @@
                (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -272,7 +272,7 @@
                is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Result] with diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -301,7 +301,7 @@
             </div>
             <div id="scenario2-scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Result] without diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -335,7 +335,7 @@
                is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Expected Result] with diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -371,7 +371,7 @@
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -411,7 +411,7 @@
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -451,7 +451,7 @@
                XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">&lt;foo&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -507,7 +507,7 @@
             <h3>When x:expect has an element of '...',</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -560,7 +560,7 @@
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both in [Result] and [Expected Result] with diff, the significant text nodes must
                   be serialized with color. (xspec/xspec#386)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -602,7 +602,7 @@
             </div>
             <div id="scenario4-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">in [Result] without diff, the significant text nodes must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -696,7 +696,7 @@
                an element with several namespaces in x:result,</h3>
             <div id="scenario5-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -726,7 +726,7 @@
             </div>
             <div id="scenario5-scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -761,7 +761,7 @@
                an element with several namespaces in x:expect,</h3>
             <div id="scenario5-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -796,7 +796,7 @@
                an element with several attributes in x:result,</h3>
             <div id="scenario5-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -825,7 +825,7 @@
             </div>
             <div id="scenario5-scenario2-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -859,7 +859,7 @@
                an element with several attributes in x:expect,</h3>
             <div id="scenario5-scenario2-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -926,7 +926,7 @@
                <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green".
                   The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
                   must be serialized as solidPink="solidPink" regardless of their values.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -973,7 +973,7 @@
             <h3>When the result contains attribute, in [Result] without diff,</h3>
             <div id="scenario6-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all the attributes must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1049,7 +1049,7 @@
                   solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
                   be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
                   serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1105,7 +1105,7 @@
             <h3>When the result contains processing instructions, in [Result] without diff,</h3>
             <div id="scenario7-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all the processing instructions must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/xspec-three-dots-result.html
@@ -180,7 +180,7 @@
             <h3>For resultant element (simple) When result is &lt;elem /&gt;</h3>
             <div id="scenario1-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -207,7 +207,7 @@
             <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt;</h3>
             <div id="scenario1-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -265,7 +265,7 @@
             <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt;</h3>
             <div id="scenario2-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -335,7 +335,7 @@
             <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</h3>
             <div id="scenario3-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -416,7 +416,7 @@
             <h3>For resultant attribute When result is @attrib="..."</h3>
             <div id="scenario4-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting @attrib="val" should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -510,7 +510,7 @@
             <h3>For resultant text node When result is usual text node</h3>
             <div id="scenario5-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -536,7 +536,7 @@
             <h3>For resultant text node When result is whitespace-only text node</h3>
             <div id="scenario5-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -563,7 +563,7 @@
             <h3>For resultant text node When result is zero-length text node</h3>
             <div id="scenario5-scenario3-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -590,7 +590,7 @@
             <h3>For resultant text node When result is three-dot text node</h3>
             <div id="scenario5-scenario4-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -614,7 +614,7 @@
             </div>
             <div id="scenario5-scenario4-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -691,7 +691,7 @@
             <h3>For resultant comment When result is &lt;!--...--&gt;</h3>
             <div id="scenario6-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;!--comment--&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -769,7 +769,7 @@
             <h3>For resultant processing instruction When result is &lt;?pi ...?&gt;</h3>
             <div id="scenario7-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;?pi data?&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -852,7 +852,7 @@
                /&gt;&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -880,7 +880,7 @@
             <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
             <div id="scenario8-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -907,7 +907,7 @@
             <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -989,7 +989,7 @@
             <h3>For resultant namespace node When result is xmlns:prefix="..."</h3>
             <div id="scenario9-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting xmlns:prefix="namespace-uri" should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1056,7 +1056,7 @@
                /&gt;</h3>
             <div id="scenario10-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1081,7 +1081,7 @@
             </div>
             <div id="scenario10-scenario1-expect4" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ...... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1106,7 +1106,7 @@
             </div>
             <div id="scenario10-scenario1-expect5" class="xTestReport">
                <h4 class="xTestReportTitle">expecting sequence of three ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1153,7 +1153,7 @@
             <h3>When result is empty sequence</h3>
             <div id="scenario11-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1226,7 +1226,7 @@
             <h3>For resultant atomic value When result is 'string'</h3>
             <div id="scenario12-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1249,7 +1249,7 @@
             </div>
             <div id="scenario12-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1274,7 +1274,7 @@
             <h3>For resultant atomic value When result is '...'</h3>
             <div id="scenario12-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1297,7 +1297,7 @@
             </div>
             <div id="scenario12-scenario2-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting 'string' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1353,7 +1353,7 @@
             <h3>For any resultant item</h3>
             <div id="scenario13-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting .... (four dots) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1377,7 +1377,7 @@
             </div>
             <div id="scenario13-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ...x (three dots with extra character) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1401,7 +1401,7 @@
             </div>
             <div id="scenario13-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... with surrounding whitespace should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1425,7 +1425,7 @@
             </div>
             <div id="scenario13-expect4" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' (xs:string) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/schematron/import-demo-02-PhaseB-result.html
+++ b/test/end-to-end/cases/expected/schematron/import-demo-02-PhaseB-result.html
@@ -84,7 +84,7 @@
             <h3>Pattern 2</h3>
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">not assert t1-1</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -73,7 +73,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -117,7 +117,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -161,7 +161,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -92,7 +92,7 @@
             <h3>error: expect-valid should fail</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">valid</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -166,7 +166,7 @@
             <h3>fatal: expect-valid should fail</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">valid</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/schematron/xspec-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/xspec-693-result.html
@@ -65,7 +65,7 @@
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[.
                   = ''] report baz-exists</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -126,7 +126,7 @@ function toggle(scenarioID) {
             <h3>a focused incorrect scenario</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -73,7 +73,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -117,7 +117,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -161,7 +161,7 @@
             <h3> &#xD; &#xD; My &#xD; Scenario</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle"> &#xD; &#xD; My &#xD; Expectation</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -77,7 +77,7 @@
             <h3>context</h3>
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">should report Expected Result correctly on failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -126,7 +126,7 @@
             <h3>function-call</h3>
             <div id="scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">should report Expected Result correctly on failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -175,7 +175,7 @@
             <h3>template-call</h3>
             <div id="scenario3-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">should report Expected Result correctly on failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-151-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-151-result.html
@@ -59,7 +59,7 @@
             <h3>When the result is a mixture of a typed element and a string</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] in the failure report HTML must wrap element and string separately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-153-result.html
@@ -63,7 +63,7 @@
             <h3>When a function returns a local date time string</h3>
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Comparing the function result with a different date time will report Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-177-result.html
@@ -69,7 +69,7 @@
                <h4 class="xTestReportTitle">When @test is "empty($x:result/self::element(foo))" (i.e. boolean), then the HTML
                   report should be "Result" = "&lt;foo /&gt;" and "Expecting" = "empty($x:result/self::element(foo))"
                   without diff.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -94,7 +94,7 @@
                <h4 class="xTestReportTitle">When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non
                   boolean), then the HTML report should be "Result" = "&lt;foo /&gt;" and "Expected Result"
                   = "&lt;bar /&gt;" with diff.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-23_2-result.html
@@ -59,7 +59,7 @@
             <h3>Test</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Result</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-346-result.html
@@ -59,7 +59,7 @@
             <h3>When a function returns a node containing a space</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting no space should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-355-result.html
@@ -66,7 +66,7 @@
             <h3>xs:integer()</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Fail deliberately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -111,7 +111,7 @@
             <h3>Anonymous</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Fail deliberately</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-452-result.html
@@ -80,7 +80,7 @@
             <h3>Text</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -125,7 +125,7 @@
             <h3>Comment</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -170,7 +170,7 @@
             <h3>Processing instruction</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -215,7 +215,7 @@
             <h3>In element</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expect</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-467-result.html
@@ -59,7 +59,7 @@
             <h3>Testing namespace differences</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting the same structure but in different namespaces</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-50-result.html
@@ -61,7 +61,7 @@
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must generate a failure report HTML which reads [Result] = "xs:untypedAtomic('0123')"
                   and [Expected Result] = "xs:hexBinary('0123')"</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-528-result.html
@@ -75,7 +75,7 @@
             <h3>Scenario 1 Scenario 1-2</h3>
             <div id="scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">should fail</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-55-result.html
@@ -68,7 +68,7 @@
             <h3>In a failure report HTML</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:decimal(1) by "1.0" (numeric literal of decimal)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -91,7 +91,7 @@
             <div id="scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:double(1) by "xs:double('1')" (constructor of
                   double)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -113,7 +113,7 @@
             </div>
             <div id="scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] must represent xs:integer(1) by "1" (numeric literal of integer)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-67-result.html
@@ -111,7 +111,7 @@
             <h3>Comparing different namespaces</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-778_ws-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-778_ws-result.html
@@ -59,7 +59,7 @@
             <h3>When transforming DITA</h3>
             <div id="scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">we get markdown</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-ambiguous-expect-result.html
@@ -89,7 +89,7 @@
             <h3>Scenario for verifying that boolean @test precedes @href When function returns true,</h3>
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting document node via @href should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -142,7 +142,7 @@
             <h3>Scenario for verifying that boolean @test precedes @select When function returns false,</h3>
             <div id="scenario2-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting false via @select along with @test=$x:result should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -195,7 +195,7 @@
                true,</h3>
             <div id="scenario3-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting element(foo) via child node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -260,7 +260,7 @@
                or child node) When function returns true,</h3>
             <div id="scenario4-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting empty sequence (no @href, @select or child node) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -282,7 +282,7 @@
             </div>
             <div id="scenario4-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">Ditto using x:label</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-focus-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-focus-1-result.html
@@ -99,7 +99,7 @@
             <h3>a focused incorrect scenario</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-function-result.html
@@ -93,7 +93,7 @@
             <h3>when calling a function and expecting incorrectly</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting an incorrect value must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -115,7 +115,7 @@
             </div>
             <div id="scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting an incorrect type must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-import-result.html
@@ -103,7 +103,7 @@
             <h3>when testing an incorrect scenario in an importing file</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">it must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -166,7 +166,7 @@
             <h3>an incorrect scenario in an imported file</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-imported-result.html
@@ -85,7 +85,7 @@
             <h3>an incorrect scenario in an imported file</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-pending-result.html
@@ -113,7 +113,7 @@
             <h3>a non-pending incorrect scenario alongside a pending scenario</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report-result.html
@@ -109,7 +109,7 @@
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Serialized array (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -136,7 +136,7 @@
             <div id="scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Serialized map (XSLT) or empty 'pseudo-other' element (XQuery) should be reported
                   upon failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -181,7 +181,7 @@
             <h3>Element, attribute (xspec/xspec#357)</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">@attr should be reported as an attribute</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -229,7 +229,7 @@
             <h3>Attributes of the same name (xspec/xspec#358)</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Both @attr=foo and @attr=bar should be reported</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -275,7 +275,7 @@
             <h3>Attribute, element, attribute (xspec/xspec#360)</h3>
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] should be reported</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -324,7 +324,7 @@
             <h3>Document node with no children (xspec/xspec#697)</h3>
             <div id="scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be reported between Result title and box</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -382,7 +382,7 @@
                [Expected Result] = element</h3>
             <div id="scenario6-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be colored as different. Serialized node should be colored as same.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -410,7 +410,7 @@
                Result] = document node.</h3>
             <div id="scenario6-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">XPath should be colored as different. Serialized node should be colored as same.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-report_schema-aware-result.html
@@ -223,7 +223,7 @@
             <h3>In a failure report HTML Derived string types xs:ID</h3>
             <div id="scenario1-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:ID('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -248,7 +248,7 @@
             <h3>In a failure report HTML Derived string types xs:IDREF</h3>
             <div id="scenario1-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:IDREF('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -273,7 +273,7 @@
             <h3>In a failure report HTML Derived string types xs:ENTITY</h3>
             <div id="scenario1-scenario1-scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:ENTITY('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -298,7 +298,7 @@
             <h3>In a failure report HTML Derived string types xs:NCName</h3>
             <div id="scenario1-scenario1-scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:NCName('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -323,7 +323,7 @@
             <h3>In a failure report HTML Derived string types xs:language</h3>
             <div id="scenario1-scenario1-scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:language('en')" (XSLT) or "'en'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -348,7 +348,7 @@
             <h3>In a failure report HTML Derived string types xs:Name</h3>
             <div id="scenario1-scenario1-scenario6-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:Name('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -373,7 +373,7 @@
             <h3>In a failure report HTML Derived string types xs:NMTOKEN</h3>
             <div id="scenario1-scenario1-scenario7-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:NMTOKEN('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -398,7 +398,7 @@
             <h3>In a failure report HTML Derived string types xs:token</h3>
             <div id="scenario1-scenario1-scenario8-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:token('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -423,7 +423,7 @@
             <h3>In a failure report HTML Derived string types xs:normalizedString</h3>
             <div id="scenario1-scenario1-scenario9-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:normalizedString('foo')" (XSLT) or "'foo'" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -448,7 +448,7 @@
             <h3>In a failure report HTML Derived numeric types xs:negativeInteger</h3>
             <div id="scenario1-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:negativeInteger(-1)" (XSLT) or "-1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -473,7 +473,7 @@
             <h3>In a failure report HTML Derived numeric types xs:nonPositiveInteger</h3>
             <div id="scenario1-scenario2-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:nonPositiveInteger(0)" (XSLT) or "0" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -498,7 +498,7 @@
             <h3>In a failure report HTML Derived numeric types xs:byte</h3>
             <div id="scenario1-scenario2-scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:byte(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -523,7 +523,7 @@
             <h3>In a failure report HTML Derived numeric types xs:short</h3>
             <div id="scenario1-scenario2-scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:short(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -548,7 +548,7 @@
             <h3>In a failure report HTML Derived numeric types xs:int</h3>
             <div id="scenario1-scenario2-scenario5-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:int(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -573,7 +573,7 @@
             <h3>In a failure report HTML Derived numeric types xs:long</h3>
             <div id="scenario1-scenario2-scenario6-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:long(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -598,7 +598,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedByte</h3>
             <div id="scenario1-scenario2-scenario7-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedByte(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -623,7 +623,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedShort</h3>
             <div id="scenario1-scenario2-scenario8-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedShort(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -648,7 +648,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedInt</h3>
             <div id="scenario1-scenario2-scenario9-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedInt(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -673,7 +673,7 @@
             <h3>In a failure report HTML Derived numeric types xs:unsignedLong</h3>
             <div id="scenario1-scenario2-scenario10-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:unsignedLong(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -698,7 +698,7 @@
             <h3>In a failure report HTML Derived numeric types xs:positiveInteger</h3>
             <div id="scenario1-scenario2-scenario11-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:positiveInteger(1)" (XSLT) or "1" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -723,7 +723,7 @@
             <h3>In a failure report HTML Derived numeric types xs:nonNegativeInteger</h3>
             <div id="scenario1-scenario2-scenario12-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] must represent it by "xs:nonNegativeInteger(0)" (XSLT) or "0" (XQuery)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-result-naming-collision-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-result-naming-collision-result.html
@@ -115,7 +115,7 @@
             <h3>When the result consists of multiple elements (xspec/xspec#361)</h3>
             <div id="scenario3-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">The result should be saved successfully in yet another external file which is well-formed</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-rule-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-rule-result.html
@@ -85,7 +85,7 @@
             <h3>x:context with incorrect x:expect</h3>
             <div id="scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">must return Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-serialize-result.html
@@ -123,7 +123,7 @@
                (xspec/xspec#356) So... When x:result in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -146,7 +146,7 @@
             </div>
             <div id="scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -173,7 +173,7 @@
                (xspec/xspec#356) So... When x:expect in the report XML contains a comment node,</h3>
             <div id="scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized as &lt;!-- --&gt;.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -271,7 +271,7 @@
                is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Result] with diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -300,7 +300,7 @@
             </div>
             <div id="scenario2-scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Result] without diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -334,7 +334,7 @@
                is a sequence of simple nested elements serialized with indentation,</h3>
             <div id="scenario2-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all elements in [Expected Result] with diff must be serialized with indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -370,7 +370,7 @@
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -410,7 +410,7 @@
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -450,7 +450,7 @@
                XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">&lt;foo&gt; must be green.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -506,7 +506,7 @@
             <h3>When x:expect has an element of '...',</h3>
             <div id="scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -559,7 +559,7 @@
             <div id="scenario4-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">both in [Result] and [Expected Result] with diff, the significant text nodes must
                   be serialized with color. (xspec/xspec#386)</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -601,7 +601,7 @@
             </div>
             <div id="scenario4-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">in [Result] without diff, the significant text nodes must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -695,7 +695,7 @@
                an element with several namespaces in x:result,</h3>
             <div id="scenario5-scenario1-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -725,7 +725,7 @@
             </div>
             <div id="scenario5-scenario1-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -760,7 +760,7 @@
                an element with several namespaces in x:expect,</h3>
             <div id="scenario5-scenario1-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -795,7 +795,7 @@
                an element with several attributes in x:result,</h3>
             <div id="scenario5-scenario2-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -824,7 +824,7 @@
             </div>
             <div id="scenario5-scenario2-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">[Result] without diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -858,7 +858,7 @@
                an element with several attributes in x:expect,</h3>
             <div id="scenario5-scenario2-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">[Expected Result] with diff must be serialized with aligned indentation.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -925,7 +925,7 @@
                <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green".
                   The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
                   must be serialized as solidPink="solidPink" regardless of their values.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -972,7 +972,7 @@
             <h3>When the result contains attribute, in [Result] without diff,</h3>
             <div id="scenario6-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all the attributes must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1048,7 +1048,7 @@
                   solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
                   be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
                   serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1104,7 +1104,7 @@
             <h3>When the result contains processing instructions, in [Result] without diff,</h3>
             <div id="scenario7-scenario2-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">all the processing instructions must be serialized without color.</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-three-dots-result.html
@@ -179,7 +179,7 @@
             <h3>For resultant element (simple) When result is &lt;elem /&gt;</h3>
             <div id="scenario1-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem attrib="..." /&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -206,7 +206,7 @@
             <h3>For resultant element (simple) When result is &lt;elem&gt;...&lt;/elem&gt;</h3>
             <div id="scenario1-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem&gt;text&lt;/elem&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -264,7 +264,7 @@
             <h3>For resultant element (with attribute) When result is &lt;elem attrib="val" /&gt;</h3>
             <div id="scenario2-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;elem&gt;...&lt;/elem&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -334,7 +334,7 @@
             <h3>For resultant element (with mixed content) When result is &lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;</h3>
             <div id="scenario3-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -415,7 +415,7 @@
             <h3>For resultant attribute When result is @attrib="..."</h3>
             <div id="scenario4-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting @attrib="val" should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -509,7 +509,7 @@
             <h3>For resultant text node When result is usual text node</h3>
             <div id="scenario5-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -535,7 +535,7 @@
             <h3>For resultant text node When result is whitespace-only text node</h3>
             <div id="scenario5-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -562,7 +562,7 @@
             <h3>For resultant text node When result is zero-length text node</h3>
             <div id="scenario5-scenario3-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -589,7 +589,7 @@
             <h3>For resultant text node When result is three-dot text node</h3>
             <div id="scenario5-scenario4-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting usual text node should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -613,7 +613,7 @@
             </div>
             <div id="scenario5-scenario4-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -690,7 +690,7 @@
             <h3>For resultant comment When result is &lt;!--...--&gt;</h3>
             <div id="scenario6-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;!--comment--&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -768,7 +768,7 @@
             <h3>For resultant processing instruction When result is &lt;?pi ...?&gt;</h3>
             <div id="scenario7-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;?pi data?&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -851,7 +851,7 @@
                /&gt;&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -879,7 +879,7 @@
             <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
             <div id="scenario8-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -906,7 +906,7 @@
             <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
             <div id="scenario8-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -988,7 +988,7 @@
             <h3>For resultant namespace node When result is xmlns:prefix="..."</h3>
             <div id="scenario9-scenario3-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting xmlns:prefix="namespace-uri" should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1055,7 +1055,7 @@
                /&gt;</h3>
             <div id="scenario10-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1080,7 +1080,7 @@
             </div>
             <div id="scenario10-scenario1-expect4" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ...... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1105,7 +1105,7 @@
             </div>
             <div id="scenario10-scenario1-expect5" class="xTestReport">
                <h4 class="xTestReportTitle">expecting sequence of three ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1152,7 +1152,7 @@
             <h3>When result is empty sequence</h3>
             <div id="scenario11-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1225,7 +1225,7 @@
             <h3>For resultant atomic value When result is 'string'</h3>
             <div id="scenario12-scenario1-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1248,7 +1248,7 @@
             </div>
             <div id="scenario12-scenario1-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1273,7 +1273,7 @@
             <h3>For resultant atomic value When result is '...'</h3>
             <div id="scenario12-scenario2-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1296,7 +1296,7 @@
             </div>
             <div id="scenario12-scenario2-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting 'string' should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1352,7 +1352,7 @@
             <h3>For any resultant item</h3>
             <div id="scenario13-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">expecting .... (four dots) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1376,7 +1376,7 @@
             </div>
             <div id="scenario13-expect2" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ...x (three dots with extra character) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1400,7 +1400,7 @@
             </div>
             <div id="scenario13-expect3" class="xTestReport">
                <h4 class="xTestReportTitle">expecting ... with surrounding whitespace should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>
@@ -1424,7 +1424,7 @@
             </div>
             <div id="scenario13-expect4" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' (xs:string) should be Failure</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>

--- a/test/end-to-end/cases/expected/stylesheet/xspec-xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xspec-xslt2-result.html
@@ -102,7 +102,7 @@
                or higher.</h3>
             <div id="scenario1-scenario3-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">Expecting the compiled stylesheet to have version=1.0</h4>
-               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">❔</a></div>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
                      <tr>


### PR DESCRIPTION
The hint mark added by #839 looks way too blurry on Firefox 76.0 on Ubuntu 20.04:
![bug](https://user-images.githubusercontent.com/8489367/81497012-aa00a300-92f6-11ea-8d9a-e7c9fb2d7e6d.png)

Probably we should not use such extended characters unless we're confident.
This pull request replaces the mark with plain characters:
![fix](https://user-images.githubusercontent.com/8489367/81497033-c7357180-92f6-11ea-9ec3-e2f5b8d49329.png)
