### PR TITLE
docs: adjust dependabot config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -26,6 +26,7 @@
         "oxygen",
         "basex",
         "deps",
+        "deps-dev",
         "report",
         "xproc",
         "schema",

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,11 +10,11 @@ update_configs:
     directory: /
     update_schedule: live
     commit_message:
-      prefix: build
+      prefix: ci
       include_scope: true
   - package_manager: python
     directory: /
     update_schedule: live
     commit_message:
-      prefix: build
+      prefix: ci
       include_scope: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ You are also encouraged to use a scope to highlight which functionality is affec
 | `oxygen`     | Oxygen                  |
 | `basex`      | BaseX                   |
 | `deps`       | Dependencies            |
+| `deps-dev`   | Development dependencies |
 | `report`     | Test result reports     |
 | `xproc`      | XProc                   |
 | `schema`     | Schema for .xspec files |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,19 +42,19 @@ These are the valid prefixes for type (see also [the Angular documentation](http
 
 You are also encouraged to use a scope to highlight which functionality is affected by your change:
 
-| Scope        | Description             |
-| ------------ | ----------------------- |
-| `xslt`       | XSLT                    |
-| `xquery`     | XQuery                  |
-| `schematron` | Schematron              |
-| `oxygen`     | Oxygen                  |
-| `basex`      | BaseX                   |
-| `deps`       | Dependencies            |
+| Scope        | Description              |
+| ------------ | ------------------------ |
+| `xslt`       | XSLT                     |
+| `xquery`     | XQuery                   |
+| `schematron` | Schematron               |
+| `oxygen`     | Oxygen                   |
+| `basex`      | BaseX                    |
+| `deps`       | Dependencies             |
 | `deps-dev`   | Development dependencies |
-| `report`     | Test result reports     |
-| `xproc`      | XProc                   |
-| `schema`     | Schema for .xspec files |
-| `maven`      | Maven                   |
+| `report`     | Test result reports      |
+| `xproc`      | XProc                    |
+| `schema`     | Schema for .xspec files  |
+| `maven`      | Maven                    |
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
 


### PR DESCRIPTION
**dependabot** detects development dependencies and sets `deps-dev` scope which is not configurable. This pull request reflects it in `commitlint` config.

Also fixes the prefix for JavaScript and Python. They aren't used for build and release.