### PR TITLE
build(oxygen): add-on v2.0.3

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,19 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.0.3</h3>
+				<ul>
+					<li>feat: <code>x:helper</code> (<a
+							href="https://github.com/xspec/xspec/pull/1103">#1103</a>)</li>
+					<li>feat(report): report all namespaces in test result report HTML (<a
+							href="https://github.com/xspec/xspec/pull/1095">#1095</a>)</li>
+					<li>Improvements in handling namespaces<ul>
+							<li>See also <a href="https://github.com/xspec/xspec/issues/1121"
+									>Breaking changes in v2.0</a></li>
+						</ul></li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.2</h3>
 				<ul>
 					<li>feat(xquery): text value templates (<a

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/61a11b74b1757ab6e42674d79482e17848c8148b.zip" />
+			href="https://github.com/xspec/xspec/archive/d490d5ed50f871061c1ebb7e6037ccf8d2d3735e.zip" />
 
-		<xt:version>2.0.2</xt:version>
+		<xt:version>2.0.3</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-61a11b74b1757ab6e42674d79482e17848c8148b/xspec.framework/XSpec</String>
+                                    <String>4/xspec-d490d5ed50f871061c1ebb7e6037ccf8d2d3735e/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
Following #1103, this pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 22.1 build 2020072902 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-0-3/oxygen-addon.xml`.
