### PR TITLE
docs: comment why lexical QName from x:xspec-name() is used

### DIFF
--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -213,6 +213,8 @@
    <!-- x:space has been replaced with x:text -->
    <xsl:template match="x:space" as="empty-sequence()" mode="x:gather-user-content">
       <xsl:message terminate="yes">
+         <!-- Use x:xspec-name() for displaying the x:text element name with the prefix preferred by
+            the user -->
          <xsl:text expand-text="yes">{name()} is obsolete. Use {x:xspec-name('text', .)} instead.</xsl:text>
       </xsl:message>
    </xsl:template>

--- a/src/compiler/generate-query-tests.xsl
+++ b/src/compiler/generate-query-tests.xsl
@@ -217,6 +217,8 @@
       <xsl:if test="x:expect and empty($call)">
          <xsl:call-template name="x:output-scenario-error">
             <xsl:with-param name="message" as="xs:string">
+               <!-- Use x:xspec-name() for displaying the element names with the prefix preferred by
+                  the user -->
                <xsl:text expand-text="yes">There are {x:xspec-name('expect', .)} but no {x:xspec-name('call', .)}</xsl:text>
             </xsl:with-param>
          </xsl:call-template>

--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -242,6 +242,8 @@
       <xsl:if test="x:expect and empty($call) and empty($apply) and empty($context)">
          <xsl:call-template name="x:output-scenario-error">
             <xsl:with-param name="message" as="xs:string">
+               <!-- Use x:xspec-name() for displaying the element names with the prefix preferred by
+                  the user -->
                <xsl:text expand-text="yes">There are {x:xspec-name('expect', .)} but no {x:xspec-name('call', .)}, {x:xspec-name('apply', .)} or {x:xspec-name('context', .)} has been given</xsl:text>
             </xsl:with-param>
          </xsl:call-template>
@@ -519,7 +521,9 @@
                <if
                   test="${x:known-UQName('x:saxon-config')} => {x:known-UQName('test:is-saxon-config')}() => not()">
                   <message terminate="yes">
-                     <xsl:text expand-text="yes">ERROR: ${x:xspec-name('saxon-config', .)} does not appear to be a Saxon configuration</xsl:text>
+                     <!-- Use URIQualifiedName for displaying the $x:saxon-config variable name, for
+                        we do not know the name prefix of the originating variable. -->
+                     <xsl:text expand-text="yes">ERROR: ${x:known-UQName('x:saxon-config')} does not appear to be a Saxon configuration</xsl:text>
                   </message>
                </if>
                <map-entry key="'vendor-options'">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2029,7 +2029,7 @@
 	<case name="$x:saxon-config is not a Saxon config">
     call :run ..\bin\xspec.bat x-saxon-config\test.xspec
     call :verify_retval 2
-    call :verify_line  8 x "ERROR: $x:saxon-config does not appear to be a Saxon configuration"
+    call :verify_line  8 x "ERROR: $Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration"
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2330,7 +2330,7 @@ load bats-helper
     run ../bin/xspec.sh x-saxon-config/test.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[7]}" = "ERROR: \$x:saxon-config does not appear to be a Saxon configuration" ]
+    [ "${lines[7]}" = "ERROR: \$Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 


### PR DESCRIPTION
Lexical QName is dangerous and should be used with constraint. This pull request adds comments to clarify why lexical QName generated by `x:xspec-name()` is used in some places.