### PR TITLE
fix(report): resolve coverage stylesheet URI via xml:base

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -37,10 +37,10 @@
   select="doc($xspec-uri)" />
 
 <xsl:variable name="stylesheet-uri" as="xs:anyURI"
-  select="resolve-uri($xspec-doc/x:description/@stylesheet, $xspec-uri)" />
+  select="$xspec-doc/x:description/resolve-uri(@stylesheet, base-uri())" />
 
 <xsl:variable name="stylesheet-trees" as="document-node()+"
-  select="test:collect-stylesheets(doc($stylesheet-uri))" />
+  select="$stylesheet-uri => doc() => test:collect-stylesheets()" />
 
 <xsl:function name="test:collect-stylesheets" as="document-node()+">
   <xsl:param name="stylesheets" as="document-node()+" />

--- a/test/issue-1135.xspec
+++ b/test/issue-1135.xspec
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<!-- To test xspec/xspec#1135 properly, @stylesheet should be accessible only when resolved via
+	@xml:base -->
+<x:description stylesheet="issue-1135.xsl" xml:base="issue-1135/"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="demo.xspec" xml:base="../../tutorial/coverage/" />
+</x:description>

--- a/test/issue-1135/issue-1135.xsl
+++ b/test/issue-1135/issue-1135.xsl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:include href="demo.xsl" xml:base="../../tutorial/coverage/" />
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes #1135

- c6c538941f1c672afe16bbeec74a00acff4b6ad6 reproduces the bug
- c2168cd0a7735e0a40cbf9fe79b3e7777aefd7e0 fixes it by resolving `@stylesheet` with the base URI