### PR TITLE
fix(xslt): set namespace on node generator

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -27,6 +27,12 @@
 		select="xs:anyURI('http://www.w3.org/2001/XMLSchema')" />
 
 	<!--
+		Standard 'xsl' namespace URI
+	-->
+	<xsl:variable as="xs:anyURI" name="x:xsl-namespace"
+		select="xs:anyURI('http://www.w3.org/1999/XSL/Transform')" />
+
+	<!--
 		U+0027
 	-->
 	<xsl:variable as="xs:string" name="x:apos">'</xsl:variable>

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -374,7 +374,7 @@
       <xsl:apply-templates select="following-sibling::*[1]" mode="#current">
          <xsl:with-param name="vars" tunnel="yes" as="element(x:var)+">
             <xsl:sequence select="$vars"/>
-            <xsl:element name="x:var">
+            <xsl:element name="x:var" namespace="{$x:xspec-namespace}">
                <xsl:attribute name="name" select="@name"/>
                <xsl:if test="not(contains(@name,'Q{')) and contains(@name,':')">
                   <xsl:attribute name="namespace-uri"
@@ -623,7 +623,7 @@
       <xsl:apply-templates select="following-sibling::*[1]" mode="#current">
          <xsl:with-param name="vars" tunnel="yes" as="element(x:var)+">
             <xsl:sequence select="$vars"/>
-            <xsl:element name="x:var">
+            <xsl:element name="x:var" namespace="{$x:xspec-namespace}">
                <xsl:attribute name="name" select="@name"/>
                <xsl:if test="not(contains(@name,'Q{')) and contains(@name,':')">
                   <xsl:attribute name="namespace-uri"
@@ -833,7 +833,7 @@
       <xsl:for-each select="$distinct-qnames">
          <xsl:variable name="this-qname" select="."/>
          <xsl:variable name="this-prefix" select="prefix-from-QName($this-qname)"/>
-         <xsl:element name="x:var">
+         <xsl:element name="x:var" namespace="{$x:xspec-namespace}">
             <xsl:choose>
                <xsl:when test="empty(prefix-from-QName($this-qname)) and (string-length(namespace-uri-from-QName($this-qname)) gt 0)">
                   <!-- No prefix but there is a nonempty namespace URI -->

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -153,6 +153,10 @@
             <xsl:attribute name="name" select="name()" />
          </xsl:if>
 
+         <xsl:if test=". instance of attribute()">
+            <xsl:attribute name="namespace" select="namespace-uri()" />
+         </xsl:if>
+
          <xsl:choose>
             <xsl:when test="(. instance of attribute()) and x:is-user-content(.)">
                <!-- AVT -->

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -65,7 +65,7 @@
       </xsl:variable>
 
       <xsl:if test="$temp-uri-name">
-         <xsl:element name="xsl:variable">
+         <xsl:element name="xsl:variable" namespace="{$x:xsl-namespace}">
             <xsl:attribute name="name" select="$temp-uri-name" />
             <xsl:attribute name="as" select="x:known-UQN('xs:anyURI')" />
 
@@ -74,7 +74,7 @@
       </xsl:if>
 
       <xsl:if test="$temp-doc-name">
-         <xsl:element name="xsl:variable">
+         <xsl:element name="xsl:variable" namespace="{$x:xsl-namespace}">
             <xsl:attribute name="name" select="$temp-doc-name" />
             <xsl:attribute name="as" select="'document-node()'" />
 
@@ -88,7 +88,7 @@
                </xsl:when>
 
                <xsl:otherwise>
-                  <xsl:element name="xsl:document">
+                  <xsl:element name="xsl:document" namespace="{$x:xsl-namespace}">
                      <xsl:apply-templates select="node() except $exclude"
                         mode="test:create-node-generator" />
                   </xsl:element>
@@ -97,7 +97,8 @@
          </xsl:element>
       </xsl:if>
 
-      <xsl:element name="xsl:{if ($is-param) then 'param' else 'variable'}">
+      <xsl:element name="xsl:{if ($is-param) then 'param' else 'variable'}"
+         namespace="{$x:xsl-namespace}">
          <xsl:sequence select="x:copy-namespaces(.)" />
 
          <xsl:attribute name="name" select="$name" />
@@ -147,7 +148,7 @@
       as="element()" mode="test:create-node-generator">
       <!-- As for attribute(), do not just throw XSLT attributes (@xsl:*) into identity
          template. If you do so, the attribute being generated becomes a generator... -->
-      <xsl:element name="xsl:{x:node-type(.)}">
+      <xsl:element name="xsl:{x:node-type(.)}" namespace="{$x:xsl-namespace}">
          <xsl:if test="(. instance of attribute()) or (. instance of processing-instruction())">
             <xsl:attribute name="name" select="name()" />
          </xsl:if>
@@ -181,12 +182,13 @@
    <xsl:template match="xsl:*" as="element(xsl:element)" mode="test:create-node-generator">
       <!-- Do not just throw XSLT elements (xsl:*) into identity template.
          If you do so, the element being generated becomes a generator... -->
-      <xsl:element name="xsl:element">
+      <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
          <xsl:attribute name="name" select="name()" />
+         <xsl:attribute name="namespace" select="namespace-uri()" />
 
          <xsl:variable name="context-element" as="element()" select="." />
          <xsl:for-each select="in-scope-prefixes($context-element)[not(. eq 'xml')]">
-            <xsl:element name="xsl:namespace">
+            <xsl:element name="xsl:namespace" namespace="{$x:xsl-namespace}">
                <xsl:attribute name="name" select="." />
                <xsl:value-of select="namespace-uri-for-prefix(., $context-element)" />
             </xsl:element>

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -470,7 +470,7 @@
 
    <xsl:template match="text()[not(normalize-space())]" as="element(test:ws)"
       mode="test:report-node">
-      <xsl:element name="test:ws">
+      <xsl:element name="test:ws" namespace="{$x:legacy-namespace}">
          <xsl:sequence select="." />
       </xsl:element>
    </xsl:template>

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -77,9 +77,9 @@
   <!-- Namespace nodes -->
   <xsl:variable name="omit-namespace-uris" as="xs:string+" select="
     $x:xspec-namespace (: x :),
-    'http://www.w3.org/1999/XSL/Transform' (: xsl :),
-    $x:xs-namespace (: xs :),
-    'http://www.w3.org/XML/1998/namespace' (: xml :)" />
+    'http://www.w3.org/XML/1998/namespace' (: xml :),
+    $x:xs-namespace,
+    $x:xsl-namespace" />
   <xsl:variable name="namespaces" as="namespace-node()*" select="namespace::*" />
   <xsl:variable name="parent-namespaces" as="namespace-node()*" select="parent::element()/namespace::*" />
   <xsl:variable name="significant-namespaces" as="namespace-node()*" select="$namespaces[not(string() = $omit-namespace-uris)]" />

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -120,7 +120,7 @@
     </xsl:template>
 
     <xsl:template match="x:expect-assert" as="element(x:expect)">
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
                 <xsl:value-of select="if (@count) then 'count' else 'exists'" />
@@ -133,7 +133,7 @@
     </xsl:template>
 
     <xsl:template match="x:expect-not-assert" as="element(x:expect)">
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
                 <xsl:text>boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:failed-assert</xsl:text>
@@ -144,7 +144,7 @@
     </xsl:template>
 
     <xsl:template match="x:expect-report" as="element(x:expect)">
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
                 <xsl:value-of select="if (@count) then 'count' else 'exists'" />
@@ -157,7 +157,7 @@
     </xsl:template>
 
     <xsl:template match="x:expect-not-report" as="element(x:expect)">
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
                 <xsl:text>boolean(svrl:schematron-output[svrl:fired-rule]) and empty(svrl:schematron-output/svrl:successful-report</xsl:text>
@@ -202,7 +202,7 @@
                 ($errors ! ($x:apos || . || $x:apos))
                 => string-join(',')" />
 
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:attribute name="label" select="'valid'"/>
             <xsl:attribute name="test">
                 <xsl:text>boolean(svrl:schematron-output[svrl:fired-rule])</xsl:text>
@@ -215,7 +215,7 @@
     </xsl:template>
 
     <xsl:template match="x:expect-rule" as="element(x:expect)">
-        <xsl:element name="x:expect">
+        <xsl:element name="x:expect" namespace="{$x:xspec-namespace}">
             <xsl:call-template name="make-label"/>
             <xsl:attribute name="test">
                 <xsl:value-of select="if (@count) then 'count' else 'exists'" />

--- a/test/xspec-453_local.xspec
+++ b/test/xspec-453_local.xspec
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:mirror" query-at="mirror.xqm" stylesheet="mirror.xsl"
-	xmlns="http://www.w3.org/1999/XSL/Transform" xmlns:mirror="x-urn:test:mirror"
-	xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xspec-453="x-urn:test:xspec-453">
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
-	<!-- This XSpec file declares all the namespaces at /x:description -->
+	<!-- This XSpec file declares all the namespaces (except 'x') at each innermost user-content
+		where the declaration is absolutely necessary -->
 
 	<x:scenario label="When a function returns an element in XSLT namespace using">
 		<x:scenario label="usual prefix (xsl:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="element(xsl:element)">
-					<xsl:element />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+					<xsl:element xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same element should be Success"
-				select="element() treat as element(xsl:element)">
-				<xsl:element />
+				select="element() treat as element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+				<xsl:element xmlns:xsl="http://www.w3.org/1999/XSL/Transform" />
 			</x:expect>
 			<x:expect label="name()" select="'xsl:element'" test="name($x:result)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -24,14 +22,14 @@
 		</x:scenario>
 
 		<x:scenario label="unusual prefix (stylesheet:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="element(stylesheet:element)">
-					<stylesheet:element />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+					<stylesheet:element xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same element should be Success"
-				select="element() treat as element(stylesheet:element)">
-				<stylesheet:element />
+				select="element() treat as element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+				<stylesheet:element xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 			</x:expect>
 			<x:expect label="name()" select="'stylesheet:element'" test="name($x:result)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -39,14 +37,14 @@
 		</x:scenario>
 
 		<x:scenario label="the default namespace">
-			<x:call function="mirror:param-mirror">
-				<x:param as="element(xsl:element)">
-					<element />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+					<element xmlns="http://www.w3.org/1999/XSL/Transform" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same element should be Success"
-				select="element() treat as element(xsl:element)">
-				<element />
+				select="element() treat as element(Q{http://www.w3.org/1999/XSL/Transform}element)">
+				<element xmlns="http://www.w3.org/1999/XSL/Transform" />
 			</x:expect>
 			<x:expect label="name()" select="'element'" test="name($x:result)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -56,14 +54,15 @@
 
 	<x:scenario label="When a function returns an attribute in XSLT namespace using">
 		<x:scenario label="usual prefix (xsl:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="attribute(xsl:use-when)" select="*/@*">
-					<xspec-453:foo xsl:use-when="false()" />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="attribute(Q{http://www.w3.org/1999/XSL/Transform}use-when)"
+					select="*/@*">
+					<foo xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:use-when="false()" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same attribute should be Success"
-				select="*/@* treat as attribute(xsl:use-when)">
-				<xspec-453:foo xsl:use-when="false()" />
+				select="*/@* treat as attribute(Q{http://www.w3.org/1999/XSL/Transform}use-when)">
+				<foo xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:use-when="false()" />
 			</x:expect>
 			<x:expect label="name()" select="'xsl:use-when'" test="name($x:result)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -71,14 +70,17 @@
 		</x:scenario>
 
 		<x:scenario label="unusual prefix (stylesheet:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="attribute(stylesheet:use-when)" select="*/@*">
-					<xspec-453:foo stylesheet:use-when="false()" />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="attribute(Q{http://www.w3.org/1999/XSL/Transform}use-when)"
+					select="*/@*">
+					<foo stylesheet:use-when="false()"
+						xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same attribute should be Success"
-				select="*/@* treat as attribute(stylesheet:use-when)">
-				<xspec-453:foo stylesheet:use-when="false()" />
+				select="*/@* treat as attribute(Q{http://www.w3.org/1999/XSL/Transform}use-when)">
+				<foo stylesheet:use-when="false()"
+					xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 			</x:expect>
 			<x:expect label="name()" select="'stylesheet:use-when'" test="name($x:result)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -88,14 +90,14 @@
 
 	<x:scenario label="When a function returns an element with an attribute in XSLT namespace using">
 		<x:scenario label="usual prefix (xsl:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="element(xspec-453:foo)">
-					<xspec-453:foo xsl:use-when="false()" />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="element(foo)">
+					<foo xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:use-when="false()" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same element should be Success"
-				select="element() treat as element(xspec-453:foo)">
-				<xspec-453:foo xsl:use-when="false()" />
+				select="element() treat as element(foo)">
+				<foo xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:use-when="false()" />
 			</x:expect>
 			<x:expect label="name()" select="'xsl:use-when'" test="name($x:result/@*)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"
@@ -103,14 +105,16 @@
 		</x:scenario>
 
 		<x:scenario label="unusual prefix (stylesheet:)">
-			<x:call function="mirror:param-mirror">
-				<x:param as="element(xspec-453:foo)">
-					<xspec-453:foo stylesheet:use-when="false()" />
+			<x:call function="Q{x-urn:test:mirror}param-mirror">
+				<x:param as="element(foo)">
+					<foo stylesheet:use-when="false()"
+						xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 				</x:param>
 			</x:call>
 			<x:expect label="Expecting the same element should be Success"
-				select="element() treat as element(xspec-453:foo)">
-				<xspec-453:foo stylesheet:use-when="false()" />
+				select="element() treat as element(foo)">
+				<foo stylesheet:use-when="false()"
+					xmlns:stylesheet="http://www.w3.org/1999/XSL/Transform" />
 			</x:expect>
 			<x:expect label="name()" select="'stylesheet:use-when'" test="name($x:result/@*)" />
 			<x:expect label="namespace-uri()" select="'http://www.w3.org/1999/XSL/Transform'"

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -37,6 +37,12 @@
 			test="$x:xs-namespace treat as xs:anyURI" />
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing variable xsl-namespace">
+		<x:context />
+		<x:expect label="'xsl' namespace URI" select="doc('')/element() => namespace-uri()"
+			test="$x:xsl-namespace treat as xs:anyURI" />
+	</x:scenario>
+
 	<x:scenario label="Scenario for testing variable capture-NCName">
 		<x:call function="replace">
 			<x:param select="'foo:bar[baz]'" />


### PR DESCRIPTION
Fixes #1031 

`@namespace` was missing from `xsl:element` created by `test:create-node-generator` mode.

This pull request fixes it and also adds `@namespace` to some other instances of `xsl:element` and `xsl:attribute`.