### PR TITLE
fix(report): report x:expect/attribute(test) separetely in report XML

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -805,6 +805,27 @@
       </xsl:message>
    </xsl:template>
 
+   <xsl:template name="x:report-test-attribute" as="node()+">
+      <xsl:context-item as="element(x:expect)" use="required" />
+
+      <xsl:variable name="expect-test" as="element(x:expect)">
+         <!-- Do not set xsl:copy/@copy-namespaces="no". @test may use namespace prefixes and/or the
+            default namespace such as xs:QName('foo') -->
+         <xsl:copy>
+            <xsl:sequence select="@test" />
+         </xsl:copy>
+      </xsl:variable>
+
+      <!-- Undeclare the default namespace in the wrapper element, because @test may use the default
+         namespace such as xs:QName('foo'). -->
+      <xsl:call-template name="x:wrap-node-generators-and-undeclare-default-ns">
+         <xsl:with-param name="wrapper-name" select="local-name() || '-test-wrap'" />
+         <xsl:with-param name="node-generators" as="node()+">
+            <xsl:apply-templates select="$expect-test" mode="test:create-node-generator" />
+         </xsl:with-param>
+      </xsl:call-template>
+   </xsl:template>
+
    <xsl:function name="x:label" as="element(x:label)">
       <xsl:param name="labelled" as="element()" />
 

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -500,35 +500,6 @@
       <xsl:text>};&#x0A;</xsl:text>
    </xsl:template>
 
-   <xsl:template name="x:report-test-attribute" as="text()+">
-      <xsl:context-item as="element(x:expect)" use="required" />
-
-      <!-- Undeclare the default namespace in the wrapper element, because @test may use the default
-         namespace such as xs:QName('foo'). -->
-      <xsl:call-template name="x:wrap-node-generators-and-undeclare-default-ns">
-         <xsl:with-param name="wrapper-name" select="local-name() || '-test-wrap'" />
-         <xsl:with-param name="node-generators" as="text()+">
-            <!-- <x:expect> -->
-            <xsl:text>element { </xsl:text>
-            <xsl:value-of select="node-name() => x:QName-expression()" />
-            <xsl:text> } {&#x0A;</xsl:text>
-
-            <xsl:call-template name="test:create-zero-or-more-node-generators">
-               <xsl:with-param name="nodes" as="node()+">
-                  <!-- @test may use namespace prefixes and/or the default namespace such as
-                     xs:QName('foo') -->
-                  <xsl:sequence select="x:element-additional-namespace-nodes(.)" />
-
-                  <xsl:sequence select="@test" />
-               </xsl:with-param>
-            </xsl:call-template>
-
-            <!-- </x:expect> -->
-            <xsl:text>}&#x0A;</xsl:text>
-         </xsl:with-param>
-      </xsl:call-template>
-   </xsl:template>
-
    <xsl:template name="x:wrap-node-generators-and-undeclare-default-ns" as="node()+">
       <xsl:param name="wrapper-name" as="xs:string" />
       <xsl:param name="node-generators" as="node()+" />

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -480,6 +480,9 @@
          <xsl:text>,&#x0A;</xsl:text>
 
          <xsl:if test="@test">
+            <xsl:call-template name="x:report-test-attribute" />
+            <xsl:text>,&#x0A;</xsl:text>
+
             <xsl:text>(&#x0A;</xsl:text>
             <xsl:text>if ( $local:boolean-test )&#x0A;</xsl:text>
             <xsl:text>then ()&#x0A;</xsl:text>
@@ -487,28 +490,7 @@
             <xsl:text>),&#x0A;</xsl:text>
          </xsl:if>
 
-         <!-- TODO: Undeclare the default namespace in the wrapper element, because x:expect/@test may use
-            the default namespace such as xs:QName('foo'). -->
-         <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(&#x0A;</xsl:text>
-         <xsl:text expand-text="yes">${x:variable-UQName(.)},&#x0A;</xsl:text>
-         <xsl:text expand-text="yes">'{name()}'</xsl:text>
-         <xsl:if test="@test">
-            <xsl:text>,&#x0A;</xsl:text>
-            <xsl:text>( </xsl:text>
-            <xsl:apply-templates select="@test" mode="test:create-node-generator" />
-            <xsl:text> ),&#x0A;</xsl:text>
-            <xsl:text>(&#x0A;</xsl:text>
-            <xsl:call-template name="test:create-zero-or-more-node-generators">
-               <xsl:with-param name="nodes" as="namespace-node()*">
-                  <!-- $test-attr may use namespace prefixes and/or the default namespace such as
-                     xs:QName('foo') -->
-                  <xsl:sequence select="x:element-additional-namespace-nodes(.)" />
-               </xsl:with-param>
-            </xsl:call-template>
-            <xsl:text>&#x0A;</xsl:text>
-            <xsl:text>)&#x0A;</xsl:text>
-         </xsl:if>
-         <xsl:text>)&#x0A;</xsl:text>
+         <xsl:text expand-text="yes">{x:known-UQName('test:report-sequence')}(${x:variable-UQName(.)}, '{name()}')&#x0A;</xsl:text>
       </xsl:if>
 
       <!-- </x:test> -->
@@ -516,6 +498,46 @@
 
       <!-- End of the function -->
       <xsl:text>};&#x0A;</xsl:text>
+   </xsl:template>
+
+   <xsl:template name="x:report-test-attribute" as="text()+">
+      <xsl:context-item as="element(x:expect)" use="required" />
+
+      <!-- Undeclare the default namespace in the wrapper element, because @test may use the default
+         namespace such as xs:QName('foo'). -->
+      <xsl:call-template name="x:wrap-node-generators-and-undeclare-default-ns">
+         <xsl:with-param name="wrapper-name" select="local-name() || '-test-wrap'" />
+         <xsl:with-param name="node-generators" as="text()+">
+            <!-- <x:expect> -->
+            <xsl:text>element { </xsl:text>
+            <xsl:value-of select="node-name() => x:QName-expression()" />
+            <xsl:text> } {&#x0A;</xsl:text>
+
+            <xsl:call-template name="test:create-zero-or-more-node-generators">
+               <xsl:with-param name="nodes" as="node()+">
+                  <!-- @test may use namespace prefixes and/or the default namespace such as
+                     xs:QName('foo') -->
+                  <xsl:sequence select="x:element-additional-namespace-nodes(.)" />
+
+                  <xsl:sequence select="@test" />
+               </xsl:with-param>
+            </xsl:call-template>
+
+            <!-- </x:expect> -->
+            <xsl:text>}&#x0A;</xsl:text>
+         </xsl:with-param>
+      </xsl:call-template>
+   </xsl:template>
+
+   <xsl:template name="x:wrap-node-generators-and-undeclare-default-ns" as="node()+">
+      <xsl:param name="wrapper-name" as="xs:string" />
+      <xsl:param name="node-generators" as="node()+" />
+
+      <xsl:text>element { QName('', '</xsl:text>
+      <xsl:value-of select="$wrapper-name" />
+      <xsl:text>') } {&#x0A;</xsl:text>
+      <xsl:sequence select="$node-generators" />
+      <xsl:text>}</xsl:text>
    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/compiler/generate-query-utils.xqm
+++ b/src/compiler/generate-query-utils.xqm
@@ -199,20 +199,10 @@ declare function test:qname-lt($n1 as xs:QName, $n2 as xs:QName) as xs:boolean
 
 declare function test:report-sequence(
     $sequence as item()*,
-    $wrapper-name as xs:string
+    $report-name as xs:string
   ) as element()
 {
-  test:report-sequence($sequence, $wrapper-name, (), ())
-};
-
-declare function test:report-sequence(
-    $sequence as item()*,
-    $wrapper-name as xs:string,
-    $test-attr as attribute(test)?,
-    $additional-namespaces as namespace-node()*
-  ) as element()
-{
-  let $wrapper-ns as xs:string := string($x:xspec-namespace)
+  let $report-namespace as xs:string := string($x:xspec-namespace)
 
   let $attribute-nodes as attribute()* := $sequence[. instance of attribute()]
   let $document-nodes as document-node()* := $sequence[. instance of document-node()]
@@ -221,11 +211,8 @@ declare function test:report-sequence(
 
   let $report-element as element() :=
     element
-      { QName($wrapper-ns, $wrapper-name) }
+      { QName($report-namespace, $report-name) }
       {
-        $additional-namespaces,
-        $test-attr,
-
         (
           (: Empty :)
           if (empty($sequence))
@@ -306,7 +293,7 @@ declare function test:report-sequence(
             },
 
             for $item in $sequence
-            return test:report-pseudo-item($item, $wrapper-ns)
+            return test:report-pseudo-item($item, $report-namespace)
           )
         )
       }
@@ -320,29 +307,29 @@ declare function test:report-sequence(
 
 declare function test:report-pseudo-item(
   $item as item(),
-  $wrapper-ns as xs:string
+  $report-namespace as xs:string
 ) as element()
 {
   let $local-name-prefix as xs:string := 'pseudo-'
   return (
     if ($item instance of xs:anyAtomicType) then
       element
-        { QName($wrapper-ns, ($local-name-prefix || 'atomic-value')) }
+        { QName($report-namespace, ($local-name-prefix || 'atomic-value')) }
         { test:report-atomic-value($item) }
 
     else if ($item instance of node()) then
       element
-        { QName($wrapper-ns, ($local-name-prefix || x:node-type($item))) }
+        { QName($report-namespace, ($local-name-prefix || x:node-type($item))) }
         { test:report-node($item) }
 
     else if (x:instance-of-function($item)) then
       element
-        { QName($wrapper-ns, ($local-name-prefix || x:function-type($item))) }
+        { QName($report-namespace, ($local-name-prefix || x:function-type($item))) }
         { test:serialize-adaptive($item) }
 
     else
       element
-        { QName($wrapper-ns, ($local-name-prefix || 'other')) }
+        { QName($report-namespace, ($local-name-prefix || 'other')) }
         {}
   )
 };

--- a/src/compiler/generate-tests-utils.xsl
+++ b/src/compiler/generate-tests-utils.xsl
@@ -287,10 +287,8 @@
       <xsl:context-item use="absent" />
 
       <xsl:param name="sequence" as="item()*" required="yes" />
-      <xsl:param name="wrapper-name" as="xs:string" required="yes" />
-      <xsl:param name="wrapper-ns" as="xs:string" select="$x:xspec-namespace" />
-      <xsl:param name="test-attr" as="attribute(test)?" />
-      <xsl:param name="additional-namespaces" as="namespace-node()*" />
+      <xsl:param name="report-name" as="xs:string" required="yes" />
+      <xsl:param name="report-namespace" as="xs:string" select="$x:xspec-namespace" />
 
       <xsl:variable name="attribute-nodes" as="attribute()*"      select="$sequence[. instance of attribute()]" />
       <xsl:variable name="document-nodes"  as="document-node()*"  select="$sequence[. instance of document-node()]" />
@@ -298,10 +296,7 @@
       <xsl:variable name="text-nodes"      as="text()*"           select="$sequence[. instance of text()]" />
 
       <xsl:variable name="report-element" as="element()">
-         <xsl:element name="{$wrapper-name}" namespace="{$wrapper-ns}">
-            <xsl:sequence select="$additional-namespaces" />
-            <xsl:sequence select="$test-attr" />
-
+         <xsl:element name="{$report-name}" namespace="{$report-namespace}">
             <xsl:choose>
                <!-- Empty -->
                <xsl:when test="empty($sequence)">
@@ -386,7 +381,7 @@
                   <xsl:sequence
                      select="
                         for $item in $sequence
-                        return test:report-pseudo-item($item, $wrapper-ns)" />
+                        return test:report-pseudo-item($item, $report-namespace)" />
                </xsl:otherwise>
             </xsl:choose>
          </xsl:element>
@@ -425,19 +420,19 @@
 
    <xsl:function name="test:report-pseudo-item" as="element()">
       <xsl:param name="item" as="item()" />
-      <xsl:param name="wrapper-ns" as="xs:string" />
+      <xsl:param name="report-namespace" as="xs:string" />
 
       <xsl:variable name="local-name-prefix" as="xs:string" select="'pseudo-'" />
 
       <xsl:choose>
          <xsl:when test="$item instance of xs:anyAtomicType">
-            <xsl:element name="{$local-name-prefix}atomic-value" namespace="{$wrapper-ns}">
+            <xsl:element name="{$local-name-prefix}atomic-value" namespace="{$report-namespace}">
                <xsl:value-of select="test:report-atomic-value($item)" />
             </xsl:element>
          </xsl:when>
 
          <xsl:when test="$item instance of node()">
-            <xsl:element name="{$local-name-prefix}{x:node-type($item)}" namespace="{$wrapper-ns}">
+            <xsl:element name="{$local-name-prefix}{x:node-type($item)}" namespace="{$report-namespace}">
                <xsl:choose>
                   <!-- Can't apply templates to namespace nodes -->
                   <xsl:when test="$item instance of namespace-node()">
@@ -453,13 +448,13 @@
 
          <xsl:when test="x:instance-of-function($item)">
             <xsl:element name="{$local-name-prefix}{x:function-type($item)}"
-               namespace="{$wrapper-ns}">
+               namespace="{$report-namespace}">
                <xsl:value-of select="test:serialize-adaptive($item)" />
             </xsl:element>
          </xsl:when>
 
          <xsl:otherwise>
-            <xsl:element name="{$local-name-prefix}other" namespace="{$wrapper-ns}" />
+            <xsl:element name="{$local-name-prefix}other" namespace="{$report-namespace}" />
          </xsl:otherwise>
       </xsl:choose>
    </xsl:function>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -821,29 +821,6 @@
       </template>
    </xsl:template>
 
-   <xsl:template name="x:report-test-attribute" as="element(xsl:element)">
-      <xsl:context-item as="element(x:expect)" use="required" />
-
-      <!-- Undeclare the default namespace in the wrapper element, because @test may use the default
-         namespace such as xs:QName('foo'). -->
-      <xsl:call-template name="x:wrap-node-generators-and-undeclare-default-ns">
-         <xsl:with-param name="wrapper-name" select="local-name() || '-test-wrap'" />
-         <xsl:with-param name="node-generators" as="element(xsl:element)">
-            <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
-               <xsl:attribute name="name" select="name()" />
-               <xsl:attribute name="namespace" select="namespace-uri()" />
-
-               <!-- @test may use namespace prefixes and/or the default namespace such as
-                  xs:QName('foo') -->
-               <xsl:apply-templates select="x:element-additional-namespace-nodes(.)"
-                  mode="test:create-node-generator" />
-
-               <xsl:apply-templates select="@test" mode="test:create-node-generator" />
-            </xsl:element>
-         </xsl:with-param>
-      </xsl:call-template>
-   </xsl:template>
-
    <xsl:template name="x:wrap-node-generators-and-undeclare-default-ns" as="element(xsl:element)">
       <xsl:param name="wrapper-name" as="xs:string" />
       <xsl:param name="node-generators" as="element()" />

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -327,7 +327,8 @@
   <div id="{@id}" class="xTestReport">
 
     <xsl:variable name="result" as="element(x:result)"
-      select="if (x:result) then x:result else ../x:result" />
+      select="(x:result, parent::x:scenario/x:result)[1]" />
+
     <h4 class="xTestReportTitle">
       <xsl:apply-templates select="x:label" mode="#current" />
     </h4>
@@ -337,8 +338,11 @@
         title="What does this report mean?">[?]</a>
     </div>
 
+    <!-- x:expect/@test which may or may not be an xs:boolean at run time -->
+    <xsl:variable as="attribute(test)?" name="test-attr" select="expect-test-wrap/x:expect/@test" />
+
     <!-- True if the expectation is boolean (i.e. x:expect/@test was an xs:boolean at runtime.) -->
-    <xsl:variable as="xs:boolean" name="boolean-test" select="not(x:result) and x:expect/@test" />
+    <xsl:variable as="xs:boolean" name="boolean-test" select="empty(x:result) and $test-attr" />
 
     <table class="xspecResult">
       <thead>
@@ -366,7 +370,7 @@
               <!-- Boolean expectation -->
               <xsl:when test="$boolean-test">
                 <pre>
-                  <xsl:value-of select="x:expect/@test" />
+                  <xsl:value-of select="$test-attr" />
                 </pre>
               </xsl:when>
 
@@ -397,7 +401,7 @@
 -->
 <xsl:mode name="x:format-result" on-multiple-match="fail" on-no-match="fail" />
 
-<xsl:template match="element()" as="element()+" mode="x:format-result">
+<xsl:template match="x:expect | x:result" as="element()+" mode="x:format-result">
   <xsl:param name="result-to-compare-with" as="element()?" required="yes" />
 
   <!-- True if this element represents Expected Result -->

--- a/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/query/ambiguous-expect-result.xml
@@ -22,10 +22,12 @@
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
             <x:label>Expecting document node via @href along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="/self::document-node()">
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="/self::document-node()">
                <foo xmlns=""/>
             </x:expect>
          </x:test>
@@ -47,10 +49,12 @@
          </x:test>
          <x:test id="scenario2-scenario1-expect2" successful="false">
             <x:label>Expecting false via @select along with @test=$x:result should be Failure</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          </x:test>
       </x:scenario>
    </x:scenario>
@@ -74,11 +78,15 @@
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
             <x:label>Expecting element(foo) via child node along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="/element()">
-               <foo xmlns=""/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="/element()">
+               <foo xmlns:mirror="x-urn:test:mirror"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -103,17 +111,21 @@
          </x:test>
          <x:test id="scenario4-scenario1-expect3" successful="true">
             <x:label>Expecting empty sequence (no @href, @select or child node) along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
          <x:test id="scenario4-scenario1-expect4" successful="true">
             <x:label>Ditto using x:label</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/query/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-1-result.xml
@@ -59,10 +59,12 @@
       <t:result select="4"/>
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/function-result.xml
+++ b/test/end-to-end/cases/expected/query/function-result.xml
@@ -20,10 +20,12 @@
       </t:test>
       <t:test id="scenario1-expect2" successful="true">
          <t:label>expecting the correct type must return Success</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:integer"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:integer"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
@@ -42,10 +44,12 @@
       </t:test>
       <t:test id="scenario2-expect2" successful="false">
          <t:label>expecting an incorrect type must return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/import-result.xml
+++ b/test/end-to-end/cases/expected/query/import-result.xml
@@ -20,10 +20,12 @@
       </t:test>
       <t:test id="scenario1-expect2" successful="true">
          <t:label>expecting the correct type must return Success</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:integer"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:integer"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
@@ -38,10 +40,12 @@
       <t:result select="4"/>
       <t:test id="scenario2-expect1" successful="false">
          <t:label>it must return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/expected/query/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-151-result.xml
@@ -19,7 +19,10 @@
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Result] in the failure report HTML must wrap element and string separately</x:label>
-         <x:expect xmlns:test-mix="x-urn:test-mix" test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:test-mix="x-urn:test-mix" test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-153-result.xml
@@ -14,17 +14,19 @@
       <x:result select="'2000-01-01T12:00:00+12:00'"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>Comparing the function result with the same date time in UTC will report Success</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema" test="xs:dateTime($x:result)"/>
+         </expect-test-wrap>
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
-         <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="xs:dateTime($x:result)"
-                   select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T00:00:00Z')"/>
+         <x:expect select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T00:00:00Z')"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>Comparing the function result with a different date time will report Failure</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema" test="xs:dateTime($x:result)"/>
+         </expect-test-wrap>
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
-         <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="xs:dateTime($x:result)"
-                   select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
+         <x:expect select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-177-result.xml
@@ -23,7 +23,10 @@
 				and
 					"Expecting" = "empty($x:result/self::element(foo))"
 				without diff.</x:label>
-         <x:expect test="empty($x:result/self::element(foo))" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="empty($x:result/self::element(foo))"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non boolean),
@@ -32,10 +35,13 @@
 				and
 					"Expected Result" = "&lt;bar /&gt;"
 				with diff.</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect test="$x:result/self::element(foo)"/>
+         </expect-test-wrap>
          <x:result select="/element()">
             <foo xmlns=""/>
          </x:result>
-         <x:expect test="$x:result/self::element(foo)" select="/element()">
+         <x:expect select="/element()">
             <bar xmlns=""/>
          </x:expect>
       </x:test>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.xml
@@ -35,15 +35,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>should work</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:myv="http://example.org/ns/my/variable"
+                      test="$global-param treat as node()+"/>
+         </expect-test-wrap>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
                   xmlns=""
                   attr="}{">}{</elem>
          </x:result>
-         <x:expect xmlns:mirror="x-urn:test:mirror"
-                   xmlns:myv="http://example.org/ns/my/variable"
-                   test="$global-param treat as node()+"
-                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
@@ -57,15 +59,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>should work</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:myv="http://example.org/ns/my/variable"
+                      test="$myv:global-var treat as node()+"/>
+         </expect-test-wrap>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
                   xmlns=""
                   attr="}{">}{</elem>
          </x:result>
-         <x:expect xmlns:mirror="x-urn:test:mirror"
-                   xmlns:myv="http://example.org/ns/my/variable"
-                   test="$myv:global-var treat as node()+"
-                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>

--- a/test/end-to-end/cases/expected/query/label-element-result.xml
+++ b/test/end-to-end/cases/expected/query/label-element-result.xml
@@ -22,7 +22,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -43,7 +46,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -64,7 +70,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/pending-result.xml
+++ b/test/end-to-end/cases/expected/query/pending-result.xml
@@ -59,10 +59,12 @@
       <t:result select="4"/>
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -21,7 +21,10 @@
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="false">
             <x:label>[Result] without diff must be serialized as &lt;!-- --&gt;.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../serialize.xspec">
@@ -73,7 +76,10 @@
             <x:test id="scenario2-scenario1-scenario1-expect2" successful="false">
                <x:label>all elements in [Result] without diff must be serialized with
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario2-scenario1-scenario2" xspec="../../serialize.xspec">
@@ -290,7 +296,10 @@
       <x:test id="scenario4-expect2" successful="false">
          <x:label>in [Result] without diff, the significant text nodes must be serialized without
 				color.</x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -320,7 +329,10 @@
             <x:test id="scenario5-scenario1-scenario1-expect2" successful="false">
                <x:label>[Result] without diff must be serialized with aligned
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario5-scenario1-scenario2" xspec="../../serialize.xspec">
@@ -362,7 +374,10 @@
             <x:test id="scenario5-scenario2-scenario1-expect2" successful="false">
                <x:label>[Result] without diff must be serialized with aligned
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario5-scenario2-scenario2" xspec="../../serialize.xspec">
@@ -422,7 +437,10 @@
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>all the attributes must be serialized without color.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>
@@ -517,7 +535,10 @@
          </x:result>
          <x:test id="scenario7-scenario2-expect1" successful="false">
             <x:label>all the processing instructions must be serialized without color.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/query/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-result.xml
@@ -12,7 +12,10 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -23,7 +26,10 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -34,11 +40,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>This nested shared x:expect should fire only at nested x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario3-expect2" successful="true">
          <x:label>This referenced shared x:expect should fire only at x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -51,7 +63,10 @@
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario4-scenario2" xspec="../../shared-like.xspec">
@@ -60,7 +75,10 @@
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -36,13 +36,17 @@
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>This expectation should be Success report bar-exists</x:label>
-         <x:expect test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'bar-exists'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'bar-exists'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>This expectation should be Failure and the failure report should contain svrl:active-pattern/@document[. = ''] report baz-exists</x:label>
-         <x:expect test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'baz-exists'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'baz-exists'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.xml
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.xml
@@ -22,7 +22,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -43,7 +46,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -64,7 +70,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -53,8 +53,10 @@
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>valid</x:label>
-         <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -104,8 +106,10 @@
       </x:result>
       <x:test id="scenario2-expect1" successful="false">
          <x:label>valid</x:label>
-         <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -142,8 +146,10 @@
       </x:result>
       <x:test id="scenario3-expect1" successful="false">
          <x:label>valid</x:label>
-         <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -81,15 +81,19 @@
       </x:result>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>assert t2-1 error</x:label>
-         <x:expect xmlns:local="local"
-                   test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't2-1'][(@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@role)[1] = 'error'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:local="local"
+                      test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't2-1'][(@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@role)[1] = 'error'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>not assert t1-1</x:label>
-         <x:expect xmlns:local="local"
-                   test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't1-1'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:local="local"
+                      test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't1-1'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -169,9 +173,11 @@
       </x:result>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>assert t3-1</x:label>
-         <x:expect xmlns:local="local"
-                   test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't3-1'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:local="local"
+                      test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't3-1'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -251,9 +257,11 @@
       </x:result>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>report t4-1 warn</x:label>
-         <x:expect xmlns:local="local"
-                   test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't4-1'][(@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@role)[1] = 'warn'])"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:local="local"
+                      test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 't4-1'][(@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@role)[1] = 'warn'])"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -32,8 +32,10 @@
          </x:result>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>valid</x:label>
-            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../tvt_label_schematron.xspec">
@@ -60,8 +62,10 @@
          </x:result>
          <x:test id="scenario1-scenario2-expect1" successful="true">
             <x:label>valid</x:label>
-            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario3" xspec="../../tvt_label_schematron.xspec">
@@ -88,8 +92,10 @@
          </x:result>
          <x:test id="scenario1-scenario3-expect1" successful="true">
             <x:label>valid</x:label>
-            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>
@@ -121,8 +127,10 @@
          </x:result>
          <x:test id="scenario2-scenario1-expect1" successful="true">
             <x:label>valid</x:label>
-            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario2-scenario2" xspec="../../tvt_label_schematron.xspec">
@@ -149,8 +157,10 @@
          </x:result>
          <x:test id="scenario2-scenario2-expect1" successful="true">
             <x:label>valid</x:label>
-            <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/(Q{http://purl.oclc.org/dsdl/svrl}failed-assert | Q{http://purl.oclc.org/dsdl/svrl}successful-report)[empty(@role) or (lower-case(@role) = ('error', 'fatal'))])"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/ambiguous-expect-result.xml
@@ -21,10 +21,12 @@
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
             <x:label>Expecting document node via @href along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="/self::document-node()">
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="/self::document-node()">
                <foo xmlns=""/>
             </x:expect>
          </x:test>
@@ -46,10 +48,12 @@
          </x:test>
          <x:test id="scenario2-scenario1-expect2" successful="false">
             <x:label>Expecting false via @select along with @test=$x:result should be Failure</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          </x:test>
       </x:scenario>
    </x:scenario>
@@ -73,11 +77,15 @@
          </x:test>
          <x:test id="scenario3-scenario1-expect2" successful="true">
             <x:label>Expecting element(foo) via child node along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="/element()">
-               <foo xmlns=""/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="/element()">
+               <foo xmlns:mirror="x-urn:test:mirror"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns=""/>
             </x:expect>
          </x:test>
       </x:scenario>
@@ -102,17 +110,21 @@
          </x:test>
          <x:test id="scenario4-scenario1-expect3" successful="true">
             <x:label>Expecting empty sequence (no @href, @select or child node) along with @test=$x:result should be Success</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
          <x:test id="scenario4-scenario1-expect4" successful="true">
             <x:label>Ditto using x:label</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result treat as xs:boolean"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result treat as xs:boolean"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-1-result.xml
@@ -58,10 +58,12 @@
       <t:result select="4"/>
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -62,11 +62,13 @@
       <t:result select="4"/>
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/function-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.xml
@@ -19,10 +19,12 @@
       </t:test>
       <t:test id="scenario1-expect2" successful="true">
          <t:label>expecting the correct type must return Success</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:integer"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:integer"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
@@ -41,10 +43,12 @@
       </t:test>
       <t:test id="scenario2-expect2" successful="false">
          <t:label>expecting an incorrect type must return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.xml
@@ -19,10 +19,12 @@
       </t:test>
       <t:test id="scenario1-expect2" successful="true">
          <t:label>expecting the correct type must return Success</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:integer"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:integer"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"
@@ -37,10 +39,12 @@
       <t:result select="4"/>
       <t:test id="scenario2-expect1" successful="false">
          <t:label>it must return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-151-result.xml
@@ -18,7 +18,10 @@
       </x:result>
       <x:test id="scenario1-expect1" successful="false">
          <x:label>[Result] in the failure report HTML must wrap element and string separately</x:label>
-         <x:expect xmlns:test-mix="x-urn:test-mix" test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:test-mix="x-urn:test-mix" test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
@@ -13,17 +13,19 @@
       <x:result select="'2000-01-01T12:00:00+12:00'"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>Comparing the function result with the same date time in UTC will report Success</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema" test="xs:dateTime($x:result)"/>
+         </expect-test-wrap>
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
-         <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="xs:dateTime($x:result)"
-                   select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T00:00:00Z')"/>
+         <x:expect select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T00:00:00Z')"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>Comparing the function result with a different date time will report Failure</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema" test="xs:dateTime($x:result)"/>
+         </expect-test-wrap>
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
-         <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="xs:dateTime($x:result)"
-                   select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
+         <x:expect select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-01T00:00:00Z')"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.xml
@@ -22,7 +22,10 @@
 				and
 					"Expecting" = "empty($x:result/self::element(foo))"
 				without diff.</x:label>
-         <x:expect test="empty($x:result/self::element(foo))" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="empty($x:result/self::element(foo))"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario1-expect2" successful="false">
          <x:label>When x:expect expects &lt;bar /&gt; and @test is "$x:result/self::element(foo)" (i.e. non boolean),
@@ -31,10 +34,13 @@
 				and
 					"Expected Result" = "&lt;bar /&gt;"
 				with diff.</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect test="$x:result/self::element(foo)"/>
+         </expect-test-wrap>
          <x:result select="/element()">
             <foo xmlns=""/>
          </x:result>
-         <x:expect test="$x:result/self::element(foo)" select="/element()">
+         <x:expect select="/element()">
             <bar xmlns=""/>
          </x:expect>
       </x:test>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.xml
@@ -34,15 +34,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>should work</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:myv="http://example.org/ns/my/variable"
+                      test="$global-param treat as node()+"/>
+         </expect-test-wrap>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
                   xmlns=""
                   attr="}{">}{</elem>
          </x:result>
-         <x:expect xmlns:mirror="x-urn:test:mirror"
-                   xmlns:myv="http://example.org/ns/my/variable"
-                   test="$global-param treat as node()+"
-                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>
@@ -56,15 +58,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>should work</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:myv="http://example.org/ns/my/variable"
+                      test="$myv:global-var treat as node()+"/>
+         </expect-test-wrap>
          <x:result select="/node()">}{<elem xmlns:mirror="x-urn:test:mirror"
                   xmlns:myv="http://example.org/ns/my/variable"
                   xmlns=""
                   attr="}{">}{</elem>
          </x:result>
-         <x:expect xmlns:mirror="x-urn:test:mirror"
-                   xmlns:myv="http://example.org/ns/my/variable"
-                   test="$myv:global-var treat as node()+"
-                   select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
+         <x:expect select="/node()">}{<elem xmlns="" attr="}{">}{</elem>
          </x:expect>
       </x:test>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.xml
@@ -21,7 +21,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -42,7 +45,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -63,7 +69,10 @@
 &#xD; Expectation	
 &#xD; 	
 &#xD; </x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.xml
@@ -58,10 +58,12 @@
       <t:result select="4"/>
       <t:test id="scenario4-expect1" successful="false">
          <t:label>must execute the test and return Failure</t:label>
-         <t:expect xmlns:my="http://example.org/ns/my"
-                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                   test="$t:result instance of xs:string"
-                   select="()"/>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <t:expect select="()"/>
       </t:test>
    </t:scenario>
    <t:scenario xmlns:t="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/result-naming-collision-result.xml
@@ -39,10 +39,12 @@
       <x:result href="HREF-8"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>x:result should be two document nodes</x:label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      test="count($x:result treat as document-node()+)"/>
+         </expect-test-wrap>
          <x:result select="2"/>
-         <x:expect xmlns:mirror="x-urn:test:mirror"
-                   test="count($x:result treat as document-node()+)"
-                   select="2"/>
+         <x:expect select="2"/>
       </x:test>
       <x:test id="scenario3-expect2" successful="false">
          <x:label>The result should be saved successfully in yet another external file which is well-formed</x:label>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -20,7 +20,10 @@
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="false">
             <x:label>[Result] without diff must be serialized as &lt;!-- --&gt;.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../serialize.xspec">
@@ -72,7 +75,10 @@
             <x:test id="scenario2-scenario1-scenario1-expect2" successful="false">
                <x:label>all elements in [Result] without diff must be serialized with
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario2-scenario1-scenario2" xspec="../../serialize.xspec">
@@ -289,7 +295,10 @@
       <x:test id="scenario4-expect2" successful="false">
          <x:label>in [Result] without diff, the significant text nodes must be serialized without
 				color.</x:label>
-         <x:expect test="false()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect test="false()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -319,7 +328,10 @@
             <x:test id="scenario5-scenario1-scenario1-expect2" successful="false">
                <x:label>[Result] without diff must be serialized with aligned
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario5-scenario1-scenario2" xspec="../../serialize.xspec">
@@ -361,7 +373,10 @@
             <x:test id="scenario5-scenario2-scenario1-expect2" successful="false">
                <x:label>[Result] without diff must be serialized with aligned
 						indentation.</x:label>
-               <x:expect test="false()" select="()"/>
+               <expect-test-wrap xmlns="">
+                  <x:expect test="false()"/>
+               </expect-test-wrap>
+               <x:expect select="()"/>
             </x:test>
          </x:scenario>
          <x:scenario id="scenario5-scenario2-scenario2" xspec="../../serialize.xspec">
@@ -421,7 +436,10 @@
          </x:result>
          <x:test id="scenario6-scenario2-expect1" successful="false">
             <x:label>all the attributes must be serialized without color.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>
@@ -516,7 +534,10 @@
          </x:result>
          <x:test id="scenario7-scenario2-expect1" successful="false">
             <x:label>all the processing instructions must be serialized without color.</x:label>
-            <x:expect test="false()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect test="false()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
@@ -11,7 +11,10 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario1-expect1" successful="true">
          <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -22,7 +25,10 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario2-expect1" successful="true">
          <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -33,11 +39,17 @@
       <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
       <x:test id="scenario3-expect1" successful="true">
          <x:label>This nested shared x:expect should fire only at nested x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
       <x:test id="scenario3-expect2" successful="true">
          <x:label>This referenced shared x:expect should fire only at x:like</x:label>
-         <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+         </expect-test-wrap>
+         <x:expect select="()"/>
       </x:test>
    </x:scenario>
    <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -50,7 +62,10 @@
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          <x:test id="scenario4-scenario1-expect1" successful="true">
             <x:label>This referenced and explicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario4-scenario2" xspec="../../shared-like.xspec">
@@ -59,7 +74,10 @@
          <x:result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
          <x:test id="scenario4-scenario2-expect1" successful="true">
             <x:label>This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like</x:label>
-            <x:expect xmlns:mirror="x-urn:test:mirror" test="true()" select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:mirror="x-urn:test:mirror" test="true()"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
@@ -13,16 +13,19 @@
          <x:result select="/text()">12</x:result>
          <x:test id="scenario1-scenario1-expect1" successful="true">
             <x:label>Result should be text nodes</x:label>
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="$x:result instance of text()+"
-                      select="()"/>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         test="$x:result instance of text()+"/>
+            </expect-test-wrap>
+            <x:expect select="()"/>
          </x:test>
          <x:test id="scenario1-scenario1-expect2" successful="true">
             <x:label>Result count should be 2</x:label>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema" test="count($x:result)"/>
+            </expect-test-wrap>
             <x:result select="2"/>
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      test="count($x:result)"
-                      select="2"/>
+            <x:expect select="2"/>
          </x:test>
       </x:scenario>
       <x:scenario id="scenario1-scenario2" xspec="../../../../xslt1.xspec">
@@ -55,11 +58,13 @@
          <x:result select="/text()">12</x:result>
          <x:test id="scenario1-scenario3-expect1" successful="false">
             <x:label>Expecting the compiled stylesheet to have version=1.0</x:label>
+            <expect-test-wrap xmlns="">
+               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                         test="document('')/xsl:stylesheet/@version/string()"/>
+            </expect-test-wrap>
             <x:result select="'2.0'"/>
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                      test="document('')/xsl:stylesheet/@version/string()"
-                      select="'1.0'"/>
+            <x:expect select="'1.0'"/>
          </x:test>
       </x:scenario>
    </x:scenario>

--- a/test/generate-tests-utils.xspec
+++ b/test/generate-tests-utils.xspec
@@ -26,7 +26,7 @@
          <t:scenario label="Integer">
             <t:call template="test:report-sequence">
                <t:param name="sequence" select="1" as="xs:integer" />
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of integer">
                <t:result select="1" />
@@ -36,7 +36,7 @@
          <t:scenario label="Empty Sequence">
             <t:call template="test:report-sequence">
                <t:param name="sequence" select="()" />
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of empty sequence">
                <t:result select="()" />
@@ -46,7 +46,7 @@
          <t:scenario label="String">
             <t:call template="test:report-sequence">
                <t:param name="sequence" select="'test'" as="xs:string" />
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of string">
                <t:result select="'test'" />
@@ -56,7 +56,7 @@
          <t:scenario label="URI">
             <t:call template="test:report-sequence">
                <t:param name="sequence" select="xs:anyURI('test.xml')" />
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of xs:anyURI">
                <t:result select="Q{{http://www.w3.org/2001/XMLSchema}}anyURI('test.xml')" />
@@ -66,7 +66,7 @@
          <t:scenario label="QName">
             <t:call template="test:report-sequence">
                <t:param name="sequence" select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of QName">
                <t:result select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
@@ -78,7 +78,7 @@
                <t:param name="sequence" select="/*/@*" as="attribute()+">
                   <doc a="1" b="2" />
                </t:param>
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes">
                <t:result select="/*/@*">
@@ -95,7 +95,7 @@
                      <foo />
                   </doc>
                </t:param>
-               <t:param name="wrapper-name" select="'t:result'" />
+               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes and content">
                <t:result select="/*/(@* | node())">


### PR DESCRIPTION
`x:expect/@test` and the content of `x:expect/@href` require different sets of namespaces. But the test result report XML reports them in a single `x:expect`, which is not possible.
This pull request fixes it by reporting `@test` in another element.