### PR TITLE
feat: force focus on demand in Ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -355,7 +355,12 @@
           level="info" />
     <saxon-xslt in="${xspec.xspecfile.preprocessed}"
                 out="${xspec.compiled.runner}"
-                style="${xspec.compiler.xsl}" />
+                style="${xspec.compiler.xsl}">
+      <xslt-elements>
+        <param name="force-focus" expression="${xspec.force.focus}"
+               if="xspec.force.focus" />
+      </xslt-elements>
+    </saxon-xslt>
   </target>
 
   <!-- Runs the compiled XSpec for XQuery -->
@@ -441,6 +446,8 @@
                 out="${xspec.result.html}"
                 style="${xspec.html.reporter.xsl}">
       <xslt-elements>
+        <param name="force-focus" expression="${xspec.force.focus}"
+               if="xspec.force.focus" />
         <param name="inline-css" expression="true" />
         <param name="report-css-uri" expression="${xspec.result.html.css.url}"
                if="xspec.result.html.css.url" />

--- a/src/compiler/generate-common-tests.xsl
+++ b/src/compiler/generate-common-tests.xsl
@@ -22,6 +22,9 @@
 
    <xsl:param name="is-external" as="xs:boolean" select="$initial-document/x:description/@run-as = 'external'" />
 
+   <xsl:param name="force-focus" as="xs:string?" />
+   <xsl:variable name="force-focus-ids" as="xs:string*" select="tokenize($force-focus, '\s+')[.]" />
+
    <!-- The initial XSpec document (the source document of the whole transformation).
       Note that this initial document is different from the document node generated within the
       name="x:generate-tests" template. The latter document is a restructured copy of the initial
@@ -105,6 +108,11 @@
          <xsl:apply-templates select="$unshared-doc" mode="x:assign-id" />
       </xsl:variable>
 
+      <!-- Force focus -->
+      <xsl:variable name="doc-maybe-focus-enforced" as="document-node()">
+         <xsl:apply-templates select="$doc-with-id" mode="x:force-focus" />
+      </xsl:variable>
+
       <!-- Combine all the children of x:description into a single x:description -->
       <xsl:variable name="combined-doc" as="document-node(element(x:description))">
          <xsl:document>
@@ -136,14 +144,14 @@
                         select="resolve-uri(., base-uri())" />
                   </xsl:for-each>
 
-                  <xsl:sequence select="$doc-with-id" />
+                  <xsl:sequence select="$doc-maybe-focus-enforced" />
                </xsl:element>
             </xsl:for-each>
          </xsl:document>
       </xsl:variable>
 
       <!-- Dispatch to a language-specific transformation (XSLT or XQuery) -->
-      <xsl:apply-templates select="$combined-doc/x:description" mode="x:generate-tests" />
+      <xsl:apply-templates select="$combined-doc/element()" mode="x:generate-tests" />
    </xsl:template>
 
    <xsl:function name="x:gather-descriptions" as="element(x:description)+">
@@ -758,6 +766,31 @@
             <xsl:apply-templates select="." mode="x:generate-id" />
          </xsl:attribute>
          <xsl:apply-templates select="attribute() | node()" mode="#current" />
+      </xsl:copy>
+   </xsl:template>
+
+   <!--
+      mode="x:force-focus"
+      This mode enforces focus on specific instances of x:scenario
+   -->
+   <xsl:mode name="x:force-focus" on-multiple-match="fail" on-no-match="shallow-copy" />
+
+   <!-- Leave user-content intact. This must be done in the highest priority. -->
+   <xsl:template match="node()[x:is-user-content(.)]" as="node()" mode="x:force-focus"
+      priority="1">
+      <xsl:sequence select="." />
+   </xsl:template>
+
+   <!-- Force or remove focus -->
+   <xsl:template match="x:scenario[exists($force-focus-ids)]" as="element(x:scenario)"
+      mode="x:force-focus">
+      <xsl:copy>
+         <xsl:if test="@id = $force-focus-ids">
+            <xsl:attribute name="focus" select="'force focus'" />
+         </xsl:if>
+         <xsl:apply-templates select="attribute() except @focus" mode="#current" />
+
+         <xsl:apply-templates select="node()" mode="#current" />
       </xsl:copy>
    </xsl:template>
 

--- a/src/reporter/format-xspec-report-folding.xsl
+++ b/src/reporter/format-xspec-report-folding.xsl
@@ -21,7 +21,7 @@
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/format-xspec-report-folding.xsl</pkg:import-uri>
 
    <xsl:template name="x:html-head-callback" as="element(xhtml:script)">
-      <xsl:context-item as="document-node(element(x:report))" use="required" />
+      <xsl:context-item use="absent" />
 
       <script language="javascript" type="text/javascript">
 function toggle(scenarioID) {

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -28,6 +28,9 @@
 
    <xsl:param name="report-css-uri" as="xs:string?" />
 
+   <xsl:param name="force-focus" as="xs:string?" />
+   <xsl:variable name="force-focus-ids" as="xs:string*" select="tokenize($force-focus, '\s+')[.]" />
+
    <!-- @use-character-maps for inline CSS -->
    <xsl:output method="xhtml" use-character-maps="test:disable-escaping" />
 
@@ -52,7 +55,7 @@
    <!-- Named template to be overridden.
       Override this template to insert additional nodes at the end of /html/head. -->
    <xsl:template name="x:html-head-callback" as="empty-sequence()">
-      <xsl:context-item as="document-node(element(x:report))" use="required" />
+      <xsl:context-item as="element(x:report)" use="required" />
    </xsl:template>
 
    <xsl:template name="x:format-top-level-scenario" as="element(xhtml:div)">
@@ -140,6 +143,11 @@
    <xsl:mode on-multiple-match="fail" on-no-match="fail" />
 
    <xsl:template match="document-node(element(x:report))" as="element(xhtml:html)">
+      <!-- Process nothing here, otherwise it's hard to override the whole processing of this stylesheet -->
+      <xsl:apply-templates />
+   </xsl:template>
+
+   <xsl:template match="x:report" as="element(xhtml:html)">
       <xsl:message>
          <xsl:call-template name="x:output-test-stats">
             <xsl:with-param name="tests" select="x:descendant-tests(.)" />
@@ -150,7 +158,7 @@
       <html>
          <head>
             <title>
-               <xsl:text expand-text="yes">Test Report for {x:report/x:format-uri((@schematron,@stylesheet,@query)[1])} (</xsl:text>
+               <xsl:text expand-text="yes">Test Report for {(@schematron, @stylesheet, @query)[1] => x:format-uri()} (</xsl:text>
                <xsl:call-template name="x:output-test-stats">
                   <xsl:with-param name="tests" select="x:descendant-tests(.)"/>
                   <xsl:with-param name="insert-labels" select="true()" />
@@ -165,13 +173,9 @@
          </head>
          <body>
             <h1>Test Report</h1>
-            <xsl:apply-templates select="*"/>
+            <xsl:apply-templates select="." mode="x:html-report"/>
          </body>
       </html>
-   </xsl:template>
-
-   <xsl:template match="x:report" as="element()+">
-      <xsl:apply-templates select="." mode="x:html-report"/>
    </xsl:template>
 
    <!-- Returns true if the top level x:scenario needs to be processed by x:format-top-level-scenario template -->

--- a/test/ant/worker/build-worker_util.xml
+++ b/test/ant/worker/build-worker_util.xml
@@ -51,6 +51,7 @@
 		<attribute default="" name="enable-coverage" />
 		<attribute default="" name="saxon-custom-options" />
 		<attribute default="" name="additional-classpath" />
+		<attribute default="" name="force-focus" />
 		<attribute default="" name="html-reporter" />
 		<attribute default="" name="coverage-reporter" />
 		<attribute default="" name="output-xml-url" />
@@ -115,6 +116,8 @@
 					value="@{saxon-custom-options}" />
 				<param name="xspec.additional.classpath" unless:blank="@{additional-classpath}"
 					value="@{additional-classpath}" />
+				<param name="xspec.force.focus" unless:blank="@{force-focus}"
+					value="@{force-focus}" />
 
 				<param name="xspec.html.reporter.xsl" unless:blank="@{html-reporter}"
 					value="@{html-reporter}" />

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -250,19 +250,19 @@
 								select="$saxon-custom-options" />
 						</xsl:if>
 
-						<xsl:for-each select="$pis[starts-with(., 'additional-classpath=')]">
-							<xsl:attribute name="additional-classpath"
-								select="substring-after(., 'additional-classpath=')" />
-						</xsl:for-each>
-
-						<xsl:for-each select="$pis[starts-with(., 'html-reporter=')]">
-							<xsl:attribute name="html-reporter"
-								select="substring-after(., 'html-reporter=')" />
-						</xsl:for-each>
-
-						<xsl:for-each select="$pis[starts-with(., 'coverage-reporter=')]">
-							<xsl:attribute name="coverage-reporter"
-								select="substring-after(., 'coverage-reporter=')" />
+						<xsl:for-each
+							select="
+								'additional-classpath',
+								'coverage-reporter',
+								'force-focus',
+								'html-reporter'">
+							<xsl:variable as="xs:string" name="left-hand-side" select="." />
+							<xsl:variable as="xs:string" name="starts-with"
+								select="$left-hand-side || '='" />
+							<xsl:for-each select="$pis[starts-with(., $starts-with)]">
+								<xsl:attribute name="{$left-hand-side}"
+									select="substring-after(., $starts-with)" />
+							</xsl:for-each>
 						</xsl:for-each>
 
 						<xsl:call-template name="on-run-xspec">

--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -36,6 +36,10 @@
 		<dirname file="${env.XMLCALABASH_JAR}" property="xmlcalabash.jar.dir" />
 		<dirname file="${xmlcalabash.jar.dir}" property="xmlcalabash.unzip.dest" />
 		<unzip dest="${xmlcalabash.unzip.dest}" src="${xmlcalabash.zip}" />
+
+		<delete verbose="true">
+			<fileset dir="${xmlcalabash.jar.dir}" includes="lib/Saxon-*.jar" />
+		</delete>
 	</target>
 
 	<target if="env.BASEX_VERSION" name="basex">

--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -37,8 +37,16 @@
 		<dirname file="${xmlcalabash.jar.dir}" property="xmlcalabash.unzip.dest" />
 		<unzip dest="${xmlcalabash.unzip.dest}" src="${xmlcalabash.zip}" />
 
+		<condition property="xmlcalabash.saxon.jar.count.ok">
+			<resourcecount count="1">
+				<fileset dir="${xmlcalabash.jar.dir}/lib/" id="xmlcalabash.saxon.jar"
+					includes="Saxon-HE-*.jar" />
+			</resourcecount>
+		</condition>
+		<fail message="Failed to identify Saxon jar in XML Calabash lib dir"
+			unless="xmlcalabash.saxon.jar.count.ok" />
 		<delete verbose="true">
-			<fileset dir="${xmlcalabash.jar.dir}" includes="lib/Saxon-*.jar" />
+			<fileset refid="xmlcalabash.saxon.jar" />
 		</delete>
 	</target>
 

--- a/test/ci/env/README.md
+++ b/test/ci/env/README.md
@@ -9,5 +9,6 @@
 
 ### Note
 
-- XML Calabash will use Saxon jar in its own lib directory.
+- XML Calabash will use Saxon jar in its own `lib` directory.
+  - You need to delete `lib/Saxon-*.jar` and add our Saxon jar to classpath.
 - BaseX test requires XML Calabash.

--- a/test/ci/env/README.md
+++ b/test/ci/env/README.md
@@ -10,5 +10,5 @@
 ### Note
 
 - XML Calabash will use Saxon jar in its own `lib` directory.
-  - You need to delete `lib/Saxon-*.jar` and add our Saxon jar to classpath.
+  - You need to delete `lib/Saxon-HE-*.jar` and add our Saxon jar to classpath.
 - BaseX test requires XML Calabash.

--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -24,7 +24,7 @@ java -cp "%SAXON_JAR%" net.sf.saxon.Version
 
 echo:
 echo === Check XML Calabash
-java -jar "%XMLCALABASH_JAR%" 2> NUL
+java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main 2> NUL
 
 echo:
 echo === Print XML Resolver version

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -22,7 +22,7 @@ java -cp "${SAXON_JAR}" net.sf.saxon.Version
 
 echo
 echo "=== Check XML Calabash"
-java -jar "${XMLCALABASH_JAR}" 2> /dev/null
+java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main 2> /dev/null
 
 echo
 echo "=== Print XML Resolver version"

--- a/test/end-to-end/cases/expected/query/force-focus_focus-1-junit.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-1-junit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_focus-1.xspec">
+   <testsuite name="an unfocused correct scenario must be Pending"
+              tests="1"
+              failures="0">
+      <testcase name="it would return Success if it were not Pending" status="passed"/>
+   </testsuite>
+   <testsuite name="an unfocused incorrect scenario must be Pending"
+              tests="1"
+              failures="1">
+      <testcase name="it would return Failure if it were not Pending" status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="a focused correct scenario" tests="1" failures="0">
+      <testcase name="must execute the test and return Success" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="a focused incorrect scenario" tests="1" failures="0">
+      <testcase name="must execute the test and return Failure" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-1-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-1-result.html
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?><!--Report filtered by focus--><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: http://example.org/ns/my</p>
+      <p>Query-at: <a href="../../../../square.xqm">square.xqm</a></p>
+      <p>XSpec: <a href="../../force-focus_focus-1.xspec">force-focus_focus-1.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 2</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">an unfocused correct scenario must be Pending</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">an unfocused incorrect scenario must be Pending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">an unfocused correct scenario must be Pending<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>an unfocused correct scenario must be Pending</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it would return Success if it were not Pending</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">an unfocused incorrect scenario must be Pending<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>an unfocused incorrect scenario must be Pending</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">it would return Failure if it were not Pending</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>an unfocused incorrect scenario must be Pending</h3>
+            <div id="scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">it would return Failure if it were not Pending</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-1-result.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-1-result.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_focus-1.xspec"
+        query="http://example.org/ns/my"
+        query-at="../../../../square.xqm"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../focus-1.xspec">
+      <label>an unfocused correct scenario must be Pending</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="3"/>
+         </t:call>
+      </input-wrap>
+      <result select="9"/>
+      <test id="scenario1-expect1" successful="true">
+         <label>it would return Success if it were not Pending</label>
+         <expect select="9"/>
+      </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../focus-1.xspec">
+      <label>an unfocused incorrect scenario must be Pending</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="2"/>
+         </t:call>
+      </input-wrap>
+      <result select="4"/>
+      <test id="scenario2-expect1" successful="false">
+         <label>it would return Failure if it were not Pending</label>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
+   <scenario id="scenario3" xspec="../../focus-1.xspec" pending="force focus">
+      <label>a focused correct scenario</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="3"/>
+         </t:call>
+      </input-wrap>
+      <test id="scenario3-expect1" pending="force focus">
+         <label>must execute the test and return Success</label>
+      </test>
+   </scenario>
+   <scenario id="scenario4" xspec="../../focus-1.xspec" pending="force focus">
+      <label>a focused incorrect scenario</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="2"/>
+         </t:call>
+      </input-wrap>
+      <test id="scenario4-expect1" pending="force focus">
+         <label>must execute the test and return Failure</label>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-junit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_escape-for-regex.xspec">
+   <testsuite name="No escaping" tests="1" failures="0">
+      <testcase name="Must not be escaped at all" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="Test simple patterns" tests="3" failures="0">
+      <testcase name="When encountering parentheses escape them." status="passed"/>
+      <testcase name="When encountering a whitespace character class escape the backslash"
+                status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+      <testcase name="When encountering a whitespace character class result should have one more character than source"
+                status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="When processing a list of phrases" tests="2" failures="0">
+      <testcase name="All phrase elements should remain" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+      <testcase name="Strings should be escaped and status attributes should be added"
+                status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?><!--Report filtered by focus--><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for escape-for-regex.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../../tutorial/escape-for-regex.xsl">escape-for-regex.xsl</a></p>
+      <p>XSpec: <a href="../../force-focus_escape-for-regex.xspec">force-focus_escape-for-regex.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="pending">
+               <th>(<strong>force focus</strong>) <a href="#top_scenario2">Test simple patterns</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario2">
+         <h2 class="pending">(<strong>force focus</strong>) Test simple patterns<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="pending">
+                  <th>(<strong>force focus</strong>) Test simple patterns</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <th>When encountering parentheses</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>escape them.</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_escape-for-regex.xspec"
+        stylesheet="../../../../../tutorial/escape-for-regex.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1"
+             xspec="../../../../../tutorial/escape-for-regex.xspec"
+             pending="force focus">
+      <label>No escaping</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:functx="http://www.functx.com"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="functx:escape-for-regex">
+            <x:param select="'Hello'"/>
+         </x:call>
+      </input-wrap>
+      <test id="scenario1-expect1" pending="force focus">
+         <label>Must not be escaped at all</label>
+      </test>
+   </scenario>
+   <scenario id="scenario2"
+             xspec="../../../../../tutorial/escape-for-regex.xspec"
+             pending="force focus">
+      <label>Test simple patterns</label>
+      <scenario id="scenario2-scenario1"
+                xspec="../../../../../tutorial/escape-for-regex.xspec">
+         <label>When encountering parentheses</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:functx="http://www.functx.com"
+                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    function="functx:escape-for-regex">
+               <x:param name="arg" select="'(Hello)'"/>
+            </x:call>
+         </input-wrap>
+         <result select="'\(Hello\)'"/>
+         <test id="scenario2-scenario1-expect1" successful="true">
+            <label>escape them.</label>
+            <expect select="'\(Hello\)'"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario2"
+                xspec="../../../../../tutorial/escape-for-regex.xspec"
+                pending="force focus">
+         <label>When encountering a whitespace character class</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:functx="http://www.functx.com"
+                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    function="functx:escape-for-regex">
+               <x:param name="arg" select="'\sHello'"/>
+            </x:call>
+         </input-wrap>
+         <test id="scenario2-scenario2-expect1" pending="force focus">
+            <label>escape the backslash</label>
+         </test>
+         <test id="scenario2-scenario2-expect2" pending="force focus">
+            <label>result should have one more character than source</label>
+         </test>
+      </scenario>
+   </scenario>
+   <scenario id="scenario3"
+             xspec="../../../../../tutorial/escape-for-regex.xspec"
+             pending="force focus">
+      <label>When processing a list of phrases</label>
+      <input-wrap xmlns="">
+         <x:context xmlns:functx="http://www.functx.com"
+                    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <phrases>
+               <phrase>Hello!</phrase>
+               <phrase>Goodbye!</phrase>
+               <phrase>(So long!)</phrase>
+            </phrases>
+         </x:context>
+      </input-wrap>
+      <test id="scenario3-expect1" pending="force focus">
+         <label>All phrase elements should remain</label>
+      </test>
+      <test id="scenario3-expect2" pending="force focus">
+         <label>Strings should be escaped and status attributes should be added</label>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-junit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_focus-1.xspec">
+   <testsuite name="an unfocused correct scenario must be Pending"
+              tests="1"
+              failures="0">
+      <testcase name="it would return Success if it were not Pending" status="passed"/>
+   </testsuite>
+   <testsuite name="an unfocused incorrect scenario must be Pending"
+              tests="1"
+              failures="1">
+      <testcase name="it would return Failure if it were not Pending" status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+   </testsuite>
+   <testsuite name="a focused correct scenario" tests="1" failures="0">
+      <testcase name="must execute the test and return Success" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="a focused incorrect scenario" tests="1" failures="0">
+      <testcase name="must execute the test and return Failure" status="skipped">
+         <skipped>force focus</skipped>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-result.html
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?><!--Report filtered by focus--><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for square.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../square.xsl">square.xsl</a></p>
+      <p>XSpec: <a href="../../force-focus_focus-1.xspec">force-focus_focus-1.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 2</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">an unfocused correct scenario must be Pending</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">an unfocused incorrect scenario must be Pending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">an unfocused correct scenario must be Pending<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>an unfocused correct scenario must be Pending</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it would return Success if it were not Pending</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">an unfocused incorrect scenario must be Pending<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>an unfocused incorrect scenario must be Pending</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">it would return Failure if it were not Pending</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>an unfocused incorrect scenario must be Pending</h3>
+            <div id="scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">it would return Failure if it were not Pending</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>4</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-1-result.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_focus-1.xspec"
+        stylesheet="../../../../square.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../focus-1.xspec">
+      <label>an unfocused correct scenario must be Pending</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="3"/>
+         </t:call>
+      </input-wrap>
+      <result select="9"/>
+      <test id="scenario1-expect1" successful="true">
+         <label>it would return Success if it were not Pending</label>
+         <expect select="9"/>
+      </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../focus-1.xspec">
+      <label>an unfocused incorrect scenario must be Pending</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="2"/>
+         </t:call>
+      </input-wrap>
+      <result select="4"/>
+      <test id="scenario2-expect1" successful="false">
+         <label>it would return Failure if it were not Pending</label>
+         <expect-test-wrap xmlns="">
+            <t:expect xmlns:my="http://example.org/ns/my"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      test="$t:result instance of xs:string"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
+   <scenario id="scenario3" xspec="../../focus-1.xspec" pending="force focus">
+      <label>a focused correct scenario</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="3"/>
+         </t:call>
+      </input-wrap>
+      <test id="scenario3-expect1" pending="force focus">
+         <label>must execute the test and return Success</label>
+      </test>
+   </scenario>
+   <scenario id="scenario4" xspec="../../focus-1.xspec" pending="force focus">
+      <label>a focused incorrect scenario</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:my="http://example.org/ns/my"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="my:square">
+            <t:param select="2"/>
+         </t:call>
+      </input-wrap>
+      <test id="scenario4-expect1" pending="force focus">
+         <label>must execute the test and return Failure</label>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/force-focus-reporter.xsl
+++ b/test/end-to-end/cases/force-focus-reporter.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:import href="../../../src/reporter/format-xspec-report.xsl" />
+
+	<xsl:template as="node()+" match="document-node(element(x:report))">
+		<xsl:comment>Report filtered by focus</xsl:comment>
+
+		<xsl:variable as="document-node(element(x:report))" name="filtered-doc">
+			<xsl:apply-templates mode="filter-focus" select="." />
+		</xsl:variable>
+
+		<xsl:apply-templates select="$filtered-doc/node()" />
+	</xsl:template>
+
+	<!--
+		mode="filter-focus"
+	-->
+	<xsl:mode name="filter-focus" on-multiple-match="fail" on-no-match="shallow-copy" />
+
+	<xsl:template as="empty-sequence()"
+		match="x:scenario[descendant-or-self::x:scenario[@id = $force-focus-ids] => empty()]"
+		mode="filter-focus" />
+
+</xsl:stylesheet>

--- a/test/end-to-end/cases/force-focus_escape-for-regex.xspec
+++ b/test/end-to-end/cases/force-focus_escape-for-regex.xspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Force focus on a child scenario -->
+<?xspec-test force-focus=scenario2-scenario1?>
+
+<!-- Exclude unrelated scenarios from the test result report HTML -->
+<?xspec-test html-reporter=${xspec.project.dir}/test/end-to-end/cases/force-focus-reporter.xsl?>
+
+<x:description stylesheet="escape-for-regex.xsl" xml:base="../../../tutorial/"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="escape-for-regex.xspec" />
+</x:description>

--- a/test/end-to-end/cases/force-focus_focus-1.xspec
+++ b/test/end-to-end/cases/force-focus_focus-1.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Force focus on multiple pending scenarios -->
+<?xspec-test force-focus=scenario1 scenario2?>
+
+<!-- Exclude unrelated scenarios from the test result report HTML -->
+<?xspec-test html-reporter=${xspec.project.dir}/test/end-to-end/cases/force-focus-reporter.xsl?>
+
+<x:description query="http://example.org/ns/my" query-at="../../square.xqm"
+	stylesheet="../../square.xsl" xmlns:t="http://www.jenitennison.com/xslt/xspec"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="focus-1.xspec" />
+</x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -332,7 +332,7 @@
     set "ACTUAL_REPORT=%ACTUAL_REPORT_DIR%\serialize-result.html"
 
     rem Run
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=end-to-end/cases/serialize.xspec ^
         -o result="file:///%ACTUAL_REPORT:\=/%" ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
@@ -355,7 +355,7 @@
     set "ACTUAL_REPORT=%ACTUAL_REPORT_DIR%\serialize-result.html"
 
     rem Run
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=end-to-end/cases/serialize.xspec ^
         -o result="file:///%ACTUAL_REPORT:\=/%" ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
@@ -372,7 +372,7 @@
 	</case>
 
 	<case ifdef="XMLCALABASH_JAR" name="XProc harness for Saxon (XQuery with special characters in expression #1020)">
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=issue-1020.xspec ^
         -o result="file:///%WORK_DIR:\=/%/issue-1020-result_%RANDOM%.html" ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
@@ -662,7 +662,7 @@
     set "EXPECTED_REPORT=%WORK_DIR%\issue-1020-result_%RANDOM%.html"
 
     rem Run (also test with special characters in expression #1020)
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=issue-1020.xspec ^
         -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p basex-jar="%BASEX_JAR%" ^
@@ -694,7 +694,7 @@
     set "EXPECTED_REPORT=%WORK_DIR%\issue-1020-result_%RANDOM%.html"
 
     rem Run (also test with special characters in expression #1020)
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=issue-1020.xspec ^
         -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p auth-method=Basic ^
@@ -1526,7 +1526,7 @@
 	-->
 
 	<case ifdef="XMLCALABASH_JAR" name="XSLT selecting nodes without context should be error (XProc) #423">
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=issue-423/test.xspec ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xslt-harness.xproc
@@ -1536,7 +1536,7 @@
 	</case>
 
 	<case ifdef="XMLCALABASH_JAR" name="XQuery selecting nodes without context should be error (XProc) #423">
-    call :run java -jar "%XMLCALABASH_JAR%" ^
+    call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
         -i source=issue-423/test.xspec ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\saxon\saxon-xquery-harness.xproc

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -423,7 +423,7 @@ load bats-helper
     actual_report="${actual_report_dir}/serialize-result.html"
 
     # Run
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=end-to-end/cases/serialize.xspec \
         -o result="file:${actual_report}" \
         -p xspec-home="file:${parent_dir_abs}/" \
@@ -452,7 +452,7 @@ load bats-helper
     actual_report="${actual_report_dir}/serialize-result.html"
 
     # Run
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=end-to-end/cases/serialize.xspec \
         -o result="file:${actual_report}" \
         -p xspec-home="file:${parent_dir_abs}/" \
@@ -475,7 +475,7 @@ load bats-helper
         skip "XMLCALABASH_JAR is not defined"
     fi
 
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=issue-1020.xspec \
         -o result="file:${work_dir}/issue-1020-result_${RANDOM}.html" \
         -p xspec-home="file:${parent_dir_abs}/" \
@@ -807,7 +807,7 @@ load bats-helper
     expected_report="${work_dir}/issue-1020-result_${RANDOM}.html"
 
     # Run (also test with special characters in expression #1020)
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=issue-1020.xspec \
         -o result="file:${expected_report}" \
         -p basex-jar="${BASEX_JAR}" \
@@ -846,7 +846,7 @@ load bats-helper
     expected_report="${work_dir}/issue-1020-result_${RANDOM}.html"
 
     # Run (also test with special characters in expression #1020)
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=issue-1020.xspec \
         -o result="file:${expected_report}" \
         -p auth-method=Basic \
@@ -1755,7 +1755,7 @@ load bats-helper
         skip "XMLCALABASH_JAR is not defined"
     fi
 
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=issue-423/test.xspec \
         -p xspec-home="file:${parent_dir_abs}/" \
         ../src/harnesses/saxon/saxon-xslt-harness.xproc
@@ -1770,7 +1770,7 @@ load bats-helper
         skip "XMLCALABASH_JAR is not defined"
     fi
 
-    run java -jar "${XMLCALABASH_JAR}" \
+    run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
         -i source=issue-423/test.xspec \
         -p xspec-home="file:${parent_dir_abs}/" \
         ../src/harnesses/saxon/saxon-xquery-harness.xproc


### PR DESCRIPTION
[Oxygen XSpec Helper View](https://github.com/xspec/oXygen-XML-editor-xspec-support) has an ability to rerun only the failed tests. Unfortunately the way it's implemented breaks `x:variable`, because the target scenario templates are called [directly](https://github.com/xspec/oXygen-XML-editor-xspec-support/blob/7240b9bf2229676c4a8097425a6cf8bd5759ca9e/frameworks/xspec/oxygen-results-view/compile-driver.xsl#L31-L34).

This pull request provides a standard interface for that use case. It's controlled by a new Ant property `xspec.force.focus` which is a string of one or more scenario IDs separated by whitespace characters. If the property is set, the string is passed on to `src/compiler/generate-common-tests.xsl` who sets `@focus` on the corresponding scenarios and removes `@focus` from the others if any. The same string parameter is also passed on to the test result HTML reporter stylesheet (`src/reporter/format-xspec-report.xsl` by default) so that the reporter stylesheet has a chance to filter the test results based on it.

Only _Oxygen XSpec Helper View_ requires this feature as far as I know. So I'm keeping this new Ant property undocumented for now.

While working on this change, I encountered some XProc test failures. It was due to an older version of Saxon (its bug [4433](https://saxonica.plan.io/issues/4433)?) bundled with XML Calabash. This testing environment discrepancy has been [a problem](https://github.com/xspec/xspec/pull/86#discussion_r104289634) for a long time. 69a1fcd07d9562e47a85beaae4d58d84d2080318 fixes it.