### PR TITLE
ci: exclude Saxon 9.8 from Windows and macOS in GitHub Actions Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [8, 11]
         env: [saxon-10, saxon-9-9, oxygen, saxon-9-8]
+        exclude:
+          - os: windows-latest
+            env: saxon-9-8
+          - os: macos-latest
+            env: saxon-9-8
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
From [Requirement](https://github.com/xspec/xspec/wiki/Requirements#saxon-98-is-deprecated):
> ### Saxon 9.8 is deprecated
>
> XSpec is partially tested on Saxon 9.8.

Reflecting its status, this pull request excludes Saxon 9.8 from Windows and macOS matrix in GitHub Actions Test workflow.