### PR TITLE
feat: boolean attribute(shared)

### DIFF
--- a/src/compiler/base/combine/mode/unshare-scenarios.xsl
+++ b/src/compiler/base/combine/mode/unshare-scenarios.xsl
@@ -18,8 +18,8 @@
    </xsl:template>
 
    <!-- Discard @shared and shared x:scenario -->
-   <xsl:template match="x:scenario/@shared | x:scenario[@shared eq 'yes']" as="empty-sequence()"
-      mode="x:unshare-scenarios" />
+   <xsl:template match="x:scenario/@shared | x:scenario[x:yes-no-synonym(@shared, false())]"
+      as="empty-sequence()" mode="x:unshare-scenarios" />
 
    <!-- Replace x:like with specified scenario's child elements -->
    <xsl:template match="x:like" as="element()+" mode="x:unshare-scenarios">

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -142,7 +142,7 @@ shared =
 	## There are shared scenarios (shared="yes") and unshared scenarios (shared="no",
 	## the default). Shared scenarios can be referenced and reused by other scenarios
 	## with the <like> element. Unshared scenarios are simply run.
-	attribute shared { "yes" | "no" }
+	attribute shared { boolean.datatype }
 
 like = 
 	## The <like> element pulls a shared scenario into this one (which may be shared

--- a/test/end-to-end/cases/expected/query/shared-like-junit.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-junit.xml
@@ -28,4 +28,12 @@
       <testcase name="implicit one This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
    </testsuite>
+   <testsuite name="Unreferenced @shared=false" tests="1" failures="0">
+      <testcase name="This unreferenced @shared=false x:expect should fire only at its original x:scenario"
+                status="passed"/>
+   </testsuite>
+   <testsuite name="Unreferenced @shared=0" tests="1" failures="0">
+      <testcase name="This unreferenced @shared=0 x:expect should fire only at its original x:scenario"
+                status="passed"/>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/shared-like-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:mirror (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -22,10 +22,10 @@
          <thead>
             <tr>
                <th></th>
-               <th class="totals">passed: 6</th>
+               <th class="totals">passed: 8</th>
                <th class="totals">pending: 0</th>
                <th class="totals">failed: 0</th>
-               <th class="totals">total: 6</th>
+               <th class="totals">total: 8</th>
             </tr>
          </thead>
          <tbody>
@@ -56,6 +56,20 @@
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario5">Unreferenced @shared=false</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario6">Unreferenced @shared=0</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
             </tr>
          </tbody>
       </table>
@@ -150,6 +164,44 @@
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
                      x:scenario and x:like</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario5">
+         <h2 class="successful">Unreferenced @shared=false<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario5">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Unreferenced @shared=false</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>This unreferenced @shared=false x:expect should fire only at its original x:scenario</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario6">
+         <h2 class="successful">Unreferenced @shared=0<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario6">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Unreferenced @shared=0</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>This unreferenced @shared=0 x:expect should fire only at its original x:scenario</td>
                   <td>Success</td>
                </tr>
             </tbody>

--- a/test/end-to-end/cases/expected/query/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/query/shared-like-result.xml
@@ -106,4 +106,40 @@
          </test>
       </scenario>
    </scenario>
+   <scenario id="scenario5" xspec="../../shared-like.xspec">
+      <label>Unreferenced @shared=false</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:mirror="x-urn:test:mirror"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="mirror:false"/>
+      </input-wrap>
+      <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+      <test id="scenario5-expect1" successful="true">
+         <label>This unreferenced @shared=false x:expect should fire only at its original x:scenario</label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      test="true()"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
+   <scenario id="scenario6" xspec="../../shared-like.xspec">
+      <label>Unreferenced @shared=0</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:mirror="x-urn:test:mirror"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="mirror:false"/>
+      </input-wrap>
+      <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+      <test id="scenario6-expect1" successful="true">
+         <label>This unreferenced @shared=0 x:expect should fire only at its original x:scenario</label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      test="true()"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-junit.xml
@@ -28,4 +28,12 @@
       <testcase name="implicit one This referenced and implicitly unshared x:expect should fire both at its original x:scenario and x:like"
                 status="passed"/>
    </testsuite>
+   <testsuite name="Unreferenced @shared=false" tests="1" failures="0">
+      <testcase name="This unreferenced @shared=false x:expect should fire only at its original x:scenario"
+                status="passed"/>
+   </testsuite>
+   <testsuite name="Unreferenced @shared=0" tests="1" failures="0">
+      <testcase name="This unreferenced @shared=0 x:expect should fire only at its original x:scenario"
+                status="passed"/>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -21,10 +21,10 @@
          <thead>
             <tr>
                <th></th>
-               <th class="totals">passed: 6</th>
+               <th class="totals">passed: 8</th>
                <th class="totals">pending: 0</th>
                <th class="totals">failed: 0</th>
-               <th class="totals">total: 6</th>
+               <th class="totals">total: 8</th>
             </tr>
          </thead>
          <tbody>
@@ -55,6 +55,20 @@
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">2</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario5">Unreferenced @shared=false</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario6">Unreferenced @shared=0</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
             </tr>
          </tbody>
       </table>
@@ -149,6 +163,44 @@
                <tr class="successful">
                   <td>This referenced and implicitly unshared x:expect should fire both at its original
                      x:scenario and x:like</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario5">
+         <h2 class="successful">Unreferenced @shared=false<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario5">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Unreferenced @shared=false</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>This unreferenced @shared=false x:expect should fire only at its original x:scenario</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario6">
+         <h2 class="successful">Unreferenced @shared=0<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario6">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Unreferenced @shared=0</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>This unreferenced @shared=0 x:expect should fire only at its original x:scenario</td>
                   <td>Success</td>
                </tr>
             </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.xml
@@ -105,4 +105,40 @@
          </test>
       </scenario>
    </scenario>
+   <scenario id="scenario5" xspec="../../shared-like.xspec">
+      <label>Unreferenced @shared=false</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:mirror="x-urn:test:mirror"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="mirror:false"/>
+      </input-wrap>
+      <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+      <test id="scenario5-expect1" successful="true">
+         <label>This unreferenced @shared=false x:expect should fire only at its original x:scenario</label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      test="true()"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
+   <scenario id="scenario6" xspec="../../shared-like.xspec">
+      <label>Unreferenced @shared=0</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:mirror="x-urn:test:mirror"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="mirror:false"/>
+      </input-wrap>
+      <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+      <test id="scenario6-expect1" successful="true">
+         <label>This unreferenced @shared=0 x:expect should fire only at its original x:scenario</label>
+         <expect-test-wrap xmlns="">
+            <x:expect xmlns:mirror="x-urn:test:mirror"
+                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      test="true()"/>
+         </expect-test-wrap>
+         <expect select="()"/>
+      </test>
+   </scenario>
 </report>

--- a/test/end-to-end/cases/shared-like.xspec
+++ b/test/end-to-end/cases/shared-like.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description query="x-urn:test:mirror" query-at="../../mirror.xqm"
-	stylesheet="../../mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+<x:description query="x-urn:test:mirror" query-at="mirror.xqm" stylesheet="mirror.xsl"
+	xml:base="../../" xmlns:mirror="x-urn:test:mirror"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:scenario label="Unreferenced shared scenario" shared="yes">
@@ -46,6 +46,34 @@
 		<x:scenario label="implicit one">
 			<x:like label="Referenced and implicitly unshared scenario" />
 		</x:scenario>
+	</x:scenario>
+
+	<!--
+		@shared[not(. = ('yes', 'no'))]
+	-->
+
+	<x:scenario label="Unreferenced @shared=true" shared="true">
+		<x:expect label="This unreferenced @shared=true x:expect should not fire at all"
+			test="true()" />
+	</x:scenario>
+
+	<x:scenario label="Unreferenced @shared=1" shared="1">
+		<x:expect label="This unreferenced @shared=true x:expect should not fire at all"
+			test="true()" />
+	</x:scenario>
+
+	<x:scenario label="Unreferenced @shared=false" shared="false">
+		<x:call function="mirror:false" />
+		<x:expect
+			label="This unreferenced @shared=false x:expect should fire only at its original x:scenario"
+			test="true()" />
+	</x:scenario>
+
+	<x:scenario label="Unreferenced @shared=0" shared="0">
+		<x:call function="mirror:false" />
+		<x:expect
+			label="This unreferenced @shared=0 x:expect should fire only at its original x:scenario"
+			test="true()" />
 	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
For consistency with the other attributes, this pull request defines `x:scenario/@shared` as `boolean.datatype`.