### PR TITLE
feat: catalog file URIs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,8 @@
     No default value. This property is occasionally provided by the user. -->
 
   <!-- "catalog" property: Documented in Wiki. DO NOT RENAME.
-    One or more XML catalog file paths. Separated by semicolons (;). -->
+    One or more XML catalog files. Separated by semicolons (;).
+    Value is either file path or URI. Must not mix file path and URI. -->
 
   <!-- File path of the original XSpec file specified by the user -->
   <property name="xspec.xspecfile.original" value="${xspec.xml}" />
@@ -145,6 +146,17 @@
     <istrue value="${xspec.is.schematron}" />
   </condition>
 
+  <!-- True if "catalog" property consists of URIs. Otherwise file paths. -->
+  <property name="catalog.is.uri" value="false" />
+
+  <!-- One or more XML catalog file paths (not URLs). Separated by semicolons (;) -->
+  <condition property="xspec.catalog.files"
+             value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}_catalog.xml"
+             else="${catalog}"
+             if:set="catalog">
+    <istrue value="${catalog.is.uri}" />
+  </condition>
+
   <!-- File path of the compiled XSLT/XQuery file that finally runs the tests -->
   <property name="xspec.compiled.runner.without.ext" 
             value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-compiled" />
@@ -163,11 +175,21 @@
     <attribute name="in" />
     <attribute name="out" />
     <attribute name="style" />
+    <attribute name="ignore-catalog" default="false" />
 
     <element name="factory-elements" optional="true" />
     <element name="xslt-elements" optional="true" />
 
     <sequential>
+      <local name="enable-catalog" />
+      <condition property="enable-catalog"
+                 else="false">
+        <and>
+          <isfalse value="@{ignore-catalog}" />
+          <isset property="xspec.catalog.files" />
+        </and>
+      </condition>
+
       <xslt in="@{in}" out="@{out}" style="@{style}" force="true">
         <factory name="net.sf.saxon.TransformerFactoryImpl">
           <factory-elements />
@@ -177,8 +199,8 @@
                      value="true"/>-->
         </factory>
 
-        <xmlcatalog if:set="catalog">
-          <catalogpath path="${catalog}" />
+        <xmlcatalog if:true="${enable-catalog}">
+          <catalogpath path="${xspec.catalog.files}" />
         </xmlcatalog>
 
         <xslt-elements />
@@ -245,6 +267,26 @@
     <retry retrycount="2" retrydelay="1000">
       <mkdir dir="${xspec.output.dir}" />
     </retry>
+  </target>
+
+  <!-- Generates a temporary catalog file which references all URIs in "catalog" property -->
+  <target name="generate-catalog" if="${catalog.is.uri}">
+    <makeurl property="basedir.uri" file="${basedir}/" />
+
+    <!-- @in doesn't matter -->
+    <saxon-xslt in="${ant.file}"
+                out="${xspec.catalog.files}"
+                style="${xspec.project.dir}/src/ant/generate-catalog.xsl"
+                ignore-catalog="true">
+      <factory-elements>
+        <attribute name="http://saxon.sf.net/feature/initialTemplate"
+                   value="{http://www.w3.org/1999/XSL/Transform}initial-template" />
+      </factory-elements>
+      <xslt-elements>
+        <param name="CATALOG-URIS" expression="${catalog}" />
+        <param name="BASE-URI" expression="${basedir.uri}" />
+      </xslt-elements>
+    </saxon-xslt>
   </target>
 
   <!-- Gets the file path (not URL) of the Schematron file -->
@@ -340,7 +382,7 @@
   </target>
 
   <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
-  <target name="compile" depends="init, preprocess-schematron-xspec">
+  <target name="compile" depends="init, generate-catalog, preprocess-schematron-xspec">
     <condition property="xspec.compiler.xsl.name"
                value="generate-query-tests.xsl"
                else="generate-xspec-tests.xsl">
@@ -370,7 +412,7 @@
       </classpath>
 
       <arg line="${saxon.custom.options}" if:set="saxon.custom.options" />
-      <arg value="-catalog:${catalog}" if:set="catalog" />
+      <arg value="-catalog:${xspec.catalog.files}" if:set="xspec.catalog.files" />
       <arg value="-o:${xspec.result.xml}" />
       <arg value="-q:${xspec.compiled.runner}" />
     </java>
@@ -419,7 +461,7 @@
                    if:true="${xspec.coverage.enabled}" />
 
       <arg line="${saxon.custom.options}" if:set="saxon.custom.options" />
-      <arg value="-catalog:${catalog}" if:set="catalog" />
+      <arg value="-catalog:${xspec.catalog.files}" if:set="xspec.catalog.files" />
       <arg value="-it:{http://www.jenitennison.com/xslt/xspec}main" />
       <arg value="-o:${xspec.result.xml}" />
       <arg value="-xsl:${xspec.compiled.runner}" />

--- a/build.xml
+++ b/build.xml
@@ -157,6 +157,14 @@
     <istrue value="${catalog.is.uri}" />
   </condition>
 
+  <!-- True if a temporary catalog file needs to be generated -->
+  <condition property="xspec.generate.catalog" else="false">
+    <and>
+      <isset property="catalog" />
+      <istrue value="${catalog.is.uri}" />
+    </and>
+  </condition>
+
   <!-- File path of the compiled XSLT/XQuery file that finally runs the tests -->
   <property name="xspec.compiled.runner.without.ext" 
             value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-compiled" />
@@ -182,8 +190,7 @@
 
     <sequential>
       <local name="enable-catalog" />
-      <condition property="enable-catalog"
-                 else="false">
+      <condition property="enable-catalog" else="false">
         <and>
           <isfalse value="@{ignore-catalog}" />
           <isset property="xspec.catalog.files" />
@@ -270,7 +277,7 @@
   </target>
 
   <!-- Generates a temporary catalog file which references all URIs in "catalog" property -->
-  <target name="generate-catalog" if="${catalog.is.uri}">
+  <target name="generate-catalog" if="${xspec.generate.catalog}">
     <makeurl property="basedir.uri" file="${basedir}/" />
 
     <!-- @in doesn't matter -->

--- a/src/ant/generate-catalog.xsl
+++ b/src/ant/generate-catalog.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+	xmlns:catalog="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!-- URIs separated by semicolons (;) -->
+	<xsl:param as="xs:string" name="CATALOG-URIS" />
+
+	<xsl:param as="xs:string" name="BASE-URI" />
+
+	<xsl:output indent="yes" />
+
+	<xsl:template as="element(catalog:catalog)" name="xsl:initial-template">
+		<xsl:context-item use="absent" />
+
+		<xsl:variable as="xs:string+" name="catalog-uris" select="tokenize($CATALOG-URIS, ';')[.]" />
+
+		<catalog>
+			<xsl:attribute name="xml:base" select="$BASE-URI" />
+			<xsl:for-each select="$catalog-uris">
+				<nextCatalog catalog="{.}" />
+			</xsl:for-each>
+		</catalog>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -891,6 +891,29 @@
 	</case>
 
 	<!--
+		Ant catalog.is.uri=true without setting catalog
+	-->
+
+	<case name="Ant catalog.is.uri=true without setting catalog">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dcatalog.is.uri=true ^
+        -Dxspec.fail=false ^
+        -Dxspec.xml="tutorial\escape-for-regex.xspec"
+    call :verify_retval 0
+    call :verify_line  * x "     [xslt] passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    rem Temporary catalog should not be created
+    call :run dir /b /o:n "%TEST_DIR%"
+    call :verify_line_count 3
+    call :verify_line 1 x escape-for-regex-compiled.xsl
+    call :verify_line 2 x escape-for-regex-result.html
+    call :verify_line 3 x escape-for-regex-result.xml
+	</case>
+
+	<!--
 		xspec.fail (Ant)
 	-->
 

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -844,6 +844,53 @@
 	</case>
 
 	<!--
+		Catalog file URI (Ant)
+		
+			Test 'catalog' property containing multiple URIs (relative and absolute)
+	-->
+
+	<case name="Ant with catalog file URI (XSLT)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        -Dcatalog.is.uri=true ^
+        -Dxspec.xml="%CD%\catalog\catalog-01_stylesheet.xspec"
+    call :verify_retval 0
+    call :verify_line -10 x "     [xslt] passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line -2  x "BUILD SUCCESSFUL"
+	</case>
+
+	<case name="Ant with catalog file URI (XQuery)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        -Dcatalog.is.uri=true ^
+        -Dtest.type=q ^
+        -Dxspec.xml="%CD%\catalog\catalog-01_query.xspec"
+    call :verify_retval 0
+    call :verify_line -10 x "     [xslt] passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line -2  x "BUILD SUCCESSFUL"
+	</case>
+
+	<case name="Ant with catalog file URI (Schematron)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -lib "%XML_RESOLVER_JAR%" ^
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        -Dcatalog.is.uri=true ^
+        -Dtest.type=s ^
+        -Dxspec.xml="%CD%\catalog\catalog-01_schematron.xspec"
+    call :verify_retval 0
+    call :verify_line -10 x "     [xslt] passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line -2  x "BUILD SUCCESSFUL"
+	</case>
+
+	<!--
 		xspec.fail (Ant)
 	-->
 
@@ -992,6 +1039,41 @@
 	</case>
 
 	<!--
+		Catalog file URI (CLI) (-catalog)
+
+			Test -catalog specifying multiple file URIs (absolute, no relative)
+	-->
+
+	<case name="CLI with -catalog file URI (XSLT)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    call :run ..\bin\xspec.bat ^
+        -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        catalog\catalog-01_stylesheet.xspec
+    call :verify_retval 0
+    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+	</case>
+
+	<case name="CLI with -catalog file URI (XQuery)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    call :run ..\bin\xspec.bat ^
+        -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        -q ^
+        catalog\catalog-01_query.xspec
+    call :verify_retval 0
+    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+	</case>
+
+	<case name="CLI with -catalog file URI (Schematron)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    call :run ..\bin\xspec.bat ^
+        -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        -s ^
+        catalog\catalog-01_schematron.xspec
+    call :verify_retval 0
+    call :verify_line 19 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+	</case>
+
+	<!--
 		Catalog file path (CLI) (XML_CATALOG)
 		
 			Test XML_CATALOG containing multiple file paths (relative and absolute)
@@ -1035,6 +1117,39 @@
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "%SPACE_DIR%\catalog-01_schematron.xspec"
+    call :verify_retval 0
+    call :verify_line 19 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+	</case>
+
+	<!--
+		Catalog file URI (CLI) (XML_CATALOG)
+		
+			Test XML_CATALOG containing multiple file URIs (absolute, no relative)
+	-->
+
+	<case name="CLI with XML_CATALOG file URI (XSLT)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
+
+    call :run ..\bin\xspec.bat "catalog\catalog-01_stylesheet.xspec"
+    call :verify_retval 0
+    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+	</case>
+
+	<case name="CLI with XML_CATALOG file URI (XQuery)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
+
+    call :run ..\bin\xspec.bat -q "catalog\catalog-01_query.xspec"
+    call :verify_retval 0
+    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+	</case>
+
+	<case name="CLI with XML_CATALOG file URI (Schematron)">
+    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
+
+    call :run ..\bin\xspec.bat -s "catalog\catalog-01_schematron.xspec"
     call :verify_retval 0
     call :verify_line 19 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1049,6 +1049,31 @@ load bats-helper
 }
 
 #
+# Ant catalog.is.uri=true without setting catalog
+#
+
+@test "Ant catalog.is.uri=true without setting catalog" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dcatalog.is.uri=true \
+        -Dxspec.fail=false \
+        -Dxspec.xml="tutorial/escape-for-regex.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    assert_regex "${output}" $'\n''     \[xslt\] passed: 5 / pending: 0 / failed: 1 / total: 6'$'\n'
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    # Temporary catalog should not be created
+    run ls "${TEST_DIR}"
+    echo "$output"
+    [ "${#lines[@]}" = "3" ]
+    [ "${lines[0]}" = "escape-for-regex-compiled.xsl" ]
+    [ "${lines[1]}" = "escape-for-regex-result.html" ]
+    [ "${lines[2]}" = "escape-for-regex-result.xml" ]
+}
+
+#
 # xspec.fail (Ant)
 #
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -999,6 +999,56 @@ load bats-helper
 }
 
 #
+# Catalog file URI (Ant)
+#
+#     Test 'catalog' property containing multiple URIs (relative and absolute)
+#
+
+@test "Ant with catalog file URI (XSLT)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        -Dcatalog.is.uri=true \
+        -Dxspec.xml="${PWD}/catalog/catalog-01_stylesheet.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]}-10]}" = "     [xslt] passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[${#lines[@]}-2]}"  = "BUILD SUCCESSFUL" ]
+}
+
+@test "Ant with catalog file URI (XQuery)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        -Dcatalog.is.uri=true \
+        -Dtest.type=q \
+        -Dxspec.xml="${PWD}/catalog/catalog-01_query.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]}-10]}" = "     [xslt] passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[${#lines[@]}-2]}"  = "BUILD SUCCESSFUL" ]
+}
+
+@test "Ant with catalog file URI (Schematron)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -lib "${XML_RESOLVER_JAR}" \
+        -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        -Dcatalog.is.uri=true \
+        -Dtest.type=s \
+        -Dxspec.xml="${PWD}/catalog/catalog-01_schematron.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]}-10]}" = "     [xslt] passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[${#lines[@]}-2]}"  = "BUILD SUCCESSFUL" ]
+}
+
+#
 # xspec.fail (Ant)
 #
 
@@ -1157,6 +1207,44 @@ load bats-helper
 }
 
 #
+# Catalog file URI (CLI) (-catalog)
+#
+#     Test -catalog specifying multiple file URIs (absolute, no relative)
+#
+
+@test "CLI with -catalog file URI (XSLT)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    run ../bin/xspec.sh \
+        -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        catalog/catalog-01_stylesheet.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+}
+
+@test "CLI with -catalog file URI (XQuery)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    run ../bin/xspec.sh \
+        -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        -q \
+        catalog/catalog-01_query.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+}
+
+@test "CLI with -catalog file URI (Schematron)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    run ../bin/xspec.sh \
+        -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        -s \
+        catalog/catalog-01_schematron.xspec
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+}
+
+#
 # Catalog file path (CLI) (XML_CATALOG)
 #
 #     Test XML_CATALOG containing multiple file paths (relative and absolute)
@@ -1202,6 +1290,42 @@ load bats-helper
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     run ../bin/xspec.sh -s "${space_dir}/catalog-01_schematron.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[18]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+}
+
+#
+# Catalog file URI (CLI) (XML_CATALOG)
+#
+#     Test XML_CATALOG containing multiple file URIs (absolute, no relative)
+#
+
+@test "CLI with XML_CATALOG file URI (XSLT)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
+
+    run ../bin/xspec.sh "catalog/catalog-01_stylesheet.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+}
+
+@test "CLI with XML_CATALOG file URI (XQuery)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
+
+    run ../bin/xspec.sh -q "catalog/catalog-01_query.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+}
+
+@test "CLI with XML_CATALOG file URI (Schematron)" {
+    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
+
+    run ../bin/xspec.sh -s "catalog/catalog-01_schematron.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${lines[18]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]

--- a/xspec.framework
+++ b/xspec.framework
@@ -481,7 +481,30 @@
 												<String>The path to catalog files that will be used for all XSLTs involved in the XSpec execution. Separated by semicolons (;).</String>
 											</field>
 											<field name="value">
-												<String>${pd}/catalog.xml</String>
+												<String>${xmlCatalogFilesList}</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>catalog.is.uri</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>true</String>
 											</field>
 											<field name="defaultValue">
 												<null/>
@@ -799,7 +822,30 @@
 												<String>The path to catalog files that will be used for all XSLTs involved in the XSpec execution. Separated by semicolons (;).</String>
 											</field>
 											<field name="value">
-												<String>${pd}/catalog.xml</String>
+												<String>${xmlCatalogFilesList}</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>catalog.is.uri</String>
+											</field>
+											<field name="description">
+												<String></String>
+											</field>
+											<field name="value">
+												<String>true</String>
 											</field>
 											<field name="defaultValue">
 												<null/>


### PR DESCRIPTION
Closes #898 

Following #913, this pull request enables CLI and Ant to use multiple catalog file URI including multiple URIs.

* New Ant property `catalog.is.uri`
  * Default `false` in `build.xml`.
  * Default `true` in `xspec.framework`.
  * Will not be documented in Wiki for the time being.
* `catalog` Ant property can be either file path (if `catalog.is.uri` is `false`) or URI (if `catalog.is.uri` is `true`). Must not mix file path and URI.
* Regardless of `catalog.is.uri`, relative paths in `catalog` are resolved with Ant `basedir` property.
* Default `catalog` property in `xspec.framework` is now `${xmlCatalogFilesList}`.
  * On Oxygen 22.1 build 2020051804, `${xmlCatalogFilesList}` has many items even when **Use default catalog** is _not_ checked and **Catalogs** list is empty in **Preferences** - **XML** - **XML Catalog**. To disable XML catalog at all, you need to duplicate **Run XSpec Test** transformation scenario and delete **catalog** parameter.

### Why a new Ant property (`catalog.is.uri`)?

Without it, Ant cannot tell whether `catalog` is URI or not, if it is relative.

### Test

`build.xml` and `bin/xspec.*` are tested in Bats.

Regarding the change in `xspec.framework`, I tested it with `<x:context href="[DITA file]" />` and verified that DITA DTD took effect via `${xmlCatalogFilesList}` on Oxygen 22.1 build 2020051804.

### Further work
Update Wiki
* [XML Catalog support](https://github.com/xspec/xspec/wiki/XML-Catalog-support)
* [Running with Oxygen](https://github.com/xspec/xspec/wiki/Running-with-Oxygen#running-the-latest-version-of-xspec-with-oxygen)