### PR TITLE
test: consolidate x:call using nesting

### DIFF
--- a/test/common-utils.xspec
+++ b/test/common-utils.xspec
@@ -22,22 +22,24 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function decimal-string">
+		<x:call function="x:decimal-string" />
+
 		<x:scenario label="xs:integer">
-			<x:call function="x:decimal-string">
+			<x:call>
 				<x:param select="xs:integer(1)" />
 			</x:call>
 			<x:expect label="Numeric literal of xs:decimal" select="'1.0'" />
 		</x:scenario>
 
 		<x:scenario label="xs:decimal (no decimal point)">
-			<x:call function="x:decimal-string">
+			<x:call>
 				<x:param select="xs:decimal(1)" />
 			</x:call>
 			<x:expect label="Numeric literal of xs:decimal" select="'1.0'" />
 		</x:scenario>
 
 		<x:scenario label="xs:decimal (with decimal point)">
-			<x:call function="x:decimal-string">
+			<x:call>
 				<x:param select="xs:decimal(1.2)" />
 			</x:call>
 			<x:expect label="Numeric literal of xs:decimal" select="'1.2'" />
@@ -45,12 +47,14 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function QName-expression">
+		<x:call function="x:QName-expression" />
+
 		<x:scenario label="With URI">
 			<x:variable as="xs:string" name="ridiculous-uri" select="string()"
 				>'">&lt;#,|%7D&#x20;%7B][$^</x:variable>
 
 			<x:scenario label="With prefix">
-				<x:call function="x:QName-expression">
+				<x:call>
 					<x:param select="QName($ridiculous-uri, 'prefix:foo')" />
 				</x:call>
 				<x:expect label="Converted with apostrophe escaped" select="string()"
@@ -58,7 +62,7 @@
 			</x:scenario>
 
 			<x:scenario label="Without prefix">
-				<x:call function="x:QName-expression">
+				<x:call>
 					<x:param select="QName($ridiculous-uri, 'foo')" />
 				</x:call>
 				<x:expect label="Converted with apostrophe escaped" select="string()"
@@ -67,7 +71,7 @@
 		</x:scenario>
 
 		<x:scenario label="Without URI">
-			<x:call function="x:QName-expression">
+			<x:call>
 				<x:param select="QName('', 'foo')" />
 			</x:call>
 			<x:expect label="Converted" select="string()">QName('',&#x20;'foo')</x:expect>
@@ -75,8 +79,10 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function quote-with-apos">
+		<x:call function="x:quote-with-apos" />
+
 		<x:scenario label="One">
-			<x:call function="x:quote-with-apos">
+			<x:call>
 				<x:param>foo'bar</x:param>
 			</x:call>
 			<x:expect label="Duplicated and quoted" select="string()">'foo''bar'</x:expect>
@@ -84,14 +90,14 @@
 
 		<x:scenario label="Three">
 			<x:scenario label="Consecutive">
-				<x:call function="x:quote-with-apos">
+				<x:call>
 					<x:param>foo'''bar</x:param>
 				</x:call>
 				<x:expect label="Duplicated and quoted" select="string()">'foo''''''bar'</x:expect>
 			</x:scenario>
 
 			<x:scenario label="Sparse">
-				<x:call function="x:quote-with-apos">
+				<x:call>
 					<x:param>foo'bar'baz'qux</x:param>
 				</x:call>
 				<x:expect label="Duplicated and quoted" select="string()"
@@ -100,14 +106,14 @@
 		</x:scenario>
 
 		<x:scenario label="No apos">
-			<x:call function="x:quote-with-apos">
+			<x:call>
 				<x:param> foo bar </x:param>
 			</x:call>
 			<x:expect label="Just quoted" select="string()">' foo bar '</x:expect>
 		</x:scenario>
 
 		<x:scenario label="Zero-length string">
-			<x:call function="x:quote-with-apos">
+			<x:call>
 				<x:param select="''" />
 			</x:call>
 			<x:expect label="Just quoted" select="string()">''</x:expect>

--- a/test/deep-equal.xspec
+++ b/test/deep-equal.xspec
@@ -18,9 +18,10 @@
        Function deq:deep-equal($seq1, $seq2, '').
    -->
    <t:scenario label="deq:deep-equal($seq1, $seq2, '')">
+      <t:call function="deq:deep-equal" />
 
       <t:scenario label="Identical Sequences">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param select="1, 2"/>
             <t:param select="1, 2"/>
             <t:param select="''" />
@@ -29,7 +30,7 @@
       </t:scenario>
 
       <t:scenario label="Non-Identical Sequences">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param select="1, 2"/>
             <t:param select="1, 3"/>
             <t:param select="''" />
@@ -38,7 +39,7 @@
       </t:scenario>
 
       <t:scenario label="Sequences with Same Items in Different Orders">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param select="1, 2"/>
             <t:param select="2, 1"/>
             <t:param select="''" />
@@ -47,7 +48,7 @@
       </t:scenario>
 
       <t:scenario label="Empty Sequences">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param select="()"/>
             <t:param select="()"/>
             <t:param select="''" />
@@ -56,7 +57,7 @@
       </t:scenario>
 
       <t:scenario label="One empty sequence">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param select="()"/>
             <t:param select="1"/>
             <t:param select="''" />
@@ -69,7 +70,7 @@
             <e>foo</e>
             <e>bar</e>
          </t:variable>
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param as="text()">foobar</t:param>
             <t:param select="$elems/text()" as="text()+"/>
             <t:param select="''" />
@@ -78,7 +79,7 @@
       </t:scenario>
 
       <t:scenario label="Identical text nodes">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param as="text()">foobar</t:param>
             <t:param as="text()">foobar</t:param>
             <t:param select="''" />
@@ -87,7 +88,7 @@
       </t:scenario>
 
       <t:scenario label="Identical Element Sequences">
-         <t:call function="deq:deep-equal">
+         <t:call>
             <t:param as="element()+"><foo/><bar/></t:param>
             <t:param as="element()+"><foo/><bar/></t:param>
             <t:param select="''" />
@@ -101,13 +102,14 @@
        Function deq:deep-equal($seq1, $seq2, version).
    -->
    <t:scenario label="deq:deep-equal($seq1, $seq2, version)">
+      <t:call function="deq:deep-equal" />
 
       <t:scenario label="In version 1.0">
 
          <t:scenario label="comparing text nodes with analogous">
 
             <t:scenario label="string">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="'12'"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -119,7 +121,7 @@
             </t:scenario>
 
             <t:scenario label="double">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:double('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -131,7 +133,7 @@
             </t:scenario>
 
             <t:scenario label="decimal">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:decimal('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -143,7 +145,7 @@
             </t:scenario>
 
             <t:scenario label="integer">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:integer('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -157,7 +159,7 @@
          </t:scenario>
 
          <t:scenario label="comparing the same strings">
-            <t:call function="deq:deep-equal">
+            <t:call>
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
                <t:param select="'1'" />
@@ -166,7 +168,7 @@
          </t:scenario>
 
          <t:scenario label="comparing different strings">
-            <t:call function="deq:deep-equal">
+            <t:call>
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
                <t:param select="'1'" />
@@ -181,7 +183,7 @@
          <t:scenario label="comparing text nodes with analogous">
 
             <t:scenario label="string">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="'12'"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -193,7 +195,7 @@
             </t:scenario>
 
             <t:scenario label="double">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:double('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -205,7 +207,7 @@
             </t:scenario>
 
             <t:scenario label="decimal">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:decimal('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -217,7 +219,7 @@
             </t:scenario>
 
             <t:scenario label="integer">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param select="xs:integer('12')"/>
                   <t:param select="descendant::text()" as="text()+">
                      <wrap>1</wrap>
@@ -231,7 +233,7 @@
          </t:scenario>
 
          <t:scenario label="comparing the same strings">
-            <t:call function="deq:deep-equal">
+            <t:call>
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
                <t:param select="''" />
@@ -240,7 +242,7 @@
          </t:scenario>
 
          <t:scenario label="comparing different strings">
-            <t:call function="deq:deep-equal">
+            <t:call>
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
                <t:param select="''" />
@@ -256,10 +258,12 @@
        Function deq:deep-equal($seq1, $seq2, 'w').
    -->
    <t:scenario label="deq:deep-equal($seq1, $seq2, 'w')" xml:base="deep-equal/">
+      <t:call function="deq:deep-equal" />
+
       <t:scenario label="Identical whitespace-only text nodes">
          <t:scenario label="In ordinal element">
             <t:scenario label="No flag">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="09.xml" />
                   <t:param href="09.xml" />
                   <t:param select="''" />
@@ -268,7 +272,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="09.xml" />
                   <t:param href="09.xml" />
                   <t:param select="'w'" />
@@ -279,7 +283,7 @@
 
          <t:scenario label="In x:ws">
             <t:scenario label="No flag">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-09.xml" />
                   <t:param select="''" />
@@ -288,7 +292,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-09.xml" />
                   <t:param select="'w'" />
@@ -301,7 +305,7 @@
       <t:scenario label="Different whitespace-only text nodes">
          <t:scenario label="In ordinal element">
             <t:scenario label="No flag">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="09.xml" />
                   <t:param href="20.xml" />
                   <t:param select="''" />
@@ -310,7 +314,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="09.xml" />
                   <t:param href="20.xml" />
                   <t:param select="'w'" />
@@ -321,7 +325,7 @@
 
          <t:scenario label="In x:ws">
             <t:scenario label="No flag">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-20.xml" />
                   <t:param select="''" />
@@ -330,7 +334,7 @@
             </t:scenario>
 
             <t:scenario label="w">
-               <t:call function="deq:deep-equal">
+               <t:call>
                   <t:param href="ws-09.xml" />
                   <t:param href="ws-20.xml" />
                   <t:param select="'w'" />
@@ -345,11 +349,12 @@
        Function deq:item-deep-equal
    -->
    <t:scenario label="deq:item-deep-equal">
+      <t:call function="deq:item-deep-equal" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L207-L227">
 
          <t:scenario label="Identical Integers">
-            <t:call function="deq:item-deep-equal">
+            <t:call>
                <t:param name="item1" select="1" />
                <t:param name="item2" select="1" />
                <t:param select="''" />
@@ -358,7 +363,7 @@
          </t:scenario>
 
          <t:scenario label="Non-Identical Strings">
-            <t:call function="deq:item-deep-equal">
+            <t:call>
                <t:param name="item1" select="'abc'" />
                <t:param name="item2" select="'def'" />
                <t:param select="''" />
@@ -367,7 +372,7 @@
          </t:scenario>
 
          <t:scenario label="String and Integer">
-            <t:call function="deq:item-deep-equal">
+            <t:call>
                <t:param name="item1" select="'1'" as="xs:string"/>
                <t:param name="item2" select="1" as="xs:integer"/>
                <t:param select="''" />
@@ -383,9 +388,10 @@
        Function deq:node-deep-equal($seq1, $seq2, '').
    -->
    <t:scenario label="deq:node-deep-equal($seq1, $seq2, '')">
+      <t:call function="deq:node-deep-equal" />
 
       <t:scenario label="Identical Attribute Sequences">
-         <t:call function="deq:node-deep-equal">
+         <t:call>
             <t:param name="node1" select="/node/@attribute" as="attribute(attribute)">
                <node attribute="foobar"/>
             </t:param>
@@ -400,7 +406,7 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L246-L372">
 
          <t:scenario label="Identical Elements">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/*" as="element(result)">
                   <result/>
                </t:param>
@@ -413,7 +419,7 @@
          </t:scenario>
 
          <t:scenario label="Elements with Identical Attributes in Different Orders">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/*" as="element(result)">
                   <result a="1" b="2" />
                </t:param>
@@ -426,7 +432,7 @@
          </t:scenario>
 
          <t:scenario label="Elements with Identical Children">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/*" as="element(result)">
                   <result><child1/><child2/></result>
                </t:param>
@@ -439,7 +445,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Attributes">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/*/@a" as="attribute(a)">
                   <result a="1" />
                </t:param>
@@ -452,7 +458,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Document Nodes">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/" as="document-node(element(result))">
                   <result />
                </t:param>
@@ -465,7 +471,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Text Nodes">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/*/text()" as="text()">
                   <result>Test</result>
                </t:param>
@@ -478,7 +484,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Comments">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/comment()" as="comment()">
                   <!-- Comment -->
                   <doc />
@@ -493,7 +499,7 @@
          </t:scenario>
 
          <t:scenario label="Identical Processing Instructions">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/processing-instruction()" as="processing-instruction(pi)">
                   <?pi data?>
                   <doc />
@@ -509,7 +515,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing text</t:label>
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -523,7 +529,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing mixed content</t:label>
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -537,7 +543,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing attribute values</t:label>
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/foo/@bar" as="attribute(bar)">
                   <foo bar="..." />
                </t:param>
@@ -551,7 +557,7 @@
 
          <t:scenario>
             <t:label>Using "..." to indicate missing empty content</t:label>
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param name="node1" select="/foo" as="element(foo)">
                   <foo>...</foo>
                </t:param>
@@ -568,7 +574,7 @@
       <t:scenario label="Namespace Nodes">
 
          <t:scenario label="Identical">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param select="$items:namespace" />
                <t:param select="$items:namespace" />
                <t:param select="''" />
@@ -577,7 +583,7 @@
          </t:scenario>
 
          <t:scenario label="Identical default namespace">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param select="$items:default-namespace" />
                <t:param select="$items:default-namespace" />
                <t:param select="''" />
@@ -586,7 +592,7 @@
          </t:scenario>
 
          <t:scenario label="Different">
-            <t:call function="deq:node-deep-equal">
+            <t:call>
                <t:param select="$items:namespace" />
                <t:param select="$items:another-namespace" />
                <t:param select="''" />
@@ -602,11 +608,12 @@
        Function deq:sorted-children
    -->
    <t:scenario label="deq:sorted-children">
+      <t:call function="deq:sorted-children" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L466-L477">
 
          <t:scenario label="Original order preserved">
-            <t:call function="deq:sorted-children">
+            <t:call>
                <t:param name="node" as="element(foo)">
                   <foo><bar /><baz /></foo>
                </t:param>

--- a/test/deep-equal.xspec
+++ b/test/deep-equal.xspec
@@ -18,13 +18,14 @@
        Function deq:deep-equal($seq1, $seq2, '').
    -->
    <t:scenario label="deq:deep-equal($seq1, $seq2, '')">
-      <t:call function="deq:deep-equal" />
+      <t:call function="deq:deep-equal">
+         <t:param position="3" select="''" />
+      </t:call>
 
       <t:scenario label="Identical Sequences">
          <t:call>
             <t:param select="1, 2"/>
             <t:param select="1, 2"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -33,7 +34,6 @@
          <t:call>
             <t:param select="1, 2"/>
             <t:param select="1, 3"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="false()"/>
       </t:scenario>
@@ -42,7 +42,6 @@
          <t:call>
             <t:param select="1, 2"/>
             <t:param select="2, 1"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="false()"/>
       </t:scenario>
@@ -51,7 +50,6 @@
          <t:call>
             <t:param select="()"/>
             <t:param select="()"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -60,7 +58,6 @@
          <t:call>
             <t:param select="()"/>
             <t:param select="1"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="false()"/>
       </t:scenario>
@@ -73,7 +70,6 @@
          <t:call>
             <t:param as="text()">foobar</t:param>
             <t:param select="$elems/text()" as="text()+"/>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -82,7 +78,6 @@
          <t:call>
             <t:param as="text()">foobar</t:param>
             <t:param as="text()">foobar</t:param>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -91,7 +86,6 @@
          <t:call>
             <t:param as="element()+"><foo/><bar/></t:param>
             <t:param as="element()+"><foo/><bar/></t:param>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -105,6 +99,9 @@
       <t:call function="deq:deep-equal" />
 
       <t:scenario label="In version 1.0">
+         <t:call>
+            <t:param position="3" select="'1'" />
+         </t:call>
 
          <t:scenario label="comparing text nodes with analogous">
 
@@ -115,7 +112,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="'1'" />
                </t:call>
                <t:expect label="returns true" select="true()"/>
             </t:scenario>
@@ -127,7 +123,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="'1'" />
                </t:call>
                <t:expect label="returns true" select="true()"/>
             </t:scenario>
@@ -139,7 +134,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="'1'" />
                </t:call>
                <t:expect label="returns true" select="true()"/>
             </t:scenario>
@@ -151,7 +145,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="'1'" />
                </t:call>
                <t:expect label="returns true" select="true()"/>
             </t:scenario>
@@ -162,7 +155,6 @@
             <t:call>
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
-               <t:param select="'1'" />
             </t:call>
             <t:expect label="returns true" select="true()"/>
          </t:scenario>
@@ -171,7 +163,6 @@
             <t:call>
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
-               <t:param select="'1'" />
             </t:call>
             <t:expect label="returns false" select="false()"/>
          </t:scenario>
@@ -179,6 +170,9 @@
       </t:scenario>
 
       <t:scenario label="In version 2.0">
+         <t:call>
+            <t:param position="3" select="''" />
+         </t:call>
 
          <t:scenario label="comparing text nodes with analogous">
 
@@ -189,7 +183,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="''" />
                </t:call>
                <t:expect label="returns false" select="false()"/>
             </t:scenario>
@@ -201,7 +194,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="''" />
                </t:call>
                <t:expect label="returns false" select="false()"/>
             </t:scenario>
@@ -213,7 +205,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="''" />
                </t:call>
                <t:expect label="returns false" select="false()"/>
             </t:scenario>
@@ -225,7 +216,6 @@
                      <wrap>1</wrap>
                      <wrap>2</wrap>
                   </t:param>
-                  <t:param select="''" />
                </t:call>
                <t:expect label="returns false" select="false()"/>
             </t:scenario>
@@ -236,7 +226,6 @@
             <t:call>
                <t:param select="'foo'"/>
                <t:param select="'foo'"/>
-               <t:param select="''" />
             </t:call>
             <t:expect label="returns true" select="true()"/>
          </t:scenario>
@@ -245,7 +234,6 @@
             <t:call>
                <t:param select="'foo'"/>
                <t:param select="'bar'"/>
-               <t:param select="''" />
             </t:call>
             <t:expect label="returns false" select="false()"/>
          </t:scenario>
@@ -352,12 +340,14 @@
       <t:call function="deq:item-deep-equal" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L207-L227">
+         <t:call>
+            <t:param position="3" select="''" />
+         </t:call>
 
          <t:scenario label="Identical Integers">
             <t:call>
                <t:param name="item1" select="1" />
                <t:param name="item2" select="1" />
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -366,7 +356,6 @@
             <t:call>
                <t:param name="item1" select="'abc'" />
                <t:param name="item2" select="'def'" />
-               <t:param select="''" />
             </t:call>
             <t:expect label="False" select="false()" />
          </t:scenario>
@@ -375,7 +364,6 @@
             <t:call>
                <t:param name="item1" select="'1'" as="xs:string"/>
                <t:param name="item2" select="1" as="xs:integer"/>
-               <t:param select="''" />
             </t:call>
             <t:expect label="False" select="false()" />
          </t:scenario>
@@ -388,7 +376,9 @@
        Function deq:node-deep-equal($seq1, $seq2, '').
    -->
    <t:scenario label="deq:node-deep-equal($seq1, $seq2, '')">
-      <t:call function="deq:node-deep-equal" />
+      <t:call function="deq:node-deep-equal">
+         <t:param position="3" select="''" />
+      </t:call>
 
       <t:scenario label="Identical Attribute Sequences">
          <t:call>
@@ -398,7 +388,6 @@
             <t:param name="node2" select="/node/@attribute" as="attribute(attribute)">
                <node attribute="foobar"/>
             </t:param>
-            <t:param select="''" />
          </t:call>
          <t:expect label="the result" select="true()"/>
       </t:scenario>
@@ -413,7 +402,6 @@
                <t:param name="node2" select="/*" as="element(result)">
                   <result/>
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -426,7 +414,6 @@
                <t:param name="node2" select="/*" as="element(result)">
                   <result b="2" a="1" />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -439,7 +426,6 @@
                <t:param name="node2" select="/*" as="element(result)">
                   <result><child1/><child2/></result>
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -452,7 +438,6 @@
                <t:param name="node2" select="/*/@a" as="attribute(a)">
                   <result a="1" />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -465,7 +450,6 @@
                <t:param name="node2" select="/" as="document-node(element(result))">
                   <result />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -478,7 +462,6 @@
                <t:param name="node2" select="/*/text()" as="text()">
                   <result>Test</result>
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -493,7 +476,6 @@
                   <!-- Comment -->
                   <doc />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -508,7 +490,6 @@
                   <?pi data?>
                   <doc />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -522,7 +503,6 @@
                <t:param name="node2" as="element(foo)">
                   <foo>foo</foo>
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -536,7 +516,6 @@
                <t:param name="node2" as="element(foo)">
                   <foo>foo<bar />foo</foo>
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -550,7 +529,6 @@
                <t:param name="node2" select="/foo/@bar" as="attribute(bar)">
                   <foo bar="bar" />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -564,7 +542,6 @@
                <t:param name="node2" select="/foo" as="element(foo)">
                   <foo />
                </t:param>
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -577,7 +554,6 @@
             <t:call>
                <t:param select="$items:namespace" />
                <t:param select="$items:namespace" />
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -586,7 +562,6 @@
             <t:call>
                <t:param select="$items:default-namespace" />
                <t:param select="$items:default-namespace" />
-               <t:param select="''" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
@@ -595,7 +570,6 @@
             <t:call>
                <t:param select="$items:namespace" />
                <t:param select="$items:another-namespace" />
-               <t:param select="''" />
             </t:call>
             <t:expect label="False" select="false()" />
          </t:scenario>

--- a/test/format-utils.xspec
+++ b/test/format-utils.xspec
@@ -3,12 +3,14 @@
 	xmlns:fmt="urn:x-xspec:reporter:format-utils" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="Scenario for testing function format-uri">
+		<x:call function="fmt:format-uri" />
+
 		<x:scenario label="file: (%20 should be unescaped)">
 			<x:scenario label="Windows">
 				<x:scenario label="Drive">
 					<x:scenario label="Win32 (file:///C:/)">
 						<x:scenario label="Upper-case drive letter">
-							<x:call function="fmt:format-uri">
+							<x:call>
 								<x:param select="'file:///C:/dir/file%20name.ext'" />
 							</x:call>
 							<x:expect label="Discard everything before drive letter"
@@ -16,7 +18,7 @@
 						</x:scenario>
 
 						<x:scenario label="Lower-case drive letter">
-							<x:call function="fmt:format-uri">
+							<x:call>
 								<x:param select="'file:///c:/dir/file%20name.ext'" />
 							</x:call>
 							<x:expect label="Discard everything before drive letter"
@@ -26,7 +28,7 @@
 
 					<x:scenario label="Java (file:/C:/)">
 						<x:scenario label="Upper-case drive letter">
-							<x:call function="fmt:format-uri">
+							<x:call>
 								<x:param select="'file:/C:/dir/file%20name.ext'" />
 							</x:call>
 							<x:expect label="Discard everything before drive letter"
@@ -34,7 +36,7 @@
 						</x:scenario>
 
 						<x:scenario label="Lower-case drive letter">
-							<x:call function="fmt:format-uri">
+							<x:call>
 								<x:param select="'file:/c:/dir/file%20name.ext'" />
 							</x:call>
 							<x:expect label="Discard everything before drive letter"
@@ -45,14 +47,14 @@
 
 				<x:scenario label="UNC">
 					<x:scenario label="Win32 (file://host/)">
-						<x:call function="fmt:format-uri">
+						<x:call>
 							<x:param select="'file://host/share/dir/file%20name.ext'" />
 						</x:call>
 						<x:expect label="Discard file:" select="'//host/share/dir/file name.ext'" />
 					</x:scenario>
 
 					<x:scenario label="Java (file:////host/)">
-						<x:call function="fmt:format-uri">
+						<x:call>
 							<x:param select="'file:////host/share/dir/file%20name.ext'" />
 						</x:call>
 						<x:expect label="Discard file://" select="'//host/share/dir/file name.ext'"
@@ -63,21 +65,21 @@
 
 			<x:scenario label="*nix">
 				<x:scenario label="One slash">
-					<x:call function="fmt:format-uri">
+					<x:call>
 						<x:param select="'file:/dir/file%20name.ext'" />
 					</x:call>
 					<x:expect label="Discard file:" select="'/dir/file name.ext'" />
 				</x:scenario>
 
 				<x:scenario label="Two slashes">
-					<x:call function="fmt:format-uri">
+					<x:call>
 						<x:param select="'file://host/dir/file%20name.ext'" />
 					</x:call>
 					<x:expect label="Discard file:" select="'//host/dir/file name.ext'" />
 				</x:scenario>
 
 				<x:scenario label="Three slashes">
-					<x:call function="fmt:format-uri">
+					<x:call>
 						<x:param select="'file:///dir/file%20name.ext'" />
 					</x:call>
 					<x:expect label="Discard file://" select="'/dir/file name.ext'" />
@@ -86,7 +88,7 @@
 		</x:scenario>
 
 		<x:scenario label="Non file: (Everything including %20 should be intact)">
-			<x:call function="fmt:format-uri">
+			<x:call>
 				<x:param select="'http://www.example.com/dir/file%20name.ext'" />
 			</x:call>
 			<x:expect label="Intact" select="'http://www.example.com/dir/file%20name.ext'" />

--- a/test/report-sequence.xspec
+++ b/test/report-sequence.xspec
@@ -17,11 +17,12 @@
        Function rep:report-atomic-value
    -->
    <t:scenario label="rep:report-atomic-value">
+      <t:call function="rep:report-atomic-value" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/8931b371bd619feeeee25bd7014d8a677ab88505/src/compiler/generate-tests-utils.xsl#L622-L629">
 
          <t:scenario label="String Containing Single Quotes">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="'don''t'" />
             </t:call>
             <t:expect label="Escaped" select="'''don''''t'''" />
@@ -32,21 +33,21 @@
       <t:scenario label="xs:integer">
 
          <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:integer(18446744073709551615)" />
             </t:call>
             <t:expect label="Numeric literal" select="'18446744073709551615'" />
          </t:scenario>
 
          <t:scenario label="0">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:integer(0)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0'" />
          </t:scenario>
 
          <t:scenario label="-1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:integer(-1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1'" />
@@ -57,49 +58,49 @@
       <t:scenario label="xs:decimal">
 
          <t:scenario label="1.2">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(1.2)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.2'" />
          </t:scenario>
 
          <t:scenario label="1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.0'" />
          </t:scenario>
 
          <t:scenario label="0.1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(0.1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0.1'" />
          </t:scenario>
 
          <t:scenario label="0">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(0)" />
             </t:call>
             <t:expect label="Numeric literal" select="'0.0'" />
          </t:scenario>
 
          <t:scenario label="-0.1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(-0.1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-0.1'" />
          </t:scenario>
 
          <t:scenario label="-1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(-1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1.0'" />
          </t:scenario>
 
          <t:scenario label="-1.2">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:decimal(-1.2)" />
             </t:call>
             <t:expect label="Numeric literal" select="'-1.2'" />
@@ -110,21 +111,21 @@
       <t:scenario label="xs:double">
 
          <t:scenario label="1.234e56">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:double(1.234e56)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.234e56'" />
          </t:scenario>
 
          <t:scenario label="1">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:double(1)" />
             </t:call>
             <t:expect label="Numeric literal" select="'1.0e0'" />
          </t:scenario>
 
          <t:scenario label="NaN">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:double('NaN')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -132,7 +133,7 @@
          </t:scenario>
 
          <t:scenario label="INF">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:double('INF')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -140,7 +141,7 @@
          </t:scenario>
 
          <t:scenario label="-INF">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:double('-INF')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -152,14 +153,14 @@
       <t:scenario label="xs:QName">
 
          <t:scenario label="No namespace">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:QName('foo')" />
             </t:call>
             <t:expect label="Function" select="'QName('''', ''foo'')'" />
          </t:scenario>
 
          <t:scenario label="In namespace, with prefix">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:QName('t:foo')" />
             </t:call>
             <t:expect label="Function" select="string()">
@@ -168,7 +169,7 @@
          </t:scenario>
 
          <t:scenario label="In namespace, without prefix">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="QName('x-urn:test:report-atomic-value', 'foo')" />
             </t:call>
             <t:expect label="Function" select="'QName(''x-urn:test:report-atomic-value'', ''foo'')'" />
@@ -179,7 +180,7 @@
       <t:scenario label="Other types that enter the ELSE branch of the function">
 
          <t:scenario label="xs:untypedAtomic">
-            <t:call function="rep:report-atomic-value">
+            <t:call>
                <t:param select="xs:untypedAtomic('foo')" />
             </t:call>
             <t:expect label="Constructor" select="string()"
@@ -195,10 +196,12 @@
            http://www.w3.org/TR/xslt20/#built-in-types
    -->
    <t:scenario label="rep:atom-type">
+      <t:call function="rep:atom-type" />
+
       <t:scenario label="All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION">
 
          <t:scenario label="xs:string">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:string('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -206,7 +209,7 @@
          </t:scenario>
 
          <t:scenario label="xs:boolean">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:boolean('true')" />
             </t:call>
             <t:expect label="xs:boolean" select="string()"
@@ -214,7 +217,7 @@
          </t:scenario>
 
          <t:scenario label="xs:decimal">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:decimal(1)" />
             </t:call>
             <t:expect label="xs:decimal" select="string()"
@@ -222,7 +225,7 @@
          </t:scenario>
 
          <t:scenario label="xs:double">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:double(1)" />
             </t:call>
             <t:expect label="xs:double" select="string()"
@@ -230,7 +233,7 @@
          </t:scenario>
 
          <t:scenario label="xs:float">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:float(1)" />
             </t:call>
             <t:expect label="xs:float" select="string()"
@@ -238,7 +241,7 @@
          </t:scenario>
 
          <t:scenario label="xs:date">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:date('1111-11-11')" />
             </t:call>
             <t:expect label="xs:date" select="string()"
@@ -246,7 +249,7 @@
          </t:scenario>
 
          <t:scenario label="xs:time">
-           <t:call function="rep:atom-type">
+           <t:call>
               <t:param select="xs:time('11:11:11')" />
            </t:call>
            <t:expect label="xs:time" select="string()"
@@ -254,7 +257,7 @@
          </t:scenario>
 
          <t:scenario label="xs:dateTime">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:dateTime('1111-11-11T11:11:11')" />
             </t:call>
             <t:expect label="xs:dateTime" select="string()"
@@ -262,7 +265,7 @@
          </t:scenario>
 
          <t:scenario label="xs:duration">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:duration('PT1S')" />
             </t:call>
             <t:expect label="xs:duration" select="string()"
@@ -270,7 +273,7 @@
          </t:scenario>
 
          <t:scenario label="xs:QName">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:QName('foo')" />
             </t:call>
             <t:expect label="xs:QName" select="string()"
@@ -278,7 +281,7 @@
          </t:scenario>
 
          <t:scenario label="xs:anyURI">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:anyURI('foo')" />
             </t:call>
             <t:expect label="xs:anyURI" select="string()"
@@ -286,7 +289,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gDay">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:gDay('---11')" />
             </t:call>
             <t:expect label="xs:gDay" select="string()"
@@ -294,7 +297,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gMonthDay">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:gMonthDay('--11-11')" />
             </t:call>
             <t:expect label="xs:gMonthDay" select="string()"
@@ -302,7 +305,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gMonth">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:gMonth('--11')" />
             </t:call>
             <t:expect label="xs:gMonth" select="string()"
@@ -310,7 +313,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gYearMonth">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:gYearMonth('1111-11')" />
             </t:call>
             <t:expect label="xs:gYearMonth" select="string()"
@@ -318,7 +321,7 @@
          </t:scenario>
 
          <t:scenario label="xs:gYear">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:gYear('1111')" />
             </t:call>
             <t:expect label="xs:gYear" select="string()"
@@ -326,7 +329,7 @@
          </t:scenario>
 
          <t:scenario label="xs:base64Binary">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:base64Binary(xs:hexBinary('11'))" />
             </t:call>
             <t:expect label="xs:base64Binary" select="string()"
@@ -334,7 +337,7 @@
          </t:scenario>
 
          <t:scenario label="xs:hexBinary">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:hexBinary('11')" />
             </t:call>
             <t:expect label="xs:hexBinary" select="string()"
@@ -346,7 +349,7 @@
       <t:scenario label="The derived atomic type xs:integer defined in [XML Schema Part 2]">
 
          <t:scenario label="xs:integer">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:integer(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -360,7 +363,7 @@
       <t:scenario label="The following types defined in [XPath 2.0]">
 
          <t:scenario label="xs:yearMonthDuration">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:yearMonthDuration('P1M')" />
             </t:call>
             <t:expect label="xs:yearMonthDuration" select="string()"
@@ -368,7 +371,7 @@
          </t:scenario>
 
          <t:scenario label="xs:dayTimeDuration">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:dayTimeDuration('PT1S')" />
             </t:call>
             <t:expect label="xs:dayTimeDuration" select="string()"
@@ -380,7 +383,7 @@
          <!-- xs:untyped: Not atomic -->
 
          <t:scenario label="xs:untypedAtomic">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:untypedAtomic('foo')" />
             </t:call>
             <t:expect label="xs:untypedAtomic" select="string()"
@@ -392,50 +395,52 @@
    </t:scenario>
 
 	<t:scenario label="Scenario for testing function node-type">
+		<t:call function="rep:node-type" />
+
 		<t:scenario label="Attribute">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:attribute" />
 			</t:call>
 			<t:expect label="attribute" select="'attribute'" />
 		</t:scenario>
 
 		<t:scenario label="Comment">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:comment" />
 			</t:call>
 			<t:expect label="comment" select="'comment'" />
 		</t:scenario>
 
 		<t:scenario label="Document">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:document" />
 			</t:call>
 			<t:expect label="document-node" select="'document-node'" />
 		</t:scenario>
 
 		<t:scenario label="Element">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:element" />
 			</t:call>
 			<t:expect label="element" select="'element'" />
 		</t:scenario>
 
 		<t:scenario label="Namespace">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:namespace" />
 			</t:call>
 			<t:expect label="namespace-node" select="'namespace-node'" />
 		</t:scenario>
 
 		<t:scenario label="Processing instruction">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:processing-instruction" />
 			</t:call>
 			<t:expect label="processing-instruction" select="'processing-instruction'" />
 		</t:scenario>
 
 		<t:scenario label="Text">
-			<t:call function="rep:node-type">
+			<t:call>
 				<t:param select="$items:text" />
 			</t:call>
 			<t:expect label="text" select="'text'" />
@@ -443,8 +448,10 @@
 	</t:scenario>
 
 	<t:scenario label="Scenario for testing function instance-of-function">
+		<t:call function="rep:instance-of-function" />
+
 		<t:scenario label="Node">
-			<t:call function="rep:instance-of-function">
+			<t:call>
 				<t:param>
 					<e />
 				</t:param>
@@ -453,7 +460,7 @@
 		</t:scenario>
 
 		<t:scenario label="Atomic value">
-			<t:call function="rep:instance-of-function">
+			<t:call>
 				<t:param select="1" />
 			</t:call>
 			<t:expect label="False" select="false()" />
@@ -461,14 +468,14 @@
 
 		<t:scenario label="function(*)">
 			<t:scenario label="Array">
-				<t:call function="rep:instance-of-function">
+				<t:call>
 					<t:param select="[ 0, 1 ]" />
 				</t:call>
 				<t:expect label="True" select="true()" />
 			</t:scenario>
 
 			<t:scenario label="Map">
-				<t:call function="rep:instance-of-function">
+				<t:call>
 					<t:param select="map { 0: 1 }" />
 				</t:call>
 				<t:expect label="True" select="true()" />
@@ -479,15 +486,17 @@
 	</t:scenario>
 
 	<t:scenario label="Scenario for testing function function-type">
+		<t:call function="rep:function-type" />
+
 		<t:scenario label="Array">
-			<t:call function="rep:function-type">
+			<t:call>
 				<t:param select="[ 0, 1 ]" />
 			</t:call>
 			<t:expect label="array" select="'array'" />
 		</t:scenario>
 
 		<t:scenario label="Map">
-			<t:call function="rep:function-type">
+			<t:call>
 				<t:param select="map { 0: 1 }" />
 			</t:call>
 			<t:expect label="map" select="'map'" />

--- a/test/report-sequence_query.xspec
+++ b/test/report-sequence_query.xspec
@@ -19,10 +19,13 @@
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L486-L550">
          <!-- These scenarios do not run on XSLT. XSLT implements the tested function as a template. -->
 
+         <t:call>
+            <t:param position="2" select="'t:result'" />
+         </t:call>
+
          <t:scenario label="Integer">
             <t:call>
                <t:param name="sequence" select="1" as="xs:integer" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of integer" href="integer.xml" select="t:result" />
          </t:scenario>
@@ -30,7 +33,6 @@
          <t:scenario label="Empty Sequence">
             <t:call>
                <t:param name="sequence" select="()" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of empty sequence" href="empty-sequence.xml"
                select="t:result" />
@@ -39,7 +41,6 @@
          <t:scenario label="String">
             <t:call>
                <t:param name="sequence" select="'test'" as="xs:string" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of string" href="string.xml" select="t:result" />
          </t:scenario>
@@ -47,7 +48,6 @@
          <t:scenario label="URI">
             <t:call>
                <t:param name="sequence" select="xs:anyURI('test.xml')" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of xs:anyURI" href="uri.xml" select="t:result" />
          </t:scenario>
@@ -55,7 +55,6 @@
          <t:scenario label="QName">
             <t:call>
                <t:param name="sequence" select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of QName" href="qname.xml" select="t:result" />
          </t:scenario>
@@ -65,7 +64,6 @@
                <t:param name="sequence" select="/*/@*" as="attribute()+">
                   <doc a="1" b="2" />
                </t:param>
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes" href="attributes.xml?strip-space=yes"
                select="t:result" />
@@ -78,7 +76,6 @@
                      <foo />
                   </doc>
                </t:param>
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes and content"
                href="attributes-and-content.xml?strip-space=yes" select="t:result" />

--- a/test/report-sequence_query.xspec
+++ b/test/report-sequence_query.xspec
@@ -14,12 +14,13 @@
        Function rep:report-sequence
    -->
    <t:scenario label="rep:report-sequence" xml:base="report-sequence/">
+      <t:call function="rep:report-sequence" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L486-L550">
          <!-- These scenarios do not run on XSLT. XSLT implements the tested function as a template. -->
 
          <t:scenario label="Integer">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="1" as="xs:integer" />
                <t:param name="report-name" select="'t:result'" />
             </t:call>
@@ -27,7 +28,7 @@
          </t:scenario>
 
          <t:scenario label="Empty Sequence">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="()" />
                <t:param name="report-name" select="'t:result'" />
             </t:call>
@@ -36,7 +37,7 @@
          </t:scenario>
 
          <t:scenario label="String">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="'test'" as="xs:string" />
                <t:param name="report-name" select="'t:result'" />
             </t:call>
@@ -44,7 +45,7 @@
          </t:scenario>
 
          <t:scenario label="URI">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="xs:anyURI('test.xml')" />
                <t:param name="report-name" select="'t:result'" />
             </t:call>
@@ -52,7 +53,7 @@
          </t:scenario>
 
          <t:scenario label="QName">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
                <t:param name="report-name" select="'t:result'" />
             </t:call>
@@ -60,7 +61,7 @@
          </t:scenario>
 
          <t:scenario label="Attributes">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="/*/@*" as="attribute()+">
                   <doc a="1" b="2" />
                </t:param>
@@ -71,7 +72,7 @@
          </t:scenario>
 
          <t:scenario label="Attributes and content">
-            <t:call function="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="/*/@*, /*/foo" as="node()+">
                   <doc a="1" b="2">
                      <foo />

--- a/test/report-sequence_query_schema-aware.xspec
+++ b/test/report-sequence_query_schema-aware.xspec
@@ -19,6 +19,8 @@
       <!-- TODO: XQuery rep:atom-type() does not cover the built-in types classified as
            "additional" in https://www.w3.org/TR/xslt20/#built-in-types. -->
 
+      <t:call function="rep:atom-type" />
+
       <t:scenario label="Derived string types">
 
          <!-- xs:IDREFS: list -->
@@ -26,7 +28,7 @@
          <!-- xs:ENTITIES: list -->
 
          <t:scenario label="xs:ID">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:ID('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -34,7 +36,7 @@
          </t:scenario>
 
          <t:scenario label="xs:IDREF">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:IDREF('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -42,7 +44,7 @@
          </t:scenario>
 
          <t:scenario label="xs:ENTITY">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:ENTITY('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -50,7 +52,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NCName">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:NCName('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -60,7 +62,7 @@
          <!-- xs:NMTOKENS: list -->
 
          <t:scenario label="xs:language">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:language('en')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -68,7 +70,7 @@
          </t:scenario>
 
          <t:scenario label="xs:Name">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:Name('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -76,7 +78,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NMTOKEN">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:NMTOKEN('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -84,7 +86,7 @@
          </t:scenario>
 
          <t:scenario label="xs:token">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:token('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -92,7 +94,7 @@
          </t:scenario>
 
          <t:scenario label="xs:normalizedString">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:normalizedString('foo')" />
             </t:call>
             <t:expect label="xs:string" select="string()"
@@ -104,7 +106,7 @@
       <t:scenario label="Derived numeric types">
 
          <t:scenario label="xs:negativeInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:negativeInteger(-1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -112,7 +114,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonPositiveInteger">
-           <t:call function="rep:atom-type">
+           <t:call>
               <t:param select="xs:nonPositiveInteger(0)" />
            </t:call>
            <t:expect label="xs:integer" select="string()"
@@ -120,7 +122,7 @@
          </t:scenario>
 
          <t:scenario label="xs:byte">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:byte(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -128,7 +130,7 @@
          </t:scenario>
 
          <t:scenario label="xs:short">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:short(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -136,7 +138,7 @@
          </t:scenario>
 
          <t:scenario label="xs:int">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:int(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -144,7 +146,7 @@
          </t:scenario>
 
          <t:scenario label="xs:long">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:long(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -152,7 +154,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedByte">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedByte(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -160,7 +162,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedShort">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedShort(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -168,7 +170,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedInt">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedInt(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -176,7 +178,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedLong">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedLong(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -184,7 +186,7 @@
          </t:scenario>
 
          <t:scenario label="xs:positiveInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:positiveInteger(1)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"
@@ -192,7 +194,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonNegativeInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:nonNegativeInteger(0)" />
             </t:call>
             <t:expect label="xs:integer" select="string()"

--- a/test/report-sequence_stylesheet.xspec
+++ b/test/report-sequence_stylesheet.xspec
@@ -15,70 +15,68 @@
        Template rep:report-sequence
    -->
    <t:scenario label="rep:report-sequence" xml:base="report-sequence/">
+      <t:call template="rep:report-sequence" />
 
       <t:scenario label="Copy of https://github.com/xspec/xspec/blob/120b3316aef2c1106287dc7c5270f3ed49062c68/src/compiler/generate-tests-utils.xsl#L486-L550">
          <!-- These scenarios do not run on XQuery. XQuery implements the tested template as a function. -->
 
+         <t:call>
+            <t:param name="report-name" select="'t:result'" />
+         </t:call>
+
          <t:scenario label="Integer">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="1" as="xs:integer" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of integer" href="integer.xml" select="t:result" />
          </t:scenario>
 
          <t:scenario label="Empty Sequence">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="()" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of empty sequence" href="empty-sequence.xml"
                select="t:result" />
          </t:scenario>
 
          <t:scenario label="String">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="'test'" as="xs:string" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of string" href="string.xml" select="t:result" />
          </t:scenario>
 
          <t:scenario label="URI">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="xs:anyURI('test.xml')" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of xs:anyURI" href="uri.xml" select="t:result" />
          </t:scenario>
 
          <t:scenario label="QName">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="QName('http://www.jenitennison.com/xslt/unit-test', 'tests')" />
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result with @select of QName" href="qname.xml" select="t:result" />
          </t:scenario>
 
          <t:scenario label="Attributes">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="/*/@*" as="attribute()+">
                   <doc a="1" b="2" />
                </t:param>
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes" href="attributes.xml?strip-space=yes"
                select="t:result" />
          </t:scenario>
 
          <t:scenario label="Attributes and content">
-            <t:call template="rep:report-sequence">
+            <t:call>
                <t:param name="sequence" select="/*/@*, /*/foo" as="node()+">
                   <doc a="1" b="2">
                      <foo />
                   </doc>
                </t:param>
-               <t:param name="report-name" select="'t:result'" />
             </t:call>
             <t:expect label="t:result containing attributes and content"
                href="attributes-and-content.xml?strip-space=yes" select="t:result" />

--- a/test/report-sequence_stylesheet_schema-aware.xspec
+++ b/test/report-sequence_stylesheet_schema-aware.xspec
@@ -20,6 +20,8 @@
            XQuery rep:atom-type() does not cover the built-in types classified as
            "additional" in https://www.w3.org/TR/xslt20/#built-in-types. -->
 
+      <t:call function="rep:atom-type" />
+
       <t:scenario label="Derived string types">
 
          <!-- xs:IDREFS: list -->
@@ -27,7 +29,7 @@
          <!-- xs:ENTITIES: list -->
 
          <t:scenario label="xs:ID">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:ID('foo')" />
             </t:call>
             <t:expect label="xs:ID" select="string()"
@@ -35,7 +37,7 @@
          </t:scenario>
 
          <t:scenario label="xs:IDREF">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:IDREF('foo')" />
             </t:call>
             <t:expect label="xs:IDREF" select="string()"
@@ -43,7 +45,7 @@
          </t:scenario>
 
          <t:scenario label="xs:ENTITY">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:ENTITY('foo')" />
             </t:call>
             <t:expect label="xs:ENTITY" select="string()"
@@ -51,7 +53,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NCName">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:NCName('foo')" />
             </t:call>
             <t:expect label="xs:NCName" select="string()"
@@ -61,7 +63,7 @@
          <!-- xs:NMTOKENS: list -->
 
          <t:scenario label="xs:language">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:language('en')" />
             </t:call>
             <t:expect label="xs:language" select="string()"
@@ -69,7 +71,7 @@
          </t:scenario>
 
          <t:scenario label="xs:Name">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:Name('foo')" />
             </t:call>
             <t:expect label="xs:Name" select="string()"
@@ -77,7 +79,7 @@
          </t:scenario>
 
          <t:scenario label="xs:NMTOKEN">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:NMTOKEN('foo')" />
             </t:call>
             <t:expect label="xs:NMTOKEN" select="string()"
@@ -85,7 +87,7 @@
          </t:scenario>
 
          <t:scenario label="xs:token">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:token('foo')" />
             </t:call>
             <t:expect label="xs:token" select="string()"
@@ -93,7 +95,7 @@
          </t:scenario>
 
          <t:scenario label="xs:normalizedString">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:normalizedString('foo')" />
             </t:call>
             <t:expect label="xs:normalizedString" select="string()"
@@ -105,7 +107,7 @@
       <t:scenario label="Derived numeric types">
 
          <t:scenario label="xs:negativeInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:negativeInteger(-1)" />
             </t:call>
             <t:expect label="xs:negativeInteger" select="string()"
@@ -113,7 +115,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonPositiveInteger">
-           <t:call function="rep:atom-type">
+           <t:call>
               <t:param select="xs:nonPositiveInteger(0)" />
            </t:call>
            <t:expect label="xs:nonPositiveInteger" select="string()"
@@ -121,7 +123,7 @@
          </t:scenario>
 
          <t:scenario label="xs:byte">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:byte(1)" />
             </t:call>
             <t:expect label="xs:byte" select="string()"
@@ -129,7 +131,7 @@
          </t:scenario>
 
          <t:scenario label="xs:short">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:short(1)" />
             </t:call>
             <t:expect label="xs:short" select="string()"
@@ -137,7 +139,7 @@
          </t:scenario>
 
          <t:scenario label="xs:int">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:int(1)" />
             </t:call>
             <t:expect label="xs:int" select="string()"
@@ -145,7 +147,7 @@
          </t:scenario>
 
          <t:scenario label="xs:long">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:long(1)" />
             </t:call>
             <t:expect label="xs:long" select="string()"
@@ -153,7 +155,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedByte">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedByte(1)" />
             </t:call>
             <t:expect label="xs:unsignedByte" select="string()"
@@ -161,7 +163,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedShort">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedShort(1)" />
             </t:call>
             <t:expect label="xs:unsignedShort" select="string()"
@@ -169,7 +171,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedInt">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedInt(1)" />
             </t:call>
             <t:expect label="xs:unsignedInt" select="string()"
@@ -177,7 +179,7 @@
          </t:scenario>
 
          <t:scenario label="xs:unsignedLong">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:unsignedLong(1)" />
             </t:call>
             <t:expect label="xs:unsignedLong" select="string()"
@@ -185,7 +187,7 @@
          </t:scenario>
 
          <t:scenario label="xs:positiveInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:positiveInteger(1)" />
             </t:call>
             <t:expect label="xs:positiveInteger" select="string()"
@@ -193,7 +195,7 @@
          </t:scenario>
 
          <t:scenario label="xs:nonNegativeInteger">
-            <t:call function="rep:atom-type">
+            <t:call>
                <t:param select="xs:nonNegativeInteger(0)" />
             </t:call>
             <t:expect label="xs:nonNegativeInteger" select="string()"

--- a/test/uqname-utils.xspec
+++ b/test/uqname-utils.xspec
@@ -7,8 +7,10 @@
 	-->
 
 	<x:scenario label="Scenario for testing function UQName">
+		<x:call function="x:UQName" />
+
 		<x:scenario label="URI length ge 1">
-			<x:call function="x:UQName">
+			<x:call>
 				<x:param select="'my-uri'" />
 				<x:param select="'my-local-name'" />
 			</x:call>
@@ -16,7 +18,7 @@
 		</x:scenario>
 
 		<x:scenario label="URI is zero-length string">
-			<x:call function="x:UQName">
+			<x:call>
 				<x:param select="''" />
 				<x:param select="'my-local-name'" />
 			</x:call>
@@ -25,8 +27,10 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function known-UQName">
+		<x:call function="x:known-UQName" />
+
 		<x:scenario label="config">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'config:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -34,7 +38,7 @@
 		</x:scenario>
 
 		<x:scenario label="deq">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'deq:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -42,7 +46,7 @@
 		</x:scenario>
 
 		<x:scenario label="err">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'err:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -50,7 +54,7 @@
 		</x:scenario>
 
 		<x:scenario label="impl">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'impl:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -58,7 +62,7 @@
 		</x:scenario>
 
 		<x:scenario label="map">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'map:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -66,7 +70,7 @@
 		</x:scenario>
 
 		<x:scenario label="output">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'output:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -74,7 +78,7 @@
 		</x:scenario>
 
 		<x:scenario label="rep">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'rep:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -82,7 +86,7 @@
 		</x:scenario>
 
 		<x:scenario label="svrl">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'svrl:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -90,7 +94,7 @@
 		</x:scenario>
 
 		<x:scenario label="x">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'x:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -98,7 +102,7 @@
 		</x:scenario>
 
 		<x:scenario label="xs">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'xs:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"
@@ -106,7 +110,7 @@
 		</x:scenario>
 
 		<x:scenario label="xsl">
-			<x:call function="x:known-UQName">
+			<x:call>
 				<x:param select="'xsl:my-local-name'" />
 			</x:call>
 			<x:expect label="Constructed" select="string()"

--- a/test/user-content-utils.xspec
+++ b/test/user-content-utils.xspec
@@ -377,7 +377,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function is-ws-only-text-node-significant">
-		<x:call function="x:is-ws-only-text-node-significant" />
+		<x:call function="x:is-ws-only-text-node-significant">
+			<x:param position="2" />
+		</x:call>
 
 		<x:scenario label="xml:space">
 			<x:scenario label="override default with preserve">
@@ -390,7 +392,6 @@
 								</grandparent>
 							</great-grandparent>
 						</x:param>
-						<x:param />
 					</x:call>
 					<x:expect label="true" select="true()" />
 				</x:scenario>
@@ -402,7 +403,6 @@
 								<grandparent xml:space="preserve"><parent>&#x09;&#x0A;&#x0D;&#x20;</parent></grandparent>
 							</great-grandparent>
 						</x:param>
-						<x:param />
 					</x:call>
 					<x:expect label="true" select="true()" />
 				</x:scenario>
@@ -418,7 +418,6 @@
 									</parent></grandparent>
 							</great-grandparent>
 						</x:param>
-						<x:param />
 					</x:call>
 					<x:expect label="false" select="false()" />
 				</x:scenario>
@@ -432,7 +431,6 @@
 									</parent>
 								</grandparent></great-grandparent>
 						</x:param>
-						<x:param />
 					</x:call>
 					<x:expect label="false" select="false()" />
 				</x:scenario>

--- a/test/user-content-utils.xspec
+++ b/test/user-content-utils.xspec
@@ -5,18 +5,19 @@
 	<x:helper stylesheet="test-utils.xsl" />
 
 	<x:scenario label="Scenario for testing function is-user-content">
+		<x:call function="x:is-user-content" />
 
 		<x:scenario label="function-param">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="//x:call[@function]/x:param/element()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec"
 							select="//x:call[@function]/x:param/element()/attribute()" />
 					</x:call>
@@ -26,14 +27,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:call[@function]/x:param)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="//x:call[@function]/x:param/attribute()"
 						 />
 					</x:call>
@@ -45,14 +46,14 @@
 		<x:scenario label="global-param">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="/x:description/x:param/element()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec"
 							select="/x:description/x:param/element()/attribute()" />
 					</x:call>
@@ -62,14 +63,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(/x:description/x:param)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(/x:description/x:param/attribute())[1]"
 						 />
 					</x:call>
@@ -81,14 +82,14 @@
 		<x:scenario label="global variable">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="/x:description/x:variable/element()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec"
 							select="/x:description/x:variable/element()/attribute()" />
 					</x:call>
@@ -98,14 +99,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(/x:description/x:variable)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec"
 							select="(/x:description/x:variable/attribute())[1]" />
 					</x:call>
@@ -117,14 +118,14 @@
 		<x:scenario label="local variable">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="//x:scenario/x:variable/element()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec"
 							select="//x:scenario/x:variable/element()/attribute()" />
 					</x:call>
@@ -134,14 +135,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:scenario/x:variable)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:scenario/x:variable/attribute())[1]"
 						 />
 					</x:call>
@@ -153,14 +154,14 @@
 		<x:scenario label="assertion">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:expect/element())[1]" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="//x:expect/element()/attribute()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
@@ -169,14 +170,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:expect)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt.xspec" select="(//x:expect/attribute())[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
@@ -187,7 +188,7 @@
 		<x:scenario label="context template-param">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec" select="//x:context/x:param/element()"
 						 />
 					</x:call>
@@ -195,7 +196,7 @@
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="//x:context/x:param/element()/attribute()" />
 					</x:call>
@@ -205,14 +206,14 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec" select="(//x:context/x:param)[1]" />
 					</x:call>
 					<x:expect label="False" select="false()" />
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="(//x:context/x:param/attribute())[1]" />
 					</x:call>
@@ -224,7 +225,7 @@
 		<x:scenario label="context">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="//x:context[not(x:param)]/element()" />
 					</x:call>
@@ -232,7 +233,7 @@
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="//x:context[not(x:param)]/element()/attribute()" />
 					</x:call>
@@ -242,7 +243,7 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec" select="(//x:context[not(x:param)])[1]"
 						 />
 					</x:call>
@@ -250,7 +251,7 @@
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="(//x:context[not(x:param)]/attribute())[1]" />
 					</x:call>
@@ -262,7 +263,7 @@
 		<x:scenario label="template-call template-param">
 			<x:scenario label="user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="//x:call[@template]/x:param/element()" />
 					</x:call>
@@ -270,7 +271,7 @@
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="//x:call[@template]/x:param/element()/attribute()" />
 					</x:call>
@@ -280,7 +281,7 @@
 
 			<x:scenario label="not user-content">
 				<x:scenario label="element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="(//x:call[@template]/x:param)[1]" />
 					</x:call>
@@ -288,7 +289,7 @@
 				</x:scenario>
 
 				<x:scenario label="attribute">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="avt_stylesheet.xspec"
 							select="(//x:call[@template]/x:param/attribute())[1]" />
 					</x:call>
@@ -300,7 +301,7 @@
 		<x:scenario label="label">
 			<x:scenario label="scenario label">
 				<x:scenario label="x:label element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="//x:scenario/x:label" />
 					</x:call>
@@ -308,7 +309,7 @@
 				</x:scenario>
 
 				<x:scenario label="child text">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="(//x:scenario/x:label/text())[1]" />
 					</x:call>
@@ -318,7 +319,7 @@
 
 			<x:scenario label="assertion label">
 				<x:scenario label="x:label element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="//x:expect/x:label" />
 					</x:call>
@@ -326,7 +327,7 @@
 				</x:scenario>
 
 				<x:scenario label="child text">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="(//x:expect/x:label/text())[1]" />
 					</x:call>
@@ -336,7 +337,7 @@
 
 			<x:scenario label="like label">
 				<x:scenario label="x:label element">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="//x:like/x:label" />
 					</x:call>
@@ -344,7 +345,7 @@
 				</x:scenario>
 
 				<x:scenario label="child text">
-					<x:call function="x:is-user-content">
+					<x:call>
 						<x:param href="end-to-end/cases/label-element.xspec"
 							select="(//x:like/x:label/text())[1]" />
 					</x:call>
@@ -376,10 +377,12 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function is-ws-only-text-node-significant">
+		<x:call function="x:is-ws-only-text-node-significant" />
+
 		<x:scenario label="xml:space">
 			<x:scenario label="override default with preserve">
 				<x:scenario label="specified by parent">
-					<x:call function="x:is-ws-only-text-node-significant">
+					<x:call>
 						<x:param select="//text()">
 							<great-grandparent>
 								<grandparent xml:space="default">
@@ -393,7 +396,7 @@
 				</x:scenario>
 
 				<x:scenario label="specified by grandparent">
-					<x:call function="x:is-ws-only-text-node-significant">
+					<x:call>
 						<x:param select="//text()">
 							<great-grandparent xml:space="default">
 								<grandparent xml:space="preserve"><parent>&#x09;&#x0A;&#x0D;&#x20;</parent></grandparent>
@@ -407,7 +410,7 @@
 
 			<x:scenario label="override preserve with default">
 				<x:scenario label="specified by parent">
-					<x:call function="x:is-ws-only-text-node-significant">
+					<x:call>
 						<x:param select="//text()">
 							<great-grandparent>
 								<grandparent xml:space="preserve"><parent xml:space="default">
@@ -421,7 +424,7 @@
 				</x:scenario>
 
 				<x:scenario label="specified by grandparent">
-					<x:call function="x:is-ws-only-text-node-significant">
+					<x:call>
 						<x:param select="//text()">
 							<great-grandparent xml:space="preserve"><grandparent xml:space="default">
 									<parent>

--- a/test/version-utils.xspec
+++ b/test/version-utils.xspec
@@ -14,30 +14,32 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function pack-version">
+		<x:call function="x:pack-version" />
+
 		<x:scenario label="Valid parameter">
 			<x:scenario label="76.0.3809.132">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="76, 0, 3809, 132" />
 				</x:call>
 				<x:expect label="0x004C00000EE10084" select="21392098479636612" />
 			</x:scenario>
 
 			<x:scenario label="1.2.3">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="1, 2, 3" />
 				</x:call>
 				<x:expect label="0x0001000200030000" select="281483566841856" />
 			</x:scenario>
 
 			<x:scenario label="10.11">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="10, 11" />
 				</x:call>
 				<x:expect label="0x000A000B00000000" select="2814797011746816" />
 			</x:scenario>
 
 			<x:scenario label="9">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="9" />
 				</x:call>
 				<x:expect label="0x0009000000000000" select="2533274790395904" />
@@ -46,7 +48,7 @@
 
 		<x:scenario catch="true" label="Invalid parameter">
 			<x:scenario label="5 components">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="1, 2, 3, 4, 5" />
 				</x:call>
 				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
@@ -54,7 +56,7 @@
 			</x:scenario>
 
 			<x:scenario label="Greater than uint16">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="65536" />
 				</x:call>
 				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
@@ -62,7 +64,7 @@
 			</x:scenario>
 
 			<x:scenario label="Less than uint16">
-				<x:call function="x:pack-version">
+				<x:call>
 					<x:param select="-1" />
 				</x:call>
 				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
@@ -72,16 +74,18 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function extract-version">
+		<x:call function="x:extract-version" />
+
 		<x:scenario label="Saxon 9">
 			<x:scenario label="Typical xsl:product-version">
-				<x:call function="x:extract-version">
+				<x:call>
 					<x:param select="'HE 9.9.1.5'" />
 				</x:call>
 				<x:expect label="Extracted" select="9, 9, 1, 5" />
 			</x:scenario>
 
 			<x:scenario label="java -cp saxon.jar net.sf.saxon.Version">
-				<x:call function="x:extract-version">
+				<x:call>
 					<x:param select="'SAXON-HE 9.9.1.5J from Saxonica (build 090514)'" />
 				</x:call>
 				<x:expect label="Extracted, stripping platform suffix ('J')" select="9, 9, 1, 5" />
@@ -97,14 +101,14 @@
 
 			<x:scenario label="Typical xsl:product-version">
 				<x:scenario label="10.0">
-					<x:call function="x:extract-version">
+					<x:call>
 						<x:param select="'HE 10.0'" />
 					</x:call>
 					<x:expect label="Extracted as major.minor.0.0" select="10, 0, 0, 0" />
 				</x:scenario>
 
 				<x:scenario label="10.1">
-					<x:call function="x:extract-version">
+					<x:call>
 						<x:param select="'HE 10.1'" />
 					</x:call>
 					<x:expect label="Extracted as major.minor.0.0" select="10, 1, 0, 0" />
@@ -112,7 +116,7 @@
 			</x:scenario>
 
 			<x:scenario label="java -cp saxon.jar net.sf.saxon.Version">
-				<x:call function="x:extract-version">
+				<x:call>
 					<x:param select="'SAXON-HE 10.0J from Saxonica (build 31609)'" />
 				</x:call>
 				<x:expect label="Extracted, stripping platform suffix ('J')" select="10, 0, 0, 0" />
@@ -120,14 +124,14 @@
 		</x:scenario>
 
 		<x:scenario label="Relatively large version">
-			<x:call function="x:extract-version">
+			<x:call>
 				<x:param select="'76.0.3809.132'" />
 			</x:call>
 			<x:expect label="Extracted" select="76, 0, 3809, 132" />
 		</x:scenario>
 
 		<x:scenario label="No #.#.#.#">
-			<x:call function="x:extract-version">
+			<x:call>
 				<x:param select="'１.２.３.４'" />
 			</x:call>
 			<x:expect label="Empty sequence" />

--- a/test/wrap.xspec
+++ b/test/wrap.xspec
@@ -21,36 +21,38 @@
       <!-- TODO: These scenarios do not run on XQuery
            t:wrappable-sequence() has not been implemented for XQuery -->
 
+      <t:call function="t:wrappable-sequence" />
+
       <t:scenario label="All kinds of nodes">
-         <t:call function="t:wrappable-sequence">
+         <t:call>
             <t:param select="$items:all-nodes" />
          </t:call>
          <t:expect label="False" select="false()" />
       </t:scenario>
 
       <t:scenario label="All nodes that can be wrapped">
-         <t:call function="t:wrappable-sequence">
+         <t:call>
             <t:param select="$items:wrappable-nodes" />
          </t:call>
          <t:expect label="True" select="true()" />
       </t:scenario>
 
       <t:scenario label="All nodes that can be wrapped, and atomic value">
-         <t:call function="t:wrappable-sequence">
+         <t:call>
             <t:param select="$items:wrappable-nodes, $items:integer" />
          </t:call>
          <t:expect label="False" select="false()" />
       </t:scenario>
 
       <t:scenario label="Nodes that cannot be wrapped">
-         <t:call function="t:wrappable-sequence">
+         <t:call>
             <t:param select="$items:non-wrappable-nodes" />
          </t:call>
          <t:expect label="False" select="false()" />
       </t:scenario>
 
       <t:scenario label="Empty sequence">
-         <t:call function="t:wrappable-sequence">
+         <t:call>
             <t:param as="empty-sequence()" />
          </t:call>
          <t:expect label="True" select="true()" />
@@ -65,52 +67,54 @@
       <!-- TODO: These scenarios do not run on XQuery
            local:wrappable-node() has not been implemented for XQuery -->
 
+      <t:call function="local:wrappable-node" />
+
       <t:scenario label="Nodes">
 
          <t:scenario label="Attribute">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:attribute" />
             </t:call>
             <t:expect label="False" select="false()" />
          </t:scenario>
 
          <t:scenario label="Comment">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:comment" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
 
          <t:scenario label="Document">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:document" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
 
          <t:scenario label="Element">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:element" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
 
          <t:scenario label="Namespace">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:namespace" />
             </t:call>
             <t:expect label="False" select="false()" />
          </t:scenario>
 
          <t:scenario label="Processing instruction">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:processing-instruction" />
             </t:call>
             <t:expect label="True" select="true()" />
          </t:scenario>
 
          <t:scenario label="Text">
-            <t:call function="local:wrappable-node">
+            <t:call>
                <t:param select="$items:text" />
             </t:call>
             <t:expect label="True" select="true()" />
@@ -119,7 +123,7 @@
       </t:scenario>
 
       <t:scenario label="Value">
-         <t:call function="local:wrappable-node">
+         <t:call>
             <t:param select="$items:integer" />
          </t:call>
          <t:expect label="False" select="false()" />
@@ -134,8 +138,10 @@
       <!-- TODO: These scenarios do not run on XQuery
            t:wrap-nodes() has not been implemented for XQuery -->
 
+      <t:call function="t:wrap-nodes" />
+
       <t:scenario label="All nodes that can be wrapped">
-         <t:call function="t:wrap-nodes">
+         <t:call>
             <t:param select="$items:wrappable-nodes" />
          </t:call>
          <t:expect label="Result is document node" test="$t:result instance of document-node()" />
@@ -148,7 +154,7 @@
       </t:scenario>
 
       <t:scenario label="Empty sequence">
-         <t:call function="t:wrap-nodes">
+         <t:call>
             <t:param as="empty-sequence()" />
          </t:call>
          <t:expect label="Result is document node" test="$t:result instance of document-node()" />

--- a/test/xspec-name.xspec
+++ b/test/xspec-name.xspec
@@ -3,10 +3,12 @@
 	xmlns="http://www.jenitennison.com/xslt/xspec">
 
 	<scenario label="Scenario for testing function xspec-name">
+		<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name" />
+
 		<scenario label="Element name is in XSpec namespace">
 			<scenario label="Element name uses the default namespace">
 				<scenario label="No other XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<elem xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:p1="u1"
@@ -17,7 +19,7 @@
 				</scenario>
 
 				<scenario label="Some other XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<elem xmlns="http://www.jenitennison.com/xslt/xspec"
@@ -31,7 +33,7 @@
 
 			<scenario label="Element name uses a prefix">
 				<scenario label="Some other XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<p2:elem xmlns="http://www.jenitennison.com/xslt/xspec"
@@ -43,7 +45,7 @@
 				</scenario>
 
 				<scenario label="No other XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<p2:elem xmlns="u" xmlns:p1="u1"
@@ -59,7 +61,7 @@
 
 			<scenario label="Element name uses the default namespace">
 				<scenario catch="yes" label="No XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<elem xmlns="u" xmlns:p1="u1" xmlns:p2="u2" />
@@ -69,7 +71,7 @@
 				</scenario>
 
 				<scenario label="Some XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<elem xmlns="u" xmlns:p1="http://www.jenitennison.com/xslt/xspec"
@@ -83,7 +85,7 @@
 
 			<scenario label="Element name uses a prefix">
 				<scenario label="Some XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<p1:elem xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:p1="u1"
@@ -95,7 +97,7 @@
 				</scenario>
 
 				<scenario catch="yes" label="No XSpec prefixes">
-					<call function="Q{http://www.jenitennison.com/xslt/xspec}xspec-name">
+					<call>
 						<param select="'local-name'" />
 						<param>
 							<p1:elem xmlns="u" xmlns:p1="u1" xmlns:p2="u2" />


### PR DESCRIPTION
Just consolidate some `x:call` in `test/*.xspec` using [nesting](https://github.com/xspec/xspec/wiki/Nesting-Scenarios).