### PR TITLE
test: use xmlns:test in tests

### DIFF
--- a/test/generate-query-utils.xspec
+++ b/test/generate-query-utils.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:test="http://www.jenitennison.com/xslt/unit-test"
                query="x-urn:test:do-nothing"
                query-at="do-nothing.xqm">
 
@@ -7,7 +8,7 @@
        Test the source file generate-query-utils.xqm.
 
        The test target is included implicitly by the XSpec compiler. You don't need
-       to specify it in /t:description/@query-at. 'test' prefix is not available, though.
+       to specify it in /t:description/@query-at.
    -->
 
    <!--
@@ -19,7 +20,7 @@
          <!-- These scenarios do not run on XSLT. XSLT implements the tested function as a template. -->
 
          <t:scenario label="Integer">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="1" as="xs:integer" />
                <t:param name="wrapper-name" select="'t:result'" />
             </t:call>
@@ -29,7 +30,7 @@
          </t:scenario>
 
          <t:scenario label="Empty Sequence">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="()" />
                <t:param name="wrapper-name" select="'t:result'" />
             </t:call>
@@ -39,7 +40,7 @@
          </t:scenario>
 
          <t:scenario label="String">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="'test'" as="xs:string" />
                <t:param name="wrapper-name" select="'t:result'" />
             </t:call>
@@ -49,7 +50,7 @@
          </t:scenario>
 
          <t:scenario label="URI">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="xs:anyURI('test.xml')" />
                <t:param name="wrapper-name" select="'t:result'" />
             </t:call>
@@ -59,7 +60,7 @@
          </t:scenario>
 
          <t:scenario label="QName">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
                <t:param name="wrapper-name" select="'t:result'" />
             </t:call>
@@ -69,7 +70,7 @@
          </t:scenario>
 
          <t:scenario label="Attributes">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="/*/@*" as="attribute()+">
                   <doc a="1" b="2" />
                </t:param>
@@ -84,7 +85,7 @@
          </t:scenario>
 
          <t:scenario label="Attributes and content">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-sequence">
+            <t:call function="test:report-sequence">
                <t:param name="sequence" select="/*/@*, /*/foo" as="node()+">
                   <doc a="1" b="2">
                      <foo />

--- a/test/generate-query-utils_schema-aware.xspec
+++ b/test/generate-query-utils_schema-aware.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test require-xquery-to-support-schema?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:test="http://www.jenitennison.com/xslt/unit-test"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                query="x-urn:test:do-nothing"
                query-at="do-nothing.xqm">
@@ -9,7 +10,7 @@
        Test the source file generate-query-utils.xqm.
 
        The test target is included implicitly by the XSpec compiler. You don't need
-       to specify it in /t:description/@query-at. 'test' prefix is not available, though.
+       to specify it in /t:description/@query-at.
    -->
 
    <!--
@@ -27,7 +28,7 @@
          <!-- xs:ENTITIES: list -->
 
          <t:scenario label="xs:ID">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:ID('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -35,7 +36,7 @@
          </t:scenario>
 
          <t:scenario label="xs:IDREF">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:IDREF('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -43,7 +44,7 @@
          </t:scenario>
 
          <t:scenario label="xs:ENTITY">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:ENTITY('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -51,7 +52,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NCName">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:NCName('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -61,7 +62,7 @@
          <!-- xs:NMTOKENS: list -->
 
          <t:scenario label="xs:language">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:language('en')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -69,7 +70,7 @@
          </t:scenario>
 
          <t:scenario label="xs:Name">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:Name('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -77,7 +78,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NMTOKEN">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:NMTOKEN('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -85,7 +86,7 @@
          </t:scenario>
 
          <t:scenario label="xs:token">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:token('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -93,7 +94,7 @@
          </t:scenario>
 
          <t:scenario label="xs:normalizedString">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:normalizedString('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -105,7 +106,7 @@
       <t:scenario label="Derived numeric types">
 
          <t:scenario label="xs:negativeInteger">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:negativeInteger(-1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -113,7 +114,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonPositiveInteger">
-           <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+           <t:call function="test:atom-type">
               <t:param select="xs:nonPositiveInteger(0)" />
            </t:call>
            <t:expect label="xs:integer" select="string()"
@@ -121,7 +122,7 @@
          </t:scenario>
 
          <t:scenario label="xs:byte">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:byte(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -129,7 +130,7 @@
          </t:scenario>
 
          <t:scenario label="xs:short">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:short(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -137,7 +138,7 @@
          </t:scenario>
 
          <t:scenario label="xs:int">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:int(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -145,7 +146,7 @@
          </t:scenario>
 
          <t:scenario label="xs:long">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:long(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -153,7 +154,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedByte">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:unsignedByte(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -161,7 +162,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedShort">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:unsignedShort(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -169,7 +170,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedInt">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:unsignedInt(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -177,7 +178,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedLong">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:unsignedLong(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -185,7 +186,7 @@
          </t:scenario>
 
          <t:scenario label="xs:positiveInteger">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:positiveInteger(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -193,7 +194,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonNegativeInteger">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:nonNegativeInteger(0)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"

--- a/test/generate-x-utils.xspec
+++ b/test/generate-x-utils.xspec
@@ -9,6 +9,7 @@
 
 <t:description xmlns:items="x-urn:test:xspec-items"
                xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               xmlns:test="http://www.jenitennison.com/xslt/unit-test"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                query="x-urn:test:xspec-items"
                query-at="items.xqm"
@@ -18,8 +19,7 @@
        Test the source files generate-tests-utils.xsl and generate-query-utils.xqm.
 
        The test target is included implicitly by the XSpec compiler. You don't need
-       to specify it in /t:description/@stylesheet or @query-at. 'test' prefix is not
-       available on XQuery, though.
+       to specify it in /t:description/@stylesheet or @query-at.
    -->
 
    <!--
@@ -28,7 +28,7 @@
    <t:scenario label="test:deep-equal($seq1, $seq2, '')">
 
       <t:scenario label="Identical Sequences">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param select="1, 2"/>
             <t:param select="1, 2"/>
             <t:param select="''" />
@@ -37,7 +37,7 @@
       </t:scenario>
 
       <t:scenario label="Non-Identical Sequences">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param select="1, 2"/>
             <t:param select="1, 3"/>
             <t:param select="''" />
@@ -46,7 +46,7 @@
       </t:scenario>
 
       <t:scenario label="Sequences with Same Items in Different Orders">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param select="1, 2"/>
             <t:param select="2, 1"/>
             <t:param select="''" />
@@ -55,7 +55,7 @@
       </t:scenario>
 
       <t:scenario label="Empty Sequences">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param select="()"/>
             <t:param select="()"/>
             <t:param select="''" />
@@ -64,7 +64,7 @@
       </t:scenario>
 
       <t:scenario label="One empty sequence">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param select="()"/>
             <t:param select="1"/>
             <t:param select="''" />
@@ -77,7 +77,7 @@
             <e>foo</e>
             <e>bar</e>
          </t:variable>
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param as="text()">foobar</t:param>
             <t:param select="$elems/text()" as="text()+"/>
             <t:param select="''" />
@@ -86,7 +86,7 @@
       </t:scenario>
 
       <t:scenario label="Identical text nodes">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param as="text()">foobar</t:param>
             <t:param as="text()">foobar</t:param>
             <t:param select="''" />
@@ -95,7 +95,7 @@
       </t:scenario>
 
       <t:scenario label="Identical Element Sequences">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+         <t:call function="test:deep-equal">
             <t:param as="element()+"><foo/><bar/></t:param>
             <t:param as="element()+"><foo/><bar/></t:param>
             <t:param select="''" />
@@ -115,7 +115,7 @@
          <t:scenario label="comparing text nodes with analogous">
 
             <t:scenario label="string">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="'12'"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -127,7 +127,7 @@
             </t:scenario>
 
             <t:scenario label="double">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:double('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -139,7 +139,7 @@
             </t:scenario>
 
             <t:scenario label="decimal">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:decimal('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -151,7 +151,7 @@
             </t:scenario>
 
             <t:scenario label="integer">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:integer('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -165,7 +165,7 @@
          </t:scenario>
 
          <t:scenario label="comparing the same strings">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+            <t:call function="test:deep-equal">
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
                <t:param select="'1'" />
@@ -174,7 +174,7 @@
          </t:scenario>
 
          <t:scenario label="comparing different strings">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+            <t:call function="test:deep-equal">
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
                <t:param select="'1'" />
@@ -189,7 +189,7 @@
          <t:scenario label="comparing text nodes with analogous">
 
             <t:scenario label="string">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="'12'"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -201,7 +201,7 @@
             </t:scenario>
 
             <t:scenario label="double">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:double('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -213,7 +213,7 @@
             </t:scenario>
 
             <t:scenario label="decimal">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:decimal('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -225,7 +225,7 @@
             </t:scenario>
 
             <t:scenario label="integer">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param select="xs:integer('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -239,7 +239,7 @@
          </t:scenario>
 
          <t:scenario label="comparing the same strings">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+            <t:call function="test:deep-equal">
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
                <t:param select="''" />
@@ -248,7 +248,7 @@
          </t:scenario>
 
          <t:scenario label="comparing different strings">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+            <t:call function="test:deep-equal">
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
                <t:param select="''" />
@@ -267,7 +267,7 @@
       <t:scenario label="Identical whitespace-only text nodes">
          <t:scenario label="In ordinal element">
             <t:scenario label="No flag">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="09.xml" />
                   <t:param href="09.xml" />
                   <t:param select="''" />
@@ -276,7 +276,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="09.xml" />
                   <t:param href="09.xml" />
                   <t:param select="'w'" />
@@ -287,7 +287,7 @@
 
          <t:scenario label="In test:ws">
             <t:scenario label="No flag">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-09.xml" />
                   <t:param select="''" />
@@ -296,7 +296,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-09.xml" />
                   <t:param select="'w'" />
@@ -309,7 +309,7 @@
       <t:scenario label="Different whitespace-only text nodes">
          <t:scenario label="In ordinal element">
             <t:scenario label="No flag">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="09.xml" />
                   <t:param href="20.xml" />
                   <t:param select="''" />
@@ -318,7 +318,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="09.xml" />
                   <t:param href="20.xml" />
                   <t:param select="'w'" />
@@ -329,7 +329,7 @@
 
          <t:scenario label="In test:ws">
             <t:scenario label="No flag">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-20.xml" />
                   <t:param select="''" />
@@ -338,7 +338,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}deep-equal">
+               <t:call function="test:deep-equal">
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-20.xml" />
                   <t:param select="'w'" />
@@ -357,7 +357,7 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L207-L227">
 
          <t:scenario label="Identical Integers">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}item-deep-equal">
+            <t:call function="test:item-deep-equal">
                <t:param name="item1" select="1" />
                <t:param name="item2" select="1" />
                <t:param select="''" />
@@ -366,7 +366,7 @@
          </t:scenario>
 
          <t:scenario label="Non-Identical Strings">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}item-deep-equal">
+            <t:call function="test:item-deep-equal">
                <t:param name="item1" select="'abc'" />
                <t:param name="item2" select="'def'" />
                <t:param select="''" />
@@ -375,7 +375,7 @@
          </t:scenario>
 
          <t:scenario label="String and Integer">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}item-deep-equal">
+            <t:call function="test:item-deep-equal">
                <t:param name="item1" select="'1'" as="xs:string"/>
                <t:param name="item2" select="1" as="xs:integer"/>
                <t:param select="''" />
@@ -393,7 +393,7 @@
    <t:scenario label="test:node-deep-equal($seq1, $seq2, '')">
 
       <t:scenario label="Identical Attribute Sequences">
-         <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+         <t:call function="test:node-deep-equal">
             <t:param name="node1" select="/node/@attribute" as="attribute(attribute)">
                <node attribute="foobar"/>
             </t:param>
@@ -408,7 +408,7 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L246-L372">
 
          <t:scenario label="Identical Elements">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/*" as="element(result)">
                   <result/>
                </t:param>
@@ -421,7 +421,7 @@
          </t:scenario>
 
          <t:scenario label="Elements with Identical Attributes in Different Orders">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/*" as="element(result)">
                   <result a="1" b="2" />
                </t:param>
@@ -434,7 +434,7 @@
          </t:scenario>
 
          <t:scenario label="Elements with Identical Children">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/*" as="element(result)">
                   <result><child1/><child2/></result>
                </t:param>
@@ -447,7 +447,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Attributes">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/*/@a" as="attribute(a)">
                   <result a="1" />
                </t:param>
@@ -460,7 +460,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Document Nodes">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/" as="document-node(element(result))">
                   <result />
                </t:param>
@@ -473,7 +473,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Text Nodes">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/*/text()" as="text()">
                   <result>Test</result>
                </t:param>
@@ -486,7 +486,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Comments">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/comment()" as="comment()">
                   <!-- Comment -->
                   <doc />
@@ -501,7 +501,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Processing Instructions">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/processing-instruction()" as="processing-instruction(pi)">
                   <?pi data?>
                   <doc />
@@ -517,7 +517,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing text</t:label>
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -531,7 +531,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing mixed content</t:label>
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -545,7 +545,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing attribute values</t:label>
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/foo/@bar" as="attribute(bar)">
                   <foo bar="..." />
                </t:param>
@@ -559,7 +559,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing empty content</t:label>
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param name="node1" select="/foo" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -576,7 +576,7 @@
       <t:scenario label="Namespace Nodes">
 
          <t:scenario label="Identical">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param select="$items:namespace" />
                <t:param select="$items:namespace" />
                <t:param select="''" />
@@ -585,7 +585,7 @@
          </t:scenario>
 
          <t:scenario label="Identical default namespace">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param select="$items:default-namespace" />
                <t:param select="$items:default-namespace" />
                <t:param select="''" />
@@ -594,7 +594,7 @@
          </t:scenario>
 
          <t:scenario label="Different">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}node-deep-equal">
+            <t:call function="test:node-deep-equal">
                <t:param select="$items:namespace" />
                <t:param select="$items:another-namespace" />
                <t:param select="''" />
@@ -614,7 +614,7 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L466-L477">
 
          <t:scenario label="Original order preserved">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}sorted-children">
+            <t:call function="test:sorted-children">
                <t:param name="node" as="element(foo)">
                   <foo><bar /><baz /></foo>
                </t:param>
@@ -637,7 +637,7 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
 
          <t:scenario label="String Containing Single Quotes">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="'don''t'" />
             </t:call>
             <t:expect label="Escaped" select="'''don''''t'''" />
@@ -648,21 +648,21 @@
       <t:scenario label="xs:integer">
 
          <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:integer(18446744073709551615)" />
             </t:call>
             <t:expect label="Numeric literal" select="'18446744073709551615'" />
          </t:scenario>
 
          <t:scenario label="0">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:integer(0)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0'" />
          </t:scenario>
 
          <t:scenario label="-1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:integer(-1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1'" />
@@ -673,49 +673,49 @@
       <t:scenario label="xs:decimal">
 
          <t:scenario label="1.2">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(1.2)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.2'" />
          </t:scenario>
 
          <t:scenario label="1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.0'" />
          </t:scenario>
 
          <t:scenario label="0.1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(0.1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0.1'" />
          </t:scenario>
 
          <t:scenario label="0">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(0)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0.0'" />
          </t:scenario>
 
          <t:scenario label="-0.1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(-0.1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-0.1'" />
          </t:scenario>
 
          <t:scenario label="-1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(-1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1.0'" />
          </t:scenario>
 
          <t:scenario label="-1.2">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:decimal(-1.2)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1.2'" />
@@ -726,21 +726,21 @@
       <t:scenario label="xs:double">
 
          <t:scenario label="1.234e56">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:double(1.234e56)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.234e56'" />
          </t:scenario>
 
          <t:scenario label="1">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:double(1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.0e0'" />
          </t:scenario>
 
          <t:scenario label="NaN">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:double('NaN')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -748,7 +748,7 @@
          </t:scenario>
 
          <t:scenario label="INF">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:double('INF')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -756,7 +756,7 @@
          </t:scenario>
 
          <t:scenario label="-INF">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:double('-INF')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -768,21 +768,21 @@
       <t:scenario label="xs:QName">
 
          <t:scenario label="No namespace">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:QName('foo')" />
             </t:call>
             <t:expect label="Function" select="'QName('''', ''foo'')'" />
          </t:scenario>
 
          <t:scenario label="In namespace, with prefix">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:QName('t:foo')" />
             </t:call>
             <t:expect label="Function" select="'QName(''http://www.jenitennison.com/xslt/xspec'', ''t:foo'')'" />
          </t:scenario>
 
          <t:scenario label="In namespace, without prefix">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="QName('x-urn:test:report-atomic-value', 'foo')" />
             </t:call>
             <t:expect label="Function" select="'QName(''x-urn:test:report-atomic-value'', ''foo'')'" />
@@ -793,7 +793,7 @@
       <t:scenario label="Other types that enter the ELSE branch of the function">
 
          <t:scenario label="xs:untypedAtomic">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}report-atomic-value">
+            <t:call function="test:report-atomic-value">
                <t:param select="xs:untypedAtomic('foo')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -812,7 +812,7 @@
       <t:scenario label="All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION">
 
          <t:scenario label="xs:string">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:string('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -820,7 +820,7 @@
          </t:scenario>
 
          <t:scenario label="xs:boolean">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:boolean('true')" />
             </t:call>
             <t:expect label="xs:boolean" select="string()"
@@ -828,7 +828,7 @@
          </t:scenario>
 
          <t:scenario label="xs:decimal">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:decimal(1)" />
             </t:call>
             <t:expect label="xs:decimal" select="string()"
@@ -836,7 +836,7 @@
          </t:scenario>
 
          <t:scenario label="xs:double">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:double(1)" />
             </t:call>
             <t:expect label="xs:double" select="string()"
@@ -844,7 +844,7 @@
          </t:scenario>
 
          <t:scenario label="xs:float">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:float(1)" />
             </t:call>
             <t:expect label="xs:float" select="string()"
@@ -852,7 +852,7 @@
          </t:scenario>
 
          <t:scenario label="xs:date">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:date('1111-11-11')" />
             </t:call>
             <t:expect label="xs:date" select="string()"
@@ -860,7 +860,7 @@
          </t:scenario>
 
          <t:scenario label="xs:time">
-           <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+           <t:call function="test:atom-type">
               <t:param select="xs:time('11:11:11')" />
            </t:call>
            <t:expect label="xs:time" select="string()"
@@ -868,7 +868,7 @@
          </t:scenario>
 
          <t:scenario label="xs:dateTime">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:dateTime('1111-11-11T11:11:11')" />
             </t:call>
             <t:expect label="xs:dateTime" select="string()"
@@ -876,7 +876,7 @@
          </t:scenario>
 
          <t:scenario label="xs:duration">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:duration('PT1S')" />
             </t:call>
             <t:expect label="xs:duration" select="string()"
@@ -884,7 +884,7 @@
          </t:scenario>
 
          <t:scenario label="xs:QName">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:QName('foo')" />
             </t:call>
             <t:expect label="xs:QName" select="string()"
@@ -892,7 +892,7 @@
          </t:scenario>
 
          <t:scenario label="xs:anyURI">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:anyURI('foo')" />
             </t:call>
             <t:expect label="xs:anyURI" select="string()"
@@ -900,7 +900,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gDay">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:gDay('---11')" />
             </t:call>
             <t:expect label="xs:gDay" select="string()"
@@ -908,7 +908,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gMonthDay">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:gMonthDay('--11-11')" />
             </t:call>
             <t:expect label="xs:gMonthDay" select="string()"
@@ -916,7 +916,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gMonth">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:gMonth('--11')" />
             </t:call>
             <t:expect label="xs:gMonth" select="string()"
@@ -924,7 +924,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gYearMonth">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:gYearMonth('1111-11')" />
             </t:call>
             <t:expect label="xs:gYearMonth" select="string()"
@@ -932,7 +932,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gYear">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:gYear('1111')" />
             </t:call>
             <t:expect label="xs:gYear" select="string()"
@@ -940,7 +940,7 @@
          </t:scenario>
 
          <t:scenario label="xs:base64Binary">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:base64Binary(xs:hexBinary('11'))" />
             </t:call>
             <t:expect label="xs:base64Binary" select="string()"
@@ -948,7 +948,7 @@
          </t:scenario>
 
          <t:scenario label="xs:hexBinary">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:hexBinary('11')" />
             </t:call>
             <t:expect label="xs:hexBinary" select="string()"
@@ -960,7 +960,7 @@
       <t:scenario label="The derived atomic type xs:integer defined in [XML Schema Part 2]">
 
          <t:scenario label="xs:integer">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:integer(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -974,7 +974,7 @@
       <t:scenario label="The following types defined in [XPath 2.0]">
 
          <t:scenario label="xs:yearMonthDuration">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:yearMonthDuration('P1M')" />
             </t:call>
             <t:expect label="xs:yearMonthDuration" select="string()"
@@ -982,7 +982,7 @@
          </t:scenario>
 
          <t:scenario label="xs:dayTimeDuration">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:dayTimeDuration('PT1S')" />
             </t:call>
             <t:expect label="xs:dayTimeDuration" select="string()"
@@ -994,7 +994,7 @@
          <!-- xs:untyped: Not atomic -->
 
          <t:scenario label="xs:untypedAtomic">
-            <t:call function="Q{http://www.jenitennison.com/xslt/unit-test}atom-type">
+            <t:call function="test:atom-type">
                <t:param select="xs:untypedAtomic('foo')" />
             </t:call>
             <t:expect label="xs:untypedAtomic" select="string()"


### PR DESCRIPTION
Following #982 and #1041, this pull request uses the `test` prefix in some tests for convenience.