### PR TITLE
refactor(xslt): do not copy namespaces to scenario templates

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -248,8 +248,6 @@
       </xsl:if>
 
       <template name="{x:known-UQName('x:' || @id)}" as="element({x:known-UQName('x:scenario')})">
-         <xsl:sequence select="x:copy-of-namespaces(.)" />
-
          <xsl:for-each select="distinct-values($stacked-variables ! x:variable-UQName(.))">
             <param name="{.}" required="yes" />
          </xsl:for-each>

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -80,9 +80,7 @@ Show the structure of a compiled test suite, both in XSLT and XQuery.
    </xsl:template>
 
    <!-- generated from the x:scenario element -->
-   <xsl:template xmlns:my="http://example.org/ns/my"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                 name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+   <xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
                  as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
       ...
       <!-- a call instruction for each x:expect element -->
@@ -188,9 +186,7 @@ result as parameter.
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template xmlns:my="http://example.org/ns/my"
-              xmlns:x="http://www.jenitennison.com/xslt/xspec"
-              name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <xsl:message>scenario</xsl:message>
    <xsl:element name="scenario" namespace="http://www.jenitennison.com/xslt/xspec">
@@ -391,7 +387,10 @@ section "[Simple scenario](#simple-scenario)").
 ```xml
 <!-- "call a function" -->
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
-   <xsl:variable name="Q{urn:x-xspec:compile:impl}param-..." select="'val1'"/>
+   <xsl:variable xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:my="http://example.org/ns/my"
+                 name="Q{urn:x-xspec:compile:impl}param-..."
+                 select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
       <xsl:document>
          <xsl:element name="val2" namespace="">
@@ -400,7 +399,9 @@ section "[Simple scenario](#simple-scenario)").
          </xsl:element>
       </xsl:document>
    </xsl:variable>
-   <xsl:variable name="Q{}p2"
+   <xsl:variable xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:my="http://example.org/ns/my"
+                 name="Q{}p2"
                  as="element()"
                  select="$Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() )"/>
    <xsl:sequence select="Q{http://example.org/ns/my}f($Q{urn:x-xspec:compile:impl}param-..., $Q{}p2)"/>
@@ -408,7 +409,10 @@ section "[Simple scenario](#simple-scenario)").
 
 <!-- "call a named template" -->
 <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
-   <xsl:variable name="Q{}p1" select="'val1'"/>
+   <xsl:variable xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:my="http://example.org/ns/my"
+                 name="Q{}p1"
+                 select="'val1'"/>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}param-...-doc" as="document-node()">
       <xsl:document>
          <xsl:element name="val2" namespace="">
@@ -420,8 +424,14 @@ section "[Simple scenario](#simple-scenario)").
    <xsl:variable name="Q{}p2"
                  select="$Q{urn:x-xspec:compile:impl}param-...-doc ! ( node() )" />
    <xsl:call-template name="Q{}t">
-      <xsl:with-param name="Q{}p1" select="$Q{}p1"/>
-      <xsl:with-param name="Q{}p2" select="$Q{}p2"/>
+      <xsl:with-param xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:my="http://example.org/ns/my"
+                      name="Q{}p1"
+                      select="$Q{}p1"/>
+      <xsl:with-param xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:my="http://example.org/ns/my"
+                      name="Q{}p2"
+                      select="$Q{}p2"/>
    </xsl:call-template>
 </xsl:variable>
 
@@ -505,15 +515,17 @@ The first example shows how an XSpec variable maps to an `xsl:variable` element 
 
 ```xml
 <!-- generated from the x:scenario element -->
-<xsl:template xmlns:my="http://example.org/ns/my"
-              xmlns:myv="http://example.org/ns/my/variable"
-              xmlns:x="http://www.jenitennison.com/xslt/xspec"
-              xmlns:xs="http://www.w3.org/2001/XMLSchema"
-              name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    ...
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var" select="'value'"/>
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 name="Q{http://example.org/ns/my/variable}var"
+                 select="'value'"/>
+   ...
    <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
       ... exercise the SUT ...
    </xsl:variable>
@@ -620,16 +632,17 @@ this accessibility.
 ### Stylesheet
 
 ```xml
-<xsl:template xmlns:my="http://example.org/ns/my"
-              xmlns:myv="http://example.org/ns/my/variable"
-              xmlns:x="http://www.jenitennison.com/xslt/xspec"
-              xmlns:xs="http://www.w3.org/2001/XMLSchema"
-              name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    ...
 
    <!-- $myv:select -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}select" select="'value'"/>
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 name="Q{http://example.org/ns/my/variable}select"
+                 select="'value'"/>
 
    <!-- $myv:href -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}variable-...-doc"
@@ -649,7 +662,11 @@ this accessibility.
          </xsl:element>
       </xsl:document>
    </xsl:variable>
-   <xsl:variable name="Q{http://example.org/ns/my/variable}content"
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 name="Q{http://example.org/ns/my/variable}content"
                  as="element()"
                  select="$Q{urn:x-xspec:compile:impl}variable-...-doc ! ( node() )"/>
 
@@ -751,13 +768,14 @@ and functions in XQuery).
               select="'global-value'"/>
 
 <!-- generated from the scenario outer -->
-<xsl:template xmlns:my="http://example.org/ns/my"
-              xmlns:myv="http://example.org/ns/my/variable"
-              xmlns:x="http://www.jenitennison.com/xslt/xspec"
-              name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-1" select="'var-1-value'" />
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 name="Q{http://example.org/ns/my/variable}var-1"
+                 select="'var-1-value'" />
    ...
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1">
       <!-- pass the variable to inner context -->
@@ -766,23 +784,28 @@ and functions in XQuery).
 </xsl:template>
 
 <!-- generated from the scenario inner -->
-<xsl:template xmlns:my="http://example.org/ns/my"
-              xmlns:myv="http://example.org/ns/my/variable"
-              xmlns:x="http://www.jenitennison.com/xslt/xspec"
-              name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1"
+<xsl:template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1"
               as="element(Q{http://www.jenitennison.com/xslt/xspec}scenario)">
    <!-- the variable is passed as param -->
    <xsl:param name="Q{http://example.org/ns/my/variable}var-1" required="yes"/>
    ...
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-2" select="'var-2-value'"/>
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 name="Q{http://example.org/ns/my/variable}var-2"
+                 select="'var-2-value'"/>
    ...
    <xsl:variable name="Q{http://www.jenitennison.com/xslt/xspec}result" as="item()*">
       <xsl:sequence select="Q{http://example.org/ns/my}square(...)"/>
    </xsl:variable>
    ...
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-3" select="'var-3-value'"/>
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 name="Q{http://example.org/ns/my/variable}var-3"
+                 select="'var-3-value'"/>
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect1">
       <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result"
                       select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>
@@ -794,7 +817,11 @@ and functions in XQuery).
                       select="$Q{http://example.org/ns/my/variable}var-3"/>
    </xsl:call-template>
    <!-- the generated variable -->
-   <xsl:variable name="Q{http://example.org/ns/my/variable}var-4" select="'var-4-value'"/>
+   <xsl:variable xmlns:my="http://example.org/ns/my"
+                 xmlns:myv="http://example.org/ns/my/variable"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 name="Q{http://example.org/ns/my/variable}var-4"
+                 select="'var-4-value'"/>
    <xsl:call-template name="Q{http://www.jenitennison.com/xslt/xspec}scenario1-scenario1-expect2">
       <xsl:with-param name="Q{http://www.jenitennison.com/xslt/xspec}result"
                       select="$Q{http://www.jenitennison.com/xslt/xspec}result"/>


### PR DESCRIPTION
Namespaces should be handled at each exact point where they are required, because each `//x:*` requires a different set of namespaces. Copying namespaces to every scenario `xsl:template` in the compiled stylesheet should be considered as harmful. This pull request removes it.