### PR TITLE
test(schematron): skip xml-1-1_schematron.xspec on GitHub Actions macOS

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -215,7 +215,16 @@
 					<xsl:when
 						test="
 							($pis = 'require-xspec-issue-1156-fixed')
-							and (environment-variable('TRAVIS_OS_NAME') eq 'linux')">
+							and
+							(
+							(environment-variable('TRAVIS_OS_NAME') eq 'linux')
+							or
+							(
+							(environment-variable('GITHUB_ACTIONS') eq 'true')
+							and
+							(environment-variable('RUNNER_OS') eq 'macOS')
+							)
+							)">
 						<xsl:text>Requires xspec/xspec#1156 to have been fixed</xsl:text>
 					</xsl:when>
 


### PR DESCRIPTION
Skip `xml-1-1_schematron.xspec` on macOS on GitHub Actions due to #1156. 
Using another XML parser may possibly fix it, but I'm reluctant to try it, as the problem has not been reproduced on my local machine and not always be reproduced on CI systems. Also, I don't want to introduce another test dependency at this moment.