### PR TITLE
refactor(xquery): do not occupy output namespace

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -666,6 +666,9 @@
 				<xsl:when test="$prefix eq 'map'">
 					<xsl:sequence select="'http://www.w3.org/2005/xpath-functions/map'" />
 				</xsl:when>
+				<xsl:when test="$prefix eq 'output'">
+					<xsl:sequence select="'http://www.w3.org/2010/xslt-xquery-serialization'" />
+				</xsl:when>
 				<xsl:when test="$prefix eq 'test'">
 					<xsl:sequence select="$x:legacy-namespace" />
 				</xsl:when>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -113,11 +113,10 @@
       <xsl:apply-templates select="$this" mode="x:decl-ns">
          <xsl:with-param name="except" select="$prefix, 'test'"/>
       </xsl:apply-templates>
-      <xsl:text>declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";&#x0A;</xsl:text>
 
       <!-- Serialization parameters -->
-      <xsl:text>declare option output:method "xml";&#x0A;</xsl:text>
-      <xsl:text>declare option output:indent "yes";&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">declare option {x:known-UQN('output:method')} "xml";&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">declare option {x:known-UQN('output:indent')} "yes";&#x0A;</xsl:text>
 
       <!-- Absolute URI of the master .xspec file -->
       <xsl:call-template name="test:declare-or-let-variable">

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1466,6 +1466,14 @@
 				>Q{http://www.w3.org/2005/xpath-functions/map}my-local-name</x:expect>
 		</x:scenario>
 
+		<x:scenario label="output">
+			<x:call function="x:known-UQN">
+				<x:param select="'output:my-local-name'" />
+			</x:call>
+			<x:expect label="Constructed" select="string()"
+				>Q{http://www.w3.org/2010/xslt-xquery-serialization}my-local-name</x:expect>
+		</x:scenario>
+
 		<x:scenario label="test">
 			<x:call function="x:known-UQN">
 				<x:param select="'test:my-local-name'" />


### PR DESCRIPTION
The compiled XQuery occupies `output` namespace prefix. This pull request frees it by replacing the option declarations with URIQualifiedName.