### PR TITLE
refactor(xquery): invoke SUT using URIQualifiedName

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -853,6 +853,40 @@
       <xsl:sequence select="$strings[not(subsequence($strings, 1, position() - 1) = .)]"/>
    </xsl:function>
 
+   <!-- Returns a text node of the function call expression. The names of the function and the
+      parameter variables are URIQualifiedName. -->
+   <xsl:function name="x:function-call-text" as="text()">
+      <xsl:param name="call" as="element(x:call)" />
+
+      <!-- xsl:for-each is not for iteration but for simplifying XPath -->
+      <xsl:for-each select="$call">
+         <xsl:variable name="function-uqname" as="xs:string">
+            <xsl:choose>
+               <xsl:when test="contains(@function, ':')">
+                  <xsl:sequence select="x:UQName-from-EQName-ignoring-default-ns(@function, .)" />
+               </xsl:when>
+               <xsl:otherwise>
+                  <!-- Function name without prefix is not Q{}local but fn:local -->
+                  <xsl:sequence select="@function/string()" />
+               </xsl:otherwise>
+            </xsl:choose>
+         </xsl:variable>
+
+         <xsl:value-of>
+            <xsl:text expand-text="yes">{$function-uqname}(</xsl:text>
+            <xsl:for-each select="x:param">
+               <xsl:sort select="xs:integer(@position)" />
+
+               <xsl:text expand-text="yes">${x:variable-UQName(.)}</xsl:text>
+               <xsl:if test="position() ne last()">
+                  <xsl:text>, </xsl:text>
+               </xsl:if>
+            </xsl:for-each>
+            <xsl:text>)</xsl:text>
+         </xsl:value-of>
+      </xsl:for-each>
+   </xsl:function>
+
 </xsl:stylesheet>
 
 

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -277,7 +277,7 @@
 
          <xsl:text>      &#10;{&#10;</xsl:text>
          <xsl:choose>
-            <xsl:when test="not($pending-p)">
+            <xsl:when test="not($pending-p) and x:expect">
                <!--
                  let $xxx-param1 := ...
                  let $xxx-param2 := ...
@@ -289,15 +289,8 @@
                <xsl:text expand-text="yes">  let ${x:known-UQName('x:result')} := (&#10;</xsl:text>
                <xsl:call-template name="x:enter-sut">
                   <xsl:with-param name="instruction" as="text()+">
-                     <xsl:text expand-text="yes">    {$call/@function}(</xsl:text>
-                     <xsl:for-each select="$call/x:param">
-                        <xsl:sort select="xs:integer(@position)" />
-                        <xsl:text expand-text="yes">${x:variable-UQName(.)}</xsl:text>
-                        <xsl:if test="position() ne last()">
-                           <xsl:text>, </xsl:text>
-                        </xsl:if>
-                     </xsl:for-each>
-                     <xsl:text>)&#10;</xsl:text>
+                     <xsl:sequence select="x:function-call-text($call)" />
+                     <xsl:text>&#x0A;</xsl:text>
                   </xsl:with-param>
                </xsl:call-template>
                <xsl:text>  )&#10;</xsl:text>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -410,28 +410,7 @@
                         <xsl:call-template name="x:enter-sut">
                            <xsl:with-param name="instruction" as="element(xsl:sequence)">
                               <sequence>
-                                 <xsl:variable name="function-name" as="xs:string">
-                                    <xsl:choose>
-                                       <xsl:when test="contains($call/@function, ':')">
-                                          <xsl:sequence
-                                             select="$call ! x:UQName-from-EQName-ignoring-default-ns(@function, .)" />
-                                       </xsl:when>
-                                       <xsl:otherwise>
-                                          <!-- Function name without prefix is not Q{}local but fn:local -->
-                                          <xsl:sequence select="$call/@function" />
-                                       </xsl:otherwise>
-                                    </xsl:choose>
-                                 </xsl:variable>
-
-                                 <xsl:attribute name="select">
-                                    <xsl:text expand-text="yes">{$function-name}(</xsl:text>
-                                    <xsl:for-each select="$call/x:param">
-                                       <xsl:sort select="xs:integer(@position)" />
-                                       <xsl:text expand-text="yes">${x:variable-UQName(.)}</xsl:text>
-                                       <xsl:if test="position() ne last()">, </xsl:if>
-                                    </xsl:for-each>
-                                    <xsl:text>)</xsl:text>
-                                 </xsl:attribute>
+                                 <xsl:attribute name="select" select="x:function-call-text($call)" />
                               </sequence>
                            </xsl:with-param>
                         </xsl:call-template>

--- a/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
@@ -8,7 +8,6 @@
           date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
          <x:call function="mirror:true"/>
@@ -29,7 +28,6 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @select</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario2-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns false,</x:label>
          <x:call function="mirror:false"/>
@@ -47,7 +45,6 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes child node</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario3-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
          <x:call function="mirror:true"/>
@@ -68,7 +65,6 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select or child node)</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario4-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
          <x:call function="mirror:true"/>

--- a/test/end-to-end/cases/expected/query/issue-448-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-448-result.xml
@@ -7,7 +7,6 @@
           date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../issue-448.xspec">
       <x:label>x:scenario/</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../issue-448.xspec">
          <x:label>x:label containing }{ should not affect test</x:label>
          <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.xml
@@ -72,7 +72,6 @@
    </x:scenario>
    <x:scenario id="scenario6" xspec="../../issue-450-451.xspec">
       <x:label>If value is from a variable instead of hard-coded,</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario6-scenario1" xspec="../../issue-450-451.xspec">
          <x:label>function-param containing curly brackets</x:label>
          <x:call function="mirror:param-mirror">

--- a/test/end-to-end/cases/expected/query/report-result.xml
+++ b/test/end-to-end/cases/expected/query/report-result.xml
@@ -6,7 +6,6 @@
           date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../report.xspec">
          <x:label>Array</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">
@@ -104,7 +103,6 @@
    </x:scenario>
    <x:scenario id="scenario6" xspec="../../report.xspec">
       <x:label>XPath is different, but serialized node looks as if same</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario6-scenario1" xspec="../../report.xspec">
          <x:label>[Result] = document node, [Expected Result] = element</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">

--- a/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
+++ b/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
@@ -7,10 +7,8 @@
           date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../report_schema-aware.xspec">
       <x:label>In a failure report HTML</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../report_schema-aware.xspec">
          <x:label>Derived string types</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario1-scenario1-scenario1"
                      xspec="../../report_schema-aware.xspec">
             <x:label>xs:ID</x:label>
@@ -131,7 +129,6 @@
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../report_schema-aware.xspec">
          <x:label>Derived numeric types</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario1-scenario2-scenario1"
                      xspec="../../report_schema-aware.xspec">
             <x:label>xs:negativeInteger</x:label>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -7,7 +7,6 @@
    <x:scenario id="scenario1" xspec="../../serialize.xspec">
       <x:label>When the result is a comment node, the report HTML must serialize it as
 			&lt;!-- --&gt;. (xspec/xspec#356) So...</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../serialize.xspec">
          <x:label>When x:result in the report XML contains a comment node,</x:label>
          <x:call function="exactly-one">
@@ -37,10 +36,8 @@
    <x:scenario id="scenario2" xspec="../../serialize.xspec">
       <x:label>When the result is indented in the report XML file, the report HTML must serialize
 			it with indentation.</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario2-scenario1" xspec="../../serialize.xspec">
          <x:label>So... (xspec/xspec#359)</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario2-scenario1-scenario1" xspec="../../serialize.xspec">
             <x:label>When x:result in the report XML file is a sequence of simple nested
 					elements serialized with indentation,</x:label>
@@ -97,11 +94,9 @@
       </x:scenario>
       <x:scenario id="scenario2-scenario2" xspec="../../serialize.xspec">
          <x:label>But the diff must not be affected by indentation. So...</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario2-scenario2-scenario1" xspec="../../serialize.xspec">
             <x:label>When a node is indented, the diff of the indented node itself must not be
 					affected. (xspec/xspec#367) So...</x:label>
-            <x:result select="()"/>
             <x:scenario id="scenario2-scenario2-scenario1-scenario1"
                         xspec="../../serialize.xspec">
                <x:label>When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in
@@ -171,7 +166,6 @@
          <x:scenario id="scenario2-scenario2-scenario2" xspec="../../serialize.xspec">
             <x:label>When a child node of an element is indented, the diff of the element must
 					not be affected.</x:label>
-            <x:result select="()"/>
             <x:scenario id="scenario2-scenario2-scenario2-scenario1"
                         xspec="../../serialize.xspec">
                <x:label>So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result
@@ -294,10 +288,8 @@
    <x:scenario id="scenario5" xspec="../../serialize.xspec">
       <x:label>When the result contains an element, the report HTML must serialize nodes in its
 			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario5-scenario1" xspec="../../serialize.xspec">
          <x:label>When the report XML contains an element with several namespaces</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario5-scenario1-scenario1" xspec="../../serialize.xspec">
             <x:label>in x:result,</x:label>
             <x:call function="exactly-one">
@@ -340,7 +332,6 @@
       </x:scenario>
       <x:scenario id="scenario5-scenario2" xspec="../../serialize.xspec">
          <x:label>When the report XML contains an element with several attributes</x:label>
-         <x:result select="()"/>
          <x:scenario id="scenario5-scenario2-scenario1" xspec="../../serialize.xspec">
             <x:label>in x:result,</x:label>
             <x:call function="exactly-one">
@@ -391,11 +382,6 @@
             <orphan attr1="value1" attr2="" attr3="..."/>
          </x:param>
       </x:call>
-      <x:result select="/element()">
-         <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-         <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-         <orphan attr1="value1" attr2="" attr3="..."/>
-      </x:result>
       <x:scenario id="scenario6-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">
@@ -449,23 +435,6 @@
             </no-match>
          </x:param>
       </x:call>
-      <x:result select="/element()">
-         <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-         <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-         <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-         <no-match>
-            <different-kind><?node1 value1?>
-               <node2/>
-               <?node3?>
-               <node4/>
-               <node5/>
-            </different-kind>
-            <orphan>
-               <node1><?node1-1 value1-1?><?node1-2?><?node1-3 ...?></node1>
-               <node2/>
-            </orphan>
-         </no-match>
-      </x:result>
       <x:scenario id="scenario7-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">

--- a/test/end-to-end/cases/expected/query/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-result.xml
@@ -38,7 +38,6 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../shared-like.xspec">
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario4-scenario1" xspec="../../shared-like.xspec">
          <x:label>explicit one</x:label>
          <x:call function="mirror:false"/>

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -7,7 +7,6 @@
           date="2000-01-01T00:00:00Z">
    <x:scenario id="scenario1" xspec="../../three-dots.xspec">
       <x:label>For resultant element (simple)</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;elem&gt;text&lt;/elem&gt;
@@ -98,7 +97,6 @@
    </x:scenario>
    <x:scenario id="scenario2" xspec="../../three-dots.xspec">
       <x:label>For resultant element (with attribute)</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;elem attrib="val" /&gt;
@@ -135,7 +133,6 @@
    </x:scenario>
    <x:scenario id="scenario3" xspec="../../three-dots.xspec">
       <x:label>For resultant element (with mixed content)</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
@@ -210,7 +207,6 @@
    </x:scenario>
    <x:scenario id="scenario4" xspec="../../three-dots.xspec">
       <x:label>For resultant attribute</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 					 @attrib="val"
@@ -293,7 +289,6 @@
    </x:scenario>
    <x:scenario id="scenario5" xspec="../../three-dots.xspec">
       <x:label>For resultant text node</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is usual text node</x:label>
          <x:call function="exactly-one">
@@ -366,7 +361,6 @@
    </x:scenario>
    <x:scenario id="scenario6" xspec="../../three-dots.xspec">
       <x:label>For resultant comment</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;!--comment--&gt;
@@ -429,7 +423,6 @@
    </x:scenario>
    <x:scenario id="scenario7" xspec="../../three-dots.xspec">
       <x:label>For resultant processing instruction</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;?pi data?&gt;
@@ -492,7 +485,6 @@
    </x:scenario>
    <x:scenario id="scenario8" xspec="../../three-dots.xspec">
       <x:label>For resultant document node</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 				&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;
@@ -564,7 +556,6 @@
    </x:scenario>
    <x:scenario id="scenario9" xspec="../../three-dots.xspec">
       <x:label>For resultant namespace node</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
 						  xmlns:prefix="namespace-uri"
@@ -648,7 +639,6 @@
    </x:scenario>
    <x:scenario id="scenario10" xspec="../../three-dots.xspec">
       <x:label>For resultant sequence of multiple nodes</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is sequence of
 				&lt;elem1 /&gt;&lt;elem2 /&gt;
@@ -701,7 +691,6 @@
    </x:scenario>
    <x:scenario id="scenario12" xspec="../../three-dots.xspec">
       <x:label>For resultant atomic value</x:label>
-      <x:result select="()"/>
       <x:scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is 'string'</x:label>
          <x:call function="exactly-one">

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -252,7 +252,7 @@ declare function local:scenario1(
 {
   ... generate scenario data in the report ...
   let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-    my:f()
+Q{http://example.org/ns/my}f()
   )
     return (
       Q{http://www.jenitennison.com/xslt/unit-test}report-sequence($Q{http://www.jenitennison.com/xslt/xspec}result, 'x:result'),
@@ -416,7 +416,7 @@ let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := ( document {
 </val2> } )
 let $p2 as element() := ( $Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() ) )
 let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-  my:f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)
+Q{http://example.org/ns/my}f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)
 )
 ```
 
@@ -715,7 +715,7 @@ declare function local:scenario1-scenario1(
   let $Q{http://example.org/ns/my/variable}var-2 := ...
   ...
   let $Q{http://www.jenitennison.com/xslt/xspec}result := (
-    my:square(...)
+Q{http://example.org/ns/my}square(...)
   )
     return (
       ...,


### PR DESCRIPTION
Following #1055, this pull request invokes XQuery SUT using URIQualifiedName.

This change inevitably contains a fix for a longstanding internal bug where the XQuery test result XML contains garbage instances of `<x:result>`.