### PR TITLE
refactor: indirect node generator

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -704,15 +704,6 @@
    -->
    <xsl:mode name="x:generate-tests" on-multiple-match="fail" on-no-match="fail" />
 
-   <!--
-      mode="x:report"
-   -->
-   <xsl:mode name="x:report" on-multiple-match="fail" on-no-match="fail" />
-
-   <xsl:template match="document-node() | attribute() | node()" as="node()+" mode="x:report">
-      <xsl:apply-templates select="." mode="test:create-node-generator" />
-   </xsl:template>
-
    <!-- Generates a gateway from x:scenario to System Under Test.
       The actual instruction to enter SUT is provided by the caller. The instruction
       should not contain other actions. -->
@@ -813,14 +804,10 @@
       </xsl:element>
    </xsl:function>
 
-   <xsl:function name="x:create-pending-attr-generator" as="node()+">
+   <xsl:function name="x:pending-attribute-from-pending-node" as="attribute(pending)">
       <xsl:param name="pending-node" as="node()" />
 
-      <xsl:variable name="pending-attr" as="attribute(pending)">
-         <xsl:attribute name="pending" select="$pending-node" />
-      </xsl:variable>
-
-      <xsl:apply-templates select="$pending-attr" mode="test:create-node-generator" />
+      <xsl:attribute name="pending" select="$pending-node" />
    </xsl:function>
 
    <!-- Returns a lexical QName in XSpec namespace that can be used at runtime.

--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -218,14 +218,20 @@
    -->
    <xsl:mode name="test:create-node-generator" on-multiple-match="fail" on-no-match="fail" />
 
-   <xsl:template match="element()" as="element()" mode="test:create-node-generator">
-      <xsl:copy>
-         <xsl:text>{ </xsl:text>
-         <xsl:call-template name="test:create-zero-or-more-node-generators">
-            <xsl:with-param name="nodes" select="attribute() | node()" />
-         </xsl:call-template>
-         <xsl:text> }&#x0A;</xsl:text>
-      </xsl:copy>
+   <xsl:template match="element()" as="node()+" mode="test:create-node-generator">
+      <xsl:text>element { </xsl:text>
+      <xsl:value-of select="node-name() => x:QName-expression()" />
+      <xsl:text> } {&#x0A;</xsl:text>
+
+      <xsl:call-template name="test:create-zero-or-more-node-generators">
+         <xsl:with-param name="nodes"
+            select="
+               x:element-additional-namespace-nodes(.),
+               attribute(),
+               node()" />
+      </xsl:call-template>
+
+      <xsl:text>&#x0A;}</xsl:text>
    </xsl:template>
 
    <xsl:template match="namespace-node()" as="text()+" mode="test:create-node-generator">

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -271,23 +271,25 @@
 
       <!-- <x:scenario> -->
       <xsl:element name="{x:xspec-name('scenario', .)}" namespace="{$x:xspec-namespace}">
-         <xsl:attribute name="id" select="$scenario-id" />
-         <xsl:sequence select="@xspec" />
-
-         <!-- Create @pending generator -->
-         <xsl:if test="$pending-p">
-            <xsl:text>{ </xsl:text>
-            <xsl:sequence select="x:create-pending-attr-generator($pending)" />
-            <xsl:text> }&#x0A;</xsl:text>
-         </xsl:if>
-
-         <!-- Create x:label generator -->
-         <xsl:apply-templates select="x:label(.)" mode="test:create-node-generator" />
-
-         <!-- Create report generator -->
-         <xsl:apply-templates select="x:call" mode="x:report"/>
-
          <xsl:text>{&#x0A;</xsl:text>
+
+         <xsl:call-template name="test:create-zero-or-more-node-generators">
+            <xsl:with-param name="nodes" as="node()+">
+               <xsl:attribute name="id" select="$scenario-id" />
+               <xsl:sequence select="@xspec" />
+
+               <xsl:if test="$pending-p">
+                  <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
+               </xsl:if>
+
+               <xsl:sequence select="x:label(.)" />
+
+               <!-- Copy the input to the test result report XML -->
+               <xsl:sequence select="x:call" />
+            </xsl:with-param>
+         </xsl:call-template>
+         <xsl:text>,&#x0A;</xsl:text>
+
          <xsl:choose>
             <xsl:when test="not($pending-p)">
                <!--
@@ -474,26 +476,25 @@
       <xsl:element name="{x:xspec-name('test', .)}" namespace="{$x:xspec-namespace}">
          <xsl:attribute name="id" select="$expect-id" />
 
-         <!-- Create @pending generator or create @successful directly -->
+         <xsl:text>{&#x0A;</xsl:text>
+
          <xsl:choose>
             <xsl:when test="$pending-p">
-               <xsl:text>{ </xsl:text>
-               <xsl:sequence select="x:create-pending-attr-generator($pending)" />
-               <xsl:text> }&#x0A;</xsl:text>
+               <xsl:apply-templates select="x:pending-attribute-from-pending-node($pending)"
+                  mode="test:create-node-generator" />
+               <xsl:text>,&#x0A;</xsl:text>
             </xsl:when>
-
             <xsl:otherwise>
-               <xsl:attribute name="successful" select="'{ $local:successful }'"/>
+               <!-- @successful must be evaluated at run time -->
+               <xsl:text>attribute { QName('', 'successful') } { $local:successful },&#x0A;</xsl:text>
             </xsl:otherwise>
          </xsl:choose>
 
-         <!-- Create x:label generator -->
          <xsl:apply-templates select="x:label(.)" mode="test:create-node-generator" />
 
          <!-- Report -->
          <xsl:if test="not($pending-p)">
-            <xsl:text>&#x0A;</xsl:text>
-            <xsl:text>{&#x0A;</xsl:text>
+            <xsl:text>,&#x0A;</xsl:text>
 
             <xsl:if test="@test">
                <xsl:text>(&#x0A;</xsl:text>
@@ -509,9 +510,9 @@
                <xsl:apply-templates select="@test" mode="test:create-node-generator" />
             </xsl:if>
             <xsl:text>)&#x0A;</xsl:text>
-
-            <xsl:text>}</xsl:text>
          </xsl:if>
+
+         <xsl:text>}</xsl:text>
 
       <!-- </x:test> -->
       </xsl:element>
@@ -520,15 +521,6 @@
 
       <!-- End of the function -->
       <xsl:text>};&#x0A;</xsl:text>
-   </xsl:template>
-
-   <!--
-      mode="x:report"
-   -->
-   <xsl:template match="document-node() | attribute() | node()" as="node()+" mode="x:report">
-      <xsl:text>{ </xsl:text>
-      <xsl:apply-imports />
-      <xsl:text> }&#x0A;</xsl:text>
    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -152,9 +152,18 @@
    -->
    <xsl:mode name="test:create-node-generator" on-multiple-match="fail" on-no-match="fail" />
 
-   <xsl:template match="element()" as="element()" mode="test:create-node-generator">
-      <!-- Non XSLT elements (non xsl:* elements) can be just thrown into identity template -->
-      <xsl:call-template name="x:identity" />
+   <xsl:template match="element()" as="element(xsl:element)" mode="test:create-node-generator">
+      <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
+         <xsl:attribute name="name" select="name()" />
+         <xsl:attribute name="namespace" select="namespace-uri()" />
+
+         <xsl:apply-templates
+            select="
+               x:element-additional-namespace-nodes(.),
+               attribute(),
+               node()"
+            mode="#current" />
+      </xsl:element>
    </xsl:template>
 
    <xsl:template match="namespace-node()" as="element(xsl:namespace)"
@@ -215,25 +224,6 @@
    <xsl:template match="x:text" as="element(xsl:text)" mode="test:create-node-generator">
       <!-- Unwrap -->
       <xsl:apply-templates mode="#current" />
-   </xsl:template>
-
-   <xsl:template match="xsl:*" as="element(xsl:element)" mode="test:create-node-generator">
-      <!-- Do not just throw XSLT elements (xsl:*) into identity template.
-         If you do so, the element being generated becomes a generator... -->
-      <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
-         <xsl:attribute name="name" select="name()" />
-         <xsl:attribute name="namespace" select="namespace-uri()" />
-
-         <xsl:variable name="context-element" as="element()" select="." />
-         <xsl:for-each select="in-scope-prefixes($context-element)">
-            <xsl:element name="xsl:namespace" namespace="{$x:xsl-namespace}">
-               <xsl:attribute name="name" select="." />
-               <xsl:value-of select="namespace-uri-for-prefix(., $context-element)" />
-            </xsl:element>
-         </xsl:for-each>
-
-         <xsl:apply-templates select="attribute() | node()" mode="#current" />
-      </xsl:element>
    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -281,7 +281,8 @@
 
             <!-- Create @pending generator -->
             <xsl:if test="$pending-p">
-               <xsl:sequence select="x:create-pending-attr-generator($pending)" />
+               <xsl:apply-templates select="x:pending-attribute-from-pending-node($pending)"
+                  mode="test:create-node-generator" />
             </xsl:if>
 
             <!-- Create x:label directly -->
@@ -292,11 +293,14 @@
             <xsl:for-each select="$local-preceding-variables | x:apply | x:call | x:context">
                <xsl:choose>
                   <xsl:when test="self::x:apply or self::x:call or self::x:context">
-                     <!-- Create report generator -->
-                     <xsl:apply-templates select="." mode="x:report" />
+                     <!-- Copy the input to the test result report XML -->
+                     <xsl:apply-templates select="." mode="test:create-node-generator" />
+                  </xsl:when>
+                  <xsl:when test="self::x:variable">
+                     <xsl:apply-templates select="." mode="test:generate-variable-declarations" />
                   </xsl:when>
                   <xsl:otherwise>
-                     <xsl:apply-templates select="." mode="test:generate-variable-declarations" />
+                     <xsl:message select="'Unhandled', name()" terminate="yes" />
                   </xsl:otherwise>
                </xsl:choose>
             </xsl:for-each>
@@ -786,7 +790,8 @@
             <!-- Create @pending generator or create @successful directly -->
             <xsl:choose>
                <xsl:when test="$pending-p">
-                  <xsl:sequence select="x:create-pending-attr-generator($pending)" />
+                  <xsl:apply-templates select="x:pending-attribute-from-pending-node($pending)"
+                     mode="test:create-node-generator" />
                </xsl:when>
 
                <xsl:otherwise>

--- a/test/end-to-end/cases/expected/query/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-467-result.xml
@@ -10,7 +10,7 @@
       <x:call function="mirror:param-mirror">
          <x:param>
             <e1 xmlns="ns1">
-               <e2 xmlns:ns4="ns4" xmlns:ns3="ns3" xmlns="ns2">
+               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
                   <ns3:e3>
                      <e4/>
                   </ns3:e3>
@@ -20,7 +20,7 @@
       </x:call>
       <x:result select="/element()">
          <e1 xmlns="ns1">
-            <e2 xmlns:ns4="ns4" xmlns:ns3="ns3" xmlns="ns2">
+            <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
                <ns3:e3>
                   <e4/>
                </ns3:e3>
@@ -31,7 +31,7 @@
          <x:label>Expecting the same structure but in different namespaces</x:label>
          <x:expect select="/element()">
             <e1 xmlns="ns1">
-               <e2 xmlns:ns4="ns4" xmlns:ns3="ns3" xmlns="ns2!">
+               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2!">
                   <ns3:e3 xmlns:ns3="ns3!">
                      <e4 xmlns=""/>
                   </ns3:e3>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -305,7 +305,7 @@
             </x:call>
             <x:result select="/element()">
                <looooooooooooooooooooooooooooooooooong>
-                  <test xmlns:ns3="ns3" xmlns:ns2="ns2" xmlns:ns1="ns1" xmlns="ns">
+                  <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                      <a/>
                   </test>
                </looooooooooooooooooooooooooooooooooong>
@@ -330,7 +330,7 @@
 						indentation.</x:label>
                <x:expect select="/element()">
                   <looooooooooooooooooooooooooooooooooong>
-                     <test xmlns:ns3="ns3" xmlns:ns2="ns2" xmlns:ns1="ns1" xmlns="ns">
+                     <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                         <a/>
                      </test>
                   </looooooooooooooooooooooooooooooooooong>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
@@ -9,7 +9,7 @@
       <x:call function="mirror:param-mirror">
          <x:param>
             <e1 xmlns="ns1">
-               <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
+               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
                   <ns3:e3>
                      <e4/>
                   </ns3:e3>
@@ -19,7 +19,7 @@
       </x:call>
       <x:result select="/element()">
          <e1 xmlns="ns1">
-            <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
+            <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
                <ns3:e3>
                   <e4/>
                </ns3:e3>
@@ -30,7 +30,7 @@
          <x:label>Expecting the same structure but in different namespaces</x:label>
          <x:expect select="/element()">
             <e1 xmlns="ns1">
-               <e2 xmlns="ns2!" xmlns:ns3="ns3" xmlns:ns4="ns4">
+               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2!">
                   <ns3:e3 xmlns:ns3="ns3!">
                      <e4 xmlns=""/>
                   </ns3:e3>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -296,7 +296,7 @@
             </x:call>
             <x:result select="/element()">
                <looooooooooooooooooooooooooooooooooong>
-                  <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
+                  <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                      <a/>
                   </test>
                </looooooooooooooooooooooooooooooooooong>
@@ -321,7 +321,7 @@
 						indentation.</x:label>
                <x:expect select="/element()">
                   <looooooooooooooooooooooooooooooooooong>
-                     <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
+                     <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                         <a/>
                      </test>
                   </looooooooooooooooooooooooooooooooooong>

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -190,9 +190,10 @@ result as parameter.
    <x:scenario id="scenario1"
                xspec=".../compilation-simple-suite.xspec">
       <x:label>scenario</x:label>
-      <x:call>
+      <xsl:element name="x:call" namespace="http://www.jenitennison.com/xslt/xspec">
+         <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
          <xsl:attribute name="function" namespace="">my:f</xsl:attribute>
-      </x:call>
+      </xsl:element>
       <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
          <xsl:sequence select="Q{http://example.org/ns/my}f()"/>
       </xsl:variable>
@@ -355,6 +356,7 @@ section "[Simple scenario](#simple-scenario)").
 </x:context>
 
 <!-- apply template rules on a node (with x:apply) -->
+<!-- TODO: x:apply not implemented yet -->
 <x:variable name="ctxt">
    <elem/>
 </x:variable>
@@ -375,7 +377,10 @@ section "[Simple scenario](#simple-scenario)").
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-..." select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
       <xsl:document>
-         <val2/>
+         <xsl:element name="val2" namespace="">
+            <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
+            <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
+         </xsl:element>
       </xsl:document>
    </xsl:variable>
    <xsl:variable name="Q{}p2"
@@ -389,7 +394,10 @@ section "[Simple scenario](#simple-scenario)").
    <xsl:variable name="Q{}p1" select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
       <xsl:document>
-         <val2/>
+         <xsl:element name="val2" namespace="">
+            <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
+            <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
+         </xsl:element>
       </xsl:document>
    </xsl:variable>
    <xsl:variable name="Q{}p2"
@@ -404,7 +412,10 @@ section "[Simple scenario](#simple-scenario)").
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
    <xsl:variable name="Q{urn:x-xspec:compile:impl}context-...-doc" as="document-node()">
       <xsl:document>
-         <elem/>
+         <xsl:element name="elem" namespace="">
+            <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
+            <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
+         </xsl:element>
       </xsl:document>
    </xsl:variable>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}context-..."
@@ -413,6 +424,7 @@ section "[Simple scenario](#simple-scenario)").
 </xsl:variable>
 
 <!-- "apply template rules on a node (with x:apply)" -->
+<!-- TODO: x:apply not implemented yet -->
 <xsl:variable name="ctxt" as="item()*">
    <elem/>
 </xsl:variable>
@@ -437,8 +449,10 @@ let $Q{urn:x-xspec:compile:impl}param-... := (
 )
 let $Q{urn:x-xspec:compile:impl}param-...-doc as document-node() := (
 document {
-<val2 xmlns:my="http://example.org/ns/my">{ () }
-</val2>
+element { QName('', 'val2') } {
+namespace { "my" } { 'http://example.org/ns/my' },
+namespace { "x" } { 'http://www.jenitennison.com/xslt/xspec' }
+}
 }
 )
 let $p2 as element() := (
@@ -598,7 +612,12 @@ this accessibility.
    <!-- $myv:content -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc" as="document-node()">
       <xsl:document>
-         <elem/>
+         <xsl:element name="elem" namespace="">
+            <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
+            <xsl:namespace name="myv">http://example.org/ns/my/variable</xsl:namespace>
+            <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
+            <xsl:namespace name="xs">http://www.w3.org/2001/XMLSchema</xsl:namespace>
+         </xsl:element>
       </xsl:document>
    </xsl:variable>
    <xsl:variable name="Q{http://example.org/ns/my/variable}content"
@@ -636,8 +655,12 @@ $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )
 (: $myv:content :)
 let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := (
 document {
-<elem xmlns:my="http://example.org/ns/my" xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">{ () }
-</elem>
+element { QName('', 'elem') } {
+namespace { "my" } { 'http://example.org/ns/my' },
+namespace { "myv" } { 'http://example.org/ns/my/variable' },
+namespace { "x" } { 'http://www.jenitennison.com/xslt/xspec' },
+namespace { "xs" } { 'http://www.w3.org/2001/XMLSchema' }
+}
 }
 )
 let $Q{http://example.org/ns/my/variable}content as element() := (


### PR DESCRIPTION
Following #1064, this pull request makes `mode="test:create-node-generator"` create indirect node generators instead of direct ones.