### PR TITLE
test: harden risky attribute(test)

### DIFF
--- a/test/select-node.xspec
+++ b/test/select-node.xspec
@@ -26,7 +26,7 @@
 				<x:param as="empty-sequence()" />
 				<x:param select="3.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 
 		<x:scenario label="Select without [1]">
@@ -36,7 +36,7 @@
 				<x:param as="empty-sequence()" />
 				<x:param select="3.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 
 		<x:scenario label="Select without leading /">
@@ -47,7 +47,7 @@
 				<x:param as="empty-sequence()" />
 				<x:param select="3.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 	</x:scenario>
 
@@ -71,7 +71,7 @@
 				<x:param select="$myv:namespaces" />
 				<x:param select="3.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 
 		<x:scenario label="Select by typeical SVRL XPath 1.0">
@@ -81,7 +81,7 @@
 				<x:param select="$myv:namespaces" />
 				<x:param select="1.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 
 		<x:scenario label="Select by typical SVRL XPath 2.0">
@@ -91,7 +91,7 @@
 				<x:param select="$myv:namespaces" />
 				<x:param select="2.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:expected" />
+			<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 		</x:scenario>
 	</x:scenario>
 
@@ -111,7 +111,8 @@
 				<x:param as="empty-sequence()" />
 				<x:param select="3.0" />
 			</x:call>
-			<x:expect label="Selected" test="$x:result is $myv:source/section/@type" />
+			<x:expect label="Selected"
+				test="exactly-one($x:result) is exactly-one($myv:source/section/@type)" />
 		</x:scenario>
 
 		<x:scenario label="In namespace">
@@ -131,7 +132,7 @@
 					<x:param select="$myv:namespaces" />
 					<x:param select="3.0" />
 				</x:call>
-				<x:expect label="Selected" test="$x:result is $myv:expected" />
+				<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 			</x:scenario>
 
 			<x:scenario label="Select by typical SVRL XPath 2.0">
@@ -142,7 +143,7 @@
 					<x:param select="$myv:namespaces" />
 					<x:param select="2.0" />
 				</x:call>
-				<x:expect label="Selected" test="$x:result is $myv:expected" />
+				<x:expect label="Selected" test="exactly-one($x:result) is $myv:expected" />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>
@@ -221,7 +222,8 @@
 					<x:param select="3.0" />
 				</x:call>
 				<x:expect label="Selected"
-					test="$x:result is $myv:source/root()/conbody[1]/p[1]/text()[1]" />
+					test="exactly-one($x:result) is exactly-one($myv:source/root()/conbody[1]/p[1]/text()[1])"
+				 />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>

--- a/test/x-context.xspec
+++ b/test/x-context.xspec
@@ -17,7 +17,7 @@
 	<!-- Shared x:expect -->
 	<x:scenario label="Expect the identical single node" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
-		<x:expect label="Identical node" test="$x:context is $items:element" />
+		<x:expect label="Identical node" test="exactly-one($x:context) is $items:element" />
 	</x:scenario>
 	<x:scenario label="Expect the identical multiple nodes" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />


### PR DESCRIPTION
Like #320, this pull request just hardens some `@test` expressions in test files.

Note that `@test` is a tricky attribute as demonstrated below.

```xspec
    <x:scenario label="Test">
        <x:call function="zero-or-one">
            <x:param as="empty-sequence()" />
        </x:call>
        <x:variable as="element(e)" name="e">
            <e />
        </x:variable>
        <x:expect label="This x:expect is Success" test="$x:result is $e" />
    </x:scenario>
```