### PR TITLE
ci(maven): replace `set-env` command with environment file

### DIFF
--- a/test/ci/test-maven-jar.cmd
+++ b/test/ci/test-maven-jar.cmd
@@ -13,7 +13,7 @@ for /f %%I in ('call mvn help:evaluate --quiet "-Dexpression=project.version" -D
 
 if "%GITHUB_ACTIONS%"=="true" (
     rem Propagate the project version as an environment variable to any actions running next in a job
-    echo ::set-env name=MAVEN_PACKAGE_VERSION::%MAVEN_PACKAGE_VERSION%
+    (echo MAVEN_PACKAGE_VERSION=%MAVEN_PACKAGE_VERSION%) >>"%GITHUB_ENV%"
 )
 
 set "XSPEC_MAVEN_JAR=%~dp0..\..\target\xspec-%MAVEN_PACKAGE_VERSION%.jar"

--- a/test/ci/test-maven-jar.sh
+++ b/test/ci/test-maven-jar.sh
@@ -11,7 +11,7 @@ maven_package_version=$(mvn help:evaluate --quiet -Dexpression=project.version -
 
 if [ "${GITHUB_ACTIONS}" = true ]; then
     # Propagate the project version as an environment variable to any actions running next in a job
-    echo "::set-env name=MAVEN_PACKAGE_VERSION::${maven_package_version}"
+    echo "MAVEN_PACKAGE_VERSION=${maven_package_version}" >> "${GITHUB_ENV}"
 fi
 
 myname="${BASH_SOURCE:-$0}"


### PR DESCRIPTION
In response to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ , this pull request replaces the deprecated `set-env` commands in GitHub Actions workflows with the new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).