### PR TITLE
docs(cli): revert 33684b7 with regard to xspec.sh

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -60,6 +60,7 @@ die() {
 # script for Saxon [1].  If it is present, that means the user already
 # configured it, so there is no point to duplicate the logic here.
 # Just use it.
+# [1]http://code.google.com/p/expath-pkg/source/browse/trunk/saxon/pkg-saxon/src/shell/saxon
 
 if command -v saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev/null 2>&1; then
     echo Saxon script found, use it.


### PR DESCRIPTION
`xspec.sh` has broken `[1]` link in one of its comments:
https://github.com/xspec/xspec/blob/cd3e7622bc550285ae75c060da7a24f94a4fb0d2/bin/xspec.sh#L57-L63
This pr fixes it by reverting a part of #66.