### PR TITLE
refactor: assign x:scenario x:expect ID right after unsharing scenarios

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -93,8 +93,13 @@
          <xsl:apply-templates select="$combined-doc" mode="x:unshare-scenarios" />
       </xsl:variable>
 
+      <!-- Assign @id -->
+      <xsl:variable name="doc-with-id" as="document-node(element(x:description))">
+         <xsl:apply-templates select="$unshared-doc" mode="x:assign-id" />
+      </xsl:variable>
+
       <!-- Dispatch to a language-specific transformation (XSLT or XQuery) -->
-      <xsl:apply-templates select="$unshared-doc/element()" mode="x:generate-tests" />
+      <xsl:apply-templates select="$doc-with-id/element()" mode="x:generate-tests" />
    </xsl:template>
 
    <xsl:function name="x:gather-descriptions" as="element(x:description)+">
@@ -696,6 +701,22 @@
    </xsl:template>
 
    <!--
+      mode="x:assign-id"
+      This mode assigns ID to x:scenario and x:expect
+   -->
+   <xsl:mode name="x:assign-id" on-multiple-match="fail" on-no-match="shallow-copy" />
+
+   <xsl:template match="(x:scenario | x:expect)[x:is-user-content(.) => not()]" as="element()"
+      mode="x:assign-id">
+      <xsl:copy>
+         <xsl:attribute name="id">
+            <xsl:apply-templates select="." mode="x:generate-id" />
+         </xsl:attribute>
+         <xsl:apply-templates select="attribute() | node()" mode="#current" />
+      </xsl:copy>
+   </xsl:template>
+
+   <!--
       mode="x:generate-tests"
       Does the generation of the test stylesheet.
       This mode assumes that all the scenarios have already been gathered and unshared.
@@ -735,6 +756,13 @@
    <xsl:mode name="x:generate-id" on-multiple-match="fail" on-no-match="fail" />
 
    <xsl:template match="x:scenario" as="xs:string" mode="x:generate-id">
+      <!-- Some ID generators may depend on @xspec, although this default generator doesn't. -->
+      <xsl:if test="empty(@xspec)">
+         <xsl:message terminate="yes">
+            <xsl:text expand-text="yes">@xspec not exist when generating ID for {name()}.</xsl:text>
+         </xsl:message>
+      </xsl:if>
+
       <xsl:variable name="ancestor-or-self-tokens" as="xs:string+">
          <xsl:for-each select="ancestor-or-self::x:scenario">
             <!-- Find preceding sibling x:scenario, taking x:pending into account -->

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -152,15 +152,11 @@
          Their order must be stable, because they are passed to a function. -->
       <xsl:param name="with-param-uqnames" as="xs:string*" />
 
-      <xsl:variable name="local-name" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
-
       <xsl:if test="exists(preceding-sibling::x:*[1][self::x:pending])">
          <xsl:text>,&#10;</xsl:text>
       </xsl:if>
 
-      <xsl:text expand-text="yes">let ${x:known-UQName('x:tmp')} := local:{$local-name}(&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">let ${x:known-UQName('x:tmp')} := local:{@id}(&#x0A;</xsl:text>
       <xsl:for-each select="$with-param-uqnames">
          <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
@@ -202,10 +198,6 @@
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
 
-      <xsl:variable name="scenario-id" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
-
       <xsl:variable name="quoted-label" as="xs:string" select="$x:apos || x:label(.) || $x:apos" />
 
       <xsl:if test="$context">
@@ -235,7 +227,7 @@
         {
       -->
       <xsl:text>&#10;(: generated from the x:scenario element :)</xsl:text>
-      <xsl:text expand-text="yes">&#10;declare function local:{$scenario-id}(&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">&#10;declare function local:{@id}(&#x0A;</xsl:text>
 
       <!-- Function parameters. Their order must be stable, because this is a function. -->
       <xsl:for-each select="x:distinct-strings-stable($stacked-variables ! x:variable-UQName(.))">
@@ -264,8 +256,7 @@
 
       <xsl:call-template name="test:create-zero-or-more-node-generators">
          <xsl:with-param name="nodes" as="node()+">
-            <xsl:attribute name="id" select="$scenario-id" />
-            <xsl:sequence select="@xspec" />
+            <xsl:sequence select="@id, @xspec" />
 
             <xsl:if test="$pending-p">
                <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
@@ -384,16 +375,12 @@
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor::*/@focus)" />
 
-      <xsl:variable name="expect-id" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
-
       <!--
         declare function local:...($t:result as item()*)
         {
       -->
       <xsl:text>&#10;(: generated from the x:expect element :)</xsl:text>
-      <xsl:text expand-text="yes">&#10;declare function local:{$expect-id}(&#x0A;</xsl:text>
+      <xsl:text expand-text="yes">&#10;declare function local:{@id}(&#x0A;</xsl:text>
       <xsl:for-each select="$param-uqnames">
          <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
@@ -459,7 +446,7 @@
 
       <xsl:call-template name="test:create-zero-or-more-node-generators">
          <xsl:with-param name="nodes" as="node()+">
-            <xsl:attribute name="id" select="$expect-id" />
+            <xsl:sequence select="@id" />
 
             <xsl:if test="$pending-p">
                <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -174,11 +174,7 @@
          URIQualifiedName) to the call -->
       <xsl:param name="with-param-uqnames" as="xs:string*" />
 
-      <xsl:variable name="local-name" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
-
-      <call-template name="{x:known-UQName('x:' || $local-name)}">
+      <call-template name="{x:known-UQName('x:' || @id)}">
          <xsl:for-each select="$with-param-uqnames">
             <with-param name="{.}" select="${.}" />
          </xsl:for-each>
@@ -205,10 +201,6 @@
 
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
-
-      <xsl:variable name="scenario-id" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
 
       <!-- We have to create these error messages at this stage because before now
          we didn't have merged versions of the environment -->
@@ -255,8 +247,7 @@
          </xsl:call-template>
       </xsl:if>
 
-      <template name="{x:known-UQName('x:' || $scenario-id)}"
-         as="element({x:known-UQName('x:scenario')})">
+      <template name="{x:known-UQName('x:' || @id)}" as="element({x:known-UQName('x:scenario')})">
          <xsl:sequence select="x:copy-of-namespaces(.)" />
 
          <xsl:for-each select="distinct-values($stacked-variables ! x:variable-UQName(.))">
@@ -282,7 +273,7 @@
             <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
             <xsl:variable name="scenario-attributes" as="attribute()+">
-               <xsl:attribute name="id" select="$scenario-id" />
+               <xsl:sequence select="@id" />
                <xsl:attribute name="xspec" select="(@xspec-original-location, @xspec)[1]" />
                <xsl:if test="$pending-p">
                   <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
@@ -647,11 +638,7 @@
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor::*/@focus)" />
 
-      <xsl:variable name="expect-id" as="xs:string">
-         <xsl:apply-templates select="." mode="x:generate-id" />
-      </xsl:variable>
-
-      <template name="{x:known-UQName('x:' || $expect-id)}" as="element({x:known-UQName('x:test')})">
+      <template name="{x:known-UQName('x:' || @id)}" as="element({x:known-UQName('x:test')})">
          <xsl:for-each select="$param-uqnames">
             <param name="{.}" required="yes" />
          </xsl:for-each>
@@ -777,7 +764,7 @@
             <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
             <xsl:variable name="test-element-attributes" as="attribute()+">
-               <xsl:attribute name="id" select="$expect-id" />
+               <xsl:sequence select="@id" />
                <xsl:if test="$pending-p">
                   <xsl:sequence select="x:pending-attribute-from-pending-node($pending)" />
                </xsl:if>

--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -39,18 +39,18 @@
             - the generator (xsl:element) of the x:scenario element
             - the generator (xsl:element) of the x:scenario/x:label element
          </t:label>
-         <xsl:template name="Q{{http://www.jenitennison.com/xslt/xspec}}scenario1"
+         <xsl:template name="Q{{http://www.jenitennison.com/xslt/xspec}}dummy-scenario-id"
                        as="element(Q{{http://www.jenitennison.com/xslt/xspec}}scenario)">
-            <xsl:message>my label</xsl:message>
+            <xsl:message>my scenario label</xsl:message>
             <xsl:element name="t:scenario"
                          namespace="http://www.jenitennison.com/xslt/xspec">
                <xsl:attribute name="id"
-                              namespace="">scenario1</xsl:attribute>
+                              namespace="">dummy-scenario-id</xsl:attribute>
                <xsl:attribute name="xspec"
                               namespace="" />
                <xsl:element name="t:label"
                             namespace="http://www.jenitennison.com/xslt/xspec">
-                  <xsl:text>my label</xsl:text>
+                  <xsl:text>my scenario label</xsl:text>
                </xsl:element>
             </xsl:element>
          </xsl:template>

--- a/test/generate-xspec-tests/expect.xspec
+++ b/test/generate-xspec-tests/expect.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec">
-	<t:scenario label="">
-		<t:expect label="" test="false()" />
+	<t:scenario label="my scenario label">
+		<t:expect id="dummy-expect-id" label="my expect label" test="false()" />
 	</t:scenario>
 </t:description>

--- a/test/generate-xspec-tests/scenario.xspec
+++ b/test/generate-xspec-tests/scenario.xspec
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:description xmlns:t="http://www.jenitennison.com/xslt/xspec">
-	<t:scenario label="my label" />
+	<t:scenario id="dummy-scenario-id" label="my scenario label" />
 </t:description>

--- a/test/schema/build.xml
+++ b/test/schema/build.xml
@@ -35,6 +35,10 @@
 			<exclude name="test/output-scenario-error/call-both-function-and-template.xspec" />
 			<exclude name="test/output-scenario-error/context-both-href-and-content.xspec" />
 			<exclude name="test/output-scenario-error/function-with-context.xspec" />
+
+			<!-- (x:expect | x:scenario)/@id which is not allowed -->
+			<exclude name="test/generate-xspec-tests/expect.xspec" />
+			<exclude name="test/generate-xspec-tests/scenario.xspec" />
 		</fileset>
 
 		<!-- Jing is silent when all files are valid.


### PR DESCRIPTION
Assign `(x:scenario | x:expect)/@id` at an earlier stage (immediately after unsharing scenarios) so that the assigned `@id` can be used in other ways.