### PR TITLE
docs(schema): fix a typo 'paraemeters'

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -139,7 +139,7 @@ matching-scenario = (variable*, context?, variable*),
                                         label, matching-scenario })*
 
 ## A function scenario is one based on a call to a stylesheet function. The
-## <call> element defines the function call and the paraemeters passed to it
+## <call> element defines the function call and the parameters passed to it
 ## and the <assertion> elements test the result of the function. Child scenarios
 ## can override the parameters in the function call.
 function-scenario = (variable*, function-call?, variable*),


### PR DESCRIPTION
Just fixes a typo in a schema annotation.