### PR TITLE
refactor: use the single-argument version of string-join()

### DIFF
--- a/src/compiler/generate-query-utils.xqm
+++ b/src/compiler/generate-query-utils.xqm
@@ -28,7 +28,7 @@ declare function test:deep-equal(
     satisfies test:item-deep-equal($seq1[$i], $seq2[$i], $flags)
 
   else if ( $seq1 instance of text() and $seq2 instance of text()+ ) then
-    test:deep-equal($seq1, text { string-join($seq2, '') }, $flags)
+    test:deep-equal($seq1, text { string-join($seq2) }, $flags)
 
   else
     false()
@@ -42,7 +42,7 @@ declare function test:deep-equal-v1(
 {
   let $seq2-adapted as xs:anyAtomicType? := (
     if ($seq2 instance of text()+) then
-      let $seq2-string as xs:string := string-join($seq2, '')
+      let $seq2-string as xs:string := string-join($seq2)
       return
         typeswitch ($seq1)
           case xs:string  return $seq2-string

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -107,7 +107,7 @@
 
       <xsl:variable name="seq2-adapted" as="xs:anyAtomicType?">
          <xsl:if test="$seq2 instance of text()+">
-            <xsl:variable name="seq2-string" as="xs:string" select="string-join($seq2, '')" />
+            <xsl:variable name="seq2-string" as="xs:string" select="string-join($seq2)" />
 
             <xsl:choose>
                <xsl:when test="$seq1 instance of xs:string">

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -103,7 +103,7 @@
   <xsl:variable name="number-width" as="xs:integer"
     select="string-length(xs:string($number-of-lines))" />
   <xsl:variable name="number-format" as="xs:string"
-  select="string-join(for $i in 1 to $number-width return '0', '')" />
+  select="string-join(for $i in 1 to $number-width return '0')" />
   <xsl:variable name="module" as="xs:string?">
     <xsl:variable name="uri" as="xs:string"
       select="if (starts-with($stylesheet-uri, '/'))

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -453,8 +453,8 @@
     /element()/xsl:character-map[@name eq 'test:disable-escaping']
     /translate(
       $input,
-      string-join(xsl:output-character/@string, ''),
-      string-join(xsl:output-character/@character, '')
+      string-join(xsl:output-character/@string),
+      string-join(xsl:output-character/@character)
       )"/>
 </xsl:function>
 


### PR DESCRIPTION
Just removes the second argument from `string-join()` wherever possible.