### PR TITLE
refactor: remove `test` prefix support from x:known-UQName()

### DIFF
--- a/src/common/xspec-utils.xsl
+++ b/src/common/xspec-utils.xsl
@@ -695,9 +695,6 @@
 				<xsl:when test="$prefix eq 'svrl'">
 					<xsl:sequence select="'http://purl.oclc.org/dsdl/svrl'" />
 				</xsl:when>
-				<xsl:when test="$prefix eq 'test'">
-					<xsl:sequence select="$x:legacy-namespace" />
-				</xsl:when>
 				<xsl:when test="$prefix eq 'x'">
 					<xsl:sequence select="$x:xspec-namespace" />
 				</xsl:when>

--- a/test/xspec-utils_stylesheet.xspec
+++ b/test/xspec-utils_stylesheet.xspec
@@ -1467,14 +1467,6 @@
 				>Q{http://purl.oclc.org/dsdl/svrl}my-local-name</x:expect>
 		</x:scenario>
 
-		<x:scenario label="test">
-			<x:call function="x:known-UQName">
-				<x:param select="'test:my-local-name'" />
-			</x:call>
-			<x:expect label="Constructed" select="string()"
-				>Q{http://www.jenitennison.com/xslt/unit-test}my-local-name</x:expect>
-		</x:scenario>
-
 		<x:scenario label="x">
 			<x:call function="x:known-UQName">
 				<x:param select="'x:my-local-name'" />


### PR DESCRIPTION
Remove `test` prefix support from `x:known-UQName()`, as #1149 has obsoleted it.