### PR TITLE
style(xquery): do not indent the compiled query

### DIFF
--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -31,6 +31,8 @@
       <!-- Reflects @pending or x:pending -->
       <xsl:param name="pending" select="()" tunnel="yes" as="node()?" />
 
+      <xsl:param name="comment" as="xs:string?" />
+
       <!-- URIQualifiedName of the variable being declared -->
       <xsl:variable name="uqname" as="xs:string" select="x:variable-UQName(.)" />
 
@@ -109,11 +111,12 @@
                   </xsl:when>
 
                   <xsl:otherwise>
-                     <xsl:text>document { </xsl:text>
+                     <xsl:text>document {&#x0A;</xsl:text>
                      <xsl:call-template name="test:create-zero-or-more-node-generators">
                         <xsl:with-param name="nodes" select="node() except $exclude" />
                      </xsl:call-template>
-                     <xsl:text> }</xsl:text>
+                     <xsl:text>&#x0A;</xsl:text>
+                     <xsl:text>}</xsl:text>
                   </xsl:otherwise>
                </xsl:choose>
             </xsl:with-param>
@@ -148,11 +151,12 @@
                   <xsl:text expand-text="yes">${$temp-doc-uqname} ! ( {test:disable-escaping($selection)} )</xsl:text>
                </xsl:when>
 
-               <xsl:otherwise>
+               <xsl:when test="@select">
                   <xsl:value-of select="test:disable-escaping(@select)" />
-               </xsl:otherwise>
+               </xsl:when>
             </xsl:choose>
          </xsl:with-param>
+         <xsl:with-param name="comment" select="$comment" />
       </xsl:call-template>
    </xsl:template>
 
@@ -169,13 +173,14 @@
       <xsl:param name="name" as="xs:string" required="yes" />
       <xsl:param name="type" as="xs:string?" required="yes" />
       <xsl:param name="value" as="node()*" required="yes" />
+      <xsl:param name="comment" as="xs:string?" />
 
       <xsl:choose>
          <xsl:when test="$is-global">
             <xsl:text>declare variable</xsl:text>
          </xsl:when>
          <xsl:otherwise>
-            <xsl:text>  let</xsl:text>
+            <xsl:text>let</xsl:text>
          </xsl:otherwise>
       </xsl:choose>
 
@@ -185,11 +190,22 @@
          <xsl:text expand-text="yes"> as {$type}</xsl:text>
       </xsl:if>
 
-      <xsl:text> := ( </xsl:text>
+      <xsl:if test="$comment">
+         <xsl:text expand-text="yes"> (:{$comment}:)</xsl:text>
+      </xsl:if>
 
-      <xsl:sequence select="$value" />
+      <xsl:text> := (&#x0A;</xsl:text>
 
-      <xsl:text> )</xsl:text>
+      <xsl:choose>
+         <xsl:when test="$value">
+            <xsl:sequence select="$value" />
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>()</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+
+      <xsl:text>&#x0A;)</xsl:text>
 
       <xsl:if test="$is-global">
          <xsl:text>;</xsl:text>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -60,6 +60,7 @@
       <xsl:text expand-text="yes">xquery version "{($this/@xquery-version, '3.1')[1]}";&#x0A;</xsl:text>
 
       <!-- Import module to be tested -->
+      <xsl:text>&#x0A;</xsl:text>
       <xsl:text>(: the tested library module :)&#10;</xsl:text>
       <xsl:text>import module </xsl:text>
       <xsl:if test="exists($sut-prefix)">
@@ -67,24 +68,28 @@
       </xsl:if>
       <xsl:text expand-text="yes">"{$this/@query}"</xsl:text>
       <xsl:if test="exists($query-at)">
-         <xsl:text expand-text="yes">&#10;  at "{$query-at}"</xsl:text>
+         <xsl:text expand-text="yes">&#x0A;at "{$query-at}"</xsl:text>
       </xsl:if>
       <xsl:text>;&#10;</xsl:text>
 
+      <xsl:text>&#x0A;</xsl:text>
+      <xsl:text>(: XSpec library modules providing tools :)&#x0A;</xsl:text>
+
       <!-- Import 'test' utils -->
-      <xsl:text>(: an XSpec library module providing tools :)&#10;</xsl:text>
       <xsl:text expand-text="yes">import module "{$x:legacy-namespace}"</xsl:text>
       <xsl:if test="$utils-library-at ne '#none'">
-         <xsl:text expand-text="yes">&#10;  at "{$utils-library-at}"</xsl:text>
+         <xsl:text expand-text="yes">&#x0A;at "{$utils-library-at}"</xsl:text>
       </xsl:if>
       <xsl:text>;&#10;</xsl:text>
 
       <!-- Import common utils -->
       <xsl:text expand-text="yes">import module "{$x:xspec-namespace}"</xsl:text>
       <xsl:if test="$utils-library-at ne '#none'">
-         <xsl:text expand-text="yes">&#x0A;  at "{resolve-uri('../common/xspec-utils.xqm')}"</xsl:text>
+         <xsl:text expand-text="yes">&#x0A;at "{resolve-uri('../common/xspec-utils.xqm')}"</xsl:text>
       </xsl:if>
       <xsl:text>;&#x0A;</xsl:text>
+
+      <xsl:text>&#x0A;</xsl:text>
 
       <!-- Declare namespaces -->
       <xsl:for-each select="x:copy-of-namespaces($this)[not(name() = ('', $sut-prefix))]">
@@ -115,8 +120,9 @@
       <xsl:text>(: set up the result document (the report) :)&#10;</xsl:text>
       <xsl:text>document {&#x0A;</xsl:text>
 
+      <!-- <x:report> -->
       <xsl:element name="{x:xspec-name('report', $this)}" namespace="{$x:xspec-namespace}">
-         <xsl:attribute name="date"  select="'{current-dateTime()}'" />
+         <xsl:attribute name="date" select="'{current-dateTime()}'" />
          <xsl:attribute name="query" select="$this/@query"/>
          <xsl:if test="exists($query-at)">
             <xsl:attribute name="query-at" select="$query-at"/>
@@ -127,12 +133,17 @@
 
          <xsl:text> {&#10;</xsl:text>
          <!-- Generate calls to the compiled top-level scenarios. -->
-         <xsl:text>      (: a call instruction for each top-level scenario :)&#10;</xsl:text>
+         <xsl:text>(: a call instruction for each top-level scenario :)&#x0A;</xsl:text>
          <xsl:call-template name="x:call-scenarios"/>
-         <xsl:text>&#10;}&#10;</xsl:text>
+         <xsl:text>}&#x0A;</xsl:text>
+
+      <!-- </x:report> -->
       </xsl:element>
 
-      <xsl:text> }&#x0A;</xsl:text>
+      <xsl:text>&#x0A;</xsl:text>
+
+      <!-- End of the document constructor -->
+      <xsl:text>}&#x0A;</xsl:text>
    </xsl:template>
 
    <!-- *** x:output-call *** -->
@@ -154,24 +165,26 @@
       <xsl:if test="exists(preceding-sibling::x:*[1][self::x:pending])">
          <xsl:text>,&#10;</xsl:text>
       </xsl:if>
-      <xsl:text expand-text="yes">      let ${x:known-UQName('x:tmp')} := local:{$local-name}(&#x0A;</xsl:text>
+
+      <xsl:text expand-text="yes">let ${x:known-UQName('x:tmp')} := local:{$local-name}(&#x0A;</xsl:text>
       <xsl:for-each select="$with-param-uqnames">
-         <xsl:text expand-text="yes">        ${.}</xsl:text>
+         <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
             <xsl:text>,</xsl:text>
          </xsl:if>
          <xsl:text>&#x0A;</xsl:text>
       </xsl:for-each>
-      <xsl:text>      )&#x0A;</xsl:text>
-      <xsl:text>      return (&#10;</xsl:text>
-      <xsl:text expand-text="yes">        ${x:known-UQName('x:tmp')}</xsl:text>
+      <xsl:text>)&#x0A;</xsl:text>
+
+      <xsl:text>return (&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">${x:known-UQName('x:tmp')}</xsl:text>
       <xsl:if test="not($last)">
          <xsl:text>,</xsl:text>
       </xsl:if>
       <xsl:text>&#10;</xsl:text>
       <!-- Continue compiling calls. -->
       <xsl:call-template name="x:continue-call-scenarios"/>
-      <xsl:text>      )&#10;</xsl:text>
+      <xsl:text>)&#x0A;</xsl:text>
    </xsl:template>
 
    <!-- *** x:compile *** -->
@@ -232,21 +245,25 @@
 
       <!-- Function parameters. Their order must be stable, because this is a function. -->
       <xsl:for-each select="x:distinct-strings-stable($stacked-variables ! x:variable-UQName(.))">
-         <xsl:text expand-text="yes">  ${.}</xsl:text>
+         <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
             <xsl:text>,</xsl:text>
          </xsl:if>
          <xsl:text>&#x0A;</xsl:text>
       </xsl:for-each>
 
-      <xsl:text>)&#10;{&#10;</xsl:text>
+      <xsl:text>)&#x0A;</xsl:text>
+
+      <!-- Start of the function body -->
+      <xsl:text>{&#x0A;</xsl:text>
 
       <!-- If there are variables before x:call, define them here followed by "return". -->
       <xsl:if test="exists($local-preceding-variables)">
          <xsl:apply-templates select="$local-preceding-variables" mode="test:generate-variable-declarations" />
-         <xsl:text>    return&#10;</xsl:text>
+         <xsl:text>return&#x0A;</xsl:text>
       </xsl:if>
 
+      <!-- <x:scenario> -->
       <xsl:element name="{x:xspec-name('scenario', .)}" namespace="{$x:xspec-namespace}">
          <xsl:attribute name="id" select="$scenario-id" />
          <xsl:sequence select="@xspec" />
@@ -264,7 +281,7 @@
          <!-- Create report generator -->
          <xsl:apply-templates select="x:call" mode="x:report"/>
 
-         <xsl:text>      &#10;{&#10;</xsl:text>
+         <xsl:text>{&#x0A;</xsl:text>
          <xsl:choose>
             <xsl:when test="not($pending-p)">
                <!--
@@ -275,10 +292,11 @@
                      test:report-sequence($t:result, 'x:result'),
                -->
                <xsl:apply-templates select="$call/x:param[1]" mode="x:compile"/>
-               <xsl:text expand-text="yes">  let ${x:known-UQName('x:result')} := (&#10;</xsl:text>
+
+               <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := (&#x0A;</xsl:text>
                <xsl:call-template name="x:enter-sut">
                   <xsl:with-param name="instruction" as="text()+">
-                     <xsl:text expand-text="yes">    {$call/@function}(</xsl:text>
+                     <xsl:text expand-text="yes">{$call/@function}(</xsl:text>
                      <xsl:for-each select="$call/x:param">
                         <xsl:sort select="xs:integer(@position)" />
                         <xsl:text expand-text="yes">${x:variable-UQName(.)}</xsl:text>
@@ -289,25 +307,38 @@
                      <xsl:text>)&#10;</xsl:text>
                   </xsl:with-param>
                </xsl:call-template>
-               <xsl:text>  )&#10;</xsl:text>
-               <xsl:text>    return (&#10;</xsl:text>
-               <xsl:text expand-text="yes">      {x:known-UQName('test:report-sequence')}(${x:known-UQName('x:result')}, '{x:xspec-name('result', .)}'),&#10;</xsl:text>
-               <xsl:text>      (: a call instruction for each x:expect element :)&#10;</xsl:text>
+               <xsl:text>)&#x0A;</xsl:text>
+
+               <xsl:text>return (&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(${x:known-UQName('x:result')}, '{x:xspec-name('result', .)}'),&#x0A;</xsl:text>
+
+               <xsl:text>&#x0A;</xsl:text>
+               <xsl:text>(: a call instruction for each x:expect element :)&#x0A;</xsl:text>
             </xsl:when>
+
             <xsl:otherwise>
                <!--
                  let $t:result := ()
                    return (
                -->
-               <xsl:text expand-text="yes">  let ${x:known-UQName('x:result')} := ()&#10;</xsl:text>
-               <xsl:text>    return (&#10;</xsl:text>
+               <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := ()&#x0A;</xsl:text>
+               <xsl:text>return (&#x0A;</xsl:text>
             </xsl:otherwise>
          </xsl:choose>
+
          <xsl:call-template name="x:call-scenarios"/>
-         <xsl:text>    )&#10;</xsl:text>
-         <xsl:text>}&#10;</xsl:text>
+         <xsl:text>)&#x0A;</xsl:text>
+
+         <xsl:text>}&#x0A;</xsl:text>
+
+      <!-- </x:scenario> -->
       </xsl:element>
-      <xsl:text>&#10;};&#10;</xsl:text>
+
+      <xsl:text>&#x0A;</xsl:text>
+
+      <!-- End of the function -->
+      <xsl:text>};&#x0A;</xsl:text>
+
       <xsl:call-template name="x:compile-scenarios"/>
    </xsl:template>
 
@@ -316,27 +347,32 @@
 
       <xsl:param name="instruction" as="text()+" required="yes" />
 
-      <xsl:text>    try {&#x0A;</xsl:text>
-      <xsl:text>  </xsl:text>
+      <xsl:text>try {&#x0A;</xsl:text>
       <xsl:sequence select="$instruction" />
-      <xsl:text>    }&#x0A;</xsl:text>
-      <xsl:text>    catch * {&#x0A;</xsl:text>
-      <xsl:text>      map {&#x0A;</xsl:text>
-      <xsl:text>        'err': map {&#x0A;</xsl:text>
+      <xsl:text>}&#x0A;</xsl:text>
+
+      <xsl:text>catch * {&#x0A;</xsl:text>
+      <xsl:text>map {&#x0A;</xsl:text>
+      <xsl:text>'err': map {&#x0A;</xsl:text>
 
       <!-- Variables available within the catch clause: https://www.w3.org/TR/xquery-31/#id-try-catch
          $err:additional doesn't work on Saxon 9.8: https://saxonica.plan.io/issues/4133 -->
       <xsl:for-each select="'code', 'description', 'value', 'module', 'line-number', 'column-number'">
-         <xsl:text expand-text="yes">                 '{.}': ${x:known-UQName('err:' || .)}</xsl:text>
+         <xsl:text expand-text="yes">'{.}': ${x:known-UQName('err:' || .)}</xsl:text>
          <xsl:if test="position() ne last()">
             <xsl:text>,</xsl:text>
          </xsl:if>
          <xsl:text>&#x0A;</xsl:text>
       </xsl:for-each>
 
-      <xsl:text>               }&#x0A;</xsl:text>
-      <xsl:text>      }&#x0A;</xsl:text>
-      <xsl:text>    }&#x0A;</xsl:text>
+      <!-- End of 'err' map -->
+      <xsl:text>}&#x0A;</xsl:text>
+
+      <!-- End of $x:result map -->
+      <xsl:text>}&#x0A;</xsl:text>
+
+      <!-- End of catch -->
+      <xsl:text>}&#x0A;</xsl:text>
    </xsl:template>
 
    <!--
@@ -371,16 +407,22 @@
       <xsl:text>&#10;(: generated from the x:expect element :)</xsl:text>
       <xsl:text expand-text="yes">&#10;declare function local:{$expect-id}(&#x0A;</xsl:text>
       <xsl:for-each select="$param-uqnames">
-         <xsl:text expand-text="yes">  ${.}</xsl:text>
+         <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
             <xsl:text>,</xsl:text>
          </xsl:if>
          <xsl:text>&#x0A;</xsl:text>
       </xsl:for-each>
-      <xsl:text>)&#10;{&#10;</xsl:text>
+      <xsl:text>)&#x0A;</xsl:text>
+
+      <!-- Start of the function body -->
+      <xsl:text>{&#x0A;</xsl:text>
+
       <xsl:if test="not($pending-p)">
          <!-- Set up the $local:expected variable -->
-         <xsl:apply-templates select="." mode="test:generate-variable-declarations" />
+         <xsl:apply-templates select="." mode="test:generate-variable-declarations">
+            <xsl:with-param name="comment" select="'expected result'" />
+         </xsl:apply-templates>
 
          <!-- Flags for test:deep-equal() enclosed in ''. -->
          <xsl:variable name="deep-equal-flags" as="xs:string">''</xsl:variable>
@@ -389,42 +431,40 @@
             <xsl:when test="@test">
                <!-- $local:test-items
                   TODO: Wrap $x:result in a document node if possible -->
-               <xsl:text expand-text="yes">  let $local:test-items as item()* := ${x:known-UQName('x:result')}&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">let $local:test-items as item()* := ${x:known-UQName('x:result')}&#x0A;</xsl:text>
 
                <!-- $local:test-result
                   TODO: Evaluate @test in the context of $local:test-items, if
                     $local:test-items is a node -->
-               <xsl:text expand-text="yes">  let $local:test-result as item()* := ({test:disable-escaping(@test)})&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">let $local:test-result as item()* (: evaluate the predicate :) := (&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">{test:disable-escaping(@test)}&#x0A;</xsl:text>
+               <xsl:text>)&#x0A;</xsl:text>
 
                <!-- $local:boolean-test -->
-               <xsl:text>  let $local:boolean-test as xs:boolean :=&#x0A;</xsl:text>
-               <xsl:text>    ($local:test-result instance of xs:boolean)&#x0A;</xsl:text>
+               <xsl:text>let $local:boolean-test as xs:boolean := ($local:test-result instance of xs:boolean)&#x0A;</xsl:text>
 
                <!-- TODO: xspec/xspec#309 -->
 
                <!-- $local:successful -->
-               <xsl:text>  let $local:successful as xs:boolean := (&#x0A;</xsl:text>
-               <xsl:text>    if ($local:boolean-test)&#x0A;</xsl:text>
-               <xsl:text>    then boolean($local:test-result)&#x0A;</xsl:text>
-               <xsl:text expand-text="yes">    else {x:known-UQName('test:deep-equal')}(${x:variable-UQName(.)}, $local:test-result, {$deep-equal-flags})&#x0A;</xsl:text>
-               <xsl:text>  )&#x0A;</xsl:text>
+               <xsl:text>let $local:successful as xs:boolean (: did the test pass? :) := (&#x0A;</xsl:text>
+               <xsl:text>if ($local:boolean-test)&#x0A;</xsl:text>
+               <xsl:text>then boolean($local:test-result)&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">else {x:known-UQName('test:deep-equal')}(${x:variable-UQName(.)}, $local:test-result, {$deep-equal-flags})&#x0A;</xsl:text>
+               <xsl:text>)&#x0A;</xsl:text>
 
             </xsl:when>
 
             <xsl:otherwise>
                <!-- $local:successful -->
-               <xsl:text>  let $local:successful as xs:boolean :=&#x0A;</xsl:text>
-               <xsl:text expand-text="yes">      {x:known-UQName('test:deep-equal')}(${x:variable-UQName(.)}, ${x:known-UQName('x:result')}, {$deep-equal-flags})&#x0A;</xsl:text>
+               <xsl:text>let $local:successful as xs:boolean :=&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">{x:known-UQName('test:deep-equal')}(${x:variable-UQName(.)}, ${x:known-UQName('x:result')}, {$deep-equal-flags})&#x0A;</xsl:text>
             </xsl:otherwise>
          </xsl:choose>
 
-         <xsl:text>    return&#x0A;</xsl:text>
-         <xsl:text>      </xsl:text>
+         <xsl:text>return&#x0A;</xsl:text>
       </xsl:if>
 
-      <!--
-        return the x:test element for the report
-      -->
+      <!-- <x:test> -->
       <xsl:element name="{x:xspec-name('test', .)}" namespace="{$x:xspec-namespace}">
          <xsl:attribute name="id" select="$expect-id" />
 
@@ -446,28 +486,34 @@
 
          <!-- Report -->
          <xsl:if test="not($pending-p)">
+            <xsl:text>&#x0A;</xsl:text>
+            <xsl:text>{&#x0A;</xsl:text>
+
             <xsl:if test="@test">
-               <xsl:text>&#x0A;</xsl:text>
-               <xsl:text>      { if ( $local:boolean-test )&#x0A;</xsl:text>
-               <xsl:text>        then ()&#x0A;</xsl:text>
-               <xsl:text expand-text="yes">        else {x:known-UQName('test:report-sequence')}($local:test-result, '{x:xspec-name('result', .)}')</xsl:text>
-               <xsl:text> }</xsl:text>
+               <xsl:text>(&#x0A;</xsl:text>
+               <xsl:text>if ( $local:boolean-test )&#x0A;</xsl:text>
+               <xsl:text>then ()&#x0A;</xsl:text>
+               <xsl:text expand-text="yes">else {x:known-UQName('test:report-sequence')}($local:test-result, '{x:xspec-name('result', .)}')&#x0A;</xsl:text>
+               <xsl:text>),&#x0A;</xsl:text>
             </xsl:if>
 
-            <xsl:text>&#x0A;</xsl:text>
-            <xsl:text>      { </xsl:text>
-            <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(</xsl:text>
-            <xsl:text expand-text="yes">${x:variable-UQName(.)}, '{x:xspec-name('expect', .)}'</xsl:text>
-
+            <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(${x:variable-UQName(.)}, '{x:xspec-name('expect', .)}'</xsl:text>
             <xsl:if test="@test">
                <xsl:text>, </xsl:text>
                <xsl:apply-templates select="@test" mode="test:create-node-generator" />
             </xsl:if>
+            <xsl:text>)&#x0A;</xsl:text>
 
-            <xsl:text>) }</xsl:text>
+            <xsl:text>}</xsl:text>
          </xsl:if>
+
+      <!-- </x:test> -->
       </xsl:element>
-      <xsl:text>&#10;};&#10;</xsl:text>
+
+      <xsl:text>&#x0A;</xsl:text>
+
+      <!-- End of the function -->
+      <xsl:text>};&#x0A;</xsl:text>
    </xsl:template>
 
    <!--

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -31,6 +31,8 @@
       <!-- Reflects @pending or x:pending -->
       <xsl:param name="pending" select="()" tunnel="yes" as="node()?" />
 
+      <xsl:param name="comment" as="xs:string?" />
+
       <!-- URIQualifiedName of the variable being declared -->
       <xsl:variable name="uqname" as="xs:string" select="x:variable-UQName(.)" />
 
@@ -138,6 +140,10 @@
                <xsl:sequence select="@select" />
             </xsl:otherwise>
          </xsl:choose>
+
+         <xsl:if test="$comment">
+            <xsl:comment select="$comment" />
+         </xsl:if>
       </xsl:element>
    </xsl:template>
 

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -678,7 +678,9 @@
             <xsl:variable name="xslt-version" as="xs:decimal" select="x:xslt-version(.)" />
 
             <!-- Set up the $impl:expected variable -->
-            <xsl:apply-templates select="." mode="test:generate-variable-declarations" />
+            <xsl:apply-templates select="." mode="test:generate-variable-declarations">
+               <xsl:with-param name="comment" select="'expected result'" />
+            </xsl:apply-templates>
 
             <!-- Flags for test:deep-equal() enclosed in ''. -->
             <xsl:variable name="deep-equal-flags" as="xs:string"
@@ -686,6 +688,7 @@
 
             <xsl:choose>
                <xsl:when test="@test">
+                  <xsl:comment> wrap $x:result into a doc node if possible </xsl:comment>
                   <!-- This variable declaration could be moved from here (the
                      template generated from x:expect) to the template
                      generated from x:scenario. It depends only on
@@ -707,6 +710,7 @@
                      </choose>
                   </variable>
 
+                  <xsl:comment> evaluate the predicate with $x:result as context node if $x:result is a single node; if not, just evaluate the predicate </xsl:comment>
                   <variable name="{x:known-UQName('impl:test-result')}" as="item()*">
                      <choose>
                         <when test="count(${x:known-UQName('impl:test-items')}) eq 1">
@@ -733,6 +737,7 @@
                      </if>
                   </xsl:if>
 
+                  <xsl:comment> did the test pass? </xsl:comment>
                   <variable name="{x:known-UQName('impl:successful')}" as="{x:known-UQName('xs:boolean')}">
                      <choose>
                         <when test="${x:known-UQName('impl:boolean-test')}">

--- a/test/end-to-end/ant/generate-expected/build.xml
+++ b/test/end-to-end/ant/generate-expected/build.xml
@@ -4,4 +4,8 @@
 		Use <import> instead of <include>, otherwise "e2e-base" build file cannot override
 		a target in "run-xspec-tests" build file. -->
 	<import file="../base/build.xml" />
+	
+	<!-- Ideally, we should wipe out the expected results directory before generating the expected
+		results. But we can't, because some of the expected results are not always be generated
+		depending on the environment (schema-aware, Saxon version, etc.) -->
 </project>

--- a/test/under-the-hood_compilation-sut_function.xspec
+++ b/test/under-the-hood_compilation-sut_function.xspec
@@ -4,9 +4,10 @@
    xmlns:my="http://example.org/ns/my"
    query="http://example.org/ns/my"
    query-at="compilation-sut.xqm"
+   stylesheet="compilation-sut.xsl"
    xml:base="../tutorial/under-the-hood/">
 
    <!-- If any of these tests changes, check whether the file
         ../tutorials/under-the-hood/Compilation.md needs updates. -->
-   <x:import href="compilation-sut_query.xspec"/>
+   <x:import href="compilation-sut_function.xspec"/>
 </x:description>

--- a/test/under-the-hood_compilation-sut_template.xspec
+++ b/test/under-the-hood_compilation-sut_template.xspec
@@ -6,5 +6,5 @@
 
    <!-- If any of these tests changes, check whether the file
         ../tutorials/under-the-hood/Compilation.md needs updates. -->
-   <x:import href="compilation-sut_stylesheet.xspec" />
+   <x:import href="compilation-sut_template.xspec" />
 </x:description>

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -24,6 +24,8 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
 
 ### Test suite
 
+[compilation-simple-suite.xspec](compilation-simple-suite.xspec)
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
@@ -96,39 +98,45 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
 ### Query
 
 ```xquery
+xquery version "3.1";
+
 (: the tested library module :)
 import module namespace my = "http://example.org/ns/my"
-  at ".../compilation-simple-suite.xqm";
-(: an XSpec library module providing tools :)
+at ".../compilation-simple-suite.xqm";
+
+(: XSpec library modules providing tools :)
 import module "http://www.jenitennison.com/xslt/unit-test"
-  at ".../src/compiler/generate-query-utils.xqm";
+at ".../src/compiler/generate-query-utils.xqm";
 import module "http://www.jenitennison.com/xslt/xspec"
-  at ".../src/common/xspec-utils.xqm";
+at ".../src/common/xspec-utils.xqm";
 
 declare namespace x = "http://www.jenitennison.com/xslt/xspec";
+declare option Q{http://www.w3.org/2010/xslt-xquery-serialization}parameter-document ".../xml-report-serialization-parameters.xml";
+declare variable $Q{http://www.jenitennison.com/xslt/xspec}xspec-uri as xs:anyURI := (
+xs:anyURI(".../compilation-simple-suite.xspec")
+);
 
 (: generated from the x:scenario element :)
 declare function local:scenario1(
 )
 {
-  ...
-  (: a call instruction for each x:expect element :)
-  let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
-    $Q{http://www.jenitennison.com/xslt/xspec}result
-  )
-  return (
-    $Q{http://www.jenitennison.com/xslt/xspec}tmp
-  )
-
-  ...
+...
+(: a call instruction for each x:expect element :)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
+$Q{http://www.jenitennison.com/xslt/xspec}result
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
+...
 };
 
 (: generated from the x:expect element :)
 declare function local:scenario1-expect1(
-  $Q{http://www.jenitennison.com/xslt/xspec}result
+$Q{http://www.jenitennison.com/xslt/xspec}result
 )
 {
-  ...
+...
 };
 
 (: the query body of this main module, to run the suite :)
@@ -140,15 +148,15 @@ document {
           query="http://example.org/ns/my"
           query-at=".../compilation-simple-suite.xqm"
           xspec=".../compilation-simple-suite.xspec"> {
-      (: a call instruction for each top-level scenario :)
-      let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1(
-      )
-      return (
-        $Q{http://www.jenitennison.com/xslt/xspec}tmp
-      )
-
+(: a call instruction for each top-level scenario :)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1(
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
 }
-</x:report> }
+</x:report>
+}
 ```
 
 ## Simple scenario
@@ -162,6 +170,8 @@ functions) are called from the first one, in sequence, with the
 result as parameter.
 
 ### Test suite
+
+[compilation-simple-suite.xspec](compilation-simple-suite.xspec)
 
 ```xml
 <x:scenario label="scenario">
@@ -180,12 +190,15 @@ result as parameter.
                xspec=".../compilation-simple-suite.xspec">
       <x:label>scenario</x:label>
       <x:call>
-         <xsl:attribute name="function">my:f</xsl:attribute>
+         <xsl:attribute name="function" namespace="">my:f</xsl:attribute>
       </x:call>
       <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
          <xsl:sequence select="Q{http://example.org/ns/my}f()"/>
       </xsl:variable>
+
       ... generate scenario data in the report ...
+
+      <!-- a call instruction for each x:expect element -->
       <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1">
          <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result" select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>
       </xsl:call-template>
@@ -195,8 +208,8 @@ result as parameter.
 <!-- generated from the x:expect element -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1">
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
-   <!-- expected result -->
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." select="()"/>
+   <xsl:message>expectations</xsl:message>
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." select="()"><!--expected result--></xsl:variable>
    <!-- wrap $x:result into a doc node if possible -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}test-items" as="item()*">
       <xsl:choose>
@@ -208,9 +221,7 @@ result as parameter.
          </xsl:otherwise>
       </xsl:choose>
    </xsl:variable>
-   <!-- evaluate the predicate with $x:result as context
-        node if $x:result is a single node; if not, just
-        evaluate the predicate -->
+   <!-- evaluate the predicate with $x:result as context node if $x:result is a single node; if not, just evaluate the predicate -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}test-result" as="item()*">
       <xsl:choose>
          <xsl:when test="count($Q{urn:x-xspec:compile:impl}test-items) eq 1">
@@ -223,10 +234,10 @@ result as parameter.
          </xsl:otherwise>
       </xsl:choose>
    </xsl:variable>
-   <!-- did the test pass? -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}boolean-test"
                  as="Q{http://www.w3.org/2001/XMLSchema}boolean"
                  select="$Q{urn:x-xspec:compile:impl}test-result instance of Q{http://www.w3.org/2001/XMLSchema}boolean"/>
+   <!-- did the test pass? -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}successful"
                  as="Q{http://www.w3.org/2001/XMLSchema}boolean">
       <xsl:choose>
@@ -249,41 +260,44 @@ result as parameter.
 declare function local:scenario1(
 )
 {
-  ... generate scenario data in the report ...
-  let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-    my:f()
-  )
-    return (
-      Q{http://www.jenitennison.com/xslt/unit-test}report-sequence($Q{http://www.jenitennison.com/xslt/xspec}result, 'x:result'),
-      let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
-         $Q{http://www.jenitennison.com/xslt/xspec}result
-      )
-      return (
-        $Q{http://www.jenitennison.com/xslt/xspec}tmp
-      )
-    )
+... generate scenario data in the report ...
+
+let $Q{http://www.jenitennison.com/xslt/xspec}result := (
+my:f()
+)
+return (
+Q{http://www.jenitennison.com/xslt/unit-test}report-sequence($Q{http://www.jenitennison.com/xslt/xspec}result, 'x:result'),
+
+(: a call instruction for each x:expect element :)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
+$Q{http://www.jenitennison.com/xslt/xspec}result
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
+)
 };
 
 (: generated from the x:expect element :)
 declare function local:scenario1-expect1(
-  $Q{http://www.jenitennison.com/xslt/xspec}result
+$Q{http://www.jenitennison.com/xslt/xspec}result
 )
 {
-  let $Q{urn:x-xspec:compile:impl}expect-... := (: expected result (none here) :)
-      (  )
-  let $local:test-items as item()* := $Q{http://www.jenitennison.com/xslt/xspec}result
-  let $local:test-result as item()* := (: evaluate the predicate :)
-      ($x:result = 1)
-
-  let $local:boolean-test as xs:boolean :=
-    ($local:test-result instance of xs:boolean)
-  let $local:successful as xs:boolean := (: did the test pass? :) (
-    if ($local:boolean-test)
-    then boolean($local:test-result)
-    else Q{http://www.jenitennison.com/xslt/unit-test}deep-equal($Q{urn:x-xspec:compile:impl}expect-..., $local:test-result, '')
-  )
-    return
-      ... generate test result in the report ...
+let $Q{urn:x-xspec:compile:impl}expect-... (: expected result :) := (
+()
+)
+let $local:test-items as item()* := $Q{http://www.jenitennison.com/xslt/xspec}result
+let $local:test-result as item()* (: evaluate the predicate :) := (
+$x:result = 1
+)
+let $local:boolean-test as xs:boolean := ($local:test-result instance of xs:boolean)
+let $local:successful as xs:boolean (: did the test pass? :) := (
+if ($local:boolean-test)
+then boolean($local:test-result)
+else Q{http://www.jenitennison.com/xslt/unit-test}deep-equal($Q{urn:x-xspec:compile:impl}expect-..., $local:test-result, '')
+)
+return
+... generate test result in the report ...
 };
 ```
 
@@ -314,18 +328,10 @@ section "[Simple scenario](#simple-scenario)").
 
 ### Test suite
 
-```xml
-<!-- apply template rules on a node (with x:apply) -->
-<x:variable name="ctxt">
-   <elem/>
-</x:variable>
-<x:apply select="$ctxt" mode="mode">
-   <x:param name="p1" select="'val1'" tunnel="yes"/>
-   <x:param name="p2" as="element()">
-      <val2/>
-   </x:param>
-</x:apply>
+- For function (XSLT and XQuery): [compilation-sut_function.xspec](compilation-sut_function.xspec)
+- For template (only XSLT) [compilation-sut_template.xspec](compilation-sut_template.xspec)
 
+```xml
 <!-- call a function -->
 <x:call function="my:f">
    <x:param select="'val1'"/>
@@ -346,26 +352,24 @@ section "[Simple scenario](#simple-scenario)").
 <x:context>
    <elem/>
 </x:context>
+
+<!-- apply template rules on a node (with x:apply) -->
+<x:variable name="ctxt">
+   <elem/>
+</x:variable>
+<x:apply select="$ctxt" mode="mode">
+   <x:param name="p1" select="'val1'" tunnel="yes"/>
+   <x:param name="p2" as="element()">
+      <val2/>
+   </x:param>
+</x:apply>
+
 ```
 
 ### Stylesheet
 
 ```xml
-<xsl:variable name="ctxt" as="item()*">
-   <elem/>
-</xsl:variable>
-<xsl:variable name="x:result" as="item()*">
-   <xsl:variable name="p1" select="'val1'"/>
-   <xsl:variable name="p2" as="element()">
-      <val2/>
-   </xsl:variable>
-   ... error if "$ctxt instance of node()" is not true ...
-   <xsl:apply-templates select="$ctxt" mode="mode">
-      <xsl:with-param name="p1" select="$p1" tunnel="yes"/>
-      <xsl:with-param name="p2" select="$p2"/>
-   </xsl:apply-templates>
-</xsl:variable>
-
+<!-- "call a function" -->
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-..." select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
@@ -379,6 +383,7 @@ section "[Simple scenario](#simple-scenario)").
    <xsl:sequence select="Q{http://example.org/ns/my}f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)"/>
 </xsl:variable>
 
+<!-- "call a named template" -->
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
    <xsl:variable name="Q{}p1" select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
@@ -394,6 +399,7 @@ section "[Simple scenario](#simple-scenario)").
    </xsl:call-template>
 </xsl:variable>
 
+<!-- "apply template rules on a node (with x:context)" -->
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
    <xsl:variable name="Q{urn:x-xspec:compile:impl}context-...-doc" as="document-node()">
       <xsl:document>
@@ -404,17 +410,41 @@ section "[Simple scenario](#simple-scenario)").
                  select="$Q{urn:x-xspec:compile:impl}context-...-doc ! ( node() )"/>
    <xsl:apply-templates select="$Q{urn:x-xspec:compile:impl}context-..."/>
 </xsl:variable>
+
+<!-- "apply template rules on a node (with x:apply)" -->
+<xsl:variable name="ctxt" as="item()*">
+   <elem/>
+</xsl:variable>
+<xsl:variable name="x:result" as="item()*">
+   <xsl:variable name="p1" select="'val1'"/>
+   <xsl:variable name="p2" as="element()">
+      <val2/>
+   </xsl:variable>
+   ... error if "$ctxt instance of node()" is not true ...
+   <xsl:apply-templates select="$ctxt" mode="mode">
+      <xsl:with-param name="p1" select="$p1" tunnel="yes"/>
+      <xsl:with-param name="p2" select="$p2"/>
+   </xsl:apply-templates>
+</xsl:variable>
 ```
 
 ### Query
 
 ```xquery
-let $Q{urn:x-xspec:compile:impl}param-... := ( 'val1' )
-let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := ( document { <val2 xmlns:my="http://example.org/ns/my">{ () }
-</val2> } )
-let $p2 as element() := ( $Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() ) )
+let $Q{urn:x-xspec:compile:impl}param-... := (
+'val1'
+)
+let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := (
+document {
+<val2 xmlns:my="http://example.org/ns/my">{ () }
+</val2>
+}
+)
+let $p2 as element() := (
+$Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() )
+)
 let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-  my:f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)
+my:f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)
 )
 ```
 
@@ -425,6 +455,8 @@ The `x:variable` element in the XSpec namespace defines an XSpec variable. Any n
 The first example shows how an XSpec variable maps to an `xsl:variable` element in generated XSLT code or a `let` statement in generated XQuery code.
 
 ### Test suite
+
+[compilation-variables.xspec](compilation-variables.xspec)
 
 ```xml
 <x:scenario label="scenario">
@@ -439,6 +471,7 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 ```xml
 <!-- generated from the x:scenario element -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+   ...
    <!-- the generated variable -->
    <xsl:variable name="Q{http://example.org/ns/my/variable}var" select="'value'"/>
    <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
@@ -457,13 +490,14 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1">
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <xsl:param name="Q{http://example.org/ns/my/variable}var" required="yes"/>
-   <!-- evaluate the expectation -->
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." ...>
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}test-items" ...>
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}test-result" ...>
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}boolean-test" ...>
+   ...
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." select="..."><!--expected result--></xsl:variable>
+   ...
    <!-- did the test pass? -->
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}successful" ...>
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}successful"
+                 as="Q{http://www.w3.org/2001/XMLSchema}boolean">
+      ...
+   </xsl:variable>
    ... generate test result in the report ...
 </xsl:template>
 ```
@@ -475,35 +509,42 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 declare function local:scenario1(
 )
 {
-  let $Q{http://example.org/ns/my/variable}var := ( 'value' )        (: the generated variable :)
-  ...
-  let $Q{http://www.jenitennison.com/xslt/xspec}result := ... exercise the SUT ...
-    return (
-      ...,
-      let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
-        $Q{http://www.jenitennison.com/xslt/xspec}result,
-        $Q{http://example.org/ns/my/variable}var
-      )
-      return (
-        $Q{http://www.jenitennison.com/xslt/xspec}tmp
-      )
-    )
-  ...
+(: the generated variable :)
+let $Q{http://example.org/ns/my/variable}var := (
+'value'
+)
+...
+let $Q{http://www.jenitennison.com/xslt/xspec}result := (
+... exercise the SUT ...
+)
+return (
+...,
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-expect1(
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+$Q{http://example.org/ns/my/variable}var
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
+)
+...
 };
 
 (: generated from the x:expect element :)
 declare function local:scenario1-expect1(
-  $Q{http://www.jenitennison.com/xslt/xspec}result,
-  $Q{http://example.org/ns/my/variable}var
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+$Q{http://example.org/ns/my/variable}var
 )
 {
-  let $Q{urn:x-xspec:compile:impl}expect-...    :=  ... (: expected result :)
-  let $local:test-items as item()* := ...
-  let $local:test-result as item()* := ...
-  let $local:boolean-test as xs:boolean :=  ...
-  let $local:successful as xs:boolean := ... (: did the test pass? :)
-    return
-      ... generate test result in the report ...
+let $Q{urn:x-xspec:compile:impl}expect-... (: expected result :) := (
+...
+)
+...
+let $local:successful as xs:boolean (: did the test pass? :) := (
+...
+)
+return
+... generate test result in the report ...
 };
 ```
 
@@ -522,51 +563,88 @@ this accessibility.
 
 ### Test suite
 
+[compilation-variable-value.xspec](compilation-variable-value.xspec)
+
 ```xml
-<x:variable name="myv:select"  select="'value'"/>
-<x:variable name="myv:href"    href="test-data.xml"/>
-<x:variable name="myv:content" as="element()">
-   <elem/>
-</x:variable>
+<x:scenario label="scenario">
+   <x:variable name="myv:select"  select="'value'"/>
+   <x:variable name="myv:href"    href="test-data.xml"/>
+   <x:variable name="myv:content" as="element()">
+      <elem/>
+   </x:variable>
+   ...
+</x:scenario>
 ```
 
 ### Stylesheet
 
 ```xml
-<xsl:variable name="Q{http://example.org/ns/my/variable}select" select="'value'"/>
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+   ...
 
-<xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-uri"
-              as="Q{http://www.w3.org/2001/XMLSchema}anyURI">.../test-data.xml</xsl:variable>
-<xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc"
-              as="document-node()"
-              select="doc($Q{urn:x-xspec:compile:impl}variable-...-uri)"/>
-<xsl:variable name="Q{http://example.org/ns/my/variable}href"
-              select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )"/>
+   <!-- $myv:select -->
+   <xsl:variable name="Q{http://example.org/ns/my/variable}select" select="'value'"/>
 
-<xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc" as="document-node()">
-   <xsl:document>
-      <elem/>
-   </xsl:document>
-</xsl:variable>
-<xsl:variable name="Q{http://example.org/ns/my/variable}content"
-              as="element()"
-              select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() )"/>
-   </xsl:for-each>
-</xsl:variable>
+   <!-- $myv:href -->
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-uri"
+                 as="Q{http://www.w3.org/2001/XMLSchema}anyURI">.../test-data.xml</xsl:variable>
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc"
+                 as="document-node()"
+                 select="doc($Q{urn:x-xspec:compile:impl}variable-...-uri)"/>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}href"
+                 select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )"/>
+
+   <!-- $myv:content -->
+   <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc" as="document-node()">
+      <xsl:document>
+         <elem/>
+      </xsl:document>
+   </xsl:variable>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}content"
+                 as="element()"
+                 select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() )"/>
+
+   ...
+</xsl:template>
 ```
 
 ### Query
 
 ```xquery
-let $Q{http://example.org/ns/my/variable}select := ( 'value' )
+declare function local:scenario1(
+)
+{
+...
 
-let $Q{urn:x-xspec:compile:impl}variable-...-uri as xs:anyURI := ( xs:anyURI(".../test-data.xml") )
-let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := ( doc($Q{urn:x-xspec:compile:impl}variable-...-uri) )
-let $Q{http://example.org/ns/my/variable}href := ( $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . ) )
+(: $myv:select :)
+let $Q{http://example.org/ns/my/variable}select := (
+'value'
+)
 
-let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := ( document { <elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
-</elem> } )
-let $Q{http://example.org/ns/my/variable}content as element() := ( $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() ) )
+(: $myv:href :)
+let $Q{urn:x-xspec:compile:impl}variable-...-uri as xs:anyURI := (
+xs:anyURI(".../test-data.xml")
+)
+let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := (
+doc($Q{urn:x-xspec:compile:impl}variable-...-uri)
+)
+let $Q{http://example.org/ns/my/variable}href := (
+$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )
+)
+
+(: $myv:content :)
+let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := (
+document {
+<elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
+</elem>
+}
+)
+let $Q{http://example.org/ns/my/variable}content as element() := (
+$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() )
+)
+
+...
+};
 ```
 
 ## Variables scope
@@ -589,19 +667,25 @@ and functions in XQuery).
 
 ### Test suite
 
+[compilation-variables-scope.xspec](compilation-variables-scope.xspec)
+
 ```xml
-<x:variable name="myv:global" ...>
+<x:variable name="myv:global" select="'global-value'"/>
+
 <x:scenario label="outer">
-   <x:variable name="myv:var-1" ...>
+   <x:variable name="myv:var-1" select="'var-1-value'"/>
+
    <x:scenario label="inner">
-      <x:variable name="myv:var-2" ...>
+      <x:variable name="myv:var-2" select="'var-2-value'"/>
       <x:call function="my:square">
          <x:param select="0"/>
       </x:call>
-      <x:variable name="myv:var-3" ...>
-      <x:expect label="expect one" ...>
-      <x:variable name="myv:var-4" ...>
-      <x:expect label="expect two" ...>
+
+      <x:variable name="myv:var-3" select="'var-3-value'"/>
+      <x:expect label="expect one" .../>
+
+      <x:variable name="myv:var-4" select="'var-4-value'"/>
+      <x:expect label="expect two" .../>
    </x:scenario>
 </x:scenario>
 ```
@@ -609,12 +693,14 @@ and functions in XQuery).
 ### Stylesheet
 
 ```xml
-<xsl:variable name="Q{http://example.org/ns/my/variable}global" ...>
+<!-- the generated global variable -->
+<xsl:variable name="Q{http://example.org/ns/my/variable}global"
+              select="'global-value'"/>
 
 <!-- generated from the scenario outer -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-1" ...>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}var-1" select="'var-1-value'" />
    ...
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1">
       <!-- pass the variable to inner context -->
@@ -625,15 +711,17 @@ and functions in XQuery).
 <!-- generated from the scenario inner -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1">
    <!-- the variable is passed as param -->
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes" ...>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
+   ...
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-2" ...>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}var-2" select="'var-2-value'"/>
+   ...
    <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
       <xsl:sequence select="Q{http://example.org/ns/my}square(...)"/>
    </xsl:variable>
    ...
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-3" ...>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}var-3" select="'var-3-value'"/>
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect1">
       <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result"
                       select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>
@@ -645,7 +733,7 @@ and functions in XQuery).
                       select="$Q{http://example.org/ns/my/variable}var-3"/>
    </xsl:call-template>
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-4" ...>
+   <xsl:variable name="Q{http://example.org/ns/my/variable}var-4" select="'var-4-value'"/>
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect2">
       <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result"
                       select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>
@@ -664,9 +752,9 @@ and functions in XQuery).
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect1">
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <!-- the variables are passed as param -->
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes" ...>
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-2" required="yes" ...>
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-3" required="yes" ...>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-2" required="yes"/>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-3" required="yes"/>
    ... evaluate the expectations ...
 </xsl:template>
 
@@ -674,10 +762,10 @@ and functions in XQuery).
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect2">
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <!-- the variables are passed as param -->
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes" ...>
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-2" required="yes" ...>
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-3" required="yes" ...>
-   <xsl:param name="Q{http://example.org/ns/my/variable}var-4" required="yes" ...>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-2" required="yes"/>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-3" required="yes"/>
+   <xsl:param name="Q{http://example.org/ns/my/variable}var-4" required="yes"/>
    ... evaluate the expectations ...
 </xsl:template>
 ```
@@ -685,79 +773,99 @@ and functions in XQuery).
 ### Query
 
 ```xquery
-declare variable $Q{http://example.org/ns/my/variable}global := ...;
+(: the generated global variable :)
+declare variable $Q{http://example.org/ns/my/variable}global := (
+'global-value'
+);
 
 (: generated from the scenario outer :)
 declare function local:scenario1(
 )
 {
-  ...
-  let $Q{http://example.org/ns/my/variable}var-1 := ...
-  let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1(
-    $Q{http://example.org/ns/my/variable}var-1
-  )
-  return (
-    $Q{http://www.jenitennison.com/xslt/xspec}tmp
-  )
-  ...
+...
+(: the generated variable :)
+let $Q{http://example.org/ns/my/variable}var-1 := (
+'var-1-value'
+)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1(
+(: pass the variable to inner context :)
+$Q{http://example.org/ns/my/variable}var-1
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
+...
 };
 
 (: generated from the scenario inner :)
 declare function local:scenario1-scenario1(
-  $Q{http://example.org/ns/my/variable}var-1
+(: the variable is passed as param :)
+$Q{http://example.org/ns/my/variable}var-1
 )
 {
-  let $Q{http://example.org/ns/my/variable}var-2 := ...
-  ...
-  let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-    my:square(...)
-  )
-    return (
-      ...,
-      let $Q{http://example.org/ns/my/variable}var-3 := ...
-      let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1-expect1(
-        $Q{http://www.jenitennison.com/xslt/xspec}result,
-        $Q{http://example.org/ns/my/variable}var-1,
-        $Q{http://example.org/ns/my/variable}var-2,
-        $Q{http://example.org/ns/my/variable}var-3
-      )
-      return (
-        $Q{http://www.jenitennison.com/xslt/xspec}tmp,
-        let $Q{http://example.org/ns/my/variable}var-4 := ...
-        let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1-expect2(
-          $Q{http://www.jenitennison.com/xslt/xspec}result,
-          $Q{http://example.org/ns/my/variable}var-1,
-          $Q{http://example.org/ns/my/variable}var-2,
-          $Q{http://example.org/ns/my/variable}var-3,
-          $Q{http://example.org/ns/my/variable}var-4
-        )
-        return (
-          $Q{http://www.jenitennison.com/xslt/xspec}tmp
-        )
-      )
-    )
+(: the generated variable :)
+let $Q{http://example.org/ns/my/variable}var-2 := (
+'var-2-value'
+)
+return
+...
+let $Q{http://www.jenitennison.com/xslt/xspec}result := (
+my:square(...)
+)
+return (
+...,
+(: the generated variable :)
+let $Q{http://example.org/ns/my/variable}var-3 := (
+'var-3-value'
+)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1-expect1(
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+$Q{http://example.org/ns/my/variable}var-1,
+$Q{http://example.org/ns/my/variable}var-2,
+$Q{http://example.org/ns/my/variable}var-3
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp,
+(: the generated variable :)
+let $Q{http://example.org/ns/my/variable}var-4 := (
+'var-4-value'
+)
+let $Q{http://www.jenitennison.com/xslt/xspec}tmp := local:scenario1-scenario1-expect2(
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+$Q{http://example.org/ns/my/variable}var-1,
+$Q{http://example.org/ns/my/variable}var-2,
+$Q{http://example.org/ns/my/variable}var-3,
+$Q{http://example.org/ns/my/variable}var-4
+)
+return (
+$Q{http://www.jenitennison.com/xslt/xspec}tmp
+)
+)
+)
 };
 
 (: generated from the expect one :)
 declare function local:scenario1-scenario1-expect1(
-  $Q{http://www.jenitennison.com/xslt/xspec}result,
-  $Q{http://example.org/ns/my/variable}var-1,
-  $Q{http://example.org/ns/my/variable}var-2,
-  $Q{http://example.org/ns/my/variable}var-3
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+(: the variables are passed as param :)
+$Q{http://example.org/ns/my/variable}var-1,
+$Q{http://example.org/ns/my/variable}var-2,
+$Q{http://example.org/ns/my/variable}var-3
 )
 {
-  ...evaluate the expectations ...
+...evaluate the expectations ...
 };
 
 (: generated from the expect two :)
 declare function local:scenario1-scenario1-expect2(
-  $Q{http://www.jenitennison.com/xslt/xspec}result,
-  $Q{http://example.org/ns/my/variable}var-1,
-  $Q{http://example.org/ns/my/variable}var-2,
-  $Q{http://example.org/ns/my/variable}var-3,
-  $Q{http://example.org/ns/my/variable}var-4
+$Q{http://www.jenitennison.com/xslt/xspec}result,
+(: the variables are passed as param :)
+$Q{http://example.org/ns/my/variable}var-1,
+$Q{http://example.org/ns/my/variable}var-2,
+$Q{http://example.org/ns/my/variable}var-3,
+$Q{http://example.org/ns/my/variable}var-4
 )
 {
-  ...evaluate the expectations ...
+...evaluate the expectations ...
 };
 ```

--- a/tutorial/under-the-hood/compilation-sut_function.xspec
+++ b/tutorial/under-the-hood/compilation-sut_function.xspec
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- galtm: NOT DONE YET -->
+<?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
    xmlns:my="http://example.org/ns/my"
    query="http://example.org/ns/my"
-   query-at="compilation-sut.xqm">
+   query-at="compilation-sut.xqm"
+   stylesheet="compilation-sut.xsl">
 
    <!-- Example in Compilation.md, under "SUT" -->
    <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->

--- a/tutorial/under-the-hood/compilation-sut_template.xspec
+++ b/tutorial/under-the-hood/compilation-sut_template.xspec
@@ -6,31 +6,6 @@
    <!-- Example in Compilation.md, under "SUT" -->
    <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->
 
-<!-- x:apply is not implemented or in the schema yet.
-   <x:scenario label="apply template rules on a node (with x:apply)">
-      <x:variable name="ctxt">
-         <elem/>
-      </x:variable>
-      <x:apply select="$ctxt" mode="mode">
-         <x:param name="p1" select="val1" tunnel="yes"/>
-         <x:param name="p2" as="element()">
-            <val2/>
-         </x:param>
-      </x:apply>
-      <x:expect label="expectations" select="true()"/>
-   </x:scenario>
--->
-
-   <x:scenario label="call a function">
-      <x:call function="my:f">
-         <x:param select="'val1'"/>
-         <x:param name="p2" as="element()">
-            <val2/>
-         </x:param>
-      </x:call>
-      <x:expect label="expectations" select="true()"/>
-   </x:scenario>
-
    <x:scenario label="call a named template">
       <x:call template="t">
          <x:param name="p1" select="'val1'"/>
@@ -49,5 +24,20 @@
    </x:scenario>
    
   
+
+<!-- x:apply is not implemented or in the schema yet.
+   <x:scenario label="apply template rules on a node (with x:apply)">
+      <x:variable name="ctxt">
+         <elem/>
+      </x:variable>
+      <x:apply select="$ctxt" mode="mode">
+         <x:param name="p1" select="val1" tunnel="yes"/>
+         <x:param name="p2" as="element()">
+            <val2/>
+         </x:param>
+      </x:apply>
+      <x:expect label="expectations" select="true()"/>
+   </x:scenario>
+-->
 
 </x:description>

--- a/tutorial/under-the-hood/compilation-variables-scope.xspec
+++ b/tutorial/under-the-hood/compilation-variables-scope.xspec
@@ -10,17 +10,24 @@
    <!-- To facilitate updating that wiki, compile this test without deleting intermediate results. -->
 
    <x:variable name="myv:global" select="'global-value'"/>
+
    <x:scenario label="outer">
       <x:variable name="myv:var-1" select="'var-1-value'"/>
+
       <x:scenario label="inner">
          <x:variable name="myv:var-2" select="'var-2-value'"/>
          <x:call function="my:square">
             <x:param select="0"/>
          </x:call>
+
          <x:variable name="myv:var-3" select="'var-3-value'"/>
-         <x:expect label="expect one" test="exists($myv:global) and exists($myv:var-1) and exists($myv:var-2) and exists($myv:var-3)"/>
+         <x:expect label="expect one"
+            test="exists($myv:global) and exists($myv:var-1) and exists($myv:var-2) and exists($myv:var-3)"/>
+
          <x:variable name="myv:var-4" select="'var-4-value'"/>
-         <x:expect label="expect two" test="exists($myv:global) and exists($myv:var-1) and exists($myv:var-2) and exists($myv:var-3) and exists($myv:var-4)"/>
+         <x:expect label="expect two"
+            test="exists($myv:global) and exists($myv:var-1) and exists($myv:var-2) and exists($myv:var-3) and exists($myv:var-4)"/>
       </x:scenario>
    </x:scenario>
+
 </x:description>


### PR DESCRIPTION
The XQuery compiler has been putting ad hoc indentation into the compiled query, but it is failing miserably. It simply doesn't scale. This pull request gives up all the indentation in the compiled query. Just put line breaks.

This change affects only the compiled query. The report XML file generated by the compiled query is not changed.

If we want to indent the compiled query, I think it should be done by a code formatter. (I have no candidate.)