### PR TITLE
ci(deps): bump BaseX from 9.3.2 to 9.3.3

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.8
 
 # Latest BaseX
-BASEX_VERSION=9.3.2
+BASEX_VERSION=9.3.3
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
https://raw.githubusercontent.com/BaseXdb/basex/master/CHANGELOG

> VERSION 9.3.3 (May 15, 2020) -------------------------------------------
> 
>  - Minor bug fixes, performance tweaks, new query optimizations