### PR TITLE
test(xslt): catch xsl:message in atomic value function/template

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -193,7 +193,7 @@
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-4621-fixed')
-							and (x:saxon-version() lt x:pack-version((10, 2)))">
+							and (x:saxon-version() le x:pack-version((10, 1)))">
 						<xsl:text>Requires Saxon bug #4621 to have been fixed</xsl:text>
 					</xsl:when>
 

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -186,8 +186,15 @@
 					<xsl:when
 						test="
 							($pis = 'require-saxon-bug-4483-fixed')
-							and (x:saxon-version() eq x:pack-version(10))">
+							and (x:saxon-version() eq x:pack-version((10, 0)))">
 						<xsl:text>Requires Saxon bug #4483 to have been fixed</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
+							($pis = 'require-saxon-bug-4621-fixed')
+							and (x:saxon-version() lt x:pack-version((10, 2)))">
+						<xsl:text>Requires Saxon bug #4621 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when

--- a/test/xspec-1029.xsl
+++ b/test/xspec-1029.xsl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:xspec-1029="x-urn:test:xspec-1029">
+
+	<!-- Function -->
+
+	<xsl:function as="xs:integer" name="xspec-1029:as-integer">
+		<xsl:message select="'my error message'" terminate="yes" />
+		<xsl:sequence select="1" />
+	</xsl:function>
+
+	<xsl:function name="xspec-1029:no-as">
+		<xsl:message select="'my error message'" terminate="yes" />
+	</xsl:function>
+
+	<!-- Named template -->
+
+	<xsl:template as="xs:integer" name="xspec-1029:as-integer">
+		<xsl:message select="'my error message'" terminate="yes" />
+		<xsl:sequence select="1" />
+	</xsl:template>
+
+	<xsl:template name="xspec-1029:no-as">
+		<xsl:message select="'my error message'" terminate="yes" />
+	</xsl:template>
+
+	<!-- Matching template -->
+
+	<xsl:template as="xs:integer" match="context-child" mode="xspec-1029:as-integer">
+		<xsl:message select="'my error message'" terminate="yes" />
+		<xsl:sequence select="1" />
+	</xsl:template>
+
+	<xsl:template match="context-child" mode="xspec-1029:no-as">
+		<xsl:message select="'my error message'" terminate="yes" />
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/xspec-1029.xspec
+++ b/test/xspec-1029.xspec
@@ -37,7 +37,7 @@
 	</x:scenario>
 
 	<x:scenario catch="yes"
-		label="catch=yes with xsl:message[@terminate=yes]in matching xsl:template">
+		label="catch=yes with xsl:message[@terminate=yes] in matching xsl:template">
 		<x:scenario label="[@as=xs:integer]">
 			<x:context mode="xspec-1029:as-integer">
 				<context-child />

--- a/test/xspec-1029.xspec
+++ b/test/xspec-1029.xspec
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-saxon-bug-4621-fixed?>
+<x:description stylesheet="xspec-1029.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xspec-1029="x-urn:test:xspec-1029">
+
+	<x:scenario label="expectations" shared="yes">
+		<x:expect label="should catch err:XTMM9000"
+			select="QName('http://www.w3.org/2005/xqt-errors', 'XTMM9000')"
+			test="$x:result?err?code treat as xs:QName" />
+		<x:expect label="should catch its message body" test="$x:result?err?value/text()"
+			><![CDATA[my error message]]></x:expect>
+	</x:scenario>
+
+	<x:scenario catch="yes" label="catch=yes with xsl:message[@terminate=yes] in xsl:function">
+		<x:scenario label="[@as=xs:integer]">
+			<x:call function="xspec-1029:as-integer" />
+			<x:like label="expectations" />
+		</x:scenario>
+
+		<x:scenario label="[empty(@as)]">
+			<x:call function="xspec-1029:no-as" />
+			<x:like label="expectations" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario catch="yes"
+		label="catch=yes with xsl:message[@terminate=yes] in calling xsl:template">
+		<x:scenario label="[@as=xs:integer]">
+			<x:call template="xspec-1029:as-integer" />
+			<x:like label="expectations" />
+		</x:scenario>
+
+		<x:scenario label="[empty(@as)]">
+			<x:call template="xspec-1029:no-as" />
+			<x:like label="expectations" />
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario catch="yes"
+		label="catch=yes with xsl:message[@terminate=yes]in matching xsl:template">
+		<x:scenario label="[@as=xs:integer]">
+			<x:context mode="xspec-1029:as-integer">
+				<context-child />
+			</x:context>
+			<x:like label="expectations" />
+		</x:scenario>
+
+		<x:scenario label="[empty(@as)]">
+			<x:context mode="xspec-1029:no-as">
+				<context-child />
+			</x:context>
+			<x:like label="expectations" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Closes #1029 

This test assumes the Saxon bug will be fixed in Saxon 10.2 (only).