### PR TITLE
ci(deps): bump BaseX from 9.4.3 to 9.4.4

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.9
 
 # Latest BaseX
-BASEX_VERSION=9.4.3
+BASEX_VERSION=9.4.4
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -32,12 +32,11 @@ echo
 echo "=== Check BaseX"
 java -cp "${BASEX_JAR}" org.basex.BaseX -h
 
-# TODO: On BaseX 9.4.3, this causes "Server is running or permission was denied (port: 1984)" in Bats test.
-# echo
-# echo "=== Check BaseX server start and stop"
-# basex_home=$(dirname -- "${BASEX_JAR}")
-# "${basex_home}/bin/basexhttp" -S
-# "${basex_home}/bin/basexhttpstop"
+echo
+echo "=== Check BaseX server start and stop"
+basex_home=$(dirname -- "${BASEX_JAR}")
+"${basex_home}/bin/basexhttp" -S
+"${basex_home}/bin/basexhttpstop"
 
 echo
 echo "=== Print Bats version"


### PR DESCRIPTION
https://github.com/BaseXdb/basex/blob/master/CHANGELOG

> VERSION 9.4.4 (November 6, 2020) ---------------------------------------
> 
>  - Performance tweaks, minor bug fixes

"minor bug" includes [a bug](https://mailman.uni-konstanz.de/pipermail/basex-talk/2020-September/015743.html) that affected `test/ci/print-env.sh`.