### PR TITLE
ci: support filtering Windows Bats-like tests

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,2 @@
-/run-bats~TEMP~.cmd
-
 # Default TEST_DIR
 xspec/

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -16,7 +16,7 @@
     set SAXON_CP=
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 2 x "SAXON_CP and SAXON_HOME both not set!"
+    call :verify_line 2 x "--SAXON_CP and SAXON_HOME both not set!"
     call :verify_line 4 r "Usage: xspec "
 	</case>
 

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -16,7 +16,7 @@
     set SAXON_CP=
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 2 x "--SAXON_CP and SAXON_HOME both not set!"
+    call :verify_line 2 x "SAXON_CP and SAXON_HOME both not set!"
     call :verify_line 4 r "Usage: xspec "
 	</case>
 

--- a/test/win-bats/generate.xsl
+++ b/test/win-bats/generate.xsl
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet exclude-result-prefixes="#all" version="2.0"
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xpath-default-namespace="x-urn:xspec:test:xspec-bat">
 
 	<xsl:output method="text" />
+
+	<xsl:param as="xs:string" name="filter" />
 
 	<xsl:mode on-multiple-match="fail" on-no-match="fail" />
 
@@ -12,17 +14,27 @@
 	</xsl:template>
 
 	<xsl:template as="text()+" match="collection">
+		<xsl:variable as="element(case)+" name="cases" select="child::case[matches(@name, $filter)]" />
+		<xsl:variable as="xs:integer" name="num-cases" select="count($cases)" />
+
+		<xsl:message>
+			<xsl:text expand-text="yes">{$num-cases} test case(s)</xsl:text>
+			<xsl:if test="$filter">
+				<xsl:text expand-text="yes"> (Filter: "{$filter}")</xsl:text>
+			</xsl:if>
+		</xsl:message>
+
 		<!-- Tell the number of test cases -->
 		<xsl:call-template name="write">
 			<xsl:with-param name="text" xml:space="preserve">
 :get-num-cases
-	set NUM_CASES=<xsl:value-of select="count(child::case)" />
+	set NUM_CASES=<xsl:value-of select="$num-cases" />
 	goto :EOF
 </xsl:with-param>
 		</xsl:call-template>
 
 		<!-- Write each case -->
-		<xsl:apply-templates select="case" />
+		<xsl:apply-templates select="$cases" />
 	</xsl:template>
 
 	<xsl:template as="text()+" match="case">

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -9,7 +9,7 @@ verify other 2> NUL
 setlocal enableextensions
 if errorlevel 1 (
     echo Unable to enable extensions
-    exit /b %ERRORLEVEL%
+    exit /b 1
 )
 
 rem
@@ -38,11 +38,6 @@ rem
 set "THIS_FILE_NX=%~nx0"
 
 rem
-rem Go to the directory where this script resides
-rem
-pushd "%~dp0"
-
-rem
 rem Full path to the parent directory
 rem
 for %%I in (..) do set "PARENT_DIR_ABS=%%~fI"
@@ -52,14 +47,8 @@ rem Run tests
 rem
 echo === START TEST CASES ================================================
 set CASE_NUM=1
-if not "%~1"=="" set "CASE_NUM=%~1"
 call :run-test-cases
 echo === END TEST CASES ==================================================
-
-rem
-rem Go back to the initial directory
-rem
-popd
 
 rem
 rem Retrieve the results and determine the exit code


### PR DESCRIPTION
This pull request adds `--filter` option to `test/run-bats.cmd`. It works like the same Bats option introduced in its [1.2.0](https://github.com/bats-core/bats-core/releases/tag/v1.2.0).

e2f579f37ab6134b19d3ae63ddac5727ad1e5ea6 is a deliberate failure to verify that the updated `run-bats.cmd` is still able to catch test failures.

### Further work

Update [Tips in Wiki](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally#tips) with these examples:

__Linux/macOS__

```console
$ test/run-bats.sh --filter "CUSTOM|HOME"
 ✓ XSPEC_HOME 
 ✓ XSPEC_HOME is not a directory 
 ✓ XSPEC_HOME seems to be corrupted 
 ✓ SAXON_CP has precedence over SAXON_HOME 
 ✓ invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar 
 ✓ invoking xspec for XSLT with SAXON_CUSTOM_OPTIONS 
 ✓ invoking xspec for XQuery with SAXON_CUSTOM_OPTIONS 

7 tests, 0 failures
```

__Windows__

```console
C:\xspec>test\run-bats.cmd --filter "CUSTOM|HOME"
7 test case(s) (Filter: "CUSTOM|HOME")
=== START TEST CASES ================================================
CASE #1: XSPEC_HOME
...
...PASS
CASE #2: XSPEC_HOME is not a directory
...
...PASS
CASE #3: XSPEC_HOME seems to be corrupted
...
...PASS
CASE #4: SAXON_CP has precedence over SAXON_HOME
...
...PASS
CASE #5: invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar
...
...PASS
CASE #6: invoking xspec for XSLT with SAXON_CUSTOM_OPTIONS
...
...PASS
CASE #7: invoking xspec for XQuery with SAXON_CUSTOM_OPTIONS
...
...PASS
=== END TEST CASES ==================================================
EXIT_CODE=0
```