### PR TITLE
fix: make x:param[attribute(position)] overridable

### DIFF
--- a/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
@@ -119,7 +119,9 @@
                   <xsl:variable name="local-params" as="element(x:param)*" select="x:param"/>
                   <xsl:sequence
                      select="
-                        $call/x:param[not(@name = $local-params/@name)],
+                        $call/x:param
+                        [not(@name = $local-params/@name)]
+                        [not(@position = $local-params/@position)],
                         $local-params"/>
                </xsl:copy>
                <!-- TODO: Test that "x:call/(node() except x:param)" is empty. -->

--- a/test/nested-context.xspec
+++ b/test/nested-context.xspec
@@ -19,6 +19,13 @@
 			<x:expect label="the attribute value should be upper-cased">
 				<foo bar="BAZ">qux</foo>
 			</x:expect>
+
+			<x:scenario label="in 'upper-case-text' mode (override an ancestor mode)">
+				<x:context mode="upper-case-text" />
+				<x:expect label="the text should be upper-cased">
+					<foo bar="baz">QUX</foo>
+				</x:expect>
+			</x:scenario>
 		</x:scenario>
 	</x:scenario>
 

--- a/test/nested-function-call.xspec
+++ b/test/nested-function-call.xspec
@@ -53,7 +53,7 @@
 			<!-- ... other scenarios around creating tables with three values (with different numbers of columns) ... -->
 		</x:scenario>
 
-		<x:scenario label="holding four values">
+		<x:scenario label="holding four values in one column">
 			<x:call>
 				<x:param position="2">
 					<value>a</value>
@@ -61,9 +61,10 @@
 					<value>c</value>
 					<value>d</value>
 				</x:param>
+				<x:param position="1" select="1" />
 			</x:call>
 
-			<x:scenario label="in two columns">
+			<x:scenario label="in two columns (override an ancestor param)">
 				<x:call>
 					<x:param position="1" select="2" />
 				</x:call>

--- a/test/nested-template-call.xspec
+++ b/test/nested-template-call.xspec
@@ -51,7 +51,7 @@
 			<!-- ... other scenarios around creating tables with three values (with different numbers of columns) ... -->
 		</x:scenario>
 
-		<x:scenario label="holding four values">
+		<x:scenario label="holding four values in one column">
 			<x:call>
 				<x:param name="nodes">
 					<value>a</value>
@@ -59,9 +59,10 @@
 					<value>c</value>
 					<value>d</value>
 				</x:param>
+				<x:param name="cols" select="1" />
 			</x:call>
 
-			<x:scenario label="in two columns">
+			<x:scenario label="in two columns (override an ancestor param)">
 				<x:call>
 					<x:param name="cols" select="2" />
 				</x:call>

--- a/test/param-position.xspec
+++ b/test/param-position.xspec
@@ -45,4 +45,37 @@
 			select="'abcd'" />
 	</x:scenario>
 
+	<x:scenario label="When parameters are nested">
+		<x:call function="param-position:join">
+			<!-- TODO: Runtime error. Fix it. -->
+			<!--<x:param select="'position-less parameter to be overridden'" />-->
+		</x:call>
+
+		<x:scenario
+			label="3 (to be overridden) and 4 (greater than count(ancestor-or-self::x:scenario/x:call/x:param))">
+			<x:call>
+				<x:param position="3" select="'3rd parameter to be overridden'" />
+				<x:param position="4" select="'d'" />
+			</x:call>
+
+			<x:scenario
+				label="3 (overrides a parent parameter) followed by a position-less parameter (overrides an ancestor parameter)">
+				<x:call>
+					<x:param position="3" select="'c'" />
+					<x:param select="'a'" />
+				</x:call>
+
+				<x:scenario label="2 (inserted in the midst)">
+					<x:call>
+						<x:param position="2" select="'b'" />
+					</x:call>
+
+					<x:scenario label="expect">
+						<x:expect label="The parameters are merged" select="'abcd'" />
+					</x:scenario>
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
 </x:description>


### PR DESCRIPTION
Related to #1262 

Currently `@position` in nested scenarios is accumulated whereas `@name` is overridden.
This pull request makes `@position` overridable.