### PR TITLE
refactor(xslt): remove duplicate xsl:namespace-alias

### DIFF
--- a/src/compiler/compile-xslt-tests.xsl
+++ b/src/compiler/compile-xslt-tests.xsl
@@ -29,8 +29,14 @@
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/compile-xslt-tests.xsl</pkg:import-uri>
 
+   <!--
+      Namespace alias for literal result elements
+   -->
    <xsl:namespace-alias stylesheet-prefix="#default" result-prefix="xsl" />
 
+   <!--
+      Serialization parameters applied to the compiled stylesheet
+   -->
    <xsl:output indent="yes" />
 
    <!--
@@ -175,7 +181,6 @@
          <xsl:call-template name="x:compile-child-scenarios-or-expects" />
       </xsl:element>
    </xsl:template>
-
 
 </xsl:stylesheet>
 

--- a/src/compiler/xslt/compile/compile-expect.xsl
+++ b/src/compiler/xslt/compile/compile-expect.xsl
@@ -6,8 +6,6 @@
                 exclude-result-prefixes="#all"
                 version="3.0">
 
-   <xsl:namespace-alias stylesheet-prefix="#default" result-prefix="xsl" />
-
    <!--
       Generate an XSLT template from the expect element.
       

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -6,8 +6,6 @@
                 exclude-result-prefixes="#all"
                 version="3.0">
 
-   <xsl:namespace-alias stylesheet-prefix="#default" result-prefix="xsl" />
-
    <!--
       Generates the templates that perform the tests.
       Called during mode="local:compile-scenarios-or-expects" in


### PR DESCRIPTION
Just remove some duplicate `xsl:namespace-alias`.