### PR TITLE
refactor: remove temp URI var from var decl

### DIFF
--- a/src/compiler/generate-query-helper.xsl
+++ b/src/compiler/generate-query-helper.xsl
@@ -63,31 +63,6 @@
          </xsl:if>
       </xsl:variable>
 
-      <!-- URIQualifiedName of the temporary runtime variable which holds the resolved URI of @href -->
-      <xsl:variable name="temp-uri-uqname" as="xs:string?">
-         <xsl:if test="$temp-doc-uqname and @href">
-            <xsl:sequence
-               select="x:known-UQName('impl:' || local-name() || '-' || generate-id() || '-uri')" />
-         </xsl:if>
-      </xsl:variable>
-
-      <!--
-         Output
-            declare variable $TEMPORARYNAME-uri as xs:anyURI := xs:anyURI("RESOLVED-HREF");
-         or
-                         let $TEMPORARYNAME-uri as xs:anyURI := xs:anyURI("RESOLVED-HREF")
-      -->
-      <xsl:if test="$temp-uri-uqname">
-         <xsl:call-template name="test:declare-or-let-variable">
-            <xsl:with-param name="is-global" select="$is-global" />
-            <xsl:with-param name="name" select="$temp-uri-uqname" />
-            <xsl:with-param name="type" select="'xs:anyURI'" />
-            <xsl:with-param name="value" as="text()">
-               <xsl:text expand-text="yes">xs:anyURI("{resolve-uri(@href, base-uri())}")</xsl:text>
-            </xsl:with-param>
-         </xsl:call-template>
-      </xsl:if>
-
       <!--
          Output
             declare variable $TEMPORARYNAME-doc as document-node() := DOCUMENT;
@@ -95,7 +70,7 @@
                          let $TEMPORARYNAME-doc as document-node() := DOCUMENT
          
          where DOCUMENT is
-            doc($TEMPORARYNAME-uri)
+            doc('RESOLVED-HREF')
          or
             document { NODE-GENERATORS }
       -->
@@ -107,7 +82,7 @@
             <xsl:with-param name="value" as="node()+">
                <xsl:choose>
                   <xsl:when test="@href">
-                     <xsl:text expand-text="yes">doc(${$temp-uri-uqname})</xsl:text>
+                     <xsl:text expand-text="yes">doc({@href => resolve-uri(base-uri()) => x:quote-with-apos()})</xsl:text>
                   </xsl:when>
 
                   <xsl:otherwise>

--- a/src/compiler/generate-tests-helper.xsl
+++ b/src/compiler/generate-tests-helper.xsl
@@ -60,23 +60,6 @@
          </xsl:if>
       </xsl:variable>
 
-      <!-- URIQualifiedName of the temporary runtime variable which holds the resolved URI of @href -->
-      <xsl:variable name="temp-uri-uqname" as="xs:string?">
-         <xsl:if test="$temp-doc-uqname and @href">
-            <xsl:sequence
-               select="x:known-UQName('impl:' || local-name() || '-' || generate-id() || '-uri')" />
-         </xsl:if>
-      </xsl:variable>
-
-      <xsl:if test="$temp-uri-uqname">
-         <xsl:element name="xsl:variable" namespace="{$x:xsl-namespace}">
-            <xsl:attribute name="name" select="$temp-uri-uqname" />
-            <xsl:attribute name="as" select="x:known-UQName('xs:anyURI')" />
-
-            <xsl:value-of select="resolve-uri(@href, base-uri())" />
-         </xsl:element>
-      </xsl:if>
-
       <xsl:if test="$temp-doc-uqname">
          <xsl:element name="xsl:variable" namespace="{$x:xsl-namespace}">
             <xsl:attribute name="name" select="$temp-doc-uqname" />
@@ -85,7 +68,7 @@
             <xsl:choose>
                <xsl:when test="@href">
                   <xsl:attribute name="select">
-                     <xsl:text expand-text="yes">doc(${$temp-uri-uqname})</xsl:text>
+                     <xsl:text expand-text="yes">doc({@href => resolve-uri(base-uri()) => x:quote-with-apos()})</xsl:text>
                   </xsl:attribute>
                </xsl:when>
 

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -633,11 +633,9 @@ this accessibility.
    <xsl:variable name="Q{http://example.org/ns/my/variable}select" select="'value'"/>
 
    <!-- $myv:href -->
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-uri"
-                 as="Q{http://www.w3.org/2001/XMLSchema}anyURI">.../test-data.xml</xsl:variable>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc"
                  as="document-node()"
-                 select="doc($Q{urn:x-xspec:compile:impl}variable-...-uri)"/>
+                 select="doc('.../test-data.xml')"/>
    <xsl:variable name="Q{http://example.org/ns/my/variable}href"
                  select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )"/>
 
@@ -674,11 +672,8 @@ let $Q{http://example.org/ns/my/variable}select := (
 )
 
 (: $myv:href :)
-let $Q{urn:x-xspec:compile:impl}variable-...-uri as xs:anyURI := (
-xs:anyURI(".../test-data.xml")
-)
 let $Q{urn:x-xspec:compile:impl}variable-...-doc as document-node() := (
-doc($Q{urn:x-xspec:compile:impl}variable-...-uri)
+doc('.../test-data.xml')
 )
 let $Q{http://example.org/ns/my/variable}href := (
 $Q{urn:x-xspec:compile:impl}variable-...-doc ! ( . )


### PR DESCRIPTION
Removes a temporary URI variable (`$...-uri`) from variable declarations. Now, URI is escaped and inserted directly in the `doc()` expression.