### PR TITLE
build(oxygen): add-on v2.0.4

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,18 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.0.4</h3>
+				<ul>
+					<li>feat(schematron): compare location based on node identity (<a
+							href="https://github.com/xspec/xspec/pull/1107">#1107</a>)</li>
+					<li>feat(xslt): static parameters (<a
+							href="https://github.com/xspec/xspec/pull/1120">#1120</a>)</li>
+					<li>feat: support XML 1.1 in Ant build (<a
+							href="https://github.com/xspec/xspec/pull/1141">#1141</a>)</li>
+					<li>Minor fixes in importing Schematron tests</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.3</h3>
 				<ul>
 					<li>feat: <code>x:helper</code> (<a

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/d490d5ed50f871061c1ebb7e6037ccf8d2d3735e.zip" />
+			href="https://github.com/xspec/xspec/archive/f2519d84dcffb420fe205ed1452e14ca4f872efb.zip" />
 
-		<xt:version>2.0.3</xt:version>
+		<xt:version>2.0.4</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-d490d5ed50f871061c1ebb7e6037ccf8d2d3735e/xspec.framework/XSpec</String>
+                                    <String>4/xspec-f2519d84dcffb420fe205ed1452e14ca4f872efb/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
Following the recent changes, this pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 22.1 build 2020072902 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-0-4/oxygen-addon.xml`.