### PR TITLE
test: function-param attribute(position) with run-as=external

### DIFF
--- a/test/external_param-position.xsl
+++ b/test/external_param-position.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:package exclude-result-prefixes="#all" version="3.0"
+	xmlns:param-position="x-urn:test:param-position"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:include href="param-position.xsl" />
+	<xsl:expose component="*" names="param-position:*" visibility="final" />
+</xsl:package>

--- a/test/external_param-position.xspec
+++ b/test/external_param-position.xspec
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" stylesheet="external_param-position.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="param-position.xspec" />
+</x:description>

--- a/test/param-position.xqm
+++ b/test/param-position.xqm
@@ -1,0 +1,11 @@
+module namespace param-position = "x-urn:test:param-position";
+
+declare function param-position:join(
+$p1 as xs:string,
+$p2 as xs:string,
+$p3 as xs:string,
+$p4 as xs:string
+) as xs:string
+{
+	($p1, $p2, $p3, $p4) => string-join()
+};

--- a/test/param-position.xsl
+++ b/test/param-position.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:param-position="x-urn:test:param-position" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:function as="xs:string" name="param-position:join">
+		<xsl:param as="xs:string" name="p1" />
+		<xsl:param as="xs:string" name="p2" />
+		<xsl:param as="xs:string" name="p3" />
+		<xsl:param as="xs:string" name="p4" />
+
+		<xsl:sequence select="($p1, $p2, $p3, $p4) => string-join()" />
+	</xsl:function>
+
+</xsl:stylesheet>

--- a/test/param-position.xspec
+++ b/test/param-position.xspec
@@ -1,43 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm"
-	stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:param-position" query-at="param-position.xqm"
+	stylesheet="param-position.xsl" xmlns:param-position="x-urn:test:param-position"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="When all instances of function-param have @position in ascending order">
-		<x:call function="replace">
-			<x:param name="input" position="1" select="'abc'" />
-			<x:param name="pattern" position="2" select="'b'" />
-			<x:param name="replacement" position="3" select="'B'" />
+		<x:call function="param-position:join">
+			<x:param position="1" select="'a'" />
+			<x:param position="2" select="'b'" />
+			<x:param position="3" select="'c'" />
+			<x:param position="4" select="'d'" />
 		</x:call>
-		<x:expect label="The parameters are picked up in @position order" select="'aBc'" />
+		<x:expect label="The parameters are picked up in @position order" select="'abcd'" />
 	</x:scenario>
 
 	<x:scenario label="When all instances of function-param have @position in descending order">
-		<x:call function="replace">
-			<x:param name="replacement" position="3" select="'B'" />
-			<x:param name="pattern" position="2" select="'b'" />
-			<x:param name="input" position="1" select="'abc'" />
+		<x:call function="param-position:join">
+			<x:param position="4" select="'d'" />
+			<x:param position="3" select="'c'" />
+			<x:param position="2" select="'b'" />
+			<x:param position="1" select="'a'" />
 		</x:call>
-		<x:expect label="The parameters are picked up in @position order" select="'aBc'" />
+		<x:expect label="The parameters are picked up in @position order" select="'abcd'" />
 	</x:scenario>
 
 	<x:scenario label="When all instances of function-param have the same @position">
-		<x:call function="replace">
-			<x:param name="input" position="1" select="'abc'" />
-			<x:param name="pattern" position="1" select="'b'" />
-			<x:param name="replacement" position="1" select="'B'" />
+		<x:call function="param-position:join">
+			<x:param position="1" select="'a'" />
+			<x:param position="1" select="'b'" />
+			<x:param position="1" select="'c'" />
+			<x:param position="1" select="'d'" />
 		</x:call>
-		<x:expect label="The parameters are picked up in document order" select="'aBc'" />
+		<x:expect label="The parameters are picked up in document order" select="'abcd'" />
 	</x:scenario>
 
-	<x:scenario label="When only the last function-param has @position">
-		<x:call function="replace">
-			<x:param name="replacement" position="1" select="'B'" />
-			<x:param name="input" select="'abc'" />
-			<x:param name="pattern" select="'b'" />
+	<x:scenario label="When instances of function-param with or without @position are interleaved">
+		<x:call function="param-position:join">
+			<x:param position="2" select="'d'" />
+			<x:param select="'a'" />
+			<x:param position="1" select="'c'" />
+			<x:param select="'b'" />
 		</x:call>
 		<x:expect
-			label="The parameters without @position are picked up in document order, followed by the one with @position"
-			select="'aBc'" />
+			label="The parameters without @position are picked up in document order, followed by the ones with @position in @position order"
+			select="'abcd'" />
 	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
Test `x:call[@function]/x:param/@position` with `@run-as="external`.

Some patterns of `@position` look bad, but that's how `@position` has been working:

- `@position` can be duplicate.
- `@position` is not absolute but relative.
- `@position[. le 0]` is allowed.
- `x:param[empty(@position)]` precedes `x:param[@position >= 1]`.