### PR TITLE
ci(basex): download BaseX using secure channel

### DIFF
--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -52,7 +52,7 @@
 			</filterchain>
 		</loadresource>
 		<get dest="${basex.zip}"
-			src="http://files.basex.org/releases/${env.BASEX_VERSION}/BaseX${basex.version.without.dot}.zip" />
+			src="https://files.basex.org/releases/${env.BASEX_VERSION}/BaseX${basex.version.without.dot}.zip" />
 
 		<dirname file="${env.BASEX_JAR}" property="basex.jar.dir" />
 		<dirname file="${basex.jar.dir}" property="basex.unzip.dest" />


### PR DESCRIPTION
Following BaseXdb/basex#1859, this pull request just replaces `http:` with `https:` for accessing `files.basex.org`.