### PR TITLE
fix: fix #987 (circular imports)

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -113,7 +113,25 @@
 		<!-- https://sourceforge.net/p/saxon/mailman/message/36339785/
 			"document-uri() returns the (absolutized) requested URI, while base-uri() returns
 			the actual document location after catalog resolution." -->
-		<xsl:sequence select="x:base-uri(doc($xml-uri))" />
+		<xsl:sequence select="
+				$xml-uri
+				=> doc()
+				=> x:base-uri()" />
+	</xsl:function>
+
+
+	<!--
+		Returns the actual document URI (i.e. resolved with the currently enabled catalog),
+		working around an XML resolver bug
+	-->
+	<xsl:function as="xs:anyURI" name="x:actual-document-uri">
+		<xsl:param as="document-node()" name="doc" />
+
+		<xsl:sequence
+			select="
+				$doc
+				=> document-uri()
+				=> x:resolve-xml-uri-with-catalog()" />
 	</xsl:function>
 
 	<!--

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -20,8 +20,7 @@
 
    <xsl:include href="../common/xspec-utils.xsl"/>
 
-   <xsl:variable name="actual-document-uri" as="xs:anyURI"
-      select="document-uri(/) => x:resolve-xml-uri-with-catalog()" />
+   <xsl:variable name="actual-document-uri" as="xs:anyURI" select="x:actual-document-uri(/)" />
 
    <!-- XSpec namespace prefix -->
    <xsl:function name="x:xspec-prefix" as="xs:string">
@@ -108,8 +107,14 @@
                     select="x:distinct-nodes-stable($docs ! x:description)" />
 
       <!-- "$imported except $visit" without sorting -->
+      <xsl:variable name="visited-actual-uris" as="xs:anyURI+"
+         select="$visit ! x:actual-document-uri(/)" />
       <xsl:variable name="imported-except-visit" as="element(x:description)*"
-                    select="$imported[empty($visit intersect .)]"/>
+         select="
+            $imported[empty(. intersect $visit)]
+
+            (: xspec/xspec#987 :)
+            [not(x:actual-document-uri(/) = $visited-actual-uris)]" />
 
       <xsl:choose>
          <xsl:when test="empty($imported-except-visit)">
@@ -142,8 +147,7 @@
       <xsl:apply-templates mode="#current">
          <xsl:with-param name="xslt-version"   tunnel="yes" select="x:xslt-version(.)"/>
          <xsl:with-param name="preserve-space" tunnel="yes" select="x:parse-preserve-space(.)" />
-         <xsl:with-param name="xspec-module-uri" tunnel="yes"
-            select="document-uri(/) => x:resolve-xml-uri-with-catalog()" />
+         <xsl:with-param name="xspec-module-uri" tunnel="yes" select="x:actual-document-uri(/)" />
       </xsl:apply-templates>
    </xsl:template>
 

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -34,10 +34,7 @@
             <xsl:namespace name="{@prefix}" select="@uri" />
         </xsl:for-each>
 
-        <xsl:attribute name="xspec-original-location"
-            select="
-                document-uri(/)
-                => x:resolve-xml-uri-with-catalog()" />
+        <xsl:attribute name="xspec-original-location" select="x:actual-document-uri(/)" />
         <xsl:attribute name="stylesheet" select="$stylesheet-uri" />
         <xsl:attribute name="schematron" select="$resolved-schematron-uri" />
     </xsl:template>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1371,10 +1371,10 @@
 	</case>
 
 	<!--
-		#185
+		Import order #185
 	-->
 
-	<case name="Import order #185">
+	<case name="Import order #185 (CLI)">
     call :run ..\bin\xspec.bat xspec-185\import-1.xspec
     call :verify_retval 0
     call :verify_line  7 x "Scenario 1-1"
@@ -1388,7 +1388,7 @@
     call :verify_line 15 x "Formatting Report..."
 	</case>
 
-	<case name="Import order with Ant #185">
+	<case name="Import order #185 (Ant)">
     set "ANT_LOG=%WORK_DIR%\ant.log"
 
     call :run ant ^
@@ -1408,6 +1408,68 @@
     call :verify_line  7 x "     [java] Scenario 2b-1"
     call :verify_line  8 x "     [java] Scenario 2b-2"
     call :verify_line  9 x "     [java] Scenario 3"
+	</case>
+
+	<!--
+		Circular import #987
+	-->
+
+	<case name="Circular import #987 (CLI)">
+    call :run ..\bin\xspec.bat xspec-987_child.xspec
+    call :verify_retval 0
+    call :verify_line  7 x "Scenario in child"
+    call :verify_line  9 x "Scenario in parent"
+    call :verify_line 12 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+
+    rem Use a fresh dir, to make the message line numbers predictable
+    set "TEST_DIR=%TEST_DIR%\parent %RANDOM%"
+    call :run ..\bin\xspec.bat xspec-987_parent.xspec
+    call :verify_retval 0
+    call :verify_line  7 x "Scenario in parent"
+    call :verify_line  9 x "Scenario in child"
+    call :verify_line 12 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+	</case>
+
+	<case name="Circular import #987 (Ant)">
+    rem
+    rem Child
+    rem
+    set "ANT_LOG=%WORK_DIR%\ant_child.log"
+
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -Dxspec.xml="%CD%\xspec-987_child.xspec"
+    call :verify_retval 0
+
+    call :run type "%ANT_LOG%"
+    call :verify_line -10 x "     [xslt] passed: 2 / pending: 0 / failed: 0 / total: 2"
+
+    call :run %SYSTEMROOT%\system32\find " Scenario in " "%ANT_LOG%"
+    call :verify_line_count 3
+    call :verify_line 2 x "     [java] Scenario in child"
+    call :verify_line 3 x "     [java] Scenario in parent"
+
+    rem
+    rem Parent
+    rem
+    set "ANT_LOG=%WORK_DIR%\ant_parent.log"
+
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -logfile "%ANT_LOG%" ^
+        -Dxspec.xml="%CD%\xspec-987_parent.xspec"
+    call :verify_retval 0
+
+    call :run type "%ANT_LOG%"
+    call :verify_line -10 x "     [xslt] passed: 2 / pending: 0 / failed: 0 / total: 2"
+
+    call :run %SYSTEMROOT%\system32\find " Scenario in " "%ANT_LOG%"
+    call :verify_line_count 3
+    call :verify_line 2 x "     [java] Scenario in parent"
+    call :verify_line 3 x "     [java] Scenario in child"
 	</case>
 
 	<!--

--- a/test/win-bats/collection.xsd
+++ b/test/win-bats/collection.xsd
@@ -15,7 +15,7 @@
 	<xs:complexType name="collectionType">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" name="case">
-				<xs:complexType mixed="true">
+				<xs:complexType>
 					<xs:simpleContent>
 						<xs:extension base="xspec-bat:scriptString">
 							<xs:attribute name="name" type="xspec-bat:nameString" use="required" />

--- a/test/xspec-987_child.xspec
+++ b/test/xspec-987_child.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!-- Circular import. Should be discarded.
+		TODO: And should be warned or error out? Any valid use cases? -->
+	<x:import href="xspec-987_parent.xspec" />
+
+	<x:scenario label="Scenario in child">
+		<x:context />
+		<x:expect label="Expect in child" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/xspec-987_parent.xspec
+++ b/test/xspec-987_parent.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:param name="global-param" />
+
+	<x:import href="xspec-987_child.xspec" />
+
+	<x:scenario label="Scenario in parent">
+		<x:context />
+		<x:expect label="Expect in parent" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -157,7 +157,23 @@
 		</x:call>
 		<x:expect label="'file' scheme" select="'file'" test="substring-before($x:result, ':')" />
 		<x:expect label="Must work around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
-			test="starts-with(substring-after($x:result, ':'), '/')" />
+			test="
+				$x:result
+				=> substring-after(':')
+				=> starts-with('/')" />
+	</x:scenario>
+
+	<x:scenario label="Scenario for testing function actual-document-uri">
+		<!-- TODO: Use catalog -->
+		<x:call function="x:actual-document-uri">
+			<x:param select="doc('')" />
+		</x:call>
+		<x:expect label="'file' scheme" select="'file'" test="substring-before($x:result, ':')" />
+		<x:expect label="Must work around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
+			test="
+				$x:result
+				=> substring-after(':')
+				=> starts-with('/')" />
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function base-uri">


### PR DESCRIPTION
Fixes a problem where `x:import` fails to eliminate duplicates.

- 72a24af24260df12378bf517ee236d02a30fca44 reproduces the problem on Saxon 9.9 and 10.1
- 870419cd1db8eb79a6e59e1d411092c2de3765c1 fixes it by comparing actual document URI _in addition to_ node identity