### PR TITLE
ci(deps-dev): run codespell 1.17.0 on Python 3.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
       - run: test/ci/run-codespell.sh
 
   jing:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-codespell == 1.16.0
+codespell == 1.17.0


### PR DESCRIPTION
`codespell` 1.17.0 package published for Python 2 is broken. (Dictionary files are missing.)

This pull request sets up Python 3 before running `codespell`.