### PR TITLE
test(schematron): skip xml-1-1_schematron.xspec on Travis CI

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -206,6 +206,13 @@
 
 					<xsl:when
 						test="
+							($pis = 'require-xspec-issue-1156-fixed')
+							and (environment-variable('TRAVIS_OS_NAME') eq 'linux')">
+						<xsl:text>Requires xspec/xspec#1156 to have been fixed</xsl:text>
+					</xsl:when>
+
+					<xsl:when
+						test="
 							($test-type eq 't')
 							and (parent::x:description/@run-as eq 'external')
 							and ($x:saxon-version lt x:pack-version((9, 8, 0, 8)))">

--- a/test/end-to-end/cases/xml-1-1_schematron.xspec
+++ b/test/end-to-end/cases/xml-1-1_schematron.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <?xspec-test require-saxon-bug-4666-fixed?>
+<?xspec-test require-xspec-issue-1156-fixed?>
 <?xspec-test xml-version=1.1?>
 <x:description schematron="xml-1-1.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 


### PR DESCRIPTION
Skip `xml-1-1_schematron.xspec` on Travis CI due to #1156, because the compiled stylesheet on a failed job seems sound and there seems to be nothing we can do in the short term.