### PR TITLE
build(oxygen): add-on v2.0.5

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,16 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.0.5</h3>
+				<ul>
+					<li>fix(report): serialize text node report (<a
+							href="https://github.com/xspec/xspec/pull/1158">#1158</a>)</li>
+					<li>fix(xquery): fix issue 446 (x:pending may crash on XQuery) (<a
+							href="https://github.com/xspec/xspec/pull/1222">#1222</a>)</li>
+					<li>Reorganized compiler modules</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.4</h3>
 				<ul>
 					<li>feat(schematron): compare location based on node identity (<a

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/f2519d84dcffb420fe205ed1452e14ca4f872efb.zip" />
+			href="https://github.com/xspec/xspec/archive/838ff9efce04552e885cbe40dd6f65d155b8a262.zip" />
 
-		<xt:version>2.0.4</xt:version>
+		<xt:version>2.0.5</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-f2519d84dcffb420fe205ed1452e14ca4f872efb/xspec.framework/XSpec</String>
+                                    <String>4/xspec-838ff9efce04552e885cbe40dd6f65d155b8a262/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
Following #1222, this pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 22.1 build 2020072902 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-0-5/oxygen-addon.xml`.