### PR TITLE
docs(xslt): attribute(test) context may not always be node

### DIFF
--- a/src/compiler/xslt/compile/compile-expect.xsl
+++ b/src/compiler/xslt/compile/compile-expect.xsl
@@ -61,7 +61,7 @@
 
             <xsl:choose>
                <xsl:when test="@test">
-                  <xsl:comment> wrap $x:result into a doc node if possible </xsl:comment>
+                  <xsl:comment> wrap $x:result into a document node if possible </xsl:comment>
                   <!-- This variable declaration could be moved from here (the
                      template generated from x:expect) to the template
                      generated from x:scenario. It depends only on
@@ -83,7 +83,7 @@
                      </choose>
                   </variable>
 
-                  <xsl:comment> evaluate the predicate with $x:result as context node if $x:result is a single node; if not, just evaluate the predicate </xsl:comment>
+                  <xsl:comment> evaluate the predicate with $x:result (or its wrapper document node) as context item if it is a single item; if not, evaluate the predicate without context item </xsl:comment>
                   <variable name="{x:known-UQName('impl:test-result')}" as="item()*">
                      <choose>
                         <when test="count(${x:known-UQName('impl:test-items')}) eq 1">

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -220,7 +220,7 @@ result as parameter.
    <xsl:param name="Q{http://www.jenitennison.com/xslt/xspec}result" required="yes"/>
    <xsl:message>expectations</xsl:message>
    <xsl:variable name="Q{urn:x-xspec:compile:impl}expect-..." select="()"><!--expected result--></xsl:variable>
-   <!-- wrap $x:result into a doc node if possible -->
+   <!-- wrap $x:result into a document node if possible -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}test-items" as="item()*">
       <xsl:choose>
          <xsl:when test="exists($Q{http://www.jenitennison.com/xslt/xspec}result) and Q{http://www.jenitennison.com/xslt/xspec}wrappable-sequence($Q{http://www.jenitennison.com/xslt/xspec}result)">
@@ -231,7 +231,7 @@ result as parameter.
          </xsl:otherwise>
       </xsl:choose>
    </xsl:variable>
-   <!-- evaluate the predicate with $x:result as context node if $x:result is a single node; if not, just evaluate the predicate -->
+   <!-- evaluate the predicate with $x:result (or its wrapper document node) as context item if it is a single item; if not, evaluate the predicate without context item -->
    <xsl:variable name="Q{urn:x-xspec:compile:impl}test-result" as="item()*">
       <xsl:choose>
          <xsl:when test="count($Q{urn:x-xspec:compile:impl}test-items) eq 1">


### PR DESCRIPTION
One of the compiled stylesheet comments assumes that `@test` context (if not absent) is always a node. In fact, it can be a non-node item. (otherwise a [tutorial](https://github.com/xspec/xspec/blob/cd3e7622bc550285ae75c060da7a24f94a4fb0d2/tutorial/escape-for-regex.xspec#L65) wouldn't work.)
This pr fixes the comment.