### PR TITLE
docs(xquery): credit for functx:capitalize-first()

### DIFF
--- a/tutorial/xquery-tutorial.xqm
+++ b/tutorial/xquery-tutorial.xqm
@@ -1,5 +1,9 @@
 module namespace functx = "http://www.functx.com";
 
+(:
+    Capitalizes the first character of a string
+    From: http://www.xqueryfunctions.com/xq/functx_capitalize-first.html
+:)
 declare function functx:capitalize-first
 ($arg as xs:string?) as xs:string? {
     


### PR DESCRIPTION
`tutorial/xquery-tutorial.xqm` takes a function from FunctX XQuery library without mentioning it.
This pull request adds its source URL, just like [tutorial/escape-for-regex.xsl](https://github.com/xspec/xspec/blob/e7755c7c42c49c2eb4edf84f187390ca15def8b7/tutorial/escape-for-regex.xsl#L11).

(Strictly speaking, I guess we should attach its license or use our original function.)