### PR TITLE
docs: update a comment about transform cache=false

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -513,7 +513,10 @@
             <!--
                Common options
             -->
-            <map-entry key="'cache'" select="false()" /><!-- cache=true() invalidates different static parameters -->
+
+            <!-- cache must be false(): https://saxonica.plan.io/issues/4667 -->
+            <map-entry key="'cache'" select="false()" />
+
             <map-entry key="'delivery-format'" select="'raw'" />
 
             <!-- 'stylesheet-node' might be faster than 'stylesheet-location' when repeated. (Just a guess.


### PR DESCRIPTION
Just updates a comment to clarify why the cache must be disabled in `@run-as="external"`.