### PR TITLE
ci(maven): error when no files found in upload-artifact action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           name: maven-package_${{ env.MAVEN_PACKAGE_VERSION }}_${{ matrix.os }}_java-${{ matrix.java }}_${{ matrix.env }}
           path: target/xspec-${{ env.MAVEN_PACKAGE_VERSION }}*.*
+          if-no-files-found: error


### PR DESCRIPTION
Reflecting actions/upload-artifact#104, this pull request adds `if-no-files-found: error`.