### PR TITLE
ci: bump Travis CI Ubuntu version from 16 to 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 os: linux
+
+# Changed from the default 'xenial' in hopes of better stability of the end-to-end test
+dist: bionic
+
 language: java
 
 jdk:


### PR DESCRIPTION
Following #1148, this is another attempt to stabilize the end-to-end test on Travis CI.