### PR TITLE
build(oxygen): add-on v2.1.0

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,14 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.1.0</h3>
+				<ul>
+					<li>Initial development version of v2.1</li>
+					<li>feat(schematron): support /x:description/attribute(run-as) (<a
+							href="https://github.com/xspec/xspec/pull/1294">#1294</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.0.7</h3>
 				<ul>
 					<li>Official release of v2.0</li>
@@ -87,16 +95,6 @@
 							href="https://github.com/xspec/xspec/pull/892">#892</a>)</li>
 					<li>fix: remove hardcoded prefixes except xsl (<a
 							href="https://github.com/xspec/xspec/pull/982">#982</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.0.0</h3>
-				<ul>
-					<li>Initial development version of v2.0</li>
-					<li>feat: allow multiple catalog file paths (<a
-							href="https://github.com/xspec/xspec/pull/913">#913</a>)</li>
-					<li>feat: catalog file URIs (<a href="https://github.com/xspec/xspec/pull/980"
-							>#980</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/29f439a213225208430acd4984bb8d5c9bb2d786.zip" />
+			href="https://github.com/xspec/xspec/archive/73b2b4c781292c9b047d23c5f3e8485855cf766b.zip" />
 
-		<xt:version>2.0.7</xt:version>
+		<xt:version>2.1.0</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-29f439a213225208430acd4984bb8d5c9bb2d786/xspec.framework/XSpec</String>
+                                    <String>4/xspec-73b2b4c781292c9b047d23c5f3e8485855cf766b/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 23.0 build 2020111805 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-1-0/oxygen-addon.xml`.