### PR TITLE
build: release v2.0.7

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,12 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.0.7</h3>
+				<ul>
+					<li>Official release of v2.0</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.6</h3>
 				<ul>
 					<li>Release Candidate of the stable release</li>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/0f6cc153bbda385602ec3f63a2429ede8b9318a6.zip" />
+			href="https://github.com/xspec/xspec/archive/29f439a213225208430acd4984bb8d5c9bb2d786.zip" />
 
-		<xt:version>2.0.6</xt:version>
+		<xt:version>2.0.7</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.0.7</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-0f6cc153bbda385602ec3f63a2429ede8b9318a6/xspec.framework/XSpec</String>
+                                    <String>4/xspec-29f439a213225208430acd4984bb8d5c9bb2d786/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request increments the version numbers in `pom.xml` and `oxygen-addon.xml`, which makes the official stable release of `v2.0`. (technically `v2.0.7`, based on #940)

As for the file paths in `oxygen-addon.xml`, I used the last `master` SHA rather than the git tag `v2.0.7`, because we haven't had the actual tag yet and therefore cannot test it. I tested the Oxygen add-on on Oxygen 23.0 build 2020111805 using `https://github.com/AirQuick/xspec/raw/rel_2-0-7/oxygen-addon.xml`.