### PR TITLE
test: test AVT with namespace prefix

### DIFF
--- a/test/xspec-avt.xspec
+++ b/test/xspec-avt.xspec
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:mirror" query-at="mirror.xquery" stylesheet="mirror.xsl"
-	xmlns:mirror="x-urn:test:mirror" xmlns:myv="http://example.org/ns/my/variable"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	xmlns:mirror="x-urn:test:mirror" xmlns:myfn="http://www.w3.org/2005/xpath-functions"
+	xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!--
 		xspec-utils_stylesheet.xspec uses this file for testing x:is-user-content().
 		When modifying this file, check whether xspec-utils_stylesheet.xspec needs any additions or updates.
 	-->
 
+	<!-- xmlns:myfn is for ensuring that namespace prefixes take effect in AVT -->
+
 	<x:scenario label="In function-param, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:call[@function]/x:param/node(),">
 			<x:call function="mirror:param-mirror">
 				<x:param>
-					<function-param-child attr="}}{false()}{{">}}{false()}{{</function-param-child>
+					<function-param-child attr="}}{myfn:false()}{{"
+						>}}{false()}{{</function-param-child>
 				</x:param>
 			</x:call>
 			<x:expect label="attribute is AVT." select="'}false{'"
@@ -33,7 +36,7 @@
 	</x:scenario>
 
 	<x:param name="global-param-no-href">
-		<global-param-child attr="}}{false()}{{">}}{false()}{{</global-param-child>
+		<global-param-child attr="}}{myfn:false()}{{">}}{false()}{{</global-param-child>
 	</x:param>
 	<x:param href="xspec-avt.xml" name="global-param-with-href" />
 	<x:scenario label="In global-param, only user-content attribute is AVT. So...">
@@ -55,7 +58,7 @@
 	</x:scenario>
 
 	<x:variable name="myv:global-var-no-href">
-		<global-var-child attr="}}{false()}{{">}}{false()}{{</global-var-child>
+		<global-var-child attr="}}{myfn:false()}{{">}}{false()}{{</global-var-child>
 	</x:variable>
 	<x:variable href="xspec-avt.xml" name="myv:global-var-with-href" />
 	<x:scenario label="In global-var, only user-content attribute is AVT. So...">
@@ -78,7 +81,7 @@
 
 	<x:scenario label="In local variable, only user-content attribute is AVT. So...">
 		<x:variable name="myv:var-no-href">
-			<variable-child attr="}}{false()}{{">}}{false()}{{</variable-child>
+			<variable-child attr="}}{myfn:false()}{{">}}{false()}{{</variable-child>
 		</x:variable>
 		<x:variable href="xspec-avt.xml" name="myv:var-with-href" />
 		<x:scenario label="In //x:scenario/x:variable/node(),">
@@ -103,7 +106,7 @@
 			<x:call function="mirror:false" />
 			<x:expect label="attribute is AVT." select="assertion-child/@attr/string()"
 				test="'}false{'">
-				<assertion-child attr="}}{false()}{{" />
+				<assertion-child attr="}}{myfn:false()}{{" />
 			</x:expect>
 			<x:expect label="text node is intact." select="assertion-child/text()/string()"
 				test="'}}{false()}{{'">

--- a/test/xspec-avt_schematron.xspec
+++ b/test/xspec-avt_schematron.xspec
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description schematron="xspec-avt.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description schematron="xspec-avt.sch" xmlns:myfn="http://www.w3.org/2005/xpath-functions"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!-- xmlns:myfn is for ensuring that namespace prefixes take effect in AVT -->
 
 	<x:scenario label="In context, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:context/node(),">
 			<x:context>
-				<context-child attr="}}{false()}{{">}}{false()}{{</context-child>
+				<context-child attr="}}{myfn:false()}{{">}}{false()}{{</context-child>
 			</x:context>
 			<x:expect-report id="context-child-attr-ok" label="attribute is AVT." />
 			<x:expect-report id="context-child-text-ok" label="text node is intact." />

--- a/test/xspec-avt_stylesheet.xspec
+++ b/test/xspec-avt_stylesheet.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:myfn="http://www.w3.org/2005/xpath-functions"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<!--
@@ -7,11 +8,15 @@
 		When modifying this file, check whether xspec-utils_stylesheet.xspec needs any additions or updates.
 	-->
 
+	<!-- xmlns:myfn is for ensuring that namespace prefixes take effect in AVT -->
+
+
 	<x:scenario label="In context template-param, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:context/x:param/node(),">
 			<x:context mode="mirror:param-mirror">
 				<x:param name="param-items">
-					<template-param-child attr="}}{false()}{{">}}{false()}{{</template-param-child>
+					<template-param-child attr="}}{myfn:false()}{{"
+						>}}{false()}{{</template-param-child>
 				</x:param>
 				<context-child />
 			</x:context>
@@ -36,7 +41,7 @@
 	<x:scenario label="In context, only user-content attribute is AVT. So...">
 		<x:scenario label="In //x:context/node(),">
 			<x:context mode="mirror:context-mirror">
-				<context-child attr="}}{false()}{{">}}{false()}{{</context-child>
+				<context-child attr="}}{myfn:false()}{{">}}{false()}{{</context-child>
 			</x:context>
 			<x:expect label="attribute is AVT." select="'}false{'"
 				test="$x:result/self::context-child/@attr/string()" />
@@ -57,7 +62,8 @@
 		<x:scenario label="In //x:call[@template]/x:param/node(),">
 			<x:call template="mirror:param-mirror">
 				<x:param name="param-items">
-					<template-param-child attr="}}{false()}{{">}}{false()}{{</template-param-child>
+					<template-param-child attr="}}{myfn:false()}{{"
+						>}}{false()}{{</template-param-child>
 				</x:param>
 			</x:call>
 			<x:expect label="attribute is AVT." select="'}false{'"


### PR DESCRIPTION
This pull request just prepends a prefix to functions in the AVT tests, to make sure that namespace prefixes are available in AVT.