### PR TITLE
ci(deps): bump BaseX from 9.3.3 to 9.4

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.8
 
 # Latest BaseX
-BASEX_VERSION=9.3.3
+BASEX_VERSION=9.4
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
There seems to be no breaking changes in https://raw.githubusercontent.com/BaseXdb/basex/master/CHANGELOG