### PR TITLE
refactor: do not use XSpec namespace URI directly

### DIFF
--- a/src/common/xspec-utils.xqm
+++ b/src/common/xspec-utils.xqm
@@ -1,6 +1,11 @@
 module namespace x = "http://www.jenitennison.com/xslt/xspec";
 
 (:
+	XSpec 'x' namespace URI
+:)
+declare variable $x:xspec-namespace as xs:anyURI := xs:anyURI('http://www.jenitennison.com/xslt/xspec');
+
+(:
 	U+0027
 :)
 declare variable $x:apos as xs:string := "'";

--- a/src/compiler/generate-query-utils.xqm
+++ b/src/compiler/generate-query-utils.xqm
@@ -212,7 +212,7 @@ declare function test:report-sequence(
     $additional-namespaces as namespace-node()*
   ) as element()
 {
-  let $wrapper-ns as xs:string := 'http://www.jenitennison.com/xslt/xspec'
+  let $wrapper-ns as xs:string := string($x:xspec-namespace)
 
   let $attribute-nodes as attribute()* := $sequence[. instance of attribute()]
   let $document-nodes as document-node()* := $sequence[. instance of document-node()]

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -288,7 +288,7 @@
 
       <xsl:param name="sequence" as="item()*" required="yes" />
       <xsl:param name="wrapper-name" as="xs:string" required="yes" />
-      <xsl:param name="wrapper-ns" as="xs:string" select="'http://www.jenitennison.com/xslt/xspec'" />
+      <xsl:param name="wrapper-ns" as="xs:string" select="$x:xspec-namespace" />
       <xsl:param name="test-attr" as="attribute(test)?" />
       <xsl:param name="additional-namespaces" as="namespace-node()*" />
 

--- a/test/generate-x-utils.xspec
+++ b/test/generate-x-utils.xspec
@@ -778,7 +778,9 @@
             <t:call function="test:report-atomic-value">
                <t:param select="xs:QName('t:foo')" />
             </t:call>
-            <t:expect label="Function" select="'QName(''http://www.jenitennison.com/xslt/xspec'', ''t:foo'')'" />
+            <t:expect label="Function" select="string()">
+               <t:text expand-text="yes" xml:space="preserve">QName('{$t:xspec-namespace}', 't:foo')</t:text>
+            </t:expect>
          </t:scenario>
 
          <t:scenario label="In namespace, without prefix">

--- a/test/xspec-utils.xspec
+++ b/test/xspec-utils.xspec
@@ -9,6 +9,13 @@
 		/x:description/@stylesheet or @query-at.
 	-->
 
+	<x:scenario label="Scenario for testing variable xspec-namespace">
+		<x:call function="false" />
+		<x:expect label="XSpec namespace URI"
+			select="doc($x:xspec-uri)/element() => namespace-uri()"
+			test="$x:xspec-namespace treat as xs:anyURI" />
+	</x:scenario>
+
 	<x:scenario label="Scenario for testing variable apos">
 		<x:call function="false" />
 		<x:expect label="One apostrophe character" select="string()"

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -19,13 +19,6 @@
 			test="$x:legacy-namespace treat as xs:anyURI" />
 	</x:scenario>
 
-	<x:scenario label="Scenario for testing variable xspec-namespace">
-		<x:context />
-		<x:expect label="XSpec namespace URI"
-			select="doc($x:xspec-uri)/element() => namespace-uri()"
-			test="$x:xspec-namespace treat as xs:anyURI" />
-	</x:scenario>
-
 	<x:scenario label="Scenario for testing variable xs-namespace">
 		<x:context />
 		<x:expect label="'xs' namespace URI"
@@ -929,7 +922,7 @@
 			test="
 				x:QName-exactly-equal(
 					$x:result[1],
-					QName('http://www.jenitennison.com/xslt/xspec', 'element-without-prefix')
+					QName($x:xspec-namespace, 'element-without-prefix')
 				)" />
 		<x:expect label="2nd QName"
 			test="


### PR DESCRIPTION
The literal XSpec namespace URI is still used in some places. This pull request replaces it with the `$x:xspec-namespace` variable.