### PR TITLE
test: relocate test for redefining variable while mixing notations

### DIFF
--- a/test/eqname.xspec
+++ b/test/eqname.xspec
@@ -105,25 +105,18 @@
 			select="/Q{}variable-child">
 			<variable-child />
 		</x:variable>
-		<!-- The following definition illustrates redefining a variable and mixing notations
-			for its name. The file variable.xspec would be a good place to test that,
-			except that that file did not use xslt-version="3.0".
-			TODO: The default @xslt-version has been changed. Consider relocating the test. -->
-		<x:variable as="element(variable-child)+" name="Q{http://example.org/ns/my/variable}var"
-			select="$myv:var, $Q{http://example.org/ns/my/variable}var" />
 		<x:call function="Q{x-urn:test:eqname}param-mirror-function">
 			<x:param name="Q{x-urn:test:eqname}param-items"
 				select="$Q{http://example.org/ns/my/variable}var" />
 		</x:call>
 		<x:expect label="should be possible as well as in function-param @select">
 			<variable-child />
-			<variable-child />
 		</x:expect>
 		<x:expect label="and assertion @select and @test"
-			select="$Q{http://example.org/ns/my/variable}var treat as element(Q{}variable-child)+"
-			test="$Q{http://example.org/ns/my/variable}var treat as element(Q{}variable-child)+" />
+			select="$Q{http://example.org/ns/my/variable}var treat as element(Q{}variable-child)"
+			test="$Q{http://example.org/ns/my/variable}var treat as element(Q{}variable-child)" />
 		<x:expect label="and boolean @test"
-			test="$Q{http://example.org/ns/my/variable}var instance of element(variable-child)+" />
+			test="$Q{http://example.org/ns/my/variable}var instance of element(variable-child)" />
 	</x:scenario>
 
 	<x:scenario

--- a/test/variable.xspec
+++ b/test/variable.xspec
@@ -137,9 +137,6 @@
 		<!-- Note: For x:variable elements that are direct children of x:description, expanded QNames must be unique.
 		 This test scenario is about *local* redefinitions of global or local variables. -->
 		<!-- For now, we assume any prefixes used in variable names are defined on x:description. -->
-		<!-- For a test that redefines a variable using URIQualifiedName, see eqname.xspec,
-		 which had xslt-version="3.0".
-		 TODO: The default @xslt-version has been changed. Consider relocating the test. -->
 		<x:scenario label="Local redefinition of global variable">
 			<x:variable name="myv:test-string" select="concat($myv:test-string,' (redefined locally using same prefix')" as="xs:string"/>
 			<x:variable name="myv_alt:test-string" select="concat($myv:test-string,' or different prefix)')" as="xs:string"/>
@@ -172,6 +169,25 @@
 			</x:call>
 			<x:expect label="reflects value redefined within same scenario."
 				select="'value #2 (redefined using same prefix or different prefix)'"/>
+		</x:scenario>
+		<x:scenario label="Redefinition of variable and mixed notations for its name">
+			<x:variable as="element(variable-child)"
+				name="
+				&#x09;&#x0A;&#x0D;&#x20;
+				Q{http://example.org/ns/my/variable}var
+				&#x09;&#x0A;&#x0D;&#x20;"
+				select="/Q{}variable-child">
+				<variable-child />
+			</x:variable>
+			<x:variable as="element(variable-child)+" name="Q{http://example.org/ns/my/variable}var"
+				select="$myv:var, $Q{http://example.org/ns/my/variable}var" />
+			<x:call function="mirror:param-mirror">
+				<x:param select="$Q{http://example.org/ns/my/variable}var" />
+			</x:call>
+			<x:expect label="reflects value redefined within same scenario.">
+				<variable-child />
+				<variable-child />
+			</x:expect>
 		</x:scenario>
 		<x:scenario label="The name 'result' in a non-XSpec namespace">
 			<x:call function="mirror:param-mirror">

--- a/test/variable.xspec
+++ b/test/variable.xspec
@@ -172,10 +172,7 @@
 		</x:scenario>
 		<x:scenario label="Redefinition of variable and mixed notations for its name">
 			<x:variable as="element(variable-child)"
-				name="
-				&#x09;&#x0A;&#x0D;&#x20;
-				Q{http://example.org/ns/my/variable}var
-				&#x09;&#x0A;&#x0D;&#x20;"
+				name="Q{http://example.org/ns/my/variable}var"
 				select="/Q{}variable-child">
 				<variable-child />
 			</x:variable>


### PR DESCRIPTION
This minor test refactoring aims to keep similar things together. Fixes issue #927.