### PR TITLE
build(oxygen): add-on v2.0.0

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,37 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
-				<h3>v1.6.0</h3>
+				<h3>v2.0.0</h3>
 				<ul>
-					<li>Official release of v1.6.0</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.6.0-SNAPSHOT.4</h3>
-				<ul>
-					<li>Minor bug fixes</li>
-					<li>Minor improvements</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.6.0-SNAPSHOT.3</h3>
-				<ul>
-					<li>feat: support Text Value Templates (expand-text) (<a
-							href="https://github.com/xspec/xspec/pull/711">#711</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.6.0-SNAPSHOT.2</h3>
-				<ul>
-					<li>feat(schema): add Schematron schema for XSpec (<a
-							href="https://github.com/xspec/xspec/pull/742">#742</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v1.6.0-SNAPSHOT.1</h3>
-				<ul>
-					<li>Support Oxygen 22.0 (<a href="https://github.com/xspec/xspec/pull/780"
-							>#780</a>)</li>
+					<li>Initial development version of v2.0</li>
+					<li>feat: allow multiple catalog file paths (<a
+							href="https://github.com/xspec/xspec/pull/913">#913</a>)</li>
+					<li>feat: catalog file URIs (<a href="https://github.com/xspec/xspec/pull/980"
+							>#980</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -10,21 +10,15 @@
 		<!-- To publish a new version, update this @href to a specific commit archive and increment
 			<xt:version>. -->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/v1.6.0.zip" />
+			href="https://github.com/xspec/xspec/archive/63f6bde07b65947f823cb5a6417039e6370b8927.zip" />
 
-		<!-- The version of this add-on. Increment only the last numeric part ('z' of "0.0.z")
-			whenever we publish a new version of this add-on.
-			Ideally, this version number should be the same as the version of XSpec being installed
-			by this add-on. But <xt:version> consists of only three numeric parts ("x.y.z") which
-			doesn't accommodate pre-release versions of XSpec ("x.y.z-SNAPSHOT.1" or something like
-			that). Use "0.0.z" until we find a better way. -->
-		<xt:version>0.0.9</xt:version>
+		<xt:version>2.0.0</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>19.0+</xt:oxy_version>
+		<xt:oxy_version>20.0+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -12,6 +12,23 @@
                         </String-array>
                     </entry>
                     <entry>
+                        <String>document.types</String>
+                        <documentTypeDescriptor-array/>
+                    </entry>
+                    <entry>
+                        <String>document.types.order</String>
+                        <documentTypeEntry-array>
+                            <documentTypeEntry>
+                                <field name="documentTypeID">
+                                    <String>4/xspec-63f6bde07b65947f823cb5a6417039e6370b8927/xspec.framework/XSpec</String>
+                                </field>
+                                <field name="enable">
+                                    <Boolean>false</Boolean>
+                                </field>
+                            </documentTypeEntry>
+                        </documentTypeEntry-array>
+                    </entry>
+                    <entry>
                         <String>editor.detect.indent.on.open</String>
                         <Boolean>true</Boolean>
                     </entry>
@@ -21,6 +38,10 @@
                     </entry>
                     <entry>
                         <String>enable.project.master.files.support</String>
+                        <Boolean>true</Boolean>
+                    </entry>
+                    <entry>
+                        <String>key.editor.document.type.association.option.pane</String>
                         <Boolean>true</Boolean>
                     </entry>
                     <entry>


### PR DESCRIPTION
Closes #940

This pull request publishes the latest `master` via Oxygen add-on channel.

* Version is `2.0.0` based on #940
* Oxygen 19 (bundled with Saxon 9.7) is dropped
* I tweaked **Document Type Association** preferences in `xspec.xpr` so that the add-on gets disabled while `xspec.xpr` is active.

I tested this change on Oxygen 22.1 (build 2020051804) and 20.0 (build 2018042410) using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-0-0/oxygen-addon.xml`