### PR TITLE
refactor: error template for x:output-scenario templates

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -790,6 +790,16 @@
       </xsl:choose>
    </xsl:template>
 
+   <xsl:template name="x:output-scenario-error" as="empty-sequence()">
+      <xsl:context-item as="element(x:scenario)" use="required" />
+
+      <xsl:param name="message" as="xs:string" />
+
+      <xsl:message terminate="yes">
+         <xsl:text expand-text="yes">ERROR in {name()} ('{x:label(.)}'): {$message}</xsl:text>
+      </xsl:message>
+   </xsl:template>
+
    <xsl:function name="x:label" as="element(x:label)">
       <xsl:param name="labelled" as="element()" />
 

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -220,26 +220,26 @@
 
       <xsl:variable name="quoted-label" as="xs:string" select="$x:apos || x:label(.) || $x:apos" />
 
-      <!-- x:context and x:call/@template not supported for XQuery -->
-      <xsl:if test="exists($context)">
-         <xsl:variable name="msg" as="xs:string">
-            <xsl:text expand-text="yes">x:context not supported for XQuery (scenario {$quoted-label})</xsl:text>
-         </xsl:variable>
-         <xsl:sequence select="xs:QName('x:XSPEC003') => error($msg)" />
+      <xsl:if test="$context">
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">{name($context)} not supported for XQuery</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
-      <xsl:if test="exists($call/@template)">
-         <xsl:variable name="msg" as="xs:string">
-            <xsl:text expand-text="yes">x:call/@template not supported for XQuery (scenario {$quoted-label})</xsl:text>
-         </xsl:variable>
-         <xsl:sequence select="xs:QName('x:XSPEC004') => error($msg)" />
+      <xsl:if test="$call/@template">
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">{name($call)}/@template not supported for XQuery</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
-
-      <!-- x:call required if there are x:expect -->
-      <xsl:if test="x:expect and not($call)">
-         <xsl:variable name="msg" as="xs:string">
-            <xsl:text expand-text="yes">there are x:expect but no x:call (scenario {$quoted-label})</xsl:text>
-         </xsl:variable>
-         <xsl:sequence select="xs:QName('x:XSPEC005') => error($msg)" />
+      <xsl:if test="x:expect and empty($call)">
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">There are {x:xspec-name('expect', .)} but no {x:xspec-name('call', .)}</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
 
       <!--

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -210,47 +210,46 @@
       <!-- We have to create these error messages at this stage because before now
          we didn't have merged versions of the environment -->
       <xsl:if test="$context/@href and ($context/node() except $context/x:param)">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": can't set the context document using both the href</xsl:text>
-            <xsl:text> attribute and the content of &lt;context&gt;</xsl:text>
-         </xsl:message>
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">Can't set the context document using both the href attribute and the content of the {name($context)} element</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
       <xsl:if test="$call/@template and $call/@function">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": can't call a function and a template at the same time</xsl:text>
-         </xsl:message>
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text>Can't call a function and a template at the same time</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
       <xsl:if test="$apply and $context">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": can't use apply and set a context at the same time</xsl:text>
-         </xsl:message>
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">Can't use {name($apply)} and set a context at the same time</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
       <xsl:if test="$apply and $call">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": can't use apply and call at the same time</xsl:text>
-         </xsl:message>
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">Can't use {name($apply)} and {name($call)} at the same time</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
       <xsl:if test="$context and $call/@function">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": can't set a context and call a function at the same time</xsl:text>
-         </xsl:message>
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text>Can't set a context and call a function at the same time</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
-      <xsl:if test="x:expect and not($call) and not($apply) and not($context)">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR in scenario "</xsl:text>
-            <xsl:value-of select="x:label(.)" />
-            <xsl:text>": there are tests in this scenario but no call, or apply or context has been given</xsl:text>
-         </xsl:message>
+      <xsl:if test="x:expect and empty($call) and empty($apply) and empty($context)">
+         <xsl:call-template name="x:output-scenario-error">
+            <xsl:with-param name="message" as="xs:string">
+               <xsl:text expand-text="yes">There are {x:xspec-name('expect', .)} but no {x:xspec-name('call', .)}, {x:xspec-name('apply', .)} or {x:xspec-name('context', .)} has been given</xsl:text>
+            </xsl:with-param>
+         </xsl:call-template>
       </xsl:if>
 
       <template name="{x:known-UQName('x:' || $scenario-id)}">

--- a/test/output-scenario-error/xquery_context.xspec
+++ b/test/output-scenario-error/xquery_context.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xqm"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="x:call/@template">
-		<x:call template="my-template" />
-		<x:expect label="should be error x:XSPEC004" test="true()" />
+	<x:scenario label="x:context">
+		<x:context />
+		<x:expect label="should be error" test="true()" />
 	</x:scenario>
 </x:description>

--- a/test/output-scenario-error/xquery_no-call.xspec
+++ b/test/output-scenario-error/xquery_no-call.xspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xqm"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="Missing x:call">
-		<x:expect label="should be error x:XSPEC005" test="true()" />
+	<x:scenario label="No x:call">
+		<x:expect label="should be error" test="true()" />
 	</x:scenario>
 </x:description>

--- a/test/output-scenario-error/xquery_template-call.xspec
+++ b/test/output-scenario-error/xquery_template-call.xspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xqm"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="x:context">
-		<x:context />
-		<x:expect label="should be error x:XSPEC003" test="true()" />
+	<x:scenario label="x:call/@template">
+		<x:call template="my-template" />
+		<x:expect label="should be error" test="true()" />
 	</x:scenario>
 </x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1758,7 +1758,7 @@
 	<case name="@catch should not catch error outside SUT (XSLT)">
     call :run ..\bin\xspec.bat catch\compiler-error.xspec
     call :verify_retval 2
-    call :verify_line  * r "ERROR in scenario .*"
+    call :verify_line  5 r "ERROR in x:scenario .*"
     call :verify_line -1 x "*** Error compiling the test suite"
 
     call :run ..\bin\xspec.bat catch\error-in-context-avt-for-template-call.xspec
@@ -1795,7 +1795,7 @@
 	<case name="@catch should not catch error outside SUT (XQuery)">
     call :run ..\bin\xspec.bat -q catch\compiler-error.xspec
     call :verify_retval 2
-    call :verify_line * r ".*x:XSPEC005[: ]"
+    call :verify_line 5 r "ERROR in x:scenario .*"
 
     call :run ..\bin\xspec.bat -q catch\error-in-function-call-param.xspec
     call :verify_retval 2
@@ -1951,42 +1951,42 @@
 	<case name="x:context both with @href and content">
     call :run ..\bin\xspec.bat output-scenario-error\context-both-href-and-content.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:context both with @href and content.: can't set the context document using both the href attribute and the content of &amp;lt;context&amp;gt;$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call both with @function and @template">
     call :run ..\bin\xspec.bat output-scenario-error\call-both-function-and-template.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:call both with @function and @template.: can't call a function and a template at the same time$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:apply with x:context">
     call :run ..\bin\xspec.bat output-scenario-error\apply-with-context.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:apply with x:context.: can't use apply and set a context at the same time$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:apply with x:call">
     call :run ..\bin\xspec.bat output-scenario-error\apply-with-call.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:apply with x:call.: can't use apply and call at the same time$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call[@function] with x:context">
     call :run ..\bin\xspec.bat output-scenario-error\function-with-context.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:call\[@function\] with x:context.: can't set a context and call a function at the same time$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:expect without action">
     call :run ..\bin\xspec.bat output-scenario-error\expect-without-action.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in scenario .x:expect without action.: there are tests in this scenario but no call, or apply or context has been given$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
@@ -1994,24 +1994,24 @@
 		Error message from x:output-scenario template (XQuery)
 	-->
 
-	<case name="x:XSPEC003">
-    call :run ..\bin\xspec.bat -q output-scenario-error\XSPEC003.xspec
+	<case name="x:context (XQuery)">
+    call :run ..\bin\xspec.bat -q output-scenario-error\xquery_context.xspec
     call :verify_retval 2
-    call :verify_line  6 r "  x:XSPEC003[: ] x:context not supported for XQuery (scenario 'x:context')$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:context'): x:context not supported for XQuery"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
-	<case name="x:XSPEC004">
-    call :run ..\bin\xspec.bat -q output-scenario-error\XSPEC004.xspec
+	<case name="x:call/@template (XQuery)">
+    call :run ..\bin\xspec.bat -q output-scenario-error\xquery_template-call.xspec
     call :verify_retval 2
-    call :verify_line  6 r "  x:XSPEC004[: ] x:call/@template not supported for XQuery (scenario 'x:call/@template')$"
+    call :verify_line  5 x "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
-	<case name="x:XSPEC005">
-    call :run ..\bin\xspec.bat -q output-scenario-error\XSPEC005.xspec
+	<case name="No x:call">
+    call :run ..\bin\xspec.bat -q output-scenario-error\xquery_no-call.xspec
     call :verify_retval 2
-    call :verify_line  6 r "  x:XSPEC005[: ] there are x:expect but no x:call (scenario 'Missing x:call')$"
+    call :verify_line  5 x "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2015,7 +2015,7 @@ load bats-helper
     run ../bin/xspec.sh catch/compiler-error.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${output}" $'\n''ERROR in scenario '
+    assert_regex "${output}" $'\n''ERROR in x:scenario '
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 
     run ../bin/xspec.sh catch/error-in-context-avt-for-template-call.xspec
@@ -2059,7 +2059,7 @@ load bats-helper
     run ../bin/xspec.sh -q catch/compiler-error.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${output}" 'x:XSPEC005[: ]'
+    assert_regex "${output}" $'\n''ERROR in x:scenario '
 
     run ../bin/xspec.sh -q catch/error-in-function-call-param.xspec
     echo "$output"
@@ -2242,7 +2242,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/context-both-href-and-content.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:context both with @href and content\": can't set the context document using both the href attribute and the content of &lt;context&gt;" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2250,7 +2250,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/call-both-function-and-template.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:call both with @function and @template\": can't call a function and a template at the same time" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2258,7 +2258,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/apply-with-context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:apply with x:context\": can't use apply and set a context at the same time" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2266,7 +2266,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/apply-with-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:apply with x:call\": can't use apply and call at the same time" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2274,7 +2274,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/function-with-context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:call[@function] with x:context\": can't set a context and call a function at the same time" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2282,7 +2282,7 @@ load bats-helper
     run ../bin/xspec.sh output-scenario-error/expect-without-action.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in scenario \"x:expect without action\": there are tests in this scenario but no call, or apply or context has been given" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2290,27 +2290,27 @@ load bats-helper
 # Error message from x:output-scenario template (XQuery)
 #
 
-@test "x:XSPEC003" {
-    run ../bin/xspec.sh -q output-scenario-error/XSPEC003.xspec
+@test "x:context (XQuery)" {
+    run ../bin/xspec.sh -q output-scenario-error/xquery_context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[5]}" '^  x:XSPEC003[: ] x:context not supported for XQuery \(scenario '\''x:context'\''\)$'
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:context'): x:context not supported for XQuery" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
-@test "x:XSPEC004" {
-    run ../bin/xspec.sh -q output-scenario-error/XSPEC004.xspec
+@test "x:call/@template (XQuery)" {
+    run ../bin/xspec.sh -q output-scenario-error/xquery_template-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[5]}" '^  x:XSPEC004[: ] x:call/@template not supported for XQuery \(scenario '\''x:call/@template'\''\)$'
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
-@test "x:XSPEC005" {
-    run ../bin/xspec.sh -q output-scenario-error/XSPEC005.xspec
+@test "No x:call (XQuery)" {
+    run ../bin/xspec.sh -q output-scenario-error/xquery_no-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[5]}" '^  x:XSPEC005[: ] there are x:expect but no x:call \(scenario '\''Missing x:call'\''\)$'
+    [ "${lines[4]}" = "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 


### PR DESCRIPTION
`x:output-scenario` templates in XSLT compiler and XQuery compiler output errors in different ways. This pull request does it in a single template `x:output-scenario-error`.

As a result, `x:XSPEC003`, `x:XSPEC004` and `x:XSPEC005` are removed. I believe the removal is fine because
- The facility for those XSpec error codes has never been established.
- The error codes have brought virtually no benefits, while their ad hoc usage just complicates the implementation and the tests.

If we want to reinstate those error codes, I think it should be done _after_ establishing the facility. For example, DITA-OT does it in a [template](https://github.com/dita-ot/dita-ot/blob/master/src/main/plugins/org.dita.base/xsl/common/output-message.xsl) and a [warehouse](https://github.com/dita-ot/dita-ot/blob/master/src/main/config/messages_template.xml).