### PR TITLE
docs(schematron): replace xsl:value-of with xsl:sequence in demo-02.sch

### DIFF
--- a/tutorial/schematron/demo-02.sch
+++ b/tutorial/schematron/demo-02.sch
@@ -8,7 +8,7 @@
     <xsl:function name="local:add" as="xs:integer"> 
         <xsl:param name="a" as="xs:integer"/>
         <xsl:param name="b" as="xs:integer"/>
-        <xsl:value-of select="$a + $b"/>
+        <xsl:sequence select="$a + $b"/>
     </xsl:function>
     
     <sch:phase id="PhaseA">


### PR DESCRIPTION
Just fixes a warning in `tutorial/schematron/demo-02.sch`:

```console
C:\xspec>bin\xspec.bat -s tutorial\schematron\demo-02-PhaseA.xspec
Saxon script not found, invoking JVM directly instead.

Creating XSpec Directory at C:\xspec\tutorial\schematron\xspec...

Setting up Schematron preprocessors...

Converting Schematron into XSLT...

Converting Schematron XSpec into XSLT XSpec...

Creating Test Stylesheet...


Running Tests...
Warning at function local:add on line 31 of demo-02-PhaseA-sch-preprocessed.xsl:
  SXWN9000: A function that computes atomic values should use xsl:sequence rather than xsl:value-of
Testing with SAXON EE 9.9.1.7
Pattern 1
assert t1-1 warn
not assert t2-1
Pattern 3 - Shared
assert t3-1
Pattern 4 - example of a second level of imported scenarios
report t4-1 warn

Formatting Report...
passed: 4 / pending: 0 / failed: 0 / total: 4
Report available at C:\xspec\tutorial\schematron\xspec\demo-02-PhaseA-result.html
Done.
```