### PR TITLE
refactor(report): do not use namespace axis

### DIFF
--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -80,8 +80,8 @@
     'http://www.w3.org/1999/XSL/Transform' (: xsl :),
     $x:xs-namespace (: xs :),
     'http://www.w3.org/XML/1998/namespace' (: xml :)" />
-  <xsl:variable name="namespaces" as="namespace-node()*" select="namespace::*" />
-  <xsl:variable name="parent-namespaces" as="namespace-node()*" select="parent::element()/namespace::*" />
+  <xsl:variable name="namespaces" as="namespace-node()*" select="x:copy-namespaces(.)" />
+  <xsl:variable name="parent-namespaces" as="namespace-node()*" select="parent::element() => x:copy-namespaces()" />
   <xsl:variable name="significant-namespaces" as="namespace-node()*" select="$namespaces[not(string() = $omit-namespace-uris)]" />
   <xsl:variable name="new-namespaces" as="namespace-node()*">
     <xsl:choose>


### PR DESCRIPTION
This pull request just replaces the deprecated namespace axis with our util function.