### PR TITLE
build(maven): put resources under unique root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
   <build>
     <resources>
       <resource>
+        <targetPath>io/xspec/xspec/impl/src</targetPath>
         <directory>src</directory>
         <excludes>
           <exclude>harnesses/**</exclude>


### PR DESCRIPTION
Related to #938 

This pull request sets [`targetPath`](https://github.com/apache/maven/blob/d657c9c6b467db60c932799485fb4210c0bd1fe0/maven-model/src/main/mdo/maven.mdo#L1780-L1795) so that the "resources" (some selected files from the XSpec repository) are stored under `io/xspec/xspec/impl/[original directory]`.

Keeping the (relative) original directory structure of the repository is important, because a file may reference another file ([example](https://github.com/xspec/xspec/blob/5836b905b23a07451e20966a7c3916056fda608d/src/schematron/generate-step3-wrapper.xsl#L34)). That's why

- the `targetPath` ends with `[original directory]`.
- [the built-in Schematron _skeleton_ implementation](https://github.com/xspec/xspec/tree/master/src/schematron/iso-schematron) is kept as is.
