### PR TITLE
feat: override compiler per language in Ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -342,14 +342,19 @@
 
   <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
   <target name="compile" depends="init, generate-catalog, preprocess-schematron-xspec">
-    <condition property="xspec.compiler.xsl.name"
-               value="generate-query-tests.xsl"
-               else="generate-xspec-tests.xsl">
+    <property name="xspec.compiler.dir"
+              value="${xspec.project.dir}/src/compiler" />
+
+    <property name="xspec.xquery.compiler.xsl"
+              value="${xspec.compiler.dir}/generate-query-tests.xsl" />
+    <property name="xspec.xslt.compiler.xsl"
+              value="${xspec.compiler.dir}/generate-xspec-tests.xsl" />
+
+    <condition property="xspec.compiler.xsl"
+               value="${xspec.xquery.compiler.xsl}"
+               else="${xspec.xslt.compiler.xsl}">
       <istrue value="${xspec.is.xquery}" />
     </condition>
-
-    <property name="xspec.compiler.xsl"
-              value="${xspec.project.dir}/src/compiler/${xspec.compiler.xsl.name}" />
 
     <echo message="Compiling Tests..."
           level="info" />

--- a/test/override-id/generate-query-tests.xsl
+++ b/test/override-id/generate-query-tests.xsl
@@ -3,14 +3,14 @@
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-	<xsl:import href="../../src/compiler/generate-xspec-tests.xsl" />
+	<xsl:import href="../../src/compiler/generate-query-tests.xsl" />
 
 	<xsl:template as="xs:string" match="x:scenario" mode="x:generate-id">
-		<xsl:sequence select="'overridden-xslt-scenario-id-' || generate-id()" />
+		<xsl:sequence select="'overridden-xquery-scenario-id-' || generate-id()" />
 	</xsl:template>
 
 	<xsl:template as="xs:string" match="x:expect" mode="x:generate-id">
-		<xsl:sequence select="'overridden-xslt-expect-id-' || generate-id()" />
+		<xsl:sequence select="'overridden-xquery-expect-id-' || generate-id()" />
 	</xsl:template>
 
 </xsl:stylesheet>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1887,11 +1887,11 @@
 		Override ID generation templates
 	-->
 
-	<case name="Override ID generation">
+	<case name="Override ID generation (XSLT)">
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -Dxspec.compiler.xsl="%CD%\override-id\generate-xspec-tests.xsl" ^
+        -Dxspec.xslt.compiler.xsl="%CD%\override-id\generate-xspec-tests.xsl" ^
         -Dxspec.fail=false ^
         -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
     call :verify_retval 0
@@ -1899,11 +1899,27 @@
     call :verify_line -2 x "BUILD SUCCESSFUL"
 
     call :run type "%TEST_DIR%\escape-for-regex-compiled.xsl"
-    call :verify_line * r "..*Q{http://www.jenitennison.com/xslt/xspec}overridden-scenario-id-"
-    call :verify_line * r "..*Q{http://www.jenitennison.com/xslt/xspec}overridden-expect-id-"
+    call :verify_line * r "..*Q{http://www.jenitennison.com/xslt/xspec}overridden-xslt-scenario-id-"
+    call :verify_line * r "..*Q{http://www.jenitennison.com/xslt/xspec}overridden-xslt-expect-id-"
 	</case>
 
-	<!--
+	<case name="Override ID generation (XQuery)">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_JAR%" ^
+        -Dtest.type=q ^
+        -Dxspec.xquery.compiler.xsl="%CD%\override-id\generate-query-tests.xsl" ^
+        -Dxspec.xml="%CD%\..\tutorial\xquery-tutorial.xspec"
+    call :verify_retval 0
+    call :verify_line  * x "     [xslt] passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line -2 x "BUILD SUCCESSFUL"
+
+    call :run type "%TEST_DIR%\xquery-tutorial-compiled.xq"
+    call :verify_line * r "declare function local:overridden-xquery-scenario-id-"
+    call :verify_line * r "declare function local:overridden-xquery-expect-id-"
+	</case>
+
+    <!--
 		Custom HTML reporter (CLI)
 		
 			Ant is tested by XSPEC_HOME/test/end-to-end/cases/format-xspec-report-folding.xspec

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2166,11 +2166,11 @@ load bats-helper
 # Override ID generation templates
 #
 
-@test "Override ID generation" {
+@test "Override ID generation (XSLT)" {
     run ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -Dxspec.compiler.xsl="${PWD}/override-id/generate-xspec-tests.xsl" \
+        -Dxspec.xslt.compiler.xsl="${PWD}/override-id/generate-xspec-tests.xsl" \
         -Dxspec.fail=false \
         -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
     echo "$output"
@@ -2180,8 +2180,26 @@ load bats-helper
 
     run cat "${TEST_DIR}/escape-for-regex-compiled.xsl"
     echo "$output"
-    assert_regex "${output}" '.+Q\{http://www.jenitennison.com/xslt/xspec\}overridden-scenario-id-'
-    assert_regex "${output}" '.+Q\{http://www.jenitennison.com/xslt/xspec\}overridden-expect-id'
+    assert_regex "${output}" '.+Q\{http://www.jenitennison.com/xslt/xspec\}overridden-xslt-scenario-id-'
+    assert_regex "${output}" '.+Q\{http://www.jenitennison.com/xslt/xspec\}overridden-xslt-expect-id'
+}
+
+@test "Override ID generation (XQuery)" {
+    run ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_JAR}" \
+        -Dtest.type=q \
+        -Dxspec.xquery.compiler.xsl="${PWD}/override-id/generate-query-tests.xsl" \
+        -Dxspec.xml="${PWD}/../tutorial/xquery-tutorial.xspec"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    assert_regex "${output}" $'\n''     \[xslt\] passed: 1 / pending: 0 / failed: 0 / total: 1'$'\n'
+    [ "${lines[${#lines[@]}-2]}" = "BUILD SUCCESSFUL" ]
+
+    run cat "${TEST_DIR}/xquery-tutorial-compiled.xq"
+    echo "$output"
+    assert_regex "${output}" $'\n''declare function local:overridden-xquery-scenario-id-'
+    assert_regex "${output}" $'\n''declare function local:overridden-xquery-expect-id-'
 }
 
 #


### PR DESCRIPTION
This pull request allows the Ant user to set an alternative XSpec compiler per language (XQuery or XSLT).

This change will allow [Oxygen XSpec Helper View](https://github.com/xspec/oXygen-XML-editor-xspec-support/blob/7240b9bf2229676c4a8097425a6cf8bd5759ca9e/frameworks/xspec/xspec.framework#L840-L862) to run XQuery XSpec.

This is an advanced internal feature so I don't think the new Ant properties (`xspec.xquery.compiler.xsl` and `xspec.xslt.compiler.xsl`) should be documented.