### PR TITLE
refactor(xslt): xsl:context-item in generated named templates

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -84,7 +84,14 @@
 
          <!-- The main compiled template. -->
          <xsl:comment> the main template to run the suite </xsl:comment>
-         <template name="{x:known-UQName('x:main')}" as="empty-sequence()">
+         <xsl:element name="xsl:template" namespace="{$x:xsl-namespace}">
+            <xsl:attribute name="name" select="x:known-UQName('x:main')" />
+            <xsl:attribute name="as" select="'empty-sequence()'" />
+
+            <xsl:element name="xsl:context-item" namespace="{$x:xsl-namespace}">
+               <xsl:attribute name="use" select="'absent'" />
+            </xsl:element>
+
             <xsl:text>&#10;      </xsl:text><xsl:comment> info message </xsl:comment>
             <!-- Message content must be constructed at run time -->
             <message>
@@ -155,7 +162,7 @@
                   <xsl:call-template name="x:call-scenarios" />
                </xsl:element>
             </xsl:element>
-         </template>
+         </xsl:element>
 
          <!-- Compile the top-level scenarios. -->
          <xsl:call-template name="x:compile-scenarios" />
@@ -247,8 +254,15 @@
          </xsl:call-template>
       </xsl:if>
 
-      <template name="{x:known-UQName('x:' || @id)}" as="element({x:known-UQName('x:scenario')})">
+      <xsl:element name="xsl:template" namespace="{$x:xsl-namespace}">
          <xsl:sequence select="x:copy-of-namespaces(.)" />
+
+         <xsl:attribute name="name" select="x:known-UQName('x:' || @id)" />
+         <xsl:attribute name="as" select="'element(' || x:known-UQName('x:scenario') || ')'" />
+
+         <xsl:element name="xsl:context-item" namespace="{$x:xsl-namespace}">
+            <xsl:attribute name="use" select="'absent'" />
+         </xsl:element>
 
          <xsl:for-each select="distinct-values($stacked-variables ! x:variable-UQName(.))">
             <param name="{.}" required="yes" />
@@ -489,7 +503,7 @@
 
          <!-- </x:scenario> -->
          </xsl:element>
-      </template>
+      </xsl:element>
 
       <xsl:call-template name="x:compile-scenarios" />
    </xsl:template>
@@ -641,7 +655,14 @@
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor::*/@focus)" />
 
-      <template name="{x:known-UQName('x:' || @id)}" as="element({x:known-UQName('x:test')})">
+      <xsl:element name="xsl:template" namespace="{$x:xsl-namespace}">
+         <xsl:attribute name="name" select="x:known-UQName('x:' || @id)" />
+         <xsl:attribute name="as" select="'element(' || x:known-UQName('x:test') || ')'" />
+
+         <xsl:element name="xsl:context-item" namespace="{$x:xsl-namespace}">
+            <xsl:attribute name="use" select="'absent'" />
+         </xsl:element>
+
          <xsl:for-each select="$param-uqnames">
             <param name="{.}" required="yes" />
          </xsl:for-each>
@@ -806,7 +827,7 @@
 
          <!-- </x:test> -->
          </xsl:element>
-      </template>
+      </xsl:element>
    </xsl:template>
 
    <xsl:template name="x:wrap-node-generators-and-undeclare-default-ns" as="element(xsl:element)">

--- a/test/generate-xspec-tests.xspec
+++ b/test/generate-xspec-tests.xspec
@@ -41,6 +41,7 @@
          </t:label>
          <xsl:template name="Q{{http://www.jenitennison.com/xslt/xspec}}dummy-scenario-id"
                        as="element(Q{{http://www.jenitennison.com/xslt/xspec}}scenario)">
+            <xsl:context-item use="absent" />
             <xsl:message>my scenario label</xsl:message>
             <xsl:element name="scenario"
                          namespace="http://www.jenitennison.com/xslt/xspec">

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -60,6 +60,7 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
    <!-- the main template to run the suite -->
    <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}main"
                  as="empty-sequence()">
+      <xsl:context-item use="absent"/>
       <!-- info message -->
       <xsl:message>
          <xsl:text>Testing with </xsl:text>
@@ -192,6 +193,7 @@ result as parameter.
               xmlns:x="http://www.jenitennison.com/xslt/xspec"
               name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
+   <xsl:context-item use="absent"/>
    <xsl:message>scenario</xsl:message>
    <xsl:element name="scenario" namespace="http://www.jenitennison.com/xslt/xspec">
       <xsl:attribute name="id" namespace="">scenario1</xsl:attribute>
@@ -219,6 +221,7 @@ result as parameter.
 <!-- generated from the x:expect element -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}test)">
+   <xsl:context-item use="absent"/>
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <xsl:message>expectations</xsl:message>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." select="()"><!--expected result--></xsl:variable>
@@ -529,6 +532,7 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 <!-- generated from the x:expect element -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-expect1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}test)">
+   ...
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <xsl:param name="Q{http://example.org/ns/my/variable}var" required="yes"/>
    ...
@@ -756,6 +760,7 @@ and functions in XQuery).
               xmlns:x="http://www.jenitennison.com/xslt/xspec"
               name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
+   ...
    <!-- the generated variable -->
    <xsl:variable name="Q{http://example.org/ns/my/variable}var-1" select="'var-1-value'" />
    ...
@@ -771,6 +776,7 @@ and functions in XQuery).
               xmlns:x="http://www.jenitennison.com/xslt/xspec"
               name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
+   ...
    <!-- the variable is passed as param -->
    <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
    ...
@@ -812,6 +818,7 @@ and functions in XQuery).
 <!-- generated from the expect one -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}test)">
+   ...
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <!-- the variables are passed as param -->
    <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
@@ -823,6 +830,7 @@ and functions in XQuery).
 <!-- generated from the expect two -->
 <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect2"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}test)">
+   ...
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <!-- the variables are passed as param -->
    <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>


### PR DESCRIPTION
Just outputs `xsl:context-item` into the generated templates to clarify their required context.