### PR TITLE
refactor(report): remove prefix from x:report in report XML

### DIFF
--- a/src/common/xspec-utils.xqm
+++ b/src/common/xspec-utils.xqm
@@ -1,6 +1,11 @@
 module namespace x = "http://www.jenitennison.com/xslt/xspec";
 
 (:
+	Legacy 'test' namespace URI
+:)
+declare variable $x:legacy-namespace as xs:anyURI := xs:anyURI('http://www.jenitennison.com/xslt/unit-test');
+
+(:
 	XSpec 'x' namespace URI
 :)
 declare variable $x:xspec-namespace as xs:anyURI := xs:anyURI('http://www.jenitennison.com/xslt/xspec');

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -122,7 +122,7 @@
 
       <!-- <x:report> -->
       <xsl:text>element { </xsl:text>
-      <xsl:value-of select="QName($x:xspec-namespace, x:xspec-name('report', $this)) => x:QName-expression()" />
+      <xsl:value-of select="QName($x:xspec-namespace, 'report') => x:QName-expression()" />
       <xsl:text> } {&#x0A;</xsl:text>
 
       <xsl:call-template name="test:create-zero-or-more-node-generators">
@@ -284,6 +284,8 @@
             <xsl:sequence select="x:label(.)" />
 
             <!-- Copy the input to the test result report XML -->
+            <!-- TODO: Undeclare the default namespace in the wrapper element, because x:param/@select may
+               use the default namespace such as xs:QName('foo'). -->
             <xsl:sequence select="x:call" />
          </xsl:with-param>
       </xsl:call-template>
@@ -495,6 +497,8 @@
             <xsl:text>),&#x0A;</xsl:text>
          </xsl:if>
 
+         <!-- TODO: Undeclare the default namespace in the wrapper element, because x:expect/@test may use
+            the default namespace such as xs:QName('foo'). -->
          <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(&#x0A;</xsl:text>
          <xsl:text expand-text="yes">${x:variable-UQName(.)},&#x0A;</xsl:text>
          <xsl:text expand-text="yes">'{name()}'</xsl:text>

--- a/src/compiler/generate-query-utils.xqm
+++ b/src/compiler/generate-query-utils.xqm
@@ -355,7 +355,9 @@ declare function test:report-node(
     ) as node()
 {
   if (($node instance of text()) and not(normalize-space($node))) then
-    element test:ws { $node }
+    (: This element name is not 'test:ws' but 'ws'. This prefix-less name is a workaround for
+      https://sourceforge.net/p/saxon/mailman/message/37066342/ :)
+    element { QName($x:legacy-namespace, 'ws') } { $node }
   else if ( $node instance of document-node() ) then
     document {
       for $child in $node/child::node() return test:report-node($child)

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -478,7 +478,9 @@
 
    <xsl:template match="text()[not(normalize-space())]" as="element(test:ws)"
       mode="test:report-node">
-      <xsl:element name="test:ws" namespace="{$x:legacy-namespace}">
+      <!-- This element name is not 'test:ws' but 'ws'. This prefix-less name is a workaround for
+         https://sourceforge.net/p/saxon/mailman/message/37066342/ -->
+      <xsl:element name="ws" namespace="{$x:legacy-namespace}">
          <xsl:sequence select="." />
       </xsl:element>
    </xsl:template>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -125,7 +125,7 @@
                </xsl:choose>
 
                <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
-                  <xsl:attribute name="name" select="x:xspec-name('report', .)" />
+                  <xsl:attribute name="name" select="'report'" />
                   <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
                   <xsl:variable name="attributes" as="attribute()+">
@@ -300,6 +300,8 @@
                <xsl:choose>
                   <xsl:when test="self::x:apply or self::x:call or self::x:context">
                      <!-- Copy the input to the test result report XML -->
+                     <!-- TODO: Undeclare the default namespace in the wrapper element, because
+                        x:param/@select may use the default namespace such as xs:QName('foo'). -->
                      <xsl:apply-templates select="." mode="test:create-node-generator" />
                   </xsl:when>
                   <xsl:when test="self::x:variable">
@@ -806,6 +808,8 @@
                   </if>
                </xsl:if>
 
+               <!-- TODO: Undeclare the default namespace in the wrapper element, because x:expect/@test
+                  may use the default namespace such as xs:QName('foo'). -->
                <call-template name="{x:known-UQName('test:report-sequence')}">
                   <with-param name="sequence" select="${x:variable-UQName(.)}" />
                   <with-param name="wrapper-name" as="{x:known-UQName('xs:string')}"

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -100,7 +100,11 @@
   </xsl:variable>
 
   <!-- Output xmlns="" to undeclare the default namespace -->
-  <xsl:if test="exists($parent-namespaces[name() = '']) and empty($namespaces[name() = ''])">
+  <xsl:if
+    test="
+      ($level ge 1)
+      and exists($parent-namespaces[name() = ''])
+      and empty($namespaces[name() = ''])">
     <xsl:text> xmlns=""</xsl:text>
   </xsl:if>
 

--- a/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../ambiguous-expect.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../ambiguous-expect.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../ambiguous-expect.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -15,7 +17,7 @@
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Expecting document node via @href should be Failure</x:label>
             <x:expect select="/self::document-node()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
@@ -24,12 +26,14 @@
                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$x:result treat as xs:boolean"
                       select="/self::document-node()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @select</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns false,</x:label>
@@ -50,7 +54,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes child node</x:label>
       <x:scenario id="scenario3-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -61,7 +67,9 @@
          <x:test id="scenario3-scenario1-expect1" successful="false">
             <x:label>Expecting element(foo) via child node should be Failure</x:label>
             <x:expect select="/element()">
-               <foo xmlns:mirror="x-urn:test:mirror" xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+               <foo xmlns:mirror="x-urn:test:mirror"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
@@ -70,12 +78,14 @@
                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$x:result treat as xs:boolean"
                       select="/element()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select or child node)</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -107,4 +117,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-1-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../focus-1.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../focus-1.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused correct scenario must be Pending</t:label>
@@ -17,7 +18,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused incorrect scenario must be Pending</t:label>
@@ -30,7 +32,9 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../focus-1.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../focus-1.xspec">
       <t:label>a focused correct scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -43,7 +47,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../focus-1.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../focus-1.xspec">
       <t:label>a focused incorrect scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -59,4 +65,4 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/focus-2-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-2-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../focus-2.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../focus-2.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../focus-2.xspec"
                pending="testing x:pending">
       <t:label>an unfocused correct scenario in x:pending must be Pending</t:label>
@@ -17,7 +18,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../focus-2.xspec">
       <t:label>a focused correct scenario in x:pending</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -30,7 +33,8 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
                xspec="../../focus-2.xspec"
                pending="testing @focus in x:pending">
       <t:label>a non-pending correct scenario alongside a focused scenario must be Pending</t:label>
@@ -43,7 +47,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../focus-2.xspec">
       <t:label>a focused correct scenario alongside another focused scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -56,7 +62,8 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario5"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
                xspec="../../focus-2.xspec"
                pending="testing @pending without @focus">
       <t:label>a correct scenario with @pending must be Pending</t:label>
@@ -69,7 +76,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario6" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../focus-2.xspec">
       <t:label>a correct scenario with both @pending and @focus (not recommended as ambiguous)</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -82,4 +91,4 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/function-result.xml
+++ b/test/end-to-end/cases/expected/query/function-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../function.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../function.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../function.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../function.xspec">
       <t:label>when calling a function and expecting correctly</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -24,7 +26,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../function.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../function.xspec">
       <t:label>when calling a function and expecting incorrectly</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -44,4 +48,4 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/import-result.xml
+++ b/test/end-to-end/cases/expected/query/import-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../import.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../import.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../import.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../import.xspec">
       <t:label>when testing a correct scenario in an importing file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -24,7 +26,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../import.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../import.xspec">
       <t:label>when testing an incorrect scenario in an importing file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -40,7 +44,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -53,7 +59,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../imported.xspec">
       <t:label>an incorrect scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -66,4 +74,4 @@
          <t:expect select="42"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/imported-result.xml
+++ b/test/end-to-end/cases/expected/query/imported-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../imported.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../imported.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../imported.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my" function="my:square">
          <t:param select="3"/>
@@ -15,7 +17,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../imported.xspec">
       <t:label>an incorrect scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my" function="my:square">
          <t:param select="2"/>
@@ -26,4 +30,4 @@
          <t:expect select="42"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-151-result.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-151.xspec"
-          query="x-urn:test-mix"
-          query-at="../../issue-151.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-151.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-151.xspec"
+        query="x-urn:test-mix"
+        query-at="../../issue-151.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-151.xspec">
       <x:label>When the result is a mixture of a typed element and a string</x:label>
       <x:call xmlns:test-mix="x-urn:test-mix" function="test-mix:element-and-string"/>
       <x:result select="/*">
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-element>
             <test-mix:fooElement xmlns:test-mix="x-urn:test-mix">
                <test-mix:barElement/>
             </test-mix:fooElement>
          </pseudo-element>
-         <pseudo-atomic-value xmlns="http://www.jenitennison.com/xslt/xspec">'string'</pseudo-atomic-value>
+         <pseudo-atomic-value>'string'</pseudo-atomic-value>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Result] in the failure report HTML must wrap element and string separately</x:label>
          <x:expect xmlns:test-mix="x-urn:test-mix" test="false()" select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-153-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-153.xspec"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-153.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-153.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-153.xspec">
       <x:label>When a function returns a local date time string</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="string">
          <x:param select="xs:dateTime('2000-01-01T12:00:00+12:00')"/>
@@ -25,4 +27,4 @@
                    select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-177-result.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-177.xspec"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-177.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-177.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-177.xspec">
       <x:label>Given the function returns &lt;foo /&gt;</x:label>
       <x:call function="exactly-one">
          <x:param as="element(foo)">
-            <foo/>
+            <foo xmlns=""/>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <foo/>
+         <foo xmlns=""/>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>When @test is "empty($x:result/self::element(foo))" (i.e. boolean),
@@ -31,11 +33,11 @@
 					"Expected Result" = "&lt;bar /&gt;"
 				with diff.</x:label>
          <x:result select="/element()">
-            <foo/>
+            <foo xmlns=""/>
          </x:result>
          <x:expect test="$x:result/self::element(foo)" select="/element()">
-            <bar/>
+            <bar xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-346-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-346-result.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-346.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-346.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-346.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param as="element(p)" href="../../issue-346.xml" select="element(p)"/>
       </x:call>
       <x:result select="/element()">
-         <p>
+         <p xmlns="">
             <span>foo</span>
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"> </test:ws>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test"> </ws>
             <span>bar</span>
          </p>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>Expecting no space should be Failure</x:label>
          <x:expect select="/element()">
-            <p xmlns:mirror="x-urn:test:mirror">
+            <p xmlns:mirror="x-urn:test:mirror" xmlns="">
                <span>foo</span>
                <span>bar</span>
             </p>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-355-result.xml
@@ -1,35 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-355.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-355.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-355.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-355.xspec">
       <x:label>xs:integer()</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
       </x:call>
       <x:result select="/*">
-         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-other/>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-355.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-355.xspec">
       <x:label>Anonymous</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function($x){$x+1}"/>
       </x:call>
       <x:result select="/*">
-         <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-other/>
       </x:result>
       <x:test id="scenario2-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-447_1-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_1-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_1.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_1.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../issue-447_1.xspec"
                pending="x:pending/x:label containing }{">
       <x:label>should not affect test</x:label>
@@ -13,4 +14,4 @@
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-447_2-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_2-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_2.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_2.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../issue-447_2.xspec"
                pending="x:pending/@label containing }{">
       <x:label>should not affect test</x:label>
@@ -13,4 +14,4 @@
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-447_3-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-447_3-result.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_3.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-447_3.xspec" pending="}{">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_3.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-447_3.xspec"
+               pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="}{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-448-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-448-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-448.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-448.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-448.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../issue-448.xspec">
          <x:label>x:label containing }{ should not affect test</x:label>
@@ -25,4 +27,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-449-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-449-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-449.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-449.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-449.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-449.xspec">
       <x:label>x:expect/</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -17,4 +19,4 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-450-451.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-450-451.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-450-451.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-450-451.xspec">
       <x:label>function-param containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
               function="mirror:param-mirror">
-         <x:param>}{<elem attr="}{">}{</elem>
+         <x:param>}{<elem xmlns="" attr="}{">}{</elem>
          </x:param>
       </x:call>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-450-451.xspec">
       <x:label>global-param containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -32,16 +37,19 @@
          <x:label>should work</x:label>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:expect xmlns:mirror="x-urn:test:mirror"
                    xmlns:myv="http://example.org/ns/my/variable"
                    test="$global-param treat as node()+"
-                   select="/node()">}{<elem attr="}{">}{</elem>
+                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-450-451.xspec">
       <x:label>global-var containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -51,16 +59,19 @@
          <x:label>should work</x:label>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:expect xmlns:mirror="x-urn:test:mirror"
                    xmlns:myv="http://example.org/ns/my/variable"
                    test="$myv:global-var treat as node()+"
-                   select="/node()">}{<elem attr="}{">}{</elem>
+                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../issue-450-451.xspec">
       <x:label>local variable containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -69,32 +80,38 @@
       </x:call>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario4-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../issue-450-451.xspec">
       <x:label>assertion containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
               function="mirror:param-mirror">
          <x:param href="../../issue-450-451.xml" select="wrap/node() treat as node()+"/>
       </x:call>
-      <x:result select="/node()">}{<elem attr="}{">}{</elem>
+      <x:result select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario5-expect1" successful="true">
          <x:label>should work</x:label>
          <x:expect select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../issue-450-451.xspec">
       <x:label>If value is from a variable instead of hard-coded,</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../issue-450-451.xspec">
          <x:label>function-param containing curly brackets</x:label>
@@ -105,11 +122,12 @@
          </x:call>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="true">
             <x:label>should work</x:label>
-            <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+            <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -120,15 +138,16 @@
                  function="mirror:param-mirror">
             <x:param href="../../issue-450-451.xml" select="wrap/node() treat as node()+"/>
          </x:call>
-         <x:result select="/node()">}{<elem attr="}{">}{</elem>
+         <x:result select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="true">
             <x:label>should work</x:label>
             <x:expect select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                      xmlns:myv="http://example.org/ns/my/variable"
+                     xmlns=""
                      attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-452-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-452-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-452.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-452.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-452.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-452.xspec">
       <x:label>Text</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>t</x:param>
@@ -15,7 +17,9 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-452.xspec">
       <x:label>Comment</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param><!--c--></x:param>
@@ -26,7 +30,9 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-452.xspec">
       <x:label>Processing instruction</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param><?p?></x:param>
@@ -37,19 +43,21 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../issue-452.xspec">
       <x:label>In element</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>
-            <elem>t<!--c--><?p?></elem>
+            <elem xmlns="">t<!--c--><?p?></elem>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <elem xmlns:mirror="x-urn:test:mirror">t<!--c--><?p?></elem>
+         <elem xmlns:mirror="x-urn:test:mirror" xmlns="">t<!--c--><?p?></elem>
       </x:result>
       <x:test id="scenario4-expect1" successful="false">
          <x:label>Expect</x:label>
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-467-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-467.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-467.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-467.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-467.xspec">
       <x:label>Testing namespace differences</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>
@@ -39,4 +41,4 @@
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-50-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-50.xspec"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-50.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-50.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-50.xspec">
       <x:label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="xs:untypedAtomic">
          <x:param select="'0123'"/>
@@ -16,4 +18,4 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}hexBinary('0123')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-55-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-55.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-55.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-55.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-55.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -26,4 +28,4 @@
          <x:expect select="1"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-67-result.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-67.xspec"
-          query="x-urn:test:xspec-items"
-          query-at="../../../../items.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-67.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-67.xspec"
+        query="x-urn:test:xspec-items"
+        query-at="../../../../items.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing identical namespace</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>must be Success</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-67.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing identical default namespace</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}default-namespace"/>
@@ -38,21 +40,21 @@
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-67.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing different namespaces</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>must be Failure</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/label-element-result.xml
+++ b/test/end-to-end/cases/expected/query/label-element-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../label-element.xspec"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../label-element.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -23,7 +25,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -42,7 +46,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -61,4 +67,4 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/pending-result.xml
+++ b/test/end-to-end/cases/expected/query/pending-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../pending.xspec"
-          query="http://example.org/ns/my"
-          query-at="../../../../square.xqm"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../pending.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../pending.xspec"
                pending="testing x:pending">
       <t:label>a correct scenario in x:pending must be Pending</t:label>
@@ -17,7 +18,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
                xspec="../../pending.xspec"
                pending="testing x:pending">
       <t:label>an incorrect scenario in x:pending must be Pending</t:label>
@@ -30,7 +32,9 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../pending.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../pending.xspec">
       <t:label>a non-pending correct scenario alongside a pending scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -43,7 +47,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../pending.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../pending.xspec">
       <t:label>a non-pending incorrect scenario alongside a pending scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -59,7 +65,8 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario5"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
                xspec="../../pending.xspec"
                pending="testing @pending of a correct scenario">
       <t:label>a correct scenario with @pending must be Pending</t:label>
@@ -72,7 +79,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario6"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
                xspec="../../pending.xspec"
                pending="testing @pending of an incorrect scenario">
       <t:label>an incorrect scenario with @pending must be Pending</t:label>
@@ -86,4 +94,4 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/query/report-result.xml
+++ b/test/end-to-end/cases/expected/query/report-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../report.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../report.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report.xspec">
          <x:label>Array</x:label>
@@ -12,7 +14,7 @@
             <x:param as="array(*)" select="['foo', 1, [2, 'bar']]"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-array xmlns="http://www.jenitennison.com/xslt/xspec">["foo",1,[2,"bar"]]</pseudo-array>
+            <pseudo-array>["foo",1,[2,"bar"]]</pseudo-array>
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Serialized array should be reported upon failure</x:label>
@@ -25,7 +27,7 @@
             <x:param as="map(*)" select="      map {       'foo': 1,       2: 'bar'      }"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{2:"bar","foo":1}</pseudo-map>
+            <pseudo-map>map{2:"bar","foo":1}</pseudo-map>
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="false">
             <x:label>Serialized map should be reported upon failure</x:label>
@@ -33,64 +35,72 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../report.xspec">
       <x:label>Element, attribute (xspec/xspec#357)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="elem1 | elem2/attribute()">
-            <elem1>text</elem1>
-            <elem2 attr="attr-val"/>
+            <elem1 xmlns="">text</elem1>
+            <elem2 xmlns="" attr="attr-val"/>
          </x:param>
       </x:call>
       <x:result select="/*/(@* | node())">
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-element>
             <elem1 xmlns="">text</elem1>
          </pseudo-element>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="attr-val"/>
+         <pseudo-attribute attr="attr-val"/>
       </x:result>
       <x:test id="scenario2-expect1" successful="false">
          <x:label>@attr should be reported as an attribute</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../report.xspec">
       <x:label>Attributes of the same name (xspec/xspec#358)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="attribute()+" select="element()/attribute()">
-            <elem1 attr="foo"/>
-            <elem2 attr="bar"/>
+            <elem1 xmlns="" attr="foo"/>
+            <elem2 xmlns="" attr="bar"/>
          </x:param>
       </x:call>
       <x:result select="/*/@*">
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="foo"/>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="bar"/>
+         <pseudo-attribute attr="foo"/>
+         <pseudo-attribute attr="bar"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>Both @attr=foo and @attr=bar should be reported</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../report.xspec">
       <x:label>Attribute, element, attribute (xspec/xspec#360)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="element()/attribute() | elem2">
-            <elem1 attr1="attr1-val"/>
-            <elem2>text</elem2>
-            <elem3 attr3="attr3-val"/>
+            <elem1 xmlns="" attr1="attr1-val"/>
+            <elem2 xmlns="">text</elem2>
+            <elem3 xmlns="" attr3="attr3-val"/>
          </x:param>
       </x:call>
       <x:result select="/*/(@* | node())">
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr1="attr1-val"/>
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-attribute attr1="attr1-val"/>
+         <pseudo-element>
             <elem2 xmlns="">text</elem2>
          </pseudo-element>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr3="attr3-val"/>
+         <pseudo-attribute attr3="attr3-val"/>
       </x:result>
       <x:test id="scenario4-expect1" successful="false">
          <x:label>[Result] should be reported</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../report.xspec">
       <x:label>Document node with no children (xspec/xspec#697)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param select="parse-xml-fragment('')"/>
@@ -101,22 +111,24 @@
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../report.xspec">
       <x:label>XPath is different, but serialized node looks as if same</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../report.xspec">
          <x:label>[Result] = document node, [Expected Result] = element</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="document-node()" select="/">
-               <test/>
+               <test xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/self::document-node()">
-            <test/>
+            <test xmlns=""/>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="false">
             <x:label>XPath should be colored as different. Serialized node should be colored as same.</x:label>
             <x:expect select="/element()">
-               <test/>
+               <test xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -124,21 +136,23 @@
          <x:label>[Result] = element, [Expected Result] = document node.</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element()">
-               <test/>
+               <test xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <test/>
+            <test xmlns=""/>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>XPath should be colored as different. Serialized node should be colored as same.</x:label>
             <x:expect select="/self::document-node()">
-               <test/>
+               <test xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../report.xspec">
       <x:label>Sequence of multiple atomic values</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param select="'foo', 1, 2, 'bar'"/>
@@ -149,4 +163,4 @@
          <x:expect select="QName('', 'foo'),&#xA;1,&#xA;2,&#xA;'bar'"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
+++ b/test/end-to-end/cases/expected/query/report_schema-aware-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../report_schema-aware.xspec"
-          query="x-urn:test:do-nothing"
-          query-at="../../../../do-nothing.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../report_schema-aware.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report_schema-aware.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../report_schema-aware.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report_schema-aware.xspec">
          <x:label>Derived string types</x:label>
@@ -288,4 +290,4 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../serialize.xspec"
-          query="x-urn:test:xspec-items"
-          query-at="../../../../items.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../serialize.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../serialize.xspec"
+        query="x-urn:test:xspec-items"
+        query-at="../../../../items.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../serialize.xspec">
       <x:label>When the result is a comment node, the report HTML must serialize it as
 			&lt;!-- --&gt;. (xspec/xspec#356) So...</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../serialize.xspec">
@@ -33,7 +35,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../serialize.xspec">
       <x:label>When the result is indented in the report XML file, the report HTML must serialize
 			it with indentation.</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../serialize.xspec">
@@ -43,21 +47,21 @@
 					elements serialized with indentation,</x:label>
             <x:call function="one-or-more">
                <x:param as="element()+">
-                  <foo/>
-                  <bar>
+                  <foo xmlns=""/>
+                  <bar xmlns="">
                      <baz/>
                   </bar>
-                  <qux>
+                  <qux xmlns="">
                      <quux/>
                   </qux>
                </x:param>
             </x:call>
             <x:result select="/element()">
-               <foo/>
-               <bar>
+               <foo xmlns=""/>
+               <bar xmlns="">
                   <baz/>
                </bar>
-               <qux>
+               <qux xmlns="">
                   <quux/>
                </qux>
             </x:result>
@@ -81,11 +85,11 @@
                <x:label>all elements in [Expected Result] with diff must be serialized with
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <foo/>
-                  <bar>
+                  <foo xmlns=""/>
+                  <bar xmlns="">
                      <baz/>
                   </bar>
-                  <qux>
+                  <qux xmlns="">
                      <quux/>
                   </qux>
                </x:expect>
@@ -103,7 +107,7 @@
 						x:result of the report XML file,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <elem1><!--foo-->
                            <bar/>
                         </elem1>
@@ -112,7 +116,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <elem1><!--foo-->
                         <bar/>
                      </elem1>
@@ -122,7 +126,7 @@
                <x:test id="scenario2-scenario2-scenario1-scenario1-expect1" successful="false">
                   <x:label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <elem1>foo<bar/>
                         </elem1>
                         <elem2>foo<?bar?></elem2>
@@ -136,7 +140,7 @@
 						x:expect of the report XML file,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <elem1>foo<bar/>
                         </elem1>
                         <elem2>foo<?bar?></elem2>
@@ -144,7 +148,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <elem1>foo<bar/>
                      </elem1>
                      <elem2>foo<?bar?></elem2>
@@ -153,7 +157,7 @@
                <x:test id="scenario2-scenario2-scenario1-scenario2-expect1" successful="false">
                   <x:label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <elem1><!--foo-->
                            <bar/>
                         </elem1>
@@ -173,7 +177,7 @@
 						length,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <foo>
                            <bar/>
                         </foo>
@@ -182,7 +186,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <foo>
                         <bar/>
                      </foo>
@@ -192,7 +196,7 @@
                <x:test id="scenario2-scenario2-scenario2-scenario1-expect1" successful="false">
                   <x:label>&lt;foo&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <foo>
                            <bar/>
                         </foo>
@@ -204,18 +208,20 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../serialize.xspec">
       <x:label>When x:expect has an element of '...',</x:label>
       <x:call function="exactly-one">
          <x:param as="element(foo)">
-            <foo>
+            <foo xmlns="">
                <bar/>
                <baz/>
             </foo>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <foo>
+         <foo xmlns="">
             <bar/>
             <baz/>
          </foo>
@@ -224,16 +230,18 @@
          <x:label>the corresponding nodes in [Result] with diff must be serialized in green.
 				(xspec/xspec#379)</x:label>
          <x:expect select="/element()">
-            <foo>...</foo>
-            <qux/>
+            <foo xmlns="">...</foo>
+            <qux xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains significant text nodes,</x:label>
       <x:call function="exactly-one">
          <x:param as="element(test)">
-            <test>
+            <test xmlns="">
                <oridinary-text-node>
                   <same>same</same>
                   <diff>actual</diff>
@@ -248,16 +256,16 @@
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <test>
+         <test xmlns="">
             <oridinary-text-node>
                <same>same</same>
                <diff>actual</diff>
             </oridinary-text-node>
             <significant-whitespace-only-text-node>
-               <same xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></same>
-               <diff xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></diff>
+               <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></same>
+               <diff xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></diff>
             </significant-whitespace-only-text-node>
          </test>
       </x:result>
@@ -265,16 +273,16 @@
          <x:label>both in [Result] and [Expected Result] with diff, the significant text nodes
 				must be serialized with color. (xspec/xspec#386)</x:label>
          <x:expect select="/element()">
-            <test>
+            <test xmlns="">
                <oridinary-text-node>
                   <same>same</same>
                   <diff>expect</diff>
                </oridinary-text-node>
                <significant-whitespace-only-text-node>
-                  <same xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></same>
-                  <diff xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"> 	
-&#xD;</test:ws></diff>
+                  <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></same>
+                  <diff xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test"> 	
+&#xD;</ws></diff>
                </significant-whitespace-only-text-node>
             </test>
          </x:expect>
@@ -285,7 +293,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains an element, the report HTML must serialize nodes in its
 			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
       <x:scenario id="scenario5-scenario1" xspec="../../serialize.xspec">
@@ -296,7 +306,7 @@
                <x:param select="$test"/>
             </x:call>
             <x:result select="/element()">
-               <looooooooooooooooooooooooooooooooooong>
+               <looooooooooooooooooooooooooooooooooong xmlns="">
                   <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                      <a/>
                   </test>
@@ -321,7 +331,7 @@
                <x:label>[Expected Result] with diff must be serialized with aligned
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <looooooooooooooooooooooooooooooooooong>
+                  <looooooooooooooooooooooooooooooooooong xmlns="">
                      <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                         <a/>
                      </test>
@@ -338,7 +348,7 @@
                <x:param select="$test"/>
             </x:call>
             <x:result select="/element()">
-               <looooooooooooooooooooooooooooooooooong>
+               <looooooooooooooooooooooooooooooooooong xmlns="">
                   <test attr1="val1" attr2="val2" attr3="val3">
                      <a/>
                   </test>
@@ -363,7 +373,7 @@
                <x:label>[Expected Result] with diff must be serialized with aligned
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <looooooooooooooooooooooooooooooooooong>
+                  <looooooooooooooooooooooooooooooooooong xmlns="">
                      <test attr1="val1" attr2="val2" attr3="val3">
                         <a/>
                      </test>
@@ -373,21 +383,23 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains attribute,</x:label>
       <x:call function="one-or-more">
          <x:param>
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:param>
       </x:call>
       <x:scenario id="scenario6-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="false">
             <x:label>The exact-match (taking '...' into account) attributes must be serialized
@@ -395,18 +407,18 @@
 					palePink="solidPink". The orphan attributes must be serialized as
 					solidPink="solidPink" regardless of their values.</x:label>
             <x:expect select="/element()">
-               <exact-match attr1="value1" attr2="..." attr3="" attr4="..."/>
-               <name-match attr1="VALUE1" attr2="" attr3="value3" attr4="value4"/>
-               <orphan attr4="value4" attr5="" attr6="..."/>
+               <exact-match xmlns="" attr1="value1" attr2="..." attr3="" attr4="..."/>
+               <name-match xmlns="" attr1="VALUE1" attr2="" attr3="value3" attr4="value4"/>
+               <orphan xmlns="" attr4="value4" attr5="" attr6="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario6-scenario2" xspec="../../serialize.xspec">
          <x:label>in [Result] without diff,</x:label>
          <x:result select="/element()">
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>all the attributes must be serialized without color.</x:label>
@@ -414,14 +426,16 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains processing instructions,</x:label>
       <x:call function="one-or-more">
          <x:param>
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -438,10 +452,10 @@
       <x:scenario id="scenario7-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -463,10 +477,10 @@
 					instructions must be serialized as &lt;?solidPink solidPink?&gt;
 					regardless of their values.</x:label>
             <x:expect select="/element()">
-               <exact-match><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>
-               <name-match><?node1 VALUE1?><?node2?><?node3 value3?><?node4 value4?></name-match>
-               <value-match><?NODE1 value1?><?NODE2 ...?><?NODE3?><?NODE4 ...?></value-match>
-               <no-match>
+               <exact-match xmlns=""><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>
+               <name-match xmlns=""><?node1 VALUE1?><?node2?><?node3 value3?><?node4 value4?></name-match>
+               <value-match xmlns=""><?NODE1 value1?><?NODE2 ...?><?NODE3?><?NODE4 ...?></value-match>
+               <no-match xmlns="">
                   <different-kind>
                      <node1/>
                      <?node2 value2?>
@@ -485,10 +499,10 @@
       <x:scenario id="scenario7-scenario2" xspec="../../serialize.xspec">
          <x:label>in [Result] without diff,</x:label>
          <x:result select="/element()">
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -507,4 +521,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../shared-like.xspec"
-          query="x-urn:test:mirror"
-          query-at="../../../../mirror.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../shared-like.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../shared-like.xspec"
+        query="x-urn:test:mirror"
+        query-at="../../../../mirror.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -13,7 +15,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../shared-like.xspec">
       <x:label>Referenced and implicitly unshared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -22,7 +26,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../shared-like.xspec">
       <x:label>Scenario for testing x:like which references a shared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -35,7 +41,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../shared-like.xspec">
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../shared-like.xspec">
          <x:label>explicit one</x:label>
@@ -56,4 +64,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../three-dots.xspec"
-          query="x-urn:test:three-dots"
-          query-at="../../three-dots.xqm"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../three-dots.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../three-dots.xspec"
+        query="x-urn:test:three-dots"
+        query-at="../../three-dots.xqm"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (simple)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -12,18 +14,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem>text</elem>
+               <elem xmlns="">text</elem>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">text</elem>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text</elem>
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
@@ -37,18 +39,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem/>
+               <elem xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario2-expect2" successful="false">
@@ -56,7 +58,7 @@
 				&lt;elem attrib="..." /&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="..."/>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -66,18 +68,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem>...</elem>
+               <elem xmlns="">...</elem>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
          </x:result>
          <x:test id="scenario1-scenario3-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario3-expect2" successful="true">
@@ -89,12 +91,14 @@
 				&lt;elem&gt;text&lt;/elem&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">text</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (with attribute)</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -102,18 +106,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem attrib="val"/>
+               <elem xmlns="" attrib="val"/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="val"/>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="val"/>
          </x:result>
          <x:test id="scenario2-scenario1-expect1" successful="true">
             <x:label>expecting
 				&lt;elem attrib="..." /&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="..."/>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario2-scenario1-expect2" successful="true">
@@ -125,12 +129,14 @@
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (with mixed content)</x:label>
       <x:scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -138,13 +144,13 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(outer)">
-               <outer>text<inner1/>
+               <outer xmlns="">text<inner1/>
                   <inner2/>
                </outer>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">text<inner1/>
+            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text<inner1/>
                <inner2/>
             </outer>
          </x:result>
@@ -153,7 +159,7 @@
 				&lt;outer&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
@@ -161,7 +167,7 @@
 				&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...<inner1/>...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...<inner1/>...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect3" successful="true">
@@ -175,13 +181,13 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(outer)">
-               <outer>
+               <outer xmlns="">
                   <inner/>
                </outer>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">
                <inner/>
             </outer>
          </x:result>
@@ -190,7 +196,7 @@
 				&lt;outer&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario2-expect2" successful="false">
@@ -198,13 +204,15 @@
 				&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...<inner/>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...<inner/>
                </outer>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant attribute</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -212,18 +220,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib="val"/>
+               <elem xmlns="" attrib="val"/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="val"/>
+            <pseudo-attribute attrib="val"/>
          </x:result>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario4-scenario1-expect2" successful="true">
@@ -237,18 +245,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib=""/>
+               <elem xmlns="" attrib=""/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib=""/>
+            <pseudo-attribute attrib=""/>
          </x:result>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -258,18 +266,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib="..."/>
+               <elem xmlns="" attrib="..."/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+            <pseudo-attribute attrib="..."/>
          </x:result>
          <x:test id="scenario4-scenario3-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario4-scenario3-expect2" successful="true">
@@ -281,12 +289,14 @@
 					 @attrib="val"
 					should be Failure</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="val"/>
+               <pseudo-attribute attrib="val"/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant text node</x:label>
       <x:scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is usual text node</x:label>
@@ -309,8 +319,8 @@
             <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_whitespace-only"/>
          </x:call>
          <x:result select="/text()">
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws>
          </x:result>
          <x:test id="scenario5-scenario2-expect1" successful="true">
             <x:label>expecting ... should be Success</x:label>
@@ -327,7 +337,7 @@
             <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_zero-length"/>
          </x:call>
          <x:result select="/text()">
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"/>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test"/>
          </x:result>
          <x:test id="scenario5-scenario3-expect1" successful="true">
             <x:label>expecting ... should be Success</x:label>
@@ -358,7 +368,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant comment</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -420,7 +432,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant processing instruction</x:label>
       <x:scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -482,7 +496,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario8" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario8"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant document node</x:label>
       <x:scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -493,7 +509,7 @@
                      select="$Q{x-urn:test:three-dots}document-node_multiple-nodes"/>
          </x:call>
          <x:result select="/self::document-node()"><?pi?><!--comment-->
-            <elem/>
+            <elem xmlns=""/>
          </x:result>
          <x:test id="scenario8-scenario1-expect1" successful="false">
             <x:label>expecting
@@ -553,7 +569,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario9" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario9"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant namespace node</x:label>
       <x:scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -565,14 +583,14 @@
             <x:param select="'namespace-uri'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:prefix="namespace-uri"/>
          </x:result>
          <x:test id="scenario9-scenario1-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario1-expect2" successful="true">
@@ -615,14 +633,14 @@
             <x:param select="'...'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:prefix="..."/>
          </x:result>
          <x:test id="scenario9-scenario3-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario3-expect2" successful="true">
@@ -634,12 +652,14 @@
 					  xmlns:prefix="namespace-uri"
 					should be Failure</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="namespace-uri"/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario10" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario10"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant sequence of multiple nodes</x:label>
       <x:scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is sequence of
@@ -647,19 +667,19 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="one-or-more">
             <x:param as="element()+">
-               <elem1/>
-               <elem2/>
+               <elem1 xmlns=""/>
+               <elem2 xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem1 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
-            <elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <elem1 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
+            <elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
          </x:result>
          <x:test id="scenario10-scenario1-expect1" successful="true">
             <x:label>expecting
 					  ...&lt;elem2 /&gt;
 					should be Success</x:label>
-            <x:expect select="/node()">...<elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <x:expect select="/node()">...<elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario10-scenario1-expect2" successful="true">
@@ -680,7 +700,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario11" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario11"
+               xspec="../../three-dots.xspec">
       <x:label>When result is empty sequence</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="zero-or-one">
          <x:param select="()"/>
@@ -691,7 +713,9 @@
          <x:expect select="/text()">...</x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario12" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario12"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant atomic value</x:label>
       <x:scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is 'string'</x:label>
@@ -732,7 +756,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario13" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario13"
+               xspec="../../three-dots.xspec">
       <x:label>For any resultant item</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
          <x:param as="text()">item</x:param>
@@ -755,4 +781,4 @@
          <x:expect select="'...'"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-693.xspec"
-          stylesheet="issue-693-sch-preprocessed.xsl"
-          schematron="../../issue-693.sch"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-693.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-693.xspec"
+        stylesheet="issue-693-sch-preprocessed.xsl"
+        schematron="../../issue-693.sch"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-693.xspec">
       <x:label>Using user-content (not @href) in x:context should work</x:label>
       <x:context select="self::document-node()">
-         <foo>
+         <foo xmlns="">
             <bar/>
             <!--<baz />-->
          </foo>
@@ -43,4 +45,4 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.xml
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../label-element.xspec"
-          stylesheet="label-element-sch-preprocessed.xsl"
-          schematron="../../../../do-nothing.sch"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../label-element.xspec"
+        stylesheet="label-element-sch-preprocessed.xsl"
+        schematron="../../../../do-nothing.sch"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -23,7 +25,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -42,7 +46,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -61,4 +67,4 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../schematron-023.xspec"
-          stylesheet="schematron-023-sch-preprocessed.xsl"
-          schematron="../../../../schematron/schematron-023.sch"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../schematron-023.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../schematron-023.xspec"
+        stylesheet="schematron-023-sch-preprocessed.xsl"
+        schematron="../../../../schematron/schematron-023.sch"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../schematron-023.xspec">
       <x:label>valid with warning: expect-valid should pass</x:label>
       <x:context select="self::document-node()">
-         <document>
+         <document xmlns="">
             <section>
                <title>INTRODUCTION</title>
                <p>Some text</p>
@@ -55,10 +57,12 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../schematron-023.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../schematron-023.xspec">
       <x:label>error: expect-valid should fail</x:label>
       <x:context select="self::document-node()">
-         <document>
+         <document xmlns="">
             <section>
                <title>INTRODUCTION</title>
             </section>
@@ -104,10 +108,12 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../schematron-023.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../schematron-023.xspec">
       <x:label>fatal: expect-valid should fail</x:label>
       <x:context select="self::document-node()">
-         <adocument/>
+         <adocument xmlns=""/>
       </x:context>
       <x:result select="/element()">
          <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -140,4 +146,4 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../schematron-import_demo-02-PhaseB.xspec"
-          stylesheet="schematron-import_demo-02-PhaseB-sch-preprocessed.xsl"
-          schematron="../../../../../tutorial/schematron/demo-02.sch"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../schematron-import_demo-02-PhaseB.xspec"
+        stylesheet="schematron-import_demo-02-PhaseB-sch-preprocessed.xsl"
+        schematron="../../../../../tutorial/schematron/demo-02.sch"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../../../../tutorial/schematron/demo-02-PhaseB.xspec">
       <x:label>Pattern 2</x:label>
       <x:context xmlns:local="local" href="../../../../../tutorial/schematron/demo-02.xml"/>
@@ -91,7 +92,8 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2"
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
                xspec="../../../../../tutorial/schematron/demo-02-import1.xspec">
       <x:label>Pattern 3 - Shared</x:label>
       <x:context xmlns:local="local" href="../../../../../tutorial/schematron/demo-02.xml"/>
@@ -172,7 +174,8 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3"
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
                xspec="../../../../../tutorial/schematron/demo-02-import2.xspec">
       <x:label>Pattern 4 - example of a second level of imported scenarios</x:label>
       <x:context xmlns:local="local" href="../../../../../tutorial/schematron/demo-02.xml"/>
@@ -253,7 +256,8 @@
                    select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4"
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
                xspec="../../../../../tutorial/schematron/demo-02-import3.xspec">
       <x:label>XSpec function scenario imported</x:label>
       <x:call xmlns:local="local"
@@ -268,4 +272,4 @@
          <x:expect select="7"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../tvt_label_schematron.xspec"
-          stylesheet="tvt_label_schematron-sch-preprocessed.xsl"
-          schematron="../../tvt_label.sch"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../tvt_label_schematron.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../tvt_label_schematron.xspec"
+        stylesheet="tvt_label_schematron-sch-preprocessed.xsl"
+        schematron="../../tvt_label.sch"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../tvt_label_schematron.xspec">
       <x:label>With @expand-text=yes</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../tvt_label_schematron.xspec">
          <x:label>}}{scenario}{{</x:label>
          <x:context select="self::document-node()">
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/element()">
             <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -37,7 +39,7 @@
       <x:scenario id="scenario1-scenario2" xspec="../../tvt_label_schematron.xspec">
          <x:label>}}{scenario}{{</x:label>
          <x:context select="self::document-node()">
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/element()">
             <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -65,7 +67,7 @@
       <x:scenario id="scenario1-scenario3" xspec="../../tvt_label_schematron.xspec">
          <x:label>}}{scenario}{{</x:label>
          <x:context select="self::document-node()">
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/element()">
             <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -91,12 +93,14 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../tvt_label_schematron.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../tvt_label_schematron.xspec">
       <x:label>With @expand-text=no</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../tvt_label_schematron.xspec">
          <x:label>}}{scenario}{{</x:label>
          <x:context select="self::document-node()">
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/element()">
             <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -124,7 +128,7 @@
       <x:scenario id="scenario2-scenario2" xspec="../../tvt_label_schematron.xspec">
          <x:label>}}{scenario}{{</x:label>
          <x:context select="self::document-node()">
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/element()">
             <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
@@ -150,4 +154,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../ambiguous-expect.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../ambiguous-expect.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../ambiguous-expect.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @href</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -14,7 +16,7 @@
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Expecting document node via @href should be Failure</x:label>
             <x:expect select="/self::document-node()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
@@ -23,12 +25,14 @@
                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$x:result treat as xs:boolean"
                       select="/self::document-node()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes @select</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns false,</x:label>
@@ -49,7 +53,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes child node</x:label>
       <x:scenario id="scenario3-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -60,7 +66,9 @@
          <x:test id="scenario3-scenario1-expect1" successful="false">
             <x:label>Expecting element(foo) via child node should be Failure</x:label>
             <x:expect select="/element()">
-               <foo xmlns:mirror="x-urn:test:mirror" xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+               <foo xmlns:mirror="x-urn:test:mirror"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
@@ -69,12 +77,14 @@
                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$x:result treat as xs:boolean"
                       select="/element()">
-               <foo/>
+               <foo xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../ambiguous-expect.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../ambiguous-expect.xspec">
       <x:label>Scenario for verifying that boolean @test precedes empty sequence (no @href, @select or child node)</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../ambiguous-expect.xspec">
          <x:label>When function returns true,</x:label>
@@ -106,4 +116,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/coverage-no-hit-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/coverage-no-hit-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../coverage-no-hit.xspec"
-          stylesheet="../../coverage-no-hit.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../coverage-no-hit.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../coverage-no-hit.xspec"
+        stylesheet="../../coverage-no-hit.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../coverage-no-hit.xspec">
       <x:label>Testing a stylesheet without any matching context</x:label>
       <x:context/>
       <x:result select="()"/>
@@ -12,4 +14,4 @@
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/coverage-tutorial-result.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../coverage-tutorial.xspec"
-          stylesheet="../../../../../tutorial/coverage/demo.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../../../../tutorial/coverage/demo.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../coverage-tutorial.xspec"
+        stylesheet="../../../../../tutorial/coverage/demo.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../../../../tutorial/coverage/demo.xspec">
       <x:label>'iron' element</x:label>
       <x:context>
-         <iron weight="1"/>
+         <iron xmlns="" weight="1"/>
       </x:context>
       <x:result select="/element()">
-         <shield weight="1"/>
+         <shield xmlns="" weight="1"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>is transformed to 'shield' element</x:label>
          <x:expect select="/element()">
-            <shield weight="1"/>
+            <shield xmlns="" weight="1"/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../custom-coverage-report.xspec"
-          stylesheet="../../../../../tutorial/coverage/demo.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../../../../tutorial/coverage/demo.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../custom-coverage-report.xspec"
+        stylesheet="../../../../../tutorial/coverage/demo.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../../../../tutorial/coverage/demo.xspec">
       <x:label>'iron' element</x:label>
       <x:context>
-         <iron weight="1"/>
+         <iron xmlns="" weight="1"/>
       </x:context>
       <x:result select="/element()">
-         <shield weight="1"/>
+         <shield xmlns="" weight="1"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>is transformed to 'shield' element</x:label>
          <x:expect select="/element()">
-            <shield weight="1"/>
+            <shield xmlns="" weight="1"/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../focus-1.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../focus-1.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused correct scenario must be Pending</t:label>
@@ -16,7 +17,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused incorrect scenario must be Pending</t:label>
@@ -29,7 +31,9 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../focus-1.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../focus-1.xspec">
       <t:label>a focused correct scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -42,7 +46,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../focus-1.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../focus-1.xspec">
       <t:label>a focused incorrect scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -58,4 +64,4 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/focus-2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-2-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../focus-2.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../focus-2.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../focus-2.xspec"
                pending="testing x:pending">
       <t:label>an unfocused correct scenario in x:pending must be Pending</t:label>
@@ -16,7 +17,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../focus-2.xspec">
       <t:label>a focused correct scenario in x:pending</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -29,7 +32,8 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
                xspec="../../focus-2.xspec"
                pending="testing @focus in x:pending">
       <t:label>a non-pending correct scenario alongside a focused scenario must be Pending</t:label>
@@ -42,7 +46,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../focus-2.xspec">
       <t:label>a focused correct scenario alongside another focused scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -55,7 +61,8 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario5"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
                xspec="../../focus-2.xspec"
                pending="testing @pending without @focus">
       <t:label>a correct scenario with @pending must be Pending</t:label>
@@ -68,7 +75,9 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario6" xspec="../../focus-2.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../focus-2.xspec">
       <t:label>a correct scenario with both @pending and @focus (not recommended as ambiguous)</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -81,4 +90,4 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../format-xspec-report-folding.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../format-xspec-report-folding.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
                id="scenario1"
                xspec="../../focus-1.xspec"
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused correct scenario must be Pending</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:x="http://www.jenitennison.com/xslt/xspec"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="my:square">
          <t:param select="3"/>
@@ -23,6 +24,7 @@
                pending="testing @focus of a correct scenario">
       <t:label>an unfocused incorrect scenario must be Pending</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:x="http://www.jenitennison.com/xslt/xspec"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="my:square">
          <t:param select="2"/>
@@ -36,6 +38,7 @@
                xspec="../../focus-1.xspec">
       <t:label>a focused correct scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:x="http://www.jenitennison.com/xslt/xspec"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="my:square">
          <t:param select="3"/>
@@ -51,6 +54,7 @@
                xspec="../../focus-1.xspec">
       <t:label>a focused incorrect scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
+              xmlns:x="http://www.jenitennison.com/xslt/xspec"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="my:square">
          <t:param select="2"/>
@@ -59,9 +63,10 @@
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
          <t:expect xmlns:my="http://example.org/ns/my"
+                   xmlns:x="http://www.jenitennison.com/xslt/xspec"
                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                    test="$t:result instance of xs:string"
                    select="()"/>
       </t:test>
    </t:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/function-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../function.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../function.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../function.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../function.xspec">
       <t:label>when calling a function and expecting correctly</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -23,7 +25,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../function.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../function.xspec">
       <t:label>when calling a function and expecting incorrectly</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -43,4 +47,4 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../import.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../import.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../import.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../import.xspec">
       <t:label>when testing a correct scenario in an importing file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -23,7 +25,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../import.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../import.xspec">
       <t:label>when testing an incorrect scenario in an importing file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -39,7 +43,9 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -52,7 +58,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../imported.xspec">
       <t:label>an incorrect scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -65,4 +73,4 @@
          <t:expect select="42"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../imported.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../imported.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../imported.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../imported.xspec">
       <t:label>a correct scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my" function="my:square">
          <t:param select="3"/>
@@ -14,7 +16,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../imported.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../imported.xspec">
       <t:label>an incorrect scenario in an imported file</t:label>
       <t:call xmlns:my="http://example.org/ns/my" function="my:square">
          <t:param select="2"/>
@@ -25,4 +29,4 @@
          <t:expect select="42"/>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-151.xspec"
-          stylesheet="../../issue-151.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-151.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-151.xspec"
+        stylesheet="../../issue-151.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-151.xspec">
       <x:label>When the result is a mixture of a typed element and a string</x:label>
       <x:call xmlns:test-mix="x-urn:test-mix" function="test-mix:element-and-string"/>
       <x:result select="/*">
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-element>
             <test-mix:fooElement xmlns:test-mix="x-urn:test-mix">
                <test-mix:barElement/>
             </test-mix:fooElement>
          </pseudo-element>
-         <pseudo-atomic-value xmlns="http://www.jenitennison.com/xslt/xspec">'string'</pseudo-atomic-value>
+         <pseudo-atomic-value>'string'</pseudo-atomic-value>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Result] in the failure report HTML must wrap element and string separately</x:label>
          <x:expect xmlns:test-mix="x-urn:test-mix" test="false()" select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-153.xspec"
-          stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-153.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-153.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-153.xspec">
       <x:label>When a function returns a local date time string</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="string">
          <x:param select="xs:dateTime('2000-01-01T12:00:00+12:00')"/>
@@ -24,4 +26,4 @@
                    select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-177.xspec"
-          stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-177.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-177.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-177.xspec">
       <x:label>Given the function returns &lt;foo /&gt;</x:label>
       <x:call function="exactly-one">
          <x:param as="element(foo)">
-            <foo/>
+            <foo xmlns=""/>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <foo/>
+         <foo xmlns=""/>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>When @test is "empty($x:result/self::element(foo))" (i.e. boolean),
@@ -30,11 +32,11 @@
 					"Expected Result" = "&lt;bar /&gt;"
 				with diff.</x:label>
          <x:result select="/element()">
-            <foo/>
+            <foo xmlns=""/>
          </x:result>
          <x:expect test="$x:result/self::element(foo)" select="/element()">
-            <bar/>
+            <bar xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-result.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-214.xspec"
-          stylesheet="../../issue-214.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-214.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-214.xspec"
+        stylesheet="../../issue-214.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-214.xspec">
       <x:label>input</x:label>
       <x:context>
-         <input/>
+         <input xmlns=""/>
       </x:context>
       <x:result select="/element()">
-         <output>
+         <output xmlns="">
 test
 </output>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>output</x:label>
          <x:expect select="/element()">
-            <output>
+            <output xmlns="">
 test
 </output>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-23_2.xspec"
-          stylesheet="../../issue-23_2.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-23_2.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-23_2.xspec"
+        stylesheet="../../issue-23_2.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-23_2.xspec">
       <x:label>Test</x:label>
       <x:context xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -18,4 +20,4 @@
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.xml
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-346.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-346.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-346.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-346.xspec">
       <x:label>When a function returns a node containing a space</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param as="element(p)" href="../../issue-346.xml" select="element(p)"/>
       </x:call>
       <x:result select="/element()">
-         <p>
+         <p xmlns="">
             <span>foo</span>
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"> </test:ws>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test"> </ws>
             <span>bar</span>
          </p>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>Expecting no space should be Failure</x:label>
          <x:expect select="/element()">
-            <p xmlns:mirror="x-urn:test:mirror">
+            <p xmlns:mirror="x-urn:test:mirror" xmlns="">
                <span>foo</span>
                <span>bar</span>
             </p>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
@@ -1,34 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-355.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-355.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-355.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-355.xspec">
       <x:label>xs:integer()</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
       </x:call>
       <x:result select="/*">
-         <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">xs:integer#1</pseudo-function>
+         <pseudo-function>xs:integer#1</pseudo-function>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-355.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-355.xspec">
       <x:label>Anonymous</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
               function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="function(*)" select="function($x){$x+1}"/>
       </x:call>
       <x:result select="/*">
-         <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">(anonymous-function)#1</pseudo-function>
+         <pseudo-function>(anonymous-function)#1</pseudo-function>
       </x:result>
       <x:test id="scenario2-expect1" successful="false">
          <x:label>Fail deliberately</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_1.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_1.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../issue-447_1.xspec"
                pending="x:pending/x:label containing }{">
       <x:label>should not affect test</x:label>
@@ -12,4 +13,4 @@
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_2.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_2.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../issue-447_2.xspec"
                pending="x:pending/@label containing }{">
       <x:label>should not affect test</x:label>
@@ -12,4 +13,4 @@
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-447_3.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-447_3.xspec" pending="}{">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-447_3.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-447_3.xspec"
+               pending="}{">
       <x:label>x:scenario/@pending containing curly brackets should not affect test</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:test id="scenario1-expect1" pending="}{">
          <x:label>(This x:expect doesn't matter)</x:label>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-448-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-448-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-448.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-448.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-448.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-448.xspec">
       <x:label>x:scenario/</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../issue-448.xspec">
          <x:label>x:label containing }{ should not affect test</x:label>
@@ -24,4 +26,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-449-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-449-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-449.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-449.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-449.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-449.xspec">
       <x:label>x:expect/</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -16,4 +18,4 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-450-451.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-450-451.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-450-451.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-450-451.xspec">
       <x:label>function-param containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
               function="mirror:param-mirror">
-         <x:param>}{<elem attr="}{">}{</elem>
+         <x:param>}{<elem xmlns="" attr="}{">}{</elem>
          </x:param>
       </x:call>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-450-451.xspec">
       <x:label>global-param containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -31,16 +36,19 @@
          <x:label>should work</x:label>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:expect xmlns:mirror="x-urn:test:mirror"
                    xmlns:myv="http://example.org/ns/my/variable"
                    test="$global-param treat as node()+"
-                   select="/node()">}{<elem attr="}{">}{</elem>
+                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-450-451.xspec">
       <x:label>global-var containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -50,16 +58,19 @@
          <x:label>should work</x:label>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:expect xmlns:mirror="x-urn:test:mirror"
                    xmlns:myv="http://example.org/ns/my/variable"
                    test="$myv:global-var treat as node()+"
-                   select="/node()">}{<elem attr="}{">}{</elem>
+                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../issue-450-451.xspec">
       <x:label>local variable containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
@@ -68,32 +79,38 @@
       </x:call>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario4-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../issue-450-451.xspec">
       <x:label>assertion containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
               function="mirror:param-mirror">
          <x:param href="../../issue-450-451.xml" select="wrap/node() treat as node()+"/>
       </x:call>
-      <x:result select="/node()">}{<elem attr="}{">}{</elem>
+      <x:result select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario5-expect1" successful="true">
          <x:label>should work</x:label>
          <x:expect select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../issue-450-451.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../issue-450-451.xspec">
       <x:label>If value is from a variable instead of hard-coded,</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../issue-450-451.xspec">
          <x:label>function-param containing curly brackets</x:label>
@@ -104,11 +121,12 @@
          </x:call>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="true">
             <x:label>should work</x:label>
-            <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+            <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -119,15 +137,16 @@
                  function="mirror:param-mirror">
             <x:param href="../../issue-450-451.xml" select="wrap/node() treat as node()+"/>
          </x:call>
-         <x:result select="/node()">}{<elem attr="}{">}{</elem>
+         <x:result select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="true">
             <x:label>should work</x:label>
             <x:expect select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                      xmlns:myv="http://example.org/ns/my/variable"
+                     xmlns=""
                      attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
@@ -1,62 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-450-451_stylesheet.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-450-451_stylesheet.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-450-451_stylesheet.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-450-451_stylesheet.xspec">
       <x:label>context template-param containing curly brackets</x:label>
       <x:context xmlns:mirror="x-urn:test:mirror"
                  xmlns:myv="http://example.org/ns/my/variable"
                  mode="mirror:param-mirror">
-         <x:param name="param-items">}{<elem attr="}{">}{</elem>
+         <x:param name="param-items">}{<elem xmlns="" attr="}{">}{</elem>
          </x:param>
-         <context-child/>
+         <context-child xmlns=""/>
       </x:context>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-450-451_stylesheet.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-450-451_stylesheet.xspec">
       <x:label>context containing curly brackets</x:label>
       <x:context xmlns:mirror="x-urn:test:mirror"
                  xmlns:myv="http://example.org/ns/my/variable"
-                 mode="mirror:context-mirror">}{<elem attr="}{">}{</elem>
+                 mode="mirror:context-mirror">}{<elem xmlns="" attr="}{">}{</elem>
       </x:context>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-450-451_stylesheet.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-450-451_stylesheet.xspec">
       <x:label>template-call template-param containing curly brackets</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:myv="http://example.org/ns/my/variable"
               template="mirror:param-mirror">
-         <x:param name="param-items">}{<elem attr="}{">}{</elem>
+         <x:param name="param-items">}{<elem xmlns="" attr="}{">}{</elem>
          </x:param>
       </x:call>
       <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                xmlns:myv="http://example.org/ns/my/variable"
+               xmlns=""
                attr="}{">}{</elem>
       </x:result>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>should work</x:label>
-         <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../issue-450-451_stylesheet.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../issue-450-451_stylesheet.xspec">
       <x:label>If value is from a variable instead of hard-coded,</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../issue-450-451_stylesheet.xspec">
          <x:label>context template-param containing curly brackets</x:label>
@@ -64,15 +75,16 @@
                     xmlns:myv="http://example.org/ns/my/variable"
                     mode="mirror:param-mirror">
             <x:param name="param-items" select="$myv:local-var"/>
-            <context-child/>
+            <context-child xmlns=""/>
          </x:context>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>should work</x:label>
-            <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+            <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -84,11 +96,12 @@
                     select="$myv:local-var"/>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>should work</x:label>
-            <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+            <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -101,13 +114,14 @@
          </x:call>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
+                  xmlns=""
                   attr="}{">}{</elem>
          </x:result>
          <x:test id="scenario4-scenario3-expect1" successful="true">
             <x:label>should work</x:label>
-            <x:expect select="/node()">}{<elem attr="}{">}{</elem>
+            <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-452.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-452.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-452.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-452.xspec">
       <x:label>Text</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>t</x:param>
@@ -14,7 +16,9 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-452.xspec">
       <x:label>Comment</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param><!--c--></x:param>
@@ -25,7 +29,9 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-452.xspec">
       <x:label>Processing instruction</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param><?p?></x:param>
@@ -36,19 +42,21 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../issue-452.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../issue-452.xspec">
       <x:label>In element</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>
-            <elem>t<!--c--><?p?></elem>
+            <elem xmlns="">t<!--c--><?p?></elem>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <elem xmlns:mirror="x-urn:test:mirror">t<!--c--><?p?></elem>
+         <elem xmlns:mirror="x-urn:test:mirror" xmlns="">t<!--c--><?p?></elem>
       </x:result>
       <x:test id="scenario4-expect1" successful="false">
          <x:label>Expect</x:label>
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-467.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-467.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-467.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-467.xspec">
       <x:label>Testing namespace differences</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param>
@@ -38,4 +40,4 @@
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-50.xspec"
-          stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-50.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-50.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-50.xspec">
       <x:label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="xs:untypedAtomic">
          <x:param select="'0123'"/>
@@ -15,4 +17,4 @@
          <x:expect select="Q{http://www.w3.org/2001/XMLSchema}hexBinary('0123')"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-528.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-528.xspec" pending="Focus on 1-2">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-528.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-528.xspec"
+               pending="Focus on 1-2">
       <x:label>Scenario 1</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:true"/>
       <x:test id="scenario1-expect1" pending="Focus on 1-2">
@@ -28,4 +31,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-55.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-55.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-55.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-55.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -25,4 +27,4 @@
          <x:expect select="1"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-67.xspec"
-          stylesheet="../../../../items.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-67.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-67.xspec"
+        stylesheet="../../../../items.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing identical namespace</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>must be Success</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../issue-67.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing identical default namespace</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}default-namespace"/>
@@ -37,21 +39,21 @@
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../issue-67.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../issue-67.xspec">
       <x:label>Comparing different namespaces</x:label>
       <x:call function="exactly-one">
          <x:param select="$Q{x-urn:test:xspec-items}namespace"/>
       </x:call>
       <x:result select="/*/namespace::*">
-         <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         <pseudo-namespace-node xmlns:namespace-name="namespace-text"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>must be Failure</x:label>
          <x:expect select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-778_ws.xspec"
-          stylesheet="../../issue-778_ws.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-778_ws.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-778_ws.xspec"
+        stylesheet="../../issue-778_ws.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-778_ws.xspec">
       <x:label>When transforming DITA</x:label>
       <x:context href="../../issue-778_ws.dita"/>
-      <x:result select="/text()"># My Title<test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">
-</test:ws>
-         <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">
-</test:ws>This is a topic.<test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">
-</test:ws>
-         <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">
-</test:ws>This is a paragraph.<test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">
-</test:ws>
+      <x:result select="/text()"># My Title<ws xmlns="http://www.jenitennison.com/xslt/unit-test">
+</ws>
+         <ws xmlns="http://www.jenitennison.com/xslt/unit-test">
+</ws>This is a topic.<ws xmlns="http://www.jenitennison.com/xslt/unit-test">
+</ws>
+         <ws xmlns="http://www.jenitennison.com/xslt/unit-test">
+</ws>This is a paragraph.<ws xmlns="http://www.jenitennison.com/xslt/unit-test">
+</ws>
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>we get markdown</x:label>
@@ -26,4 +28,4 @@ This is a paragraph.
 </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-793-cr.xspec"
-          stylesheet="../../issue-793-cr.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-793-cr.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-793-cr.xspec"
+        stylesheet="../../issue-793-cr.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-793-cr.xspec">
       <x:label>input</x:label>
       <x:context>
-         <input/>
+         <input xmlns=""/>
       </x:context>
       <x:result select="/element()">
-         <output>
+         <output xmlns="">
 test
 </output>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>output</x:label>
          <x:expect select="/element()">
-            <output>
+            <output xmlns="">
 test
 </output>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-793-crlf.xspec"
-          stylesheet="../../issue-793-crlf.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-793-crlf.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-793-crlf.xspec"
+        stylesheet="../../issue-793-crlf.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-793-crlf.xspec">
       <x:label>input</x:label>
       <x:context>
-         <input/>
+         <input xmlns=""/>
       </x:context>
       <x:result select="/element()">
-         <output>
+         <output xmlns="">
 test
 </output>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>output</x:label>
          <x:expect select="/element()">
-            <output>
+            <output xmlns="">
 test
 </output>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../issue-793-lf.xspec"
-          stylesheet="../../issue-793-lf.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../issue-793-lf.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-793-lf.xspec"
+        stylesheet="../../issue-793-lf.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../issue-793-lf.xspec">
       <x:label>input</x:label>
       <x:context>
-         <input/>
+         <input xmlns=""/>
       </x:context>
       <x:result select="/element()">
-         <output>
+         <output xmlns="">
 test
 </output>
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>output</x:label>
          <x:expect select="/element()">
-            <output>
+            <output xmlns="">
 test
 </output>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../label-element.xspec"
-          stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../label-element.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../label-element.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -22,7 +24,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -41,7 +45,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../label-element.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../label-element.xspec">
       <x:label>	
 &#xD; 	
 &#xD; My	
@@ -60,4 +66,4 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../mode-all.xspec"
-          stylesheet="../../mode-all.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../mode-all.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../mode-all.xspec"
+        stylesheet="../../mode-all.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../mode-all.xspec">
       <x:label>context</x:label>
       <x:context>
-         <foo/>
+         <foo xmlns=""/>
       </x:context>
       <x:result select="'Caught by #all mode'"/>
       <x:test id="scenario1-expect1" successful="true">
@@ -16,11 +18,13 @@
       <x:test id="scenario1-expect2" successful="false">
          <x:label>should report Expected Result correctly on failure</x:label>
          <x:expect select="/element()">
-            <expected-element/>
+            <expected-element xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../mode-all.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../mode-all.xspec">
       <x:label>function-call</x:label>
       <x:call function="string">
          <x:param select="'Returned from function'"/>
@@ -33,11 +37,13 @@
       <x:test id="scenario2-expect2" successful="false">
          <x:label>should report Expected Result correctly on failure</x:label>
          <x:expect select="/element()">
-            <expected-element/>
+            <expected-element xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../mode-all.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../mode-all.xspec">
       <x:label>template-call</x:label>
       <x:call template="named-template"/>
       <x:result select="'Returned from named template'"/>
@@ -48,8 +54,8 @@
       <x:test id="scenario3-expect2" successful="false">
          <x:label>should report Expected Result correctly on failure</x:label>
          <x:expect select="/element()">
-            <expected-element/>
+            <expected-element xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../pending.xspec"
-          stylesheet="../../../../square.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1"
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../pending.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
                xspec="../../pending.xspec"
                pending="testing x:pending">
       <t:label>a correct scenario in x:pending must be Pending</t:label>
@@ -16,7 +17,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
                xspec="../../pending.xspec"
                pending="testing x:pending">
       <t:label>an incorrect scenario in x:pending must be Pending</t:label>
@@ -29,7 +31,9 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario3" xspec="../../pending.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../pending.xspec">
       <t:label>a non-pending correct scenario alongside a pending scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -42,7 +46,9 @@
          <t:expect select="9"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario4" xspec="../../pending.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../pending.xspec">
       <t:label>a non-pending incorrect scenario alongside a pending scenario</t:label>
       <t:call xmlns:my="http://example.org/ns/my"
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -58,7 +64,8 @@
                    select="()"/>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario5"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
                xspec="../../pending.xspec"
                pending="testing @pending of a correct scenario">
       <t:label>a correct scenario with @pending must be Pending</t:label>
@@ -71,7 +78,8 @@
          <t:label>it would return Success if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario6"
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
                xspec="../../pending.xspec"
                pending="testing @pending of an incorrect scenario">
       <t:label>an incorrect scenario with @pending must be Pending</t:label>
@@ -85,4 +93,4 @@
          <t:label>it would return Failure if it were not Pending</t:label>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../report.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../report.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../report.xspec">
       <x:label>Function (xspec/xspec#355)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report.xspec">
          <x:label>Array</x:label>
@@ -11,7 +13,7 @@
             <x:param as="array(*)" select="['foo', 1, [2, 'bar']]"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-array xmlns="http://www.jenitennison.com/xslt/xspec">["foo",1,[2,"bar"]]</pseudo-array>
+            <pseudo-array>["foo",1,[2,"bar"]]</pseudo-array>
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="false">
             <x:label>Serialized array should be reported upon failure</x:label>
@@ -24,7 +26,7 @@
             <x:param as="map(*)" select="      map {       'foo': 1,       2: 'bar'      }"/>
          </x:call>
          <x:result select="/*">
-            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{2:"bar","foo":1}</pseudo-map>
+            <pseudo-map>map{2:"bar","foo":1}</pseudo-map>
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="false">
             <x:label>Serialized map should be reported upon failure</x:label>
@@ -32,64 +34,72 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../report.xspec">
       <x:label>Element, attribute (xspec/xspec#357)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="elem1 | elem2/attribute()">
-            <elem1>text</elem1>
-            <elem2 attr="attr-val"/>
+            <elem1 xmlns="">text</elem1>
+            <elem2 xmlns="" attr="attr-val"/>
          </x:param>
       </x:call>
       <x:result select="/*/(@* | node())">
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-element>
             <elem1 xmlns="">text</elem1>
          </pseudo-element>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="attr-val"/>
+         <pseudo-attribute attr="attr-val"/>
       </x:result>
       <x:test id="scenario2-expect1" successful="false">
          <x:label>@attr should be reported as an attribute</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../report.xspec">
       <x:label>Attributes of the same name (xspec/xspec#358)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="attribute()+" select="element()/attribute()">
-            <elem1 attr="foo"/>
-            <elem2 attr="bar"/>
+            <elem1 xmlns="" attr="foo"/>
+            <elem2 xmlns="" attr="bar"/>
          </x:param>
       </x:call>
       <x:result select="/*/@*">
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="foo"/>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="bar"/>
+         <pseudo-attribute attr="foo"/>
+         <pseudo-attribute attr="bar"/>
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>Both @attr=foo and @attr=bar should be reported</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../report.xspec">
       <x:label>Attribute, element, attribute (xspec/xspec#360)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param as="node()+" select="element()/attribute() | elem2">
-            <elem1 attr1="attr1-val"/>
-            <elem2>text</elem2>
-            <elem3 attr3="attr3-val"/>
+            <elem1 xmlns="" attr1="attr1-val"/>
+            <elem2 xmlns="">text</elem2>
+            <elem3 xmlns="" attr3="attr3-val"/>
          </x:param>
       </x:call>
       <x:result select="/*/(@* | node())">
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr1="attr1-val"/>
-         <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
+         <pseudo-attribute attr1="attr1-val"/>
+         <pseudo-element>
             <elem2 xmlns="">text</elem2>
          </pseudo-element>
-         <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr3="attr3-val"/>
+         <pseudo-attribute attr3="attr3-val"/>
       </x:result>
       <x:test id="scenario4-expect1" successful="false">
          <x:label>[Result] should be reported</x:label>
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../report.xspec">
       <x:label>Document node with no children (xspec/xspec#697)</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param select="parse-xml-fragment('')"/>
@@ -100,22 +110,24 @@
          <x:expect select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../report.xspec">
       <x:label>XPath is different, but serialized node looks as if same</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../report.xspec">
          <x:label>[Result] = document node, [Expected Result] = element</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="document-node()" select="/">
-               <test/>
+               <test xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/self::document-node()">
-            <test/>
+            <test xmlns=""/>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="false">
             <x:label>XPath should be colored as different. Serialized node should be colored as same.</x:label>
             <x:expect select="/element()">
-               <test/>
+               <test xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -123,21 +135,23 @@
          <x:label>[Result] = element, [Expected Result] = document node.</x:label>
          <x:call function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element()">
-               <test/>
+               <test xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <test/>
+            <test xmlns=""/>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>XPath should be colored as different. Serialized node should be colored as same.</x:label>
             <x:expect select="/self::document-node()">
-               <test/>
+               <test xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../report.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../report.xspec">
       <x:label>Sequence of multiple atomic values</x:label>
       <x:call function="Q{x-urn:test:mirror}param-mirror">
          <x:param select="'foo', 1, 2, 'bar'"/>
@@ -148,4 +162,4 @@
          <x:expect select="QName('', 'foo'),&#xA;1,&#xA;2,&#xA;'bar'"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../report_schema-aware.xspec"
-          stylesheet="../../../../do-nothing.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../report_schema-aware.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report_schema-aware.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../report_schema-aware.xspec">
       <x:label>In a failure report HTML</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../report_schema-aware.xspec">
          <x:label>Derived string types</x:label>
@@ -287,4 +289,4 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../result-naming-collision.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../result-naming-collision.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../result-naming-collision.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../result-naming-collision.xspec">
       <x:label>scenario 1</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param href="../../result-naming-collision.xml"/>
@@ -14,7 +16,9 @@
          <x:expect href="HREF-3"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../result-naming-collision.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../result-naming-collision.xspec">
       <x:label>scenario 2</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param href="../../result-naming-collision.xml"/>
@@ -25,7 +29,9 @@
          <x:expect href="HREF-6"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../result-naming-collision.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../result-naming-collision.xspec">
       <x:label>When the result consists of multiple elements (xspec/xspec#361)</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:param-mirror">
          <x:param href="../../result-naming-collision.xml" select="., ."/>
@@ -41,8 +47,8 @@
       <x:test id="scenario3-expect2" successful="false">
          <x:label>The result should be saved successfully in yet another external file which is well-formed</x:label>
          <x:expect select="/element()">
-            <foo xmlns:mirror="x-urn:test:mirror"/>
+            <foo xmlns:mirror="x-urn:test:mirror" xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/rule-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/rule-result.xml
@@ -1,36 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:report xmlns:t="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../rule.xspec"
-          stylesheet="../../rule.xsl"
-          date="2000-01-01T00:00:00Z">
-   <t:scenario id="scenario1" xspec="../../rule.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../rule.xspec"
+        stylesheet="../../rule.xsl"
+        date="2000-01-01T00:00:00Z">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../rule.xspec">
       <t:label>x:context with correct x:expect</t:label>
       <t:context>
-         <rule/>
+         <rule xmlns=""/>
       </t:context>
       <t:result select="/element()">
-         <transformed/>
+         <transformed xmlns=""/>
       </t:result>
       <t:test id="scenario1-expect1" successful="true">
          <t:label>must return Success</t:label>
          <t:expect select="/element()">
-            <transformed/>
+            <transformed xmlns=""/>
          </t:expect>
       </t:test>
    </t:scenario>
-   <t:scenario id="scenario2" xspec="../../rule.xspec">
+   <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../rule.xspec">
       <t:label>x:context with incorrect x:expect</t:label>
       <t:context>
-         <rule/>
+         <rule xmlns=""/>
       </t:context>
       <t:result select="/element()">
-         <transformed/>
+         <transformed xmlns=""/>
       </t:result>
       <t:test id="scenario2-expect1" successful="false">
          <t:label>must return Failure</t:label>
          <t:expect select="/element()">
-            <erroneous/>
+            <erroneous xmlns=""/>
          </t:expect>
       </t:test>
    </t:scenario>
-</t:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../serialize.xspec"
-          stylesheet="../../../../items.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../serialize.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../serialize.xspec"
+        stylesheet="../../../../items.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../serialize.xspec">
       <x:label>When the result is a comment node, the report HTML must serialize it as
 			&lt;!-- --&gt;. (xspec/xspec#356) So...</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../serialize.xspec">
@@ -32,7 +34,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../serialize.xspec">
       <x:label>When the result is indented in the report XML file, the report HTML must serialize
 			it with indentation.</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../serialize.xspec">
@@ -42,21 +46,21 @@
 					elements serialized with indentation,</x:label>
             <x:call function="one-or-more">
                <x:param as="element()+">
-                  <foo/>
-                  <bar>
+                  <foo xmlns=""/>
+                  <bar xmlns="">
                      <baz/>
                   </bar>
-                  <qux>
+                  <qux xmlns="">
                      <quux/>
                   </qux>
                </x:param>
             </x:call>
             <x:result select="/element()">
-               <foo/>
-               <bar>
+               <foo xmlns=""/>
+               <bar xmlns="">
                   <baz/>
                </bar>
-               <qux>
+               <qux xmlns="">
                   <quux/>
                </qux>
             </x:result>
@@ -80,11 +84,11 @@
                <x:label>all elements in [Expected Result] with diff must be serialized with
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <foo/>
-                  <bar>
+                  <foo xmlns=""/>
+                  <bar xmlns="">
                      <baz/>
                   </bar>
-                  <qux>
+                  <qux xmlns="">
                      <quux/>
                   </qux>
                </x:expect>
@@ -102,7 +106,7 @@
 						x:result of the report XML file,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <elem1><!--foo-->
                            <bar/>
                         </elem1>
@@ -111,7 +115,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <elem1><!--foo-->
                         <bar/>
                      </elem1>
@@ -121,7 +125,7 @@
                <x:test id="scenario2-scenario2-scenario1-scenario1-expect1" successful="false">
                   <x:label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <elem1>foo<bar/>
                         </elem1>
                         <elem2>foo<?bar?></elem2>
@@ -135,7 +139,7 @@
 						x:expect of the report XML file,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <elem1>foo<bar/>
                         </elem1>
                         <elem2>foo<?bar?></elem2>
@@ -143,7 +147,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <elem1>foo<bar/>
                      </elem1>
                      <elem2>foo<?bar?></elem2>
@@ -152,7 +156,7 @@
                <x:test id="scenario2-scenario2-scenario1-scenario2-expect1" successful="false">
                   <x:label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <elem1><!--foo-->
                            <bar/>
                         </elem1>
@@ -172,7 +176,7 @@
 						length,</x:label>
                <x:call function="exactly-one">
                   <x:param as="element(test)">
-                     <test>
+                     <test xmlns="">
                         <foo>
                            <bar/>
                         </foo>
@@ -181,7 +185,7 @@
                   </x:param>
                </x:call>
                <x:result select="/element()">
-                  <test>
+                  <test xmlns="">
                      <foo>
                         <bar/>
                      </foo>
@@ -191,7 +195,7 @@
                <x:test id="scenario2-scenario2-scenario2-scenario1-expect1" successful="false">
                   <x:label>&lt;foo&gt; must be green.</x:label>
                   <x:expect select="/element()">
-                     <test>
+                     <test xmlns="">
                         <foo>
                            <bar/>
                         </foo>
@@ -203,18 +207,20 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../serialize.xspec">
       <x:label>When x:expect has an element of '...',</x:label>
       <x:call function="exactly-one">
          <x:param as="element(foo)">
-            <foo>
+            <foo xmlns="">
                <bar/>
                <baz/>
             </foo>
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <foo>
+         <foo xmlns="">
             <bar/>
             <baz/>
          </foo>
@@ -223,16 +229,18 @@
          <x:label>the corresponding nodes in [Result] with diff must be serialized in green.
 				(xspec/xspec#379)</x:label>
          <x:expect select="/element()">
-            <foo>...</foo>
-            <qux/>
+            <foo xmlns="">...</foo>
+            <qux xmlns=""/>
          </x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains significant text nodes,</x:label>
       <x:call function="exactly-one">
          <x:param as="element(test)">
-            <test>
+            <test xmlns="">
                <oridinary-text-node>
                   <same>same</same>
                   <diff>actual</diff>
@@ -247,16 +255,16 @@
          </x:param>
       </x:call>
       <x:result select="/element()">
-         <test>
+         <test xmlns="">
             <oridinary-text-node>
                <same>same</same>
                <diff>actual</diff>
             </oridinary-text-node>
             <significant-whitespace-only-text-node>
-               <same xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></same>
-               <diff xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></diff>
+               <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></same>
+               <diff xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></diff>
             </significant-whitespace-only-text-node>
          </test>
       </x:result>
@@ -264,16 +272,16 @@
          <x:label>both in [Result] and [Expected Result] with diff, the significant text nodes
 				must be serialized with color. (xspec/xspec#386)</x:label>
          <x:expect select="/element()">
-            <test>
+            <test xmlns="">
                <oridinary-text-node>
                   <same>same</same>
                   <diff>expect</diff>
                </oridinary-text-node>
                <significant-whitespace-only-text-node>
-                  <same xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws></same>
-                  <diff xml:space="preserve"><test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"> 	
-&#xD;</test:ws></diff>
+                  <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws></same>
+                  <diff xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/unit-test"> 	
+&#xD;</ws></diff>
                </significant-whitespace-only-text-node>
             </test>
          </x:expect>
@@ -284,7 +292,9 @@
          <x:expect test="false()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains an element, the report HTML must serialize nodes in its
 			opening tag with aligned indentation. (xspec/xspec#689) So...</x:label>
       <x:scenario id="scenario5-scenario1" xspec="../../serialize.xspec">
@@ -295,7 +305,7 @@
                <x:param select="$test"/>
             </x:call>
             <x:result select="/element()">
-               <looooooooooooooooooooooooooooooooooong>
+               <looooooooooooooooooooooooooooooooooong xmlns="">
                   <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                      <a/>
                   </test>
@@ -320,7 +330,7 @@
                <x:label>[Expected Result] with diff must be serialized with aligned
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <looooooooooooooooooooooooooooooooooong>
+                  <looooooooooooooooooooooooooooooooooong xmlns="">
                      <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
                         <a/>
                      </test>
@@ -337,7 +347,7 @@
                <x:param select="$test"/>
             </x:call>
             <x:result select="/element()">
-               <looooooooooooooooooooooooooooooooooong>
+               <looooooooooooooooooooooooooooooooooong xmlns="">
                   <test attr1="val1" attr2="val2" attr3="val3">
                      <a/>
                   </test>
@@ -362,7 +372,7 @@
                <x:label>[Expected Result] with diff must be serialized with aligned
 						indentation.</x:label>
                <x:expect select="/element()">
-                  <looooooooooooooooooooooooooooooooooong>
+                  <looooooooooooooooooooooooooooooooooong xmlns="">
                      <test attr1="val1" attr2="val2" attr3="val3">
                         <a/>
                      </test>
@@ -372,21 +382,23 @@
          </x:scenario>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains attribute,</x:label>
       <x:call function="one-or-more">
          <x:param>
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:param>
       </x:call>
       <x:scenario id="scenario6-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:result>
          <x:test id="scenario6-scenario1-expect1" successful="false">
             <x:label>The exact-match (taking '...' into account) attributes must be serialized
@@ -394,18 +406,18 @@
 					palePink="solidPink". The orphan attributes must be serialized as
 					solidPink="solidPink" regardless of their values.</x:label>
             <x:expect select="/element()">
-               <exact-match attr1="value1" attr2="..." attr3="" attr4="..."/>
-               <name-match attr1="VALUE1" attr2="" attr3="value3" attr4="value4"/>
-               <orphan attr4="value4" attr5="" attr6="..."/>
+               <exact-match xmlns="" attr1="value1" attr2="..." attr3="" attr4="..."/>
+               <name-match xmlns="" attr1="VALUE1" attr2="" attr3="value3" attr4="value4"/>
+               <orphan xmlns="" attr4="value4" attr5="" attr6="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario6-scenario2" xspec="../../serialize.xspec">
          <x:label>in [Result] without diff,</x:label>
          <x:result select="/element()">
-            <exact-match attr1="value1" attr2="value2" attr3="" attr4=""/>
-            <name-match attr1="value1" attr2="value2" attr3="" attr4="..."/>
-            <orphan attr1="value1" attr2="" attr3="..."/>
+            <exact-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4=""/>
+            <name-match xmlns="" attr1="value1" attr2="value2" attr3="" attr4="..."/>
+            <orphan xmlns="" attr1="value1" attr2="" attr3="..."/>
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>all the attributes must be serialized without color.</x:label>
@@ -413,14 +425,16 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../serialize.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../serialize.xspec">
       <x:label>When the result contains processing instructions,</x:label>
       <x:call function="one-or-more">
          <x:param>
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -437,10 +451,10 @@
       <x:scenario id="scenario7-scenario1" xspec="../../serialize.xspec">
          <x:label>both in [Result] and [Expected Result] with diff,</x:label>
          <x:result select="/element()">
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -462,10 +476,10 @@
 					instructions must be serialized as &lt;?solidPink solidPink?&gt;
 					regardless of their values.</x:label>
             <x:expect select="/element()">
-               <exact-match><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>
-               <name-match><?node1 VALUE1?><?node2?><?node3 value3?><?node4 value4?></name-match>
-               <value-match><?NODE1 value1?><?NODE2 ...?><?NODE3?><?NODE4 ...?></value-match>
-               <no-match>
+               <exact-match xmlns=""><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>
+               <name-match xmlns=""><?node1 VALUE1?><?node2?><?node3 value3?><?node4 value4?></name-match>
+               <value-match xmlns=""><?NODE1 value1?><?NODE2 ...?><?NODE3?><?NODE4 ...?></value-match>
+               <no-match xmlns="">
                   <different-kind>
                      <node1/>
                      <?node2 value2?>
@@ -484,10 +498,10 @@
       <x:scenario id="scenario7-scenario2" xspec="../../serialize.xspec">
          <x:label>in [Result] without diff,</x:label>
          <x:result select="/element()">
-            <exact-match><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
-            <name-match><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
-            <value-match><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
-            <no-match>
+            <exact-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></exact-match>
+            <name-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4 ...?></name-match>
+            <value-match xmlns=""><?node1 value1?><?node2 value2?><?node3?><?node4?></value-match>
+            <no-match xmlns="">
                <different-kind><?node1 value1?>
                   <node2/>
                   <?node3?>
@@ -506,4 +520,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../shared-like.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../shared-like.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../shared-like.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../shared-like.xspec">
       <x:label>Referenced and explicitly unshared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -12,7 +14,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../shared-like.xspec">
       <x:label>Referenced and implicitly unshared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -21,7 +25,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../shared-like.xspec">
       <x:label>Scenario for testing x:like which references a shared scenario</x:label>
       <x:call xmlns:mirror="x-urn:test:mirror" function="mirror:false"/>
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
@@ -34,7 +40,9 @@
          <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../shared-like.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../shared-like.xspec">
       <x:label>Scenario for testing x:like which references unshared scenarios</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../shared-like.xspec">
          <x:label>explicit one</x:label>
@@ -55,4 +63,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../three-dots.xspec"
-          stylesheet="../../three-dots.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../three-dots.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../three-dots.xspec"
+        stylesheet="../../three-dots.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (simple)</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -11,18 +13,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem>text</elem>
+               <elem xmlns="">text</elem>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">text</elem>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text</elem>
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
@@ -36,18 +38,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem/>
+               <elem xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario2-expect2" successful="false">
@@ -55,7 +57,7 @@
 				&lt;elem attrib="..." /&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="..."/>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -65,18 +67,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem>...</elem>
+               <elem xmlns="">...</elem>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
          </x:result>
          <x:test id="scenario1-scenario3-expect1" successful="true">
             <x:label>expecting
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
          <x:test id="scenario1-scenario3-expect2" successful="true">
@@ -88,12 +90,14 @@
 				&lt;elem&gt;text&lt;/elem&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">text</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (with attribute)</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -101,18 +105,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(elem)">
-               <elem attrib="val"/>
+               <elem xmlns="" attrib="val"/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="val"/>
+            <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="val"/>
          </x:result>
          <x:test id="scenario2-scenario1-expect1" successful="true">
             <x:label>expecting
 				&lt;elem attrib="..." /&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" attrib="..."/>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="" attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario2-scenario1-expect2" successful="true">
@@ -124,12 +128,14 @@
 				&lt;elem&gt;...&lt;/elem&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema">...</elem>
+               <elem xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</elem>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario3" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario3"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant element (with mixed content)</x:label>
       <x:scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -137,13 +143,13 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(outer)">
-               <outer>text<inner1/>
+               <outer xmlns="">text<inner1/>
                   <inner2/>
                </outer>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">text<inner1/>
+            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">text<inner1/>
                <inner2/>
             </outer>
          </x:result>
@@ -152,7 +158,7 @@
 				&lt;outer&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
@@ -160,7 +166,7 @@
 				&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...<inner1/>...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...<inner1/>...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario1-expect3" successful="true">
@@ -174,13 +180,13 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="element(outer)">
-               <outer>
+               <outer xmlns="">
                   <inner/>
                </outer>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">
                <inner/>
             </outer>
          </x:result>
@@ -189,7 +195,7 @@
 				&lt;outer&gt;...&lt;/outer&gt;
 				should be Success</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...</outer>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...</outer>
             </x:expect>
          </x:test>
          <x:test id="scenario3-scenario2-expect2" successful="false">
@@ -197,13 +203,15 @@
 				&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;
 				should be Failure</x:label>
             <x:expect select="/element()">
-               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema">...<inner/>
+               <outer xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="">...<inner/>
                </outer>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario4" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario4"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant attribute</x:label>
       <x:scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -211,18 +219,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib="val"/>
+               <elem xmlns="" attrib="val"/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="val"/>
+            <pseudo-attribute attrib="val"/>
          </x:result>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario4-scenario1-expect2" successful="true">
@@ -236,18 +244,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib=""/>
+               <elem xmlns="" attrib=""/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib=""/>
+            <pseudo-attribute attrib=""/>
          </x:result>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -257,18 +265,18 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
             <x:param as="attribute(attrib)" select="elem/@*">
-               <elem attrib="..."/>
+               <elem xmlns="" attrib="..."/>
             </x:param>
          </x:call>
          <x:result select="/*/@*">
-            <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+            <pseudo-attribute attrib="..."/>
          </x:result>
          <x:test id="scenario4-scenario3-expect1" successful="true">
             <x:label>expecting
 					 @attrib="..."
 					should be Success</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="..."/>
+               <pseudo-attribute attrib="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario4-scenario3-expect2" successful="true">
@@ -280,12 +288,14 @@
 					 @attrib="val"
 					should be Failure</x:label>
             <x:expect select="/*/@*">
-               <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attrib="val"/>
+               <pseudo-attribute attrib="val"/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario5" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario5"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant text node</x:label>
       <x:scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is usual text node</x:label>
@@ -308,8 +318,8 @@
             <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_whitespace-only"/>
          </x:call>
          <x:result select="/text()">
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test">	
-&#xD; </test:ws>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test">	
+&#xD; </ws>
          </x:result>
          <x:test id="scenario5-scenario2-expect1" successful="true">
             <x:label>expecting ... should be Success</x:label>
@@ -326,7 +336,7 @@
             <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_zero-length"/>
          </x:call>
          <x:result select="/text()">
-            <test:ws xmlns:test="http://www.jenitennison.com/xslt/unit-test"/>
+            <ws xmlns="http://www.jenitennison.com/xslt/unit-test"/>
          </x:result>
          <x:test id="scenario5-scenario3-expect1" successful="true">
             <x:label>expecting ... should be Success</x:label>
@@ -357,7 +367,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario6" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario6"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant comment</x:label>
       <x:scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -419,7 +431,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario7" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario7"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant processing instruction</x:label>
       <x:scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -481,7 +495,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario8" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario8"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant document node</x:label>
       <x:scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -492,7 +508,7 @@
                      select="$Q{x-urn:test:three-dots}document-node_multiple-nodes"/>
          </x:call>
          <x:result select="/self::document-node()"><?pi?><!--comment-->
-            <elem/>
+            <elem xmlns=""/>
          </x:result>
          <x:test id="scenario8-scenario1-expect1" successful="false">
             <x:label>expecting
@@ -552,7 +568,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario9" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario9"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant namespace node</x:label>
       <x:scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is
@@ -564,14 +582,14 @@
             <x:param select="'namespace-uri'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:prefix="namespace-uri"/>
          </x:result>
          <x:test id="scenario9-scenario1-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario1-expect2" successful="true">
@@ -614,14 +632,14 @@
             <x:param select="'...'"/>
          </x:call>
          <x:result select="/*/namespace::*">
-            <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns:prefix="..."/>
          </x:result>
          <x:test id="scenario9-scenario3-expect1" successful="true">
             <x:label>expecting
 					  xmlns:prefix="..."
 					should be Success</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="..."/>
             </x:expect>
          </x:test>
          <x:test id="scenario9-scenario3-expect2" successful="true">
@@ -633,12 +651,14 @@
 					  xmlns:prefix="namespace-uri"
 					should be Failure</x:label>
             <x:expect select="/*/namespace::*">
-               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns:prefix="namespace-uri"/>
             </x:expect>
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario10" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario10"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant sequence of multiple nodes</x:label>
       <x:scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is sequence of
@@ -646,19 +666,19 @@
 				</x:label>
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="one-or-more">
             <x:param as="element()+">
-               <elem1/>
-               <elem2/>
+               <elem1 xmlns=""/>
+               <elem2 xmlns=""/>
             </x:param>
          </x:call>
          <x:result select="/element()">
-            <elem1 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
-            <elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <elem1 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
+            <elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
          </x:result>
          <x:test id="scenario10-scenario1-expect1" successful="true">
             <x:label>expecting
 					  ...&lt;elem2 /&gt;
 					should be Success</x:label>
-            <x:expect select="/node()">...<elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+            <x:expect select="/node()">...<elem2 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns=""/>
             </x:expect>
          </x:test>
          <x:test id="scenario10-scenario1-expect2" successful="true">
@@ -679,7 +699,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario11" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario11"
+               xspec="../../three-dots.xspec">
       <x:label>When result is empty sequence</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="zero-or-one">
          <x:param select="()"/>
@@ -690,7 +712,9 @@
          <x:expect select="/text()">...</x:expect>
       </x:test>
    </x:scenario>
-   <x:scenario id="scenario12" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario12"
+               xspec="../../three-dots.xspec">
       <x:label>For resultant atomic value</x:label>
       <x:scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <x:label>When result is 'string'</x:label>
@@ -731,7 +755,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario13" xspec="../../three-dots.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario13"
+               xspec="../../three-dots.xspec">
       <x:label>For any resultant item</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" function="exactly-one">
          <x:param as="text()">item</x:param>
@@ -754,4 +780,4 @@
          <x:expect select="'...'"/>
       </x:test>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/tvt_label-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/tvt_label-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../tvt_label.xspec"
-          stylesheet="../../../../mirror.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../tvt_label.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../tvt_label.xspec"
+        stylesheet="../../../../mirror.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../tvt_label.xspec">
       <x:label>With @expand-text=yes</x:label>
       <x:scenario id="scenario1-scenario1" xspec="../../tvt_label.xspec">
          <x:label>}}{scenario}{{</x:label>
@@ -33,7 +35,9 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-   <x:scenario id="scenario2" xspec="../../tvt_label.xspec">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario2"
+               xspec="../../tvt_label.xspec">
       <x:label>With @expand-text=no</x:label>
       <x:scenario id="scenario2-scenario1" xspec="../../tvt_label.xspec">
          <x:label>}}{scenario}{{</x:label>
@@ -54,4 +58,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:report xmlns:x="http://www.jenitennison.com/xslt/xspec"
-          xspec="../../xslt2.xspec"
-          stylesheet="../../../../xslt1.xsl"
-          date="2000-01-01T00:00:00Z">
-   <x:scenario id="scenario1" xspec="../../../../xslt1.xspec">
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../xslt2.xspec"
+        stylesheet="../../../../xslt1.xsl"
+        date="2000-01-01T00:00:00Z">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               id="scenario1"
+               xspec="../../../../xslt1.xspec">
       <x:label>With 2 text nodes</x:label>
       <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema" template="text-nodes"/>
       <x:scenario id="scenario1-scenario1" xspec="../../../../xslt1.xspec">
@@ -61,4 +63,4 @@
          </x:test>
       </x:scenario>
    </x:scenario>
-</x:report>
+</report>

--- a/test/xspec-utils.xspec
+++ b/test/xspec-utils.xspec
@@ -9,6 +9,17 @@
 		/x:description/@stylesheet or @query-at.
 	-->
 
+	<x:scenario label="Scenario for testing variable legacy-namespace">
+		<x:call function="false" />
+		<x:expect label="'test' namespace URI"
+			select="
+				namespace-uri-for-prefix(
+					'test',
+					doc(resolve-uri('../src/compiler/generate-tests-utils.xsl', $x:xspec-uri))/element()
+				)"
+			test="$x:legacy-namespace treat as xs:anyURI" />
+	</x:scenario>
+
 	<x:scenario label="Scenario for testing variable xspec-namespace">
 		<x:call function="false" />
 		<x:expect label="XSpec namespace URI"

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -8,17 +8,6 @@
 		/x:description/@stylesheet.
 	-->
 
-	<x:scenario label="Scenario for testing variable legacy-namespace">
-		<x:context />
-		<x:expect label="'test' namespace URI"
-			select="
-				namespace-uri-for-prefix(
-					'test',
-					doc(resolve-uri('../src/compiler/generate-tests-utils.xsl', $x:xspec-uri))/element()
-				)"
-			test="$x:legacy-namespace treat as xs:anyURI" />
-	</x:scenario>
-
 	<x:scenario label="Scenario for testing variable xs-namespace">
 		<x:context />
 		<x:expect label="'xs' namespace URI"

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -70,7 +70,7 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
       </xsl:message>
       <!-- set up the result document (the report) -->
       <xsl:result-document format="Q{{http://www.jenitennison.com/xslt/xspec}}xml-report-serialization-parameters">
-         <xsl:element name="x:report" namespace="http://www.jenitennison.com/xslt/xspec">
+         <xsl:element name="report" namespace="http://www.jenitennison.com/xslt/xspec">
             <xsl:attribute name="xspec" namespace="">.../compilation-simple-suite.xspec</xsl:attribute>
             <xsl:attribute name="stylesheet" namespace="">.../compilation-simple-suite.xsl</xsl:attribute>
             <xsl:attribute name="date" namespace="" select="current-dateTime()"/>
@@ -146,7 +146,7 @@ $Q{http://www.jenitennison.com/xslt/xspec}result
 (: the query body of this main module, to run the suite :)
 (: set up the result document (the report) :)
 document {
-element { QName('http://www.jenitennison.com/xslt/xspec', 'x:report') } {
+element { QName('http://www.jenitennison.com/xslt/xspec', 'report') } {
 attribute { QName('', 'xspec') } { '.../compilation-simple-suite.xspec' },
 attribute { QName('', 'query') } { 'http://example.org/ns/my' },
 attribute { QName('', 'query-at') } { '.../compilation-simple-suite.xqm' },


### PR DESCRIPTION
The `/x:report` element in the report XML has a name prefix taken from the master `/x:description`. This prefix (usually `x`) contaminates all the descendant elements including the elements derived from unrelated trees.

This pull request fixes it by not using a prefix in the `x:report` element name. This default namespace can be undeclared in descendant elements. This undeclaration has yet to be implemented. (commented as TODO)