### PR TITLE
refactor(report): create x:report indirectly

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -723,4 +723,29 @@
 		</xsl:for-each>
 	</xsl:function>
 
+	<!--
+		Returns namespace nodes in the element excluding the same prefix as the element name.
+		'xml' is excluded in the first place.
+
+			Example:
+				in:  <prefix1:e xmlns="default-ns" xmlns:prefix1="ns1" xmlns:prefix2="ns2" />
+				out: xmlns="default-ns" and xmlns:prefix2="ns2"
+	-->
+	<xsl:function as="namespace-node()*" name="x:element-additional-namespace-nodes">
+		<xsl:param as="element()" name="element" />
+
+		<xsl:variable as="xs:string" name="element-name-prefix"
+			select="
+				$element
+				=> node-name()
+				=> prefix-from-QName()
+				=> string()" />
+
+		<!-- Sort for better serialization (hopefully) -->
+		<xsl:perform-sort
+			select="x:copy-of-namespaces($element)[not(name() eq $element-name-prefix)]">
+			<xsl:sort select="name()" />
+		</xsl:perform-sort>
+	</xsl:function>
+
 </xsl:stylesheet>

--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -109,7 +109,7 @@
                   </xsl:when>
 
                   <xsl:otherwise>
-                     <xsl:text>document { </xsl:text>
+                     <xsl:text>document {&#x0A;</xsl:text>
                      <xsl:call-template name="test:create-zero-or-more-node-generators">
                         <xsl:with-param name="nodes" select="node() except $exclude" />
                      </xsl:call-template>
@@ -212,13 +212,21 @@
       </xsl:copy>
    </xsl:template>
 
-   <xsl:template match="attribute() | comment() | processing-instruction() | text()"
-      as="node()+" mode="test:create-node-generator">
-      <xsl:value-of select="x:node-type(.), name()" />
-      <xsl:text> { </xsl:text>
+   <xsl:template match="namespace-node()" as="text()+" mode="test:create-node-generator">
+      <xsl:text>namespace { "</xsl:text>
+      <xsl:value-of select="name()" />
+      <xsl:text>" } { </xsl:text>
+      <xsl:value-of select="x:quote-with-apos(.)" />
+      <xsl:text> }</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="attribute()" as="node()+" mode="test:create-node-generator">
+      <xsl:text>attribute { </xsl:text>
+      <xsl:value-of select="node-name() => x:QName-expression()" />
+      <xsl:text> } { </xsl:text>
 
       <xsl:choose>
-         <xsl:when test="(. instance of attribute()) and x:is-user-content(.)">
+         <xsl:when test="x:is-user-content(.)">
             <!-- AVT -->
             <!-- TODO: '<' and '>' inside expressions should not be escaped. They (and other special
                characters) should be escaped outside expressions. In other words,
@@ -228,19 +236,42 @@
                <xsl:value-of select="." />
             </xsl:element>
          </xsl:when>
-
-         <!-- TODO: TVT
-         <xsl:when test="(. instance of text()) and x:is-user-content(.)
-            and x:yes-no-synonym(parent::x:text/@expand-text)">
-         </xsl:when>
-         -->
-
          <xsl:otherwise>
-            <xsl:variable name="escaped" as="xs:string" select="replace(., '(&quot;)', '$1$1')" />
-            <xsl:text expand-text="yes">"{$escaped}"</xsl:text>
+            <xsl:value-of select="x:quote-with-apos(.)" />
          </xsl:otherwise>
       </xsl:choose>
 
+      <xsl:text> }</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="text()" as="text()+" mode="test:create-node-generator">
+      <xsl:text>text { </xsl:text>
+
+      <xsl:choose>
+         <!-- TODO: TVT
+         <xsl:when test="x:is-user-content(.) and parent::x:text/@expand-text/x:yes-no-synonym(.)">
+         </xsl:when>
+         -->
+
+         <xsl:when test="true()">
+            <xsl:value-of select="x:quote-with-apos(.)" />
+         </xsl:when>
+      </xsl:choose>
+
+      <xsl:text> }</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="processing-instruction()" as="text()+" mode="test:create-node-generator">
+      <xsl:text>processing-instruction { "</xsl:text>
+      <xsl:value-of select="name()" />
+      <xsl:text>" } { </xsl:text>
+      <xsl:value-of select="x:quote-with-apos(.)" />
+      <xsl:text> }</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="comment()" as="text()+" mode="test:create-node-generator">
+      <xsl:text>comment { </xsl:text>
+      <xsl:value-of select="x:quote-with-apos(.)" />
       <xsl:text> }</xsl:text>
    </xsl:template>
 

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -115,24 +115,35 @@
       <xsl:text>(: set up the result document (the report) :)&#10;</xsl:text>
       <xsl:text>document {&#x0A;</xsl:text>
 
-      <xsl:element name="{x:xspec-name('report', $this)}" namespace="{$x:xspec-namespace}">
-         <xsl:attribute name="date"  select="'{current-dateTime()}'" />
-         <xsl:attribute name="query" select="$this/@query"/>
-         <xsl:if test="exists($query-at)">
-            <xsl:attribute name="query-at" select="$query-at"/>
-         </xsl:if>
-         <xsl:attribute name="xspec" select="$actual-document-uri"/>
+      <!-- <x:report> -->
+      <xsl:text>element { </xsl:text>
+      <xsl:value-of select="QName($x:xspec-namespace, x:xspec-name('report', $this)) => x:QName-expression()" />
+      <xsl:text> } {&#x0A;</xsl:text>
 
-         <xsl:sequence select="x:copy-of-namespaces($this)" />
+      <xsl:call-template name="test:create-zero-or-more-node-generators">
+         <xsl:with-param name="nodes" as="node()+">
+            <xsl:sequence select="x:element-additional-namespace-nodes(.)" />
 
-         <xsl:text> {&#10;</xsl:text>
-         <!-- Generate calls to the compiled top-level scenarios. -->
-         <xsl:text>      (: a call instruction for each top-level scenario :)&#10;</xsl:text>
-         <xsl:call-template name="x:call-scenarios"/>
-         <xsl:text>&#10;}&#10;</xsl:text>
-      </xsl:element>
+            <xsl:attribute name="xspec" select="$actual-document-uri" />
+            <xsl:attribute name="query" select="$this/@query" />
+            <xsl:if test="exists($query-at)">
+               <xsl:attribute name="query-at" select="$query-at" />
+            </xsl:if>
+         </xsl:with-param>
+      </xsl:call-template>
+      <xsl:text>,&#x0A;</xsl:text>
 
-      <xsl:text> }&#x0A;</xsl:text>
+      <!-- @date must be evaluated at run time -->
+      <xsl:text>attribute { QName('', 'date') } { current-dateTime() },&#x0A;</xsl:text>
+
+      <!-- Generate calls to the compiled top-level scenarios. -->
+      <xsl:text>      (: a call instruction for each top-level scenario :)&#x0A;</xsl:text>
+      <xsl:call-template name="x:call-scenarios"/>
+
+      <!-- </x:report> -->
+      <xsl:text>}&#x0A;</xsl:text>
+
+      <xsl:text>}&#x0A;</xsl:text>
    </xsl:template>
 
    <!-- *** x:output-call *** -->

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -151,36 +151,57 @@
       <xsl:call-template name="x:identity" />
    </xsl:template>
 
-   <xsl:template match="attribute() | comment() | processing-instruction() | text()"
-      as="element()" mode="test:create-node-generator">
-      <!-- As for attribute(), do not just throw XSLT attributes (@xsl:*) into identity
-         template. If you do so, the attribute being generated becomes a generator... -->
-      <xsl:element name="xsl:{x:node-type(.)}" namespace="{$x:xsl-namespace}">
-         <xsl:if test="(. instance of attribute()) or (. instance of processing-instruction())">
-            <xsl:attribute name="name" select="name()" />
-         </xsl:if>
+   <xsl:template match="namespace-node()" as="element(xsl:namespace)"
+      mode="test:create-node-generator">
+      <xsl:element name="xsl:namespace" namespace="{$x:xsl-namespace}">
+         <xsl:attribute name="name" select="name()" />
+         <xsl:value-of select="." />
+      </xsl:element>
+   </xsl:template>
 
-         <xsl:if test=". instance of attribute()">
-            <xsl:attribute name="namespace" select="namespace-uri()" />
-         </xsl:if>
+   <xsl:template match="attribute()" as="element(xsl:attribute)" mode="test:create-node-generator">
+      <xsl:variable name="maybe-avt" as="xs:boolean" select="x:is-user-content(.)" />
+
+      <xsl:element name="xsl:attribute" namespace="{$x:xsl-namespace}">
+         <xsl:attribute name="name" select="name()" />
+         <xsl:attribute name="namespace" select="namespace-uri()" />
 
          <xsl:choose>
-            <xsl:when test="(. instance of attribute()) and x:is-user-content(.)">
-               <!-- AVT -->
+            <xsl:when test="$maybe-avt">
                <xsl:attribute name="select">'', ''</xsl:attribute>
                <xsl:attribute name="separator" select="." />
-            </xsl:when>
-
-            <xsl:when test="(. instance of text()) and x:is-user-content(.)">
-               <!-- May be TVT -->
-               <xsl:sequence select="parent::x:text/@expand-text" />
-               <xsl:sequence select="." />
             </xsl:when>
 
             <xsl:otherwise>
                <xsl:value-of select="." />
             </xsl:otherwise>
          </xsl:choose>
+      </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="text()" as="element(xsl:text)" mode="test:create-node-generator">
+      <xsl:element name="xsl:text" namespace="{$x:xsl-namespace}">
+         <xsl:if test="x:is-user-content(.)">
+            <!-- TVT -->
+            <xsl:sequence select="parent::x:text/@expand-text" />
+         </xsl:if>
+
+         <xsl:sequence select="." />
+      </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="processing-instruction()" as="element(xsl:processing-instruction)"
+      mode="test:create-node-generator">
+      <xsl:element name="xsl:processing-instruction" namespace="{$x:xsl-namespace}">
+         <xsl:attribute name="name" select="name()" />
+
+         <xsl:value-of select="." />
+      </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="comment()" as="element(xsl:comment)" mode="test:create-node-generator">
+      <xsl:element name="xsl:comment" namespace="{$x:xsl-namespace}">
+         <xsl:value-of select="." />
       </xsl:element>
    </xsl:template>
 

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -116,21 +116,36 @@
                   </xsl:choose>
                </xsl:attribute>
 
-               <xsl:element name="{x:xspec-name('report', .)}" namespace="{$x:xspec-namespace}">
-                  <!-- This bit of jiggery-pokery with the $stylesheet-uri variable is so
-                     that the URI appears in the trace report generated from running the
-                     test stylesheet, which can then be picked up by stylesheets that
-                     process *that* to generate a coverage report -->
-                  <xsl:attribute name="stylesheet" select="$stylesheet-uri" />
+               <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
+                  <xsl:attribute name="name" select="x:xspec-name('report', .)" />
+                  <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
-                  <xsl:attribute name="date" select="'{current-dateTime()}'" />
-                  <xsl:attribute name="xspec" select="$xspec-master-uri" />
+                  <xsl:apply-templates select="x:element-additional-namespace-nodes(.)"
+                     mode="test:create-node-generator"/>
 
-                  <!-- Do not always copy @schematron.
-                     @schematron may exist even when this XSpec is not testing Schematron. -->
-                  <xsl:if test="$is-schematron">
-                     <xsl:sequence select="@schematron" />
-                  </xsl:if>
+                  <xsl:variable name="attributes" as="attribute()+">
+                     <xsl:attribute name="xspec" select="$xspec-master-uri" />
+
+                     <!-- This bit of jiggery-pokery with the $stylesheet-uri variable is so
+                        that the URI appears in the trace report generated from running the
+                        test stylesheet, which can then be picked up by stylesheets that
+                        process *that* to generate a coverage report -->
+                     <xsl:attribute name="stylesheet" select="$stylesheet-uri" />
+
+                     <!-- Do not always copy @schematron.
+                        @schematron may exist even when this XSpec is not testing Schematron. -->
+                     <xsl:if test="$is-schematron">
+                        <xsl:sequence select="@schematron" />
+                     </xsl:if>
+                  </xsl:variable>
+                  <xsl:apply-templates select="$attributes" mode="test:create-node-generator" />
+
+                  <!-- @date must be evaluated at run time -->
+                  <xsl:element name="xsl:attribute" namespace="{$x:xsl-namespace}">
+                     <xsl:attribute name="name" select="'date'" />
+                     <xsl:attribute name="namespace" />
+                     <xsl:attribute name="select" select="'current-dateTime()'" />
+                  </xsl:element>
 
                   <!-- Generate calls to the compiled top-level scenarios. -->
                   <xsl:text>&#10;            </xsl:text><xsl:comment> a call instruction for each top-level scenario </xsl:comment>

--- a/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../ambiguous-expect.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../ambiguous-expect.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:result select="()"/>

--- a/test/end-to-end/cases/expected/query/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-1-result.xml
@@ -2,10 +2,10 @@
 <t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../focus-1.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../focus-1.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">

--- a/test/end-to-end/cases/expected/query/focus-2-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-2-result.xml
@@ -2,10 +2,10 @@
 <t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../focus-2.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../focus-2.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../focus-2.xspec"
                pending="testing x:pending">

--- a/test/end-to-end/cases/expected/query/function-result.xml
+++ b/test/end-to-end/cases/expected/query/function-result.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:my="http://example.org/ns/my"
+<t:report xmlns:my="http://example.org/ns/my"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../function.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../function.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../function.xspec">
       <t:label>when calling a function and expecting correctly</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/query/import-result.xml
+++ b/test/end-to-end/cases/expected/query/import-result.xml
@@ -2,10 +2,10 @@
 <t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../import.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../import.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../import.xspec">
       <t:label>when testing a correct scenario in an importing file</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/query/imported-result.xml
+++ b/test/end-to-end/cases/expected/query/imported-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:report xmlns:my="http://example.org/ns/my"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../imported.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../imported.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/query/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-151-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:test-mix="x-urn:test-mix"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:test-mix="x-urn:test-mix"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-151.xspec"
           query="x-urn:test-mix"
           query-at="../../issue-151.xqm"
-          xspec="../../issue-151.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-151.xspec">
       <x:label>When the result is a mixture of a typed element and a string</x:label>
       <x:call function="test-mix:element-and-string"/>

--- a/test/end-to-end/cases/expected/query/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-153-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-153.xspec"
           query="x-urn:test:do-nothing"
           query-at="../../../../do-nothing.xqm"
-          xspec="../../issue-153.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-153.xspec">
       <x:label>When a function returns a local date time string</x:label>
       <x:call function="string">

--- a/test/end-to-end/cases/expected/query/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-177-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-177.xspec"
           query="x-urn:test:do-nothing"
           query-at="../../../../do-nothing.xqm"
-          xspec="../../issue-177.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-177.xspec">
       <x:label>Given the function returns &lt;foo /&gt;</x:label>
       <x:call function="exactly-one">

--- a/test/end-to-end/cases/expected/query/issue-346-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-346-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-346.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-346.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/query/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-355-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-355.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-355.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-355.xspec">
       <x:label>xs:integer()</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">

--- a/test/end-to-end/cases/expected/query/issue-447_1-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_1-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_1.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-447_1.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1"
                xspec="../../issue-447_1.xspec"
                pending="x:pending/x:label containing }{">

--- a/test/end-to-end/cases/expected/query/issue-447_2-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_2-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_2.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-447_2.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1"
                xspec="../../issue-447_2.xspec"
                pending="x:pending/@label containing }{">

--- a/test/end-to-end/cases/expected/query/issue-447_3-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_3-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_3.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-447_3.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-447_3.xspec" pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/query/issue-448-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-448-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-448.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-448.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:result select="()"/>

--- a/test/end-to-end/cases/expected/query/issue-449-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-449-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-449.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-449.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-449.xspec">
       <x:label>x:expect/</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:myv="http://example.org/ns/my/variable"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-450-451.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-450-451.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-450-451.xspec">
       <x:label>function-param containing curly brackets</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/query/issue-452-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-452-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-452.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-452.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-452.xspec">
       <x:label>Text</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/query/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-467-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-467.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-467.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-467.xspec">
       <x:label>Testing namespace differences</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/query/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-50-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-50.xspec"
           query="x-urn:test:do-nothing"
           query-at="../../../../do-nothing.xqm"
-          xspec="../../issue-50.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-50.xspec">
       <x:label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</x:label>
       <x:call function="xs:untypedAtomic">

--- a/test/end-to-end/cases/expected/query/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-55-result.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-55.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../issue-55.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-55.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:call function="mirror:true"/>

--- a/test/end-to-end/cases/expected/query/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-67-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../issue-67.xspec"
           query="x-urn:test:xspec-items"
           query-at="../../../../items.xqm"
-          xspec="../../issue-67.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-67.xspec">
       <x:label>Comparing identical namespace</x:label>
       <x:call function="exactly-one">

--- a/test/end-to-end/cases/expected/query/label-element-result.xml
+++ b/test/end-to-end/cases/expected/query/label-element-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../label-element.xspec"
           query="x-urn:test:do-nothing"
           query-at="../../../../do-nothing.xqm"
-          xspec="../../label-element.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	

--- a/test/end-to-end/cases/expected/query/pending-result.xml
+++ b/test/end-to-end/cases/expected/query/pending-result.xml
@@ -2,10 +2,10 @@
 <t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../pending.xspec"
           query="http://example.org/ns/my"
           query-at="../../../../square.xqm"
-          xspec="../../pending.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../pending.xspec"
                pending="testing x:pending">

--- a/test/end-to-end/cases/expected/query/report-result.xml
+++ b/test/end-to-end/cases/expected/query/report-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../report.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../report.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:result select="()"/>

--- a/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
+++ b/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../report_schema-aware.xspec"
           query="x-urn:test:do-nothing"
           query-at="../../../../do-nothing.xqm"
-          xspec="../../report_schema-aware.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report_schema-aware.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:result select="()"/>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../serialize.xspec"
           query="x-urn:test:xspec-items"
           query-at="../../../../items.xqm"
-          xspec="../../serialize.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../serialize.xspec">
       <x:label>When the result is a comment node, the report HTML must serialize it as
 			&lt;!-- --&gt;. (xspec/xspec#356) So...</x:label>

--- a/test/end-to-end/cases/expected/query/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:mirror="x-urn:test:mirror"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:mirror="x-urn:test:mirror"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../shared-like.xspec"
           query="x-urn:test:mirror"
           query-at="../../../../mirror.xqm"
-          xspec="../../shared-like.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          date="2000-01-01T00:00:00Z"
+          xspec="../../three-dots.xspec"
           query="x-urn:test:three-dots"
           query-at="../../three-dots.xqm"
-          xspec="../../three-dots.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../three-dots.xspec">
       <x:label>For resultant element (simple)</x:label>
       <x:result select="()"/>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-          stylesheet="issue-693-sch-preprocessed.xsl"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xspec="../../issue-693.xspec"
-          schematron="../../issue-693.sch">
+          stylesheet="issue-693-sch-preprocessed.xsl"
+          schematron="../../issue-693.sch"
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-693.xspec">
       <x:label>Using user-content (not @href) in x:context should work</x:label>
       <x:context select="self::document-node()">

--- a/test/end-to-end/cases/expected/schematron/label-element-result.xml
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-          stylesheet="label-element-sch-preprocessed.xsl"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xspec="../../label-element.xspec"
-          schematron="../../../../do-nothing.sch">
+          stylesheet="label-element-sch-preprocessed.xsl"
+          schematron="../../../../do-nothing.sch"
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-          stylesheet="schematron-023-sch-preprocessed.xsl"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xspec="../../schematron-023.xspec"
-          schematron="../../../../schematron/schematron-023.sch">
+          stylesheet="schematron-023-sch-preprocessed.xsl"
+          schematron="../../../../schematron/schematron-023.sch"
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../schematron-023.xspec">
       <x:label>valid with warning: expect-valid should pass</x:label>
       <x:context select="self::document-node()">

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+<x:report xmlns:local="local"
           xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-          xmlns:local="local"
-          stylesheet="schematron-import_demo-02-PhaseB-sch-preprocessed.xsl"
-          date="2000-01-01T00:00:00Z"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xspec="../../schematron-import_demo-02-PhaseB.xspec"
-          schematron="../../../../../tutorial/schematron/demo-02.sch">
+          stylesheet="schematron-import_demo-02-PhaseB-sch-preprocessed.xsl"
+          schematron="../../../../../tutorial/schematron/demo-02.sch"
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1"
                xspec="../../../../../tutorial/schematron/demo-02-PhaseB.xspec">
       <x:label>Pattern 2</x:label>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-          stylesheet="tvt_label_schematron-sch-preprocessed.xsl"
-          date="2000-01-01T00:00:00Z"
+<x:report xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xspec="../../tvt_label_schematron.xspec"
-          schematron="../../tvt_label.sch">
+          stylesheet="tvt_label_schematron-sch-preprocessed.xsl"
+          schematron="../../tvt_label.sch"
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../tvt_label_schematron.xspec">
       <x:label>With @expand-text=yes</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../tvt_label_schematron.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
-          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../ambiguous-expect.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../ambiguous-expect.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../ambiguous-expect.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/coverage-no-hit-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/coverage-no-hit-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../coverage-no-hit.xspec"
           stylesheet="../../coverage-no-hit.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../coverage-no-hit.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../coverage-no-hit.xspec">
       <x:label>Testing a stylesheet without any matching context</x:label>
       <x:context/>

--- a/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../coverage-tutorial.xspec"
           stylesheet="../../../../../tutorial/coverage/demo.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../coverage-tutorial.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../../../../tutorial/coverage/demo.xspec">
       <x:label>'iron' element</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../custom-coverage-report.xspec"
           stylesheet="../../../../../tutorial/coverage/demo.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../custom-coverage-report.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../../../../tutorial/coverage/demo.xspec">
       <x:label>'iron' element</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
+<t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:my="http://example.org/ns/my"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../focus-1.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../focus-1.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">

--- a/test/end-to-end/cases/expected/stylesheet/focus-2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-2-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
+<t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:my="http://example.org/ns/my"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../focus-2.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../focus-2.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../focus-2.xspec"
                pending="testing x:pending">

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../format-xspec-report-folding.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../format-xspec-report-folding.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:my="http://example.org/ns/my"

--- a/test/end-to-end/cases/expected/stylesheet/function-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xmlns:my="http://example.org/ns/my"
+<t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../function.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../function.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../function.xspec">
       <t:label>when calling a function and expecting correctly</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/stylesheet/import-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
+<t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:my="http://example.org/ns/my"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../import.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../import.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../import.xspec">
       <t:label>when testing a correct scenario in an importing file</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xmlns:my="http://example.org/ns/my"
+<t:report xmlns:my="http://example.org/ns/my"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../imported.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../imported.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call function="my:square">

--- a/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:test-mix="x-urn:test-mix"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-151.xspec"
           stylesheet="../../issue-151.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-151.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-151.xspec">
       <x:label>When the result is a mixture of a typed element and a string</x:label>
       <x:call function="test-mix:element-and-string"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-153.xspec"
           stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-153.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-153.xspec">
       <x:label>When a function returns a local date time string</x:label>
       <x:call function="string">

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-177.xspec"
           stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-177.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-177.xspec">
       <x:label>Given the function returns &lt;foo /&gt;</x:label>
       <x:call function="exactly-one">

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-214.xspec"
           stylesheet="../../issue-214.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-214.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-214.xspec">
       <x:label>input</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-23_2.xspec"
           stylesheet="../../issue-23_2.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-23_2.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-23_2.xspec">
       <x:label>Test</x:label>
       <x:context href="../../issue-23_2_context.xml"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-346.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-346.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-355.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-355.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-355.xspec">
       <x:label>xs:integer()</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_1.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-447_1.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1"
                xspec="../../issue-447_1.xspec"
                pending="x:pending/x:label containing }{">

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_2.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-447_2.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1"
                xspec="../../issue-447_2.xspec"
                pending="x:pending/@label containing }{">

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-447_3.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-447_3.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-447_3.xspec" pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-448-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-448-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-448.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-448.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../issue-448.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/issue-449-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-449-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-449.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-449.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-449.xspec">
       <x:label>x:expect/</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
@@ -2,9 +2,9 @@
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:myv="http://example.org/ns/my/variable"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-450-451.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-450-451.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-450-451.xspec">
       <x:label>function-param containing curly brackets</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
@@ -2,9 +2,9 @@
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:myv="http://example.org/ns/my/variable"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-450-451_stylesheet.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-450-451_stylesheet.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-450-451_stylesheet.xspec">
       <x:label>context template-param containing curly brackets</x:label>
       <x:context mode="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-452.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-452.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-452.xspec">
       <x:label>Text</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-467.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-467.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-467.xspec">
       <x:label>Testing namespace differences</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-50.xspec"
           stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-50.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-50.xspec">
       <x:label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</x:label>
       <x:call function="xs:untypedAtomic">

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-528.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-528.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-528.xspec" pending="Focus on 1-2">
       <x:label>Scenario 1</x:label>
       <x:call function="mirror:true"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
-          xmlns:x="http://www.jenitennison.com/xslt/xspec"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-55.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-55.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-55.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:call function="mirror:true"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-67.xspec"
           stylesheet="../../../../items.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-67.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-67.xspec">
       <x:label>Comparing identical namespace</x:label>
       <x:call function="exactly-one">

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-778_ws.xspec"
           stylesheet="../../issue-778_ws.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-778_ws.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-778_ws.xspec">
       <x:label>When transforming DITA</x:label>
       <x:context href="../../issue-778_ws.dita"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-793-cr.xspec"
           stylesheet="../../issue-793-cr.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-793-cr.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-793-cr.xspec">
       <x:label>input</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-793-crlf.xspec"
           stylesheet="../../issue-793-crlf.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-793-crlf.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-793-crlf.xspec">
       <x:label>input</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../issue-793-lf.xspec"
           stylesheet="../../issue-793-lf.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../issue-793-lf.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-793-lf.xspec">
       <x:label>input</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../label-element.xspec"
           stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../label-element.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../mode-all.xspec"
           stylesheet="../../mode-all.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../mode-all.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../mode-all.xspec">
       <x:label>context</x:label>
       <x:context>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
+<t:report xmlns:my="http://example.org/ns/my"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:my="http://example.org/ns/my"
+          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../pending.xspec"
           stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../pending.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1"
                xspec="../../pending.xspec"
                pending="testing x:pending">

--- a/test/end-to-end/cases/expected/stylesheet/report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../report.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../report.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../report_schema-aware.xspec"
           stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../report_schema-aware.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report_schema-aware.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report_schema-aware.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../result-naming-collision.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../result-naming-collision.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../result-naming-collision.xspec">
       <x:label>scenario 1</x:label>
       <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/stylesheet/rule-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/rule-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../rule.xspec"
           stylesheet="../../rule.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../rule.xspec">
+          date="2000-01-01T00:00:00Z">
    <t:scenario id="scenario1" xspec="../../rule.xspec">
       <t:label>x:context with correct x:expect</t:label>
       <t:context>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../serialize.xspec"
           stylesheet="../../../../items.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../serialize.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../serialize.xspec">
       <x:label>When the result is a comment node, the report HTML must serialize it as
 			&lt;!-- --&gt;. (xspec/xspec#356) So...</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../shared-like.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../shared-like.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
       <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:report xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../three-dots.xspec"
           stylesheet="../../three-dots.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../three-dots.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../three-dots.xspec">
       <x:label>For resultant element (simple)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/tvt_label-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/tvt_label-result.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:mirror="x-urn:test:mirror"
           xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../tvt_label.xspec"
           stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../tvt_label.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../tvt_label.xspec">
       <x:label>With @expand-text=yes</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../tvt_label.xspec">

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
+          xspec="../../xslt2.xspec"
           stylesheet="../../../../xslt1.xsl"
-          date="2000-01-01T00:00:00Z"
-          xspec="../../xslt2.xspec">
+          date="2000-01-01T00:00:00Z">
    <x:scenario xmlns:xs="http://www.w3.org/2001/XMLSchema"
                id="scenario1"
                xspec="../../../../xslt1.xspec">

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1488,4 +1488,48 @@
 		</x:scenario>
 	</x:scenario>
 
+	<x:scenario label="Scenario for testing function element-additional-namespace-nodes">
+		<x:scenario label="Element has a prefix">
+			<x:call function="x:element-additional-namespace-nodes">
+				<x:param>
+					<prefix1:e xmlns="default-ns" xmlns:prefix1="ns1" xmlns:prefix2="ns2" />
+				</x:param>
+			</x:call>
+			<x:expect label="Namespace nodes" test="$x:result instance of namespace-node()+" />
+			<x:expect label="xml" test="$x:result[name() eq 'xml'] => empty()" />
+			<x:expect label="Default" test="$x:result[name() eq ''][. eq 'default-ns'] => exists()" />
+			<x:expect label="prefix1" test="$x:result[name() eq 'prefix1'] => empty()" />
+			<x:expect label="prefix2" test="$x:result[name() eq 'prefix2'][. eq 'ns2'] => exists()"
+			 />
+		</x:scenario>
+
+		<x:scenario label="Element does not have a prefix">
+			<x:call function="x:element-additional-namespace-nodes">
+				<x:param>
+					<e xmlns="default-ns" xmlns:prefix1="ns1" xmlns:prefix2="ns2" />
+				</x:param>
+			</x:call>
+			<x:expect label="Namespace nodes" test="$x:result instance of namespace-node()+" />
+			<x:expect label="xml" test="$x:result[name() eq 'xml'] => empty()" />
+			<x:expect label="Default" test="$x:result[name() eq ''] => empty()" />
+			<x:expect label="prefix1" test="$x:result[name() eq 'prefix1'][. eq 'ns1'] => exists()" />
+			<x:expect label="prefix2" test="$x:result[name() eq 'prefix2'][. eq 'ns2'] => exists()"
+			 />
+		</x:scenario>
+
+		<x:scenario label="Element namespace is undeclared">
+			<x:call function="x:element-additional-namespace-nodes">
+				<x:param>
+					<e xmlns="" xmlns:prefix1="ns1" xmlns:prefix2="ns2" />
+				</x:param>
+			</x:call>
+			<x:expect label="Namespace nodes" test="$x:result instance of namespace-node()+" />
+			<x:expect label="xml" test="$x:result[name() eq 'xml'] => empty()" />
+			<x:expect label="Default" test="$x:result[name() eq ''] => empty()" />
+			<x:expect label="prefix1" test="$x:result[name() eq 'prefix1'][. eq 'ns1'] => exists()" />
+			<x:expect label="prefix2" test="$x:result[name() eq 'prefix2'][. eq 'ns2'] => exists()"
+			 />
+		</x:scenario>
+	</x:scenario>
+
 </x:description>

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -67,12 +67,14 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
       </xsl:message>
       <!-- set up the result document (the report) -->
       <xsl:result-document format="Q{{http://www.jenitennison.com/xslt/xspec}}xml-report-serialization-parameters">
-         <x:report stylesheet=".../compilation-simple-suite.xsl"
-                   date="{current-dateTime()}"
-                   xspec=".../compilation-simple-suite.xspec">
+         <xsl:element name="x:report" namespace="http://www.jenitennison.com/xslt/xspec">
+            <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
+            <xsl:attribute name="xspec" namespace="">.../compilation-simple-suite.xspec</xsl:attribute>
+            <xsl:attribute name="stylesheet" namespace="">.../compilation-simple-suite.xsl</xsl:attribute>
+            <xsl:attribute name="date" namespace="" select="current-dateTime()"/>
             <!-- a call instruction for each top-level scenario -->
             <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"/>
-         </x:report>
+         </xsl:element>
       </xsl:result-document>
    </xsl:template>
 
@@ -134,21 +136,20 @@ declare function local:scenario1-expect1(
 (: the query body of this main module, to run the suite :)
 (: set up the result document (the report) :)
 document {
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xmlns:my="http://example.org/ns/my"
-          date="{current-dateTime()}"
-          query="http://example.org/ns/my"
-          query-at=".../compilation-simple-suite.xqm"
-          xspec=".../compilation-simple-suite.xspec"> {
+element { QName('http://www.jenitennison.com/xslt/xspec', 'x:report') } {
+namespace { "my" } { 'http://example.org/ns/my' },
+attribute { QName('', 'xspec') } { '.../compilation-simple-suite.xspec' },
+attribute { QName('', 'query') } { 'http://example.org/ns/my' },
+attribute { QName('', 'query-at') } { '.../compilation-simple-suite.xqm' },
+attribute { QName('', 'date') } { current-dateTime() },
       (: a call instruction for each top-level scenario :)
       let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1(
       )
       return (
         $Q{http://www.jenitennison.com/xslt/xspec}tmp
       )
-
 }
-</x:report> }
+}
 ```
 
 ## Simple scenario
@@ -410,7 +411,8 @@ section "[Simple scenario](#simple-scenario)").
 
 ```xquery
 let $Q{urn:x-xspec:compile:impl}param-... := ( 'val1' )
-let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := ( document { <val2 xmlns:my="http://example.org/ns/my">{ () }
+let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := ( document {
+<val2 xmlns:my="http://example.org/ns/my">{ () }
 </val2> } )
 let $p2 as element() := ( $Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() ) )
 let $Q{http://www.jenitennison.com/xslt/xspec}result := (
@@ -475,9 +477,11 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 declare function local:scenario1(
 )
 {
-  let $Q{http://example.org/ns/my/variable}var := ( 'value' )        (: the generated variable :)
+  let $Q{http://example.org/ns/my/variable}var := ( 'value' ) (: the generated variable :)
   ...
-  let $Q{http://www.jenitennison.com/xslt/xspec}result := ... exercise the SUT ...
+  let $Q{http://www.jenitennison.com/xslt/xspec}result := (
+    ... exercise the SUT ...
+  )
     return (
       ...,
       let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
@@ -564,7 +568,8 @@ let $Q{urn:x-xspec:compile:impl}variable-...-uri as xs:anyURI := ( xs:anyURI("..
 let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := ( doc($Q{urn:x-xspec:compile:impl}variable-...-uri) )
 let $Q{http://example.org/ns/my/variable}href := ( $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . ) )
 
-let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := ( document { <elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
+let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := ( document {
+<elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
 </elem> } )
 let $Q{http://example.org/ns/my/variable}content as element() := ( $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() ) )
 ```


### PR DESCRIPTION
Both XSLT and XQuery compilers write literal result elements in the compiled stylesheet/query. That's one of the root causes of the namespace issues in XSpec.
This pull request replaces one of the literal result elements (`x:report`) with its indirect constructor.