### PR TITLE
test: replace U+0008 with U+0016

### DIFF
--- a/test/end-to-end/cases/expected/query/xml-1-1-junit.xml
+++ b/test/end-to-end/cases/expected/query/xml-1-1-junit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <testsuites name="xml-1-1.xspec">
    <testsuite name="Return &#x7;" tests="1" failures="1">
-      <testcase name="Expect &#x8;" status="failed">
+      <testcase name="Expect &#x16;" status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.html
@@ -65,7 +65,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario1-expect1">Expect &#x8;</a></td>
+                  <td><a href="#scenario1-expect1">Expect &#x16;</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -73,7 +73,7 @@
          <div id="scenario1">
             <h3>Return &#x7;</h3>
             <div id="scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">Expect &#x8;</h4>
+               <h4 class="xTestReportTitle">Expect &#x16;</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -94,7 +94,7 @@
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns">xmlns:mirror="x-urn:test:mirror"</span>
       <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
-      <span class="xmlns">xmlns:xi="http://www.w3.org/2001/XInclude"</span>&gt;<span class="diff">&#x8;</span>&lt;/test&gt;</pre>
+      <span class="xmlns">xmlns:xi="http://www.w3.org/2001/XInclude"</span>&gt;<span class="diff">&#x16;</span>&lt;/test&gt;</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.xml
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.xml
@@ -24,12 +24,12 @@
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="false">
-         <label>Expect &#x8;</label>
+         <label>Expect &#x16;</label>
          <expect select="/element()">
             <content-wrap xmlns="">
                <test xmlns:mirror="x-urn:test:mirror"
                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                     xmlns:xi="http://www.w3.org/2001/XInclude">&#x8;</test>
+                     xmlns:xi="http://www.w3.org/2001/XInclude">&#x16;</test>
             </content-wrap>
          </expect>
       </test>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-junit.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-junit.xml
@@ -2,8 +2,8 @@
 <testsuites name="xml-1-1_schematron.xspec">
    <testsuite name="Set up a context containing &#x7;" tests="2" failures="1">
       <testcase name="Expect &#x7; reported report U0007" status="passed"/>
-      <testcase name="Expect &#x8; reported report U0008" status="failed">
-         <failure message="expect assertion failed">Expecting: exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0008'])</failure>
+      <testcase name="Expect &#x16; reported report U0016" status="failed">
+         <failure message="expect assertion failed">Expecting: exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0016'])</failure>
       </testcase>
    </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -54,7 +54,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario1-expect2">Expect &#x8; reported report U0008</a></td>
+                  <td><a href="#scenario1-expect2">Expect &#x16; reported report U0016</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -62,7 +62,7 @@
          <div id="scenario1">
             <h3>Set up a context containing &#x7;</h3>
             <div id="scenario1-expect2" class="xTestReport">
-               <h4 class="xTestReportTitle">Expect &#x8; reported report U0008</h4>
+               <h4 class="xTestReportTitle">Expect &#x16; reported report U0016</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -97,7 +97,7 @@
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
-                           <pre>exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0008'])</pre>
+                           <pre>exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0016'])</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -43,10 +43,10 @@
          <expect select="()"/>
       </test>
       <test id="scenario1-expect2" successful="false">
-         <label>Expect &#x8; reported report U0008</label>
+         <label>Expect &#x16; reported report U0016</label>
          <expect-test-wrap xmlns="">
             <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                      test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0008'])"/>
+                      test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}successful-report[(@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@id, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@id)[1] = 'U0016'])"/>
          </expect-test-wrap>
          <expect select="()"/>
       </test>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-junit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <testsuites name="xml-1-1.xspec">
    <testsuite name="Return &#x7;" tests="1" failures="1">
-      <testcase name="Expect &#x8;" status="failed">
+      <testcase name="Expect &#x16;" status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
@@ -64,7 +64,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario1-expect1">Expect &#x8;</a></td>
+                  <td><a href="#scenario1-expect1">Expect &#x16;</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -72,7 +72,7 @@
          <div id="scenario1">
             <h3>Return &#x7;</h3>
             <div id="scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">Expect &#x8;</h4>
+               <h4 class="xTestReportTitle">Expect &#x16;</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -93,7 +93,7 @@
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns">xmlns:mirror="x-urn:test:mirror"</span>
       <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
-      <span class="xmlns">xmlns:xi="http://www.w3.org/2001/XInclude"</span>&gt;<span class="diff">&#x8;</span>&lt;/test&gt;</pre>
+      <span class="xmlns">xmlns:xi="http://www.w3.org/2001/XInclude"</span>&gt;<span class="diff">&#x16;</span>&lt;/test&gt;</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.xml
@@ -23,12 +23,12 @@
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="false">
-         <label>Expect &#x8;</label>
+         <label>Expect &#x16;</label>
          <expect select="/element()">
             <content-wrap xmlns="">
                <test xmlns:mirror="x-urn:test:mirror"
                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                     xmlns:xi="http://www.w3.org/2001/XInclude">&#x8;</test>
+                     xmlns:xi="http://www.w3.org/2001/XInclude">&#x16;</test>
             </content-wrap>
          </expect>
       </test>

--- a/test/end-to-end/cases/xml-1-1.sch
+++ b/test/end-to-end/cases/xml-1-1.sch
@@ -3,7 +3,7 @@
 	<sch:pattern>
 		<sch:rule context="test">
 			<sch:report id="U0007" test="string() eq '&#x07;'" />
-			<sch:report id="U0008" test="string() eq '&#x08;'" />
+			<sch:report id="U0016" test="string() eq '&#x16;'" />
 		</sch:rule>
 	</sch:pattern>
 </sch:schema>

--- a/test/end-to-end/cases/xml-1-1.xspec
+++ b/test/end-to-end/cases/xml-1-1.xspec
@@ -16,8 +16,8 @@
 
 		<!-- This x:expect fails deliberately so that the control characters appear in the report
 			files. -->
-		<x:expect label="Expect &#x08;">
-			<test>&#x08;</test>
+		<x:expect label="Expect &#x16;">
+			<test>&#x16;</test>
 		</x:expect>
 	</x:scenario>
 

--- a/test/end-to-end/cases/xml-1-1_schematron.xspec
+++ b/test/end-to-end/cases/xml-1-1_schematron.xspec
@@ -13,7 +13,7 @@
 
 		<!-- This x:expect fails deliberately so that the control characters appear in the report
 			files. -->
-		<x:expect-report id="U0008" label="Expect &#x08; reported" />
+		<x:expect-report id="U0016" label="Expect &#x16; reported" />
 	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
Looks like for some reason a certain control character breaks Travis CI. Not always, but sometimes.

Replace U+0008 with U+0016 in hopes of better stability. I don't know if it works...