### PR TITLE
refactor(report): create x:scenario indirectly

### DIFF
--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -258,7 +258,7 @@
          <xsl:text>&#x0A;</xsl:text>
       </xsl:for-each>
 
-      <xsl:text>)&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">) as element({x:known-UQName('x:scenario')})&#x0A;</xsl:text>
 
       <!-- Start of the function body -->
       <xsl:text>{&#x0A;</xsl:text>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -270,72 +270,69 @@
       </xsl:if>
 
       <!-- <x:scenario> -->
-      <xsl:element name="{x:xspec-name('scenario', .)}" namespace="{$x:xspec-namespace}">
-         <xsl:text>{&#x0A;</xsl:text>
+      <xsl:text>element { </xsl:text>
+      <xsl:value-of select="QName($x:xspec-namespace, x:xspec-name('scenario', .)) => x:QName-expression()" />
+      <xsl:text> } {&#x0A;</xsl:text>
 
-         <xsl:call-template name="test:create-zero-or-more-node-generators">
-            <xsl:with-param name="nodes" as="node()+">
-               <xsl:attribute name="id" select="$scenario-id" />
-               <xsl:sequence select="@xspec" />
+      <xsl:call-template name="test:create-zero-or-more-node-generators">
+         <xsl:with-param name="nodes" as="node()+">
+            <xsl:attribute name="id" select="$scenario-id" />
+            <xsl:sequence select="@xspec" />
 
-               <xsl:if test="$pending-p">
-                  <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
-               </xsl:if>
+            <xsl:if test="$pending-p">
+               <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
+            </xsl:if>
 
-               <xsl:sequence select="x:label(.)" />
+            <xsl:sequence select="x:label(.)" />
 
-               <!-- Copy the input to the test result report XML -->
-               <xsl:sequence select="x:call" />
-            </xsl:with-param>
-         </xsl:call-template>
-         <xsl:text>,&#x0A;</xsl:text>
+            <!-- Copy the input to the test result report XML -->
+            <xsl:sequence select="x:call" />
+         </xsl:with-param>
+      </xsl:call-template>
+      <xsl:text>,&#x0A;</xsl:text>
 
-         <xsl:choose>
-            <xsl:when test="not($pending-p) and x:expect">
-               <!--
-                 let $xxx-param1 := ...
-                 let $xxx-param2 := ...
-                 let $t:result   := ...($xxx-param1, $xxx-param2)
-                   return (
-                     test:report-sequence($t:result, 'x:result'),
-               -->
-               <xsl:apply-templates select="$call/x:param[1]" mode="x:compile"/>
+      <xsl:choose>
+         <xsl:when test="not($pending-p) and x:expect">
+            <!--
+              let $xxx-param1 := ...
+              let $xxx-param2 := ...
+              let $t:result   := ...($xxx-param1, $xxx-param2)
+              return (
+                test:report-sequence($t:result, 'x:result'),
+            -->
+            <xsl:apply-templates select="$call/x:param[1]" mode="x:compile"/>
 
-               <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := (&#x0A;</xsl:text>
-               <xsl:call-template name="x:enter-sut">
-                  <xsl:with-param name="instruction" as="text()+">
-                     <xsl:sequence select="x:function-call-text($call)" />
-                     <xsl:text>&#x0A;</xsl:text>
-                  </xsl:with-param>
-               </xsl:call-template>
-               <xsl:text>)&#x0A;</xsl:text>
+            <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := (&#x0A;</xsl:text>
+            <xsl:call-template name="x:enter-sut">
+               <xsl:with-param name="instruction" as="text()+">
+                  <xsl:sequence select="x:function-call-text($call)" />
+                  <xsl:text>&#x0A;</xsl:text>
+               </xsl:with-param>
+            </xsl:call-template>
+            <xsl:text>)&#x0A;</xsl:text>
 
-               <xsl:text>return (&#x0A;</xsl:text>
-               <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(${x:known-UQName('x:result')}, '{x:xspec-name('result', .)}'),&#x0A;</xsl:text>
+            <xsl:text>return (&#x0A;</xsl:text>
+            <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(${x:known-UQName('x:result')}, '{x:xspec-name('result', .)}'),&#x0A;</xsl:text>
 
-               <xsl:text>&#x0A;</xsl:text>
-               <xsl:text>(: a call instruction for each x:expect element :)&#x0A;</xsl:text>
-            </xsl:when>
+            <xsl:text>&#x0A;</xsl:text>
+            <xsl:text>(: a call instruction for each x:expect element :)&#x0A;</xsl:text>
+         </xsl:when>
 
-            <xsl:otherwise>
-               <!--
-                 let $t:result := ()
-                   return (
-               -->
-               <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := ()&#x0A;</xsl:text>
-               <xsl:text>return (&#x0A;</xsl:text>
-            </xsl:otherwise>
-         </xsl:choose>
+         <xsl:otherwise>
+            <!--
+               let $t:result := ()
+               return (
+            -->
+            <xsl:text expand-text="yes">let ${x:known-UQName('x:result')} := ()&#x0A;</xsl:text>
+            <xsl:text>return (&#x0A;</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
 
-         <xsl:call-template name="x:call-scenarios"/>
-         <xsl:text>)&#x0A;</xsl:text>
-
-         <xsl:text>}&#x0A;</xsl:text>
+      <xsl:call-template name="x:call-scenarios"/>
+      <xsl:text>)&#x0A;</xsl:text>
 
       <!-- </x:scenario> -->
-      </xsl:element>
-
-      <xsl:text>&#x0A;</xsl:text>
+      <xsl:text>}&#x0A;</xsl:text>
 
       <!-- End of the function -->
       <xsl:text>};&#x0A;</xsl:text>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -253,7 +253,8 @@
          </xsl:message>
       </xsl:if>
 
-      <template name="{x:known-UQName('x:' || $scenario-id)}" as="element()+">
+      <template name="{x:known-UQName('x:' || $scenario-id)}"
+         as="element({x:known-UQName('x:scenario')})">
          <xsl:sequence select="x:copy-of-namespaces(.)" />
 
          <xsl:for-each select="distinct-values($stacked-variables ! x:variable-UQName(.))">

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -253,7 +253,7 @@
          </xsl:message>
       </xsl:if>
 
-      <template name="{x:known-UQName('x:' || $scenario-id)}">
+      <template name="{x:known-UQName('x:' || $scenario-id)}" as="element()+">
          <xsl:sequence select="x:copy-of-namespaces(.)" />
 
          <xsl:for-each select="distinct-values($stacked-variables ! x:variable-UQName(.))">
@@ -275,18 +275,21 @@
             <xsl:value-of select="normalize-space(x:label(.))" />
          </message>
 
-         <xsl:element name="{x:xspec-name('scenario', .)}" namespace="{$x:xspec-namespace}">
-            <xsl:attribute name="id" select="$scenario-id" />
-            <xsl:attribute name="xspec" select="(@xspec-original-location, @xspec)[1]" />
+         <!-- <x:scenario> -->
+         <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
+            <xsl:attribute name="name" select="x:xspec-name('scenario', .)" />
+            <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
-            <!-- Create @pending generator -->
-            <xsl:if test="$pending-p">
-               <xsl:apply-templates select="x:pending-attribute-from-pending-node($pending)"
-                  mode="test:create-node-generator" />
-            </xsl:if>
+            <xsl:variable name="scenario-attributes" as="attribute()+">
+               <xsl:attribute name="id" select="$scenario-id" />
+               <xsl:attribute name="xspec" select="(@xspec-original-location, @xspec)[1]" />
+               <xsl:if test="$pending-p">
+                  <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
+               </xsl:if>
+            </xsl:variable>
+            <xsl:apply-templates select="$scenario-attributes" mode="test:create-node-generator" />
 
-            <!-- Create x:label directly -->
-            <xsl:sequence select="x:label(.)" />
+            <xsl:apply-templates select="x:label(.)" mode="test:create-node-generator" />
 
             <!-- Handle variables and apply/call/context in document order,
                instead of apply/call/context first and variables second. -->
@@ -400,11 +403,11 @@
                            <xsl:when test="$context">
                               <!-- Switch to the context and call the template -->
                               <for-each select="${x:variable-UQName($context)}">
-                                 <xsl:copy-of select="$template-call" />
+                                 <xsl:sequence select="$template-call" />
                               </for-each>
                            </xsl:when>
                            <xsl:otherwise>
-                              <xsl:copy-of select="$template-call" />
+                              <xsl:sequence select="$template-call" />
                            </xsl:otherwise>
                         </xsl:choose>
                      </xsl:when>
@@ -501,6 +504,8 @@
             </xsl:if>
 
             <xsl:call-template name="x:call-scenarios" />
+
+         <!-- </x:scenario> -->
          </xsl:element>
       </template>
 

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -245,16 +245,17 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               id="scenario4"
+   <x:scenario id="scenario4"
                xspec="../../../../../tutorial/schematron/demo-02-import3.xspec">
       <x:label>XSpec function scenario imported</x:label>
-      <x:call function="local:add">
+      <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="local:add">
          <x:param name="a" select="5" as="xs:integer"/>
          <x:param name="b" select="2" as="xs:integer"/>
       </x:call>
       <x:result select="7"/>
-      <x:test id="scenario4-expect1" successful="true">
+      <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              id="scenario4-expect1"
+              successful="true">
          <x:label>add 5 + 2</x:label>
          <x:expect select="7"/>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -4,59 +4,71 @@
           stylesheet="../../../../square.xsl"
           date="2000-01-01T00:00:00Z">
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:my="http://example.org/ns/my"
                id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused correct scenario must be Pending</t:label>
-      <t:call function="my:square">
+      <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              function="my:square">
          <t:param select="3"/>
       </t:call>
-      <t:test id="scenario1-expect1" pending="testing @focus of a correct scenario">
+      <t:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:my="http://example.org/ns/my"
+              id="scenario1-expect1"
+              pending="testing @focus of a correct scenario">
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:my="http://example.org/ns/my"
                id="scenario2"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused incorrect scenario must be Pending</t:label>
-      <t:call function="my:square">
+      <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              function="my:square">
          <t:param select="2"/>
       </t:call>
-      <t:test id="scenario2-expect1" pending="testing @focus of a correct scenario">
+      <t:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:my="http://example.org/ns/my"
+              id="scenario2-expect1"
+              pending="testing @focus of a correct scenario">
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:my="http://example.org/ns/my"
                id="scenario3"
                xspec="../../focus-1.xspec">
       <t:label>a focused correct scenario</t:label>
-      <t:call function="my:square">
+      <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              function="my:square">
          <t:param select="3"/>
       </t:call>
       <t:result select="9"/>
-      <t:test id="scenario3-expect1" successful="true">
+      <t:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:my="http://example.org/ns/my"
+              id="scenario3-expect1"
+              successful="true">
          <t:label>must execute the test and return Success</t:label>
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:my="http://example.org/ns/my"
                id="scenario4"
                xspec="../../focus-1.xspec">
       <t:label>a focused incorrect scenario</t:label>
-      <t:call function="my:square">
+      <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              function="my:square">
          <t:param select="2"/>
       </t:call>
       <t:result select="4"/>
-      <t:test id="scenario4-expect1" successful="false">
+      <t:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:my="http://example.org/ns/my"
+              id="scenario4-expect1"
+              successful="false">
          <t:label>must execute the test and return Failure</t:label>
          <t:expect test="$t:result instance of xs:string" select="()"/>
       </t:test>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
@@ -3,19 +3,21 @@
           xspec="../../xslt2.xspec"
           stylesheet="../../../../xslt1.xsl"
           date="2000-01-01T00:00:00Z">
-   <x:scenario xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               id="scenario1"
-               xspec="../../../../xslt1.xspec">
+   <x:scenario id="scenario1" xspec="../../../../xslt1.xspec">
       <x:label>With 2 text nodes</x:label>
-      <x:call template="text-nodes"/>
+      <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" template="text-nodes"/>
       <x:scenario id="scenario1-scenario1" xspec="../../../../xslt1.xspec">
          <x:label>This scenario is to verify that $x:result consists of two text nodes</x:label>
          <x:result select="/text()">12</x:result>
-         <x:test id="scenario1-scenario1-expect1" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario1-expect1"
+                 successful="true">
             <x:label>Result should be text nodes</x:label>
             <x:expect test="$x:result instance of text()+" select="()"/>
          </x:test>
-         <x:test id="scenario1-scenario1-expect2" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario1-expect2"
+                 successful="true">
             <x:label>Result count should be 2</x:label>
             <x:result select="2"/>
             <x:expect test="count($x:result)" select="2"/>
@@ -26,19 +28,27 @@
 				scenario Success, even when this XSpec file is imported to another XSpec file which
 				has xslt-version=2.0 or higher.</x:label>
          <x:result select="/text()">12</x:result>
-         <x:test id="scenario1-scenario2-expect1" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario2-expect1"
+                 successful="true">
             <x:label>Comparing the text nodes with string</x:label>
             <x:expect select="'12'"/>
          </x:test>
-         <x:test id="scenario1-scenario2-expect2" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario2-expect2"
+                 successful="true">
             <x:label>Comparing the text nodes with double</x:label>
             <x:expect select="1.2e1"/>
          </x:test>
-         <x:test id="scenario1-scenario2-expect3" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario2-expect3"
+                 successful="true">
             <x:label>Comparing the text nodes with decimal</x:label>
             <x:expect select="12.0"/>
          </x:test>
-         <x:test id="scenario1-scenario2-expect4" successful="true">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario2-expect4"
+                 successful="true">
             <x:label>Comparing the text nodes with integer</x:label>
             <x:expect select="12"/>
          </x:test>
@@ -49,7 +59,9 @@
 				Failure when this XSpec file is imported to another XSpec file which has
 				xslt-version=2.0 or higher.</x:label>
          <x:result select="/text()">12</x:result>
-         <x:test id="scenario1-scenario3-expect1" successful="false">
+         <x:test xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 id="scenario1-scenario3-expect1"
+                 successful="false">
             <x:label>Expecting the compiled stylesheet to have version=1.0</x:label>
             <x:result select="'2.0'"/>
             <x:expect test="document('')/xsl:stylesheet/@version/string()" select="'1.0'"/>

--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -40,7 +40,7 @@
             - the generator (xsl:element) of the x:scenario/x:label element
          </t:label>
          <xsl:template name="Q{{http://www.jenitennison.com/xslt/xspec}}scenario1"
-                       as="element()+">
+                       as="element(Q{{http://www.jenitennison.com/xslt/xspec}}scenario)">
             <xsl:message>my label</xsl:message>
             <xsl:element name="t:scenario"
                          namespace="http://www.jenitennison.com/xslt/xspec">

--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -31,12 +31,30 @@
 
    <t:scenario label="x:scenario[@label] transformed in x:compile mode">
       <t:context mode="t:compile" href="generate-xspec-tests/scenario.xspec" select="//t:scenario" />
-      <t:expect label="is a template" test="$t:result instance of element(xsl:template)"/>
-      <t:expect label="the name is a URIQualifiedName in XSpec namespace"
-                test="starts-with($t:result/@name, 'Q{http://www.jenitennison.com/xslt/xspec}')" />
-      <t:expect label="the label message" test="$t:result/xsl:message/string()" select="'my label'"/>
-      <t:expect label="the scenario" test="exists($t:result/t:scenario)"/>
-      <t:expect label="the scenario label" test="$t:result/t:scenario/t:label/string()" select="'my label'"/>
+      <t:expect>
+         <t:label>
+            - is xsl:template
+            - @name is Q{XSpec-namespace}scenario-ID
+            - the scenario label xsl:message
+            - the generator (xsl:element) of the x:scenario element
+            - the generator (xsl:element) of the x:scenario/x:label element
+         </t:label>
+         <xsl:template name="Q{{http://www.jenitennison.com/xslt/xspec}}scenario1"
+                       as="element()+">
+            <xsl:message>my label</xsl:message>
+            <xsl:element name="t:scenario"
+                         namespace="http://www.jenitennison.com/xslt/xspec">
+               <xsl:attribute name="id"
+                              namespace="">scenario1</xsl:attribute>
+               <xsl:attribute name="xspec"
+                              namespace="" />
+               <xsl:element name="t:label"
+                            namespace="http://www.jenitennison.com/xslt/xspec">
+                  <xsl:text>my label</xsl:text>
+               </xsl:element>
+            </xsl:element>
+         </xsl:template>
+      </t:expect>
    </t:scenario>
 
    <!--
@@ -54,7 +72,7 @@
                 test="$t:result instance of element(xsl:template)"/>
       <t:expect label="@test must be transformed to @select"
                 test="$t:result/xsl:variable[@name eq 'Q{urn:x-xspec:compile:impl}test-result']/*/xsl:otherwise/*">
-         <xsl:sequence select="false()" version="..."/>
+         <xsl:sequence select="false()" version="3" />
       </t:expect>
    </t:scenario>
 

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -81,7 +81,8 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
    </xsl:template>
 
    <!-- generated from the x:scenario element -->
-   <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+   <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+                 as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
       ...
       <!-- a call instruction for each x:expect element -->
       <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1">
@@ -120,7 +121,7 @@ xs:anyURI(".../compilation-simple-suite.xspec")
 
 (: generated from the x:scenario element :)
 declare function local:scenario1(
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 ...
 (: a call instruction for each x:expect element :)
@@ -185,7 +186,8 @@ result as parameter.
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+              as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <xsl:message>scenario</xsl:message>
    <xsl:element name="x:scenario" namespace="http://www.jenitennison.com/xslt/xspec">
       <xsl:attribute name="id" namespace="">scenario1</xsl:attribute>
@@ -263,7 +265,7 @@ result as parameter.
 ```xquery
 (: generated from the x:scenario element :)
 declare function local:scenario1(
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 ... generate scenario data in the report ...
 
@@ -489,7 +491,8 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+              as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    ...
    <!-- the generated variable -->
    <xsl:variable name="Q{http://example.org/ns/my/variable}var" select="'value'"/>
@@ -526,7 +529,7 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 ```xquery
 (: generated from the x:scenario element :)
 declare function local:scenario1(
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 (: the generated variable :)
 let $Q{http://example.org/ns/my/variable}var := (
@@ -598,7 +601,8 @@ this accessibility.
 ### Stylesheet
 
 ```xml
-<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+              as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    ...
 
    <!-- $myv:select -->
@@ -636,7 +640,7 @@ this accessibility.
 
 ```xquery
 declare function local:scenario1(
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 ...
 
@@ -726,7 +730,8 @@ and functions in XQuery).
               select="'global-value'"/>
 
 <!-- generated from the scenario outer -->
-<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+              as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <!-- the generated variable -->
    <xsl:variable name="Q{http://example.org/ns/my/variable}var-1" select="'var-1-value'" />
    ...
@@ -737,7 +742,8 @@ and functions in XQuery).
 </xsl:template>
 
 <!-- generated from the scenario inner -->
-<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1">
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1"
+              as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <!-- the variable is passed as param -->
    <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
    ...
@@ -808,7 +814,7 @@ declare variable $Q{http://example.org/ns/my/variable}global := (
 
 (: generated from the scenario outer :)
 declare function local:scenario1(
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 ...
 (: the generated variable :)
@@ -829,7 +835,7 @@ $Q{http://www.jenitennison.com/xslt/xspec}tmp
 declare function local:scenario1-scenario1(
 (: the variable is passed as param :)
 $Q{http://example.org/ns/my/variable}var-1
-)
+) as element(Q{http://www.jenitennison.com/xslt/xspec}scenario)
 {
 (: the generated variable :)
 let $Q{http://example.org/ns/my/variable}var-2 := (

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -187,9 +187,12 @@ result as parameter.
 <!-- generated from the x:scenario element -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1">
    <xsl:message>scenario</xsl:message>
-   <x:scenario id="scenario1"
-               xspec=".../compilation-simple-suite.xspec">
-      <x:label>scenario</x:label>
+   <xsl:element name="x:scenario" namespace="http://www.jenitennison.com/xslt/xspec">
+      <xsl:attribute name="id" namespace="">scenario1</xsl:attribute>
+      <xsl:attribute name="xspec" namespace="">.../compilation-simple-suite.xspec</xsl:attribute>
+      <xsl:element name="x:label" namespace="http://www.jenitennison.com/xslt/xspec">
+         <xsl:text>scenario</xsl:text>
+      </xsl:element>
       <xsl:element name="x:call" namespace="http://www.jenitennison.com/xslt/xspec">
          <xsl:namespace name="my">http://example.org/ns/my</xsl:namespace>
          <xsl:attribute name="function" namespace="">my:f</xsl:attribute>
@@ -204,7 +207,7 @@ result as parameter.
       <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1">
          <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result" select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>
       </xsl:call-template>
-   </x:scenario>
+   </x:element>
 </xsl:template>
 
 <!-- generated from the x:expect element -->
@@ -278,6 +281,7 @@ return (
 $Q{http://www.jenitennison.com/xslt/xspec}tmp
 )
 )
+}
 };
 
 (: generated from the x:expect element :)
@@ -866,6 +870,7 @@ $Q{http://www.jenitennison.com/xslt/xspec}tmp
 )
 )
 )
+}
 };
 
 (: generated from the expect one :)


### PR DESCRIPTION
Following #1064, this pull request replaces `x:scenario` literal result elements with its indirect constructor.