### PR TITLE
build(oxygen): add-on v2.0.6

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,20 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.0.6</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>feat: reject suspicious x:expect[attribute(test)] (<a
+							href="https://github.com/xspec/xspec/pull/1245">#1245</a>)</li>
+					<li>feat: attribute(as) for x:context and x:expect (<a
+							href="https://github.com/xspec/xspec/pull/1256">#1256</a>)</li>
+					<li>fix(xslt): variables declared between x:context and x:call (<a
+							href="https://github.com/xspec/xspec/pull/1246">#1246</a>)</li>
+					<li><code>x:param[@position]</code> is designed more clearly (<a
+							href="https://github.com/xspec/xspec/pull/1267">#1267</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.5</h3>
 				<ul>
 					<li>fix(report): serialize text node report (<a

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/838ff9efce04552e885cbe40dd6f65d155b8a262.zip" />
+			href="https://github.com/xspec/xspec/archive/0f6cc153bbda385602ec3f63a2429ede8b9318a6.zip" />
 
-		<xt:version>2.0.5</xt:version>
+		<xt:version>2.0.6</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-838ff9efce04552e885cbe40dd6f65d155b8a262/xspec.framework/XSpec</String>
+                                    <String>4/xspec-0f6cc153bbda385602ec3f63a2429ede8b9318a6/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.
- The [changelog](https://htmlpreview.github.io/?https://github.com/AirQuick/xspec/blob/ea78100bc514891cedbfc497467ea18aab70c77a/editors/oxygen/add-on/description/latest.xhtml) denotes this version as "Release Candidate of the stable release".
- #1276 is not mentioned in the changelog, because it has nothing to do with Oxygen.

I tested this change on Oxygen 22.1 build 2020100710 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-0-6/oxygen-addon.xml`:
- All the 4 transformation scenarios work including **Run XSpec Test** with XSLT, XQuery, Schematron and the latest visible change (#1273).
- DITA DTD takes effect via `${xmlCatalogFilesList}` (#980).
- Loading `xspec.xpr` disables the add-on.