### PR TITLE
refactor(cli): remove "Saxon script not found" message

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -186,13 +186,6 @@ if errorlevel 1 (
 )
 
 rem
-rem To be compatible with xspec.sh, do not omit this message. It makes the
-rem test automation easier.
-rem
-echo Saxon script not found, invoking JVM directly instead.
-echo:
-
-rem
 rem ##
 rem ## some variables ############################################################
 rem ##

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -77,8 +77,6 @@ if command -v saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" >
         saxon --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xq "$@"
     }
 else
-    echo Saxon script not found, invoking JVM directly instead.
-    echo
     xslt() {
         java \
             -Dxspec.coverage.ignore="${TEST_DIR}" \

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -9,35 +9,35 @@
 	<case name="invoking xspec without arguments prints usage">
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 3 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-e|-h] file"
+    call :verify_line 2 x "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-e|-h] file"
 	</case>
 
 	<case name="invoking xspec without arguments prints usage even if Saxon environment variables are not defined">
     set SAXON_CP=
     call :run ..\bin\xspec.bat
     call :verify_retval 1
-    call :verify_line 2 x "SAXON_CP and SAXON_HOME both not set!"
-    call :verify_line 4 r "Usage: xspec "
+    call :verify_line 1 x "SAXON_CP and SAXON_HOME both not set!"
+    call :verify_line 3 r "Usage: xspec "
 	</case>
 
 	<case name="invoking xspec with -h prints usage and does so even when it is 11th argument">
     call :run ..\bin\xspec.bat -t -t -t -t -t -t -t -t -t -t -h
     call :verify_retval 0
-    call :verify_line 2 r "Usage: xspec "
+    call :verify_line 1 r "Usage: xspec "
 	</case>
 
 	<case name="invoking xspec with unknown option prints usage">
     call :run ..\bin\xspec.bat -bogus ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Error: Unknown option: -bogus"
-    call :verify_line 3 r "Usage: xspec "
+    call :verify_line 1 x "Error: Unknown option: -bogus"
+    call :verify_line 2 r "Usage: xspec "
 	</case>
 
 	<case name="invoking xspec with extra arguments prints usage">
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec bogus
     call :verify_retval 1
-    call :verify_line 2 x "Error: Extra option: bogus"
-    call :verify_line 3 r "Usage: xspec "
+    call :verify_line 1 x "Error: Extra option: bogus"
+    call :verify_line 2 r "Usage: xspec "
 	</case>
 
 	<!--
@@ -47,19 +47,19 @@
 	<case name="invoking xspec with -s and -t prints error message">
     call :run ..\bin\xspec.bat -s -t
     call :verify_retval 1
-    call :verify_line 2 x "-s and -t are mutually exclusive"
+    call :verify_line 1 x "-s and -t are mutually exclusive"
 	</case>
 
 	<case name="invoking xspec with -s and -q prints error message">
     call :run ..\bin\xspec.bat -s -q
     call :verify_retval 1
-    call :verify_line 2 x "-s and -q are mutually exclusive"
+    call :verify_line 1 x "-s and -q are mutually exclusive"
 	</case>
 
 	<case name="invoking xspec with -t and -q prints error message">
     call :run ..\bin\xspec.bat -t -q
     call :verify_retval 1
-    call :verify_line 2 x "-t and -q are mutually exclusive"
+    call :verify_line 1 x "-t and -q are mutually exclusive"
 	</case>
 
 	<!--
@@ -75,8 +75,8 @@
 
     call :run my-xspec.bat "%XSPEC_HOME%\tutorial\escape-for-regex.xspec"
     call :verify_retval 0
-    call :verify_line 20 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
-    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
+    call :verify_line 19 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line 20 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 	</case>
 
 	<case name="XSPEC_HOME is not a directory">
@@ -85,7 +85,7 @@
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "ERROR: XSPEC_HOME is not a directory: %XSPEC_HOME%"
+    call :verify_line 1 x "ERROR: XSPEC_HOME is not a directory: %XSPEC_HOME%"
 	</case>
 
 	<case name="XSPEC_HOME seems to be corrupted">
@@ -93,7 +93,7 @@
 
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 1
-    call :verify_line 2 x "ERROR: XSPEC_HOME seems to be corrupted: %XSPEC_HOME%"
+    call :verify_line 1 x "ERROR: XSPEC_HOME seems to be corrupted: %XSPEC_HOME%"
 	</case>
 
 	<!--
@@ -146,13 +146,13 @@
 	<case name="invoking xspec -c -q prints error message">
     call :run ..\bin\xspec.bat -c -q ..\tutorial\xquery-tutorial.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Coverage is supported only for XSLT"
+    call :verify_line 1 x "Coverage is supported only for XSLT"
 	</case>
 
 	<case name="invoking xspec -c -s prints error message">
     call :run ..\bin\xspec.bat -c -s ..\tutorial\schematron\demo-01.xspec
     call :verify_retval 1
-    call :verify_line 2 x "Coverage is supported only for XSLT"
+    call :verify_line 1 x "Coverage is supported only for XSLT"
 	</case>
 
 	<!--
@@ -175,9 +175,9 @@
     call :verify_retval 0
 
     rem Verify message
-    call :verify_line 14 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 15 x "Report available at %TEST_COPY%\xspec\function-result.html"
-    call :verify_line 16 x "Done."
+    call :verify_line 13 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 14 x "Report available at %TEST_COPY%\xspec\function-result.html"
+    call :verify_line 15 x "Done."
 
     rem Verify report files
     rem * XML report file is created
@@ -214,9 +214,9 @@
     call :verify_retval 0
 
     rem Verify message
-    call :verify_line 17 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 19 x "Report available at %TEST_COPY%\xspec\function-coverage.html"
-    call :verify_line 20 x "Done."
+    call :verify_line 16 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 18 x "Report available at %TEST_COPY%\xspec\function-coverage.html"
+    call :verify_line 19 x "Done."
 
     rem Verify report files
     rem * XML report file is created
@@ -249,9 +249,9 @@
     call :verify_retval 0
 
     rem Verify message
-    call :verify_line 7 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 8 x "Report available at %TEST_COPY%\xspec\function-result.html"
-    call :verify_line 9 x "Done."
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 7 x "Report available at %TEST_COPY%\xspec\function-result.html"
+    call :verify_line 8 x "Done."
 
     rem Verify report files
     rem * XML report file is created
@@ -281,10 +281,10 @@
 
     rem Verify message
     rem * No Schematron warnings #129 #131
-    call :verify_line  4 x "Converting Schematron XSpec into XSLT XSpec..."
-    call :verify_line 16 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 17 x "Report available at %TEST_COPY%\xspec\schematron-result.html"
-    call :verify_line 18 x "Done."
+    call :verify_line  3 x "Converting Schematron XSpec into XSLT XSpec..."
+    call :verify_line 15 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 16 x "Report available at %TEST_COPY%\xspec\schematron-result.html"
+    call :verify_line 17 x "Done."
 
     rem Verify report files
     rem * XML report file is created
@@ -306,25 +306,25 @@
 	<case name="CLI -e with some failures (XSLT)">
     call :run ..\bin\xspec.bat -e some-failures\function.xspec
     call :verify_retval 2
-    call :verify_line 14 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 15 x "Report available at %TEST_DIR%\function-result.html"
-    call :verify_line 16 x "*** Found a test failure"
+    call :verify_line 13 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 14 x "Report available at %TEST_DIR%\function-result.html"
+    call :verify_line 15 x "*** Found a test failure"
 	</case>
 
 	<case name="CLI -e with some failures (XQuery)">
     call :run ..\bin\xspec.bat -e -q some-failures\function.xspec
     call :verify_retval 2
-    call :verify_line 7 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 8 x "Report available at %TEST_DIR%\function-result.html"
-    call :verify_line 9 x "*** Found a test failure"
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 7 x "Report available at %TEST_DIR%\function-result.html"
+    call :verify_line 8 x "*** Found a test failure"
 	</case>
 
 	<case name="CLI -e with some failures (Schematron)">
     call :run ..\bin\xspec.bat -e -s some-failures\schematron.xspec
     call :verify_retval 2
-    call :verify_line 16 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
-    call :verify_line 17 x "Report available at %TEST_DIR%\schematron-result.html"
-    call :verify_line 18 x "*** Found a test failure"
+    call :verify_line 15 x "passed: 1 / pending: 0 / failed: 2 / total: 3"
+    call :verify_line 16 x "Report available at %TEST_DIR%\schematron-result.html"
+    call :verify_line 17 x "*** Found a test failure"
 	</case>
 
 	<!--
@@ -334,25 +334,25 @@
 	<case name="CLI -e with no failures (XSLT)">
     call :run ..\bin\xspec.bat -e xslt3.xspec
     call :verify_retval 0
-    call :verify_line 11 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
-    call :verify_line 12 x "Report available at %TEST_DIR%\xslt3-result.html"
-    call :verify_line 13 x "Done."
+    call :verify_line 10 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line 11 x "Report available at %TEST_DIR%\xslt3-result.html"
+    call :verify_line 12 x "Done."
 	</case>
 
 	<case name="CLI -e with no failures (XQuery)">
     call :run ..\bin\xspec.bat -e -q ..\tutorial\xquery-tutorial.xspec
     call :verify_retval 0
-    call :verify_line 7 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-    call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
-    call :verify_line 9 x "Done."
+    call :verify_line 6 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 7 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
+    call :verify_line 8 x "Done."
 	</case>
 
 	<case name="CLI -e with no failures (Schematron)">
     call :run ..\bin\xspec.bat -e -s ..\tutorial\schematron\demo-01.xspec
     call :verify_retval 0
-    call :verify_line 16 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
-    call :verify_line 17 x "Report available at %TEST_DIR%\demo-01-result.html"
-    call :verify_line 18 x "Done."
+    call :verify_line 15 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
+    call :verify_line 16 x "Report available at %TEST_DIR%\demo-01-result.html"
+    call :verify_line 17 x "Done."
 	</case>
 
 	<!--
@@ -362,7 +362,7 @@
 	<case name="invoking xspec with -j option generates message with JUnit report location and creates report files">
     call :run ..\bin\xspec.bat -j ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line 22 x "Report available at %TEST_DIR%\escape-for-regex-junit.xml"
+    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-junit.xml"
 
     rem XML report file
     call :verify_exist "%TEST_DIR%\escape-for-regex-result.xml"
@@ -381,13 +381,13 @@
 	<case name="invoking xspec that passes a non xs:boolean does not raise a warning #46">
     call :run ..\bin\xspec.bat issue-46.xspec
     call :verify_retval 0
-    call :verify_line 6 r "Testing with "
+    call :verify_line 5 r "Testing with "
 	</case>
 
 	<case name="x:resolve-EQName-ignoring-default-ns() with non-empty prefix does not raise a warning #826">
     call :run ..\bin\xspec.bat issue-826.xspec
     call :verify_retval 0
-    call :verify_line 6 r "Testing with "
+    call :verify_line 5 r "Testing with "
 	</case>
 
 	<!--
@@ -466,7 +466,7 @@
 
     call :run ..\bin\xspec.bat "%SPECIAL_CHARS_DIR%\node-selection.xspec"
     call :verify_retval 0
-    call :verify_line 30 x "Report available at %EXPECTED_REPORT%"
+    call :verify_line 29 x "Report available at %EXPECTED_REPORT%"
     call :verify_exist "%EXPECTED_REPORT%"
 	</case>
 
@@ -481,7 +481,7 @@
 
     call :run ..\bin\xspec.bat -q "%SPECIAL_CHARS_DIR%\node-selection.xspec"
     call :verify_retval 0
-    call :verify_line 8 x "Report available at %EXPECTED_REPORT%"
+    call :verify_line 7 x "Report available at %EXPECTED_REPORT%"
     call :verify_exist "%EXPECTED_REPORT%"
 	</case>
 
@@ -495,7 +495,7 @@
 
     call :run ..\bin\xspec.bat -s "%SPECIAL_CHARS_DIR%\demo-03.xspec"
     call :verify_retval 0
-    call :verify_line 32 x "Report available at %EXPECTED_REPORT%"
+    call :verify_line 31 x "Report available at %EXPECTED_REPORT%"
     call :verify_exist "%EXPECTED_REPORT%"
 	</case>
 
@@ -520,7 +520,7 @@
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-param-001-step3.xsl
     call :run ..\bin\xspec.bat -s schematron\schematron-param-001.xspec
     call :verify_retval 0
-    call :verify_line 20 x "passed: 9 / pending: 0 / failed: 0 / total: 9"
+    call :verify_line 19 x "passed: 9 / pending: 0 / failed: 0 / total: 9"
 	</case>
 
 	<case name="Schematron phase/parameters are passed to Schematron compile (Ant)">
@@ -546,7 +546,7 @@
 
     call :run ..\bin\xspec.bat -s schematron\schematron-xslt.xspec
     call :verify_retval 0
-    call :verify_line 12 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 11 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
 
 	<case ifdef="SAXON_BUG_4696_FIXED" name="invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)">
@@ -576,7 +576,7 @@
     rem Run with absolute TEST_DIR
     call :run ..\bin\xspec.bat "%TUTORIAL_COPY%\escape-for-regex.xspec"
     call :verify_retval 0
-    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
+    call :verify_line 20 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -593,7 +593,7 @@
     set "TEST_DIR=relative-test-dir %RANDOM%"
     call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" "%TUTORIAL_COPY%\escape-for-regex.xspec""
     call :verify_retval 0
-    call :verify_line 21 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
+    call :verify_line 20 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -612,7 +612,7 @@
     rem Run with absolute TEST_DIR
     call :run ..\bin\xspec.bat -c "%TUTORIAL_COPY%\demo.xspec"
     call :verify_retval 0
-    call :verify_line 15 x "Report available at %TEST_DIR%\demo-coverage.html"
+    call :verify_line 14 x "Report available at %TEST_DIR%\demo-coverage.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -631,7 +631,7 @@
     set "TEST_DIR=relative-test-dir %RANDOM%"
     call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -c "%TUTORIAL_COPY%\demo.xspec""
     call :verify_retval 0
-    call :verify_line 15 x "Report available at %TEST_DIR%\demo-coverage.html"
+    call :verify_line 14 x "Report available at %TEST_DIR%\demo-coverage.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -652,7 +652,7 @@
     rem Run with absolute TEST_DIR
     call :run ..\bin\xspec.bat -q "%TUTORIAL_COPY%\xquery-tutorial.xspec"
     call :verify_retval 0
-    call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
+    call :verify_line 7 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -669,7 +669,7 @@
     set "TEST_DIR=relative-test-dir %RANDOM%"
     call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -q "%TUTORIAL_COPY%\xquery-tutorial.xspec""
     call :verify_retval 0
-    call :verify_line 8 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
+    call :verify_line 7 x "Report available at %TEST_DIR%\xquery-tutorial-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -690,7 +690,7 @@
     rem Run with absolute TEST_DIR
     call :run ..\bin\xspec.bat -s "%TUTORIAL_COPY%\demo-03.xspec"
     call :verify_retval 0
-    call :verify_line 32 x "Report available at %TEST_DIR%\demo-03-result.html"
+    call :verify_line 31 x "Report available at %TEST_DIR%\demo-03-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -709,7 +709,7 @@
     set "TEST_DIR=relative-test-dir %RANDOM%"
     call :run ""%PARENT_DIR_ABS%\bin\xspec.bat" -s "%TUTORIAL_COPY%\demo-03.xspec""
     call :verify_retval 0
-    call :verify_line 32 x "Report available at %TEST_DIR%\demo-03-result.html"
+    call :verify_line 31 x "Report available at %TEST_DIR%\demo-03-result.html"
 
     rem Verify files in specified TEST_DIR
     call :run dir /b /o:n "%TEST_DIR%"
@@ -1122,7 +1122,7 @@
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         "%SPACE_DIR%\catalog-01_stylesheet.xspec"
     call :verify_retval 0
-    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 15 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<case name="CLI with -catalog file path (XQuery)">
@@ -1137,7 +1137,7 @@
         -q ^
         "%SPACE_DIR%\catalog-01_query.xspec"
     call :verify_retval 0
-    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line 6 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
 	<case name="CLI with -catalog file path (Schematron)">
@@ -1152,7 +1152,7 @@
         -s ^
         "%SPACE_DIR%\catalog-01_schematron.xspec"
     call :verify_retval 0
-    call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 17 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<!--
@@ -1167,7 +1167,7 @@
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
     call :verify_retval 0
-    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 15 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<case name="CLI with -catalog file URI (XQuery)">
@@ -1177,7 +1177,7 @@
         -q ^
         catalog\catalog-01_query.xspec
     call :verify_retval 0
-    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line 6 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
 	<case name="CLI with -catalog file URI (Schematron)">
@@ -1187,7 +1187,7 @@
         -s ^
         catalog\catalog-01_schematron.xspec
     call :verify_retval 0
-    call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 17 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<!--
@@ -1207,7 +1207,7 @@
 
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01_stylesheet.xspec"
     call :verify_retval 0
-    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 15 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<case name="CLI with XML_CATALOG file path (XQuery)">
@@ -1221,7 +1221,7 @@
 
     call :run ..\bin\xspec.bat -q "%SPACE_DIR%\catalog-01_query.xspec"
     call :verify_retval 0
-    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line 6 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
 	<case name="CLI with XML_CATALOG file path (Schematron)">
@@ -1235,7 +1235,7 @@
 
     call :run ..\bin\xspec.bat -s "%SPACE_DIR%\catalog-01_schematron.xspec"
     call :verify_retval 0
-    call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 17 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<!--
@@ -1250,7 +1250,7 @@
 
     call :run ..\bin\xspec.bat "catalog\catalog-01_stylesheet.xspec"
     call :verify_retval 0
-    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 15 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<case name="CLI with XML_CATALOG file URI (XQuery)">
@@ -1259,7 +1259,7 @@
 
     call :run ..\bin\xspec.bat -q "catalog\catalog-01_query.xspec"
     call :verify_retval 0
-    call :verify_line 7 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line 6 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
 	<case name="CLI with XML_CATALOG file URI (Schematron)">
@@ -1268,7 +1268,7 @@
 
     call :run ..\bin\xspec.bat -s "catalog\catalog-01_schematron.xspec"
     call :verify_retval 0
-    call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 17 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<!--
@@ -1290,7 +1290,7 @@
         -catalog "catalog\01\catalog-public.xml;catalog\01\catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
     call :verify_retval 0
-    call :verify_line 16 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+    call :verify_line 15 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
 	<!--
@@ -1305,7 +1305,7 @@
         -catalog "%CD%\catalog\02\catalog.xml" ^
         catalog\catalog-02.xspec
     call :verify_retval 0
-    call :verify_line 10 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
+    call :verify_line 9 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
 	</case>
 
 	<case name="Catalog Saxon bug 3025 (Ant)">
@@ -1500,15 +1500,15 @@
 	<case name="Import order #185 (CLI)">
     call :run ..\bin\xspec.bat issue-185\import-1.xspec
     call :verify_retval 0
-    call :verify_line  7 x "Scenario 1-1"
-    call :verify_line  8 x "Scenario 1-2"
-    call :verify_line  9 x "Scenario 1-3"
-    call :verify_line 10 x "Scenario 2a-1"
-    call :verify_line 11 x "Scenario 2a-2"
-    call :verify_line 12 x "Scenario 2b-1"
-    call :verify_line 13 x "Scenario 2b-2"
-    call :verify_line 14 x "Scenario 3"
-    call :verify_line 15 x "Formatting Report..."
+    call :verify_line  6 x "Scenario 1-1"
+    call :verify_line  7 x "Scenario 1-2"
+    call :verify_line  8 x "Scenario 1-3"
+    call :verify_line  9 x "Scenario 2a-1"
+    call :verify_line 10 x "Scenario 2a-2"
+    call :verify_line 11 x "Scenario 2b-1"
+    call :verify_line 12 x "Scenario 2b-2"
+    call :verify_line 13 x "Scenario 3"
+    call :verify_line 14 x "Formatting Report..."
 	</case>
 
 	<case name="Import order #185 (Ant)">
@@ -1540,17 +1540,17 @@
 	<case name="Circular import #987 (CLI)">
     call :run ..\bin\xspec.bat issue-987_child.xspec
     call :verify_retval 0
-    call :verify_line  7 x "Scenario in child"
-    call :verify_line  9 x "Scenario in parent"
-    call :verify_line 12 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line  6 x "Scenario in child"
+    call :verify_line  8 x "Scenario in parent"
+    call :verify_line 11 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 
     rem Use a fresh dir, to make the message line numbers predictable
     set "TEST_DIR=%TEST_DIR%\parent %RANDOM%"
     call :run ..\bin\xspec.bat issue-987_parent.xspec
     call :verify_retval 0
-    call :verify_line  7 x "Scenario in parent"
-    call :verify_line  9 x "Scenario in child"
-    call :verify_line 12 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
+    call :verify_line  6 x "Scenario in parent"
+    call :verify_line  8 x "Scenario in child"
+    call :verify_line 11 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
 	<case name="Circular import #987 (Ant)">
@@ -1602,60 +1602,60 @@
 	<case name="Boolean @test with @as (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\boolean-test\as.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with @as (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\boolean-test\as.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must$"
-    call :verify_line  8 x "  not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must$"
+    call :verify_line  7 x "  not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with child node (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\boolean-test\child-node.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Boolean @test with child node should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Boolean @test with child node should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with child node (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\boolean-test\child-node.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with child node should be error'): Boolean$"
-    call :verify_line  8 x "  @test must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with child node should be error'): Boolean$"
+    call :verify_line  7 x "  @test must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with @href (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\boolean-test\href.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with @href (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\boolean-test\href.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test$"
-    call :verify_line  8 x "  must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test$"
+    call :verify_line  7 x "  must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with @select (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\boolean-test\select.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Boolean @test with @select (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\boolean-test\select.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test$"
-    call :verify_line  8 x "  must not be accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test$"
+    call :verify_line  7 x "  must not be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
@@ -1666,48 +1666,48 @@
 	<case name="Non-boolean @test (empty sequence) with no comparison factors (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\non-boolean-test\empty.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Non-boolean @test (empty sequence) with no comparison factors (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\non-boolean-test\empty.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison$"
-    call :verify_line  8 x "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be"
-    call :verify_line  9 x "  accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison$"
+    call :verify_line  7 x "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be"
+    call :verify_line  8 x "  accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Non-boolean @test (multiple xs:boolean) with no comparison factors (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\non-boolean-test\multiple-boolean.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Non-boolean @test (multiple xs:boolean) with no comparison factors (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\non-boolean-test\multiple-boolean.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison$"
-    call :verify_line  8 x "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be"
-    call :verify_line  9 x "  accompanied by @as, @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison$"
+    call :verify_line  7 x "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be"
+    call :verify_line  8 x "  accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Non-boolean @test (node) with no comparison factors (XSLT)">
     call :run ..\bin\xspec.bat bad-assertion\non-boolean-test\node.xspec
     call :verify_retval 2
-    call :verify_line  9 x "ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
+    call :verify_line  8 x "ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
 	<case name="Non-boolean @test (node) with no comparison factors (XQuery)">
     call :run ..\bin\xspec.bat -q bad-assertion\non-boolean-test\node.xspec
     call :verify_retval 2
-    call :verify_line  7 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should$"
-    call :verify_line  8 x "  be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as,"
-    call :verify_line  9 x "  @href, @select, or child node."
+    call :verify_line  6 r "  FOER0000[: ] ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should$"
+    call :verify_line  7 x "  be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as,"
+    call :verify_line  8 x "  @href, @select, or child node."
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
@@ -1843,7 +1843,7 @@
 	<case name="Error message when source is not XSpec #522">
     call :run ..\bin\xspec.bat do-nothing.xsl
     call :verify_retval 2
-    call :verify_line 5 x "Source document is not XSpec. /x:description is missing. Supplied source has /xsl:stylesheet instead."
+    call :verify_line 4 x "Source document is not XSpec. /x:description is missing. Supplied source has /xsl:stylesheet instead."
 	</case>
 
 	<!--
@@ -1853,13 +1853,13 @@
 	<case name="Error on user-defined variable in XSpec namespace (URIQualifiedName in local variable)">
     call :run ..\bin\xspec.bat variable\reserved-uqname-in-local.xspec
     call :verify_retval 2
-    call :verify_line 5 x "ERROR: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo, must not use the XSpec namespace."
+    call :verify_line 4 x "ERROR: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo, must not use the XSpec namespace."
 	</case>
 
 	<case name="Error on user-defined variable in XSpec namespace (Lexical QName in global variable)">
     call :run ..\bin\xspec.bat variable\reserved-lexical-qname-in-global.xspec
     call :verify_retval 2
-    call :verify_line 5 x "ERROR: User-defined XSpec variable, u:foo, must not use the XSpec namespace."
+    call :verify_line 4 x "ERROR: User-defined XSpec variable, u:foo, must not use the XSpec namespace."
 	</case>
 
 	<!--
@@ -1871,13 +1871,13 @@
     call :verify_retval 0
 
     if "%SAXON_VERSION:~0,4%"=="9.8." (
-        call :verify_line 4 x "WARNING: Saxon version 9.8 is not recommended. Consider migrating to Saxon 9.9."
+        call :verify_line 3 x "WARNING: Saxon version 9.8 is not recommended. Consider migrating to Saxon 9.9."
     ) else (
-        call :verify_line 4 x " "
+        call :verify_line 3 x " "
     )
 
-    call :verify_line 5 x "Running Tests..."
-    call :verify_line 6 r "Testing with SAXON [EHP]E [1-9][0-9]*\.[1-9][0-9]*"
+    call :verify_line 4 x "Running Tests..."
+    call :verify_line 5 r "Testing with SAXON [EHP]E [1-9][0-9]*\.[1-9][0-9]*"
 	</case>
 
 	<!--
@@ -1957,7 +1957,7 @@
 	<case name="@catch should not catch error outside SUT (XSLT)">
     call :run ..\bin\xspec.bat catch\compiler-error.xspec
     call :verify_retval 2
-    call :verify_line  5 r "ERROR in x:scenario .*"
+    call :verify_line  4 r "ERROR in x:scenario .*"
     call :verify_line -1 x "*** Error compiling the test suite"
 
     call :run ..\bin\xspec.bat catch\error-in-context-avt-for-template-call.xspec
@@ -1994,7 +1994,7 @@
 	<case name="@catch should not catch error outside SUT (XQuery)">
     call :run ..\bin\xspec.bat -q catch\compiler-error.xspec
     call :verify_retval 2
-    call :verify_line 5 r "ERROR in x:scenario .*"
+    call :verify_line 4 r "ERROR in x:scenario .*"
 
     call :run ..\bin\xspec.bat -q catch\error-in-function-call-param.xspec
     call :verify_retval 2
@@ -2065,19 +2065,19 @@
 	<case name="x:like error (scenario not found)">
     call :run ..\bin\xspec.bat like\none.xspec
     call :verify_retval 2
-    call :verify_line 5 x "ERROR in x:like: Scenario not found: 'none'"
+    call :verify_line 4 x "ERROR in x:like: Scenario not found: 'none'"
 	</case>
 
 	<case name="x:like error (multiple scenarios)">
     call :run ..\bin\xspec.bat like\multiple.xspec
     call :verify_retval 2
-    call :verify_line 5 x "ERROR in x:like: 2 scenarios found with same label: 'shared scenario'"
+    call :verify_line 4 x "ERROR in x:like: 2 scenarios found with same label: 'shared scenario'"
 	</case>
 
 	<case name="x:like error (infinite loop)">
     call :run ..\bin\xspec.bat like\loop.xspec
     call :verify_retval 2
-    call :verify_line 5 x "ERROR in x:like: Reference to ancestor scenario creates infinite loop: 'parent scenario'"
+    call :verify_line 4 x "ERROR in x:like: Reference to ancestor scenario creates infinite loop: 'parent scenario'"
 	</case>
 
 	<!--
@@ -2170,44 +2170,44 @@
 	<case name="x:context both with @href and content">
     call :run ..\bin\xspec.bat error-compiling-scenario\context-both-href-and-content.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element"
+    call :verify_line  4 x "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call both with @function and @template">
     call :run ..\bin\xspec.bat error-compiling-scenario\call-both-function-and-template.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time"
+    call :verify_line  4 x "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:apply with x:context">
     call :run ..\bin\xspec.bat error-compiling-scenario\apply-with-context.xspec
     call :verify_retval 2
-    call :verify_line  5 x "WARNING: The instruction x:apply is not supported yet!"
-    call :verify_line  6 x "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time"
+    call :verify_line  4 x "WARNING: The instruction x:apply is not supported yet!"
+    call :verify_line  5 x "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:apply with x:call">
     call :run ..\bin\xspec.bat error-compiling-scenario\apply-with-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "WARNING: The instruction x:apply is not supported yet!"
-    call :verify_line  6 x "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time"
+    call :verify_line  4 x "WARNING: The instruction x:apply is not supported yet!"
+    call :verify_line  5 x "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call[@function] with x:context">
     call :run ..\bin\xspec.bat error-compiling-scenario\function-with-context.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time"
+    call :verify_line  4 x "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:expect without action">
     call :run ..\bin\xspec.bat error-compiling-scenario\expect-without-action.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given"
+    call :verify_line  4 x "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
@@ -2218,21 +2218,21 @@
 	<case name="x:context (XQuery)">
     call :run ..\bin\xspec.bat -q error-compiling-scenario\xquery_context.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:context'): x:context not supported for XQuery"
+    call :verify_line  4 x "ERROR in x:scenario ('x:context'): x:context not supported for XQuery"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call/@template (XQuery)">
     call :run ..\bin\xspec.bat -q error-compiling-scenario\xquery_template-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery"
+    call :verify_line  4 x "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="No x:call">
     call :run ..\bin\xspec.bat -q error-compiling-scenario\xquery_no-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call"
+    call :verify_line  4 x "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
@@ -2243,7 +2243,7 @@
 	<case name="$x:saxon-config is not a Saxon config">
     call :run ..\bin\xspec.bat x-saxon-config\test.xspec
     call :verify_retval 2
-    call :verify_line  8 x "ERROR: $Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration"
+    call :verify_line  7 x "ERROR: $Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration"
     call :verify_line -1 x "*** Error running the test suite"
 	</case>
 
@@ -2254,28 +2254,28 @@
 	<case name="Duplicate function-call param name (XSLT)">
     call :run ..\bin\xspec.bat dup-param-name\function-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Duplicate function-call param name (XQuery)">
     call :run ..\bin\xspec.bat -q dup-param-name\function-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Duplicate context param name">
     call :run ..\bin\xspec.bat dup-param-name\context.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of context template-param (i.e. //x:context/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:context."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of context template-param (i.e. //x:context/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:context."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Duplicate template-call param name">
     call :run ..\bin\xspec.bat dup-param-name\template-call.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of template-call template-param (i.e. //x:call[@template]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of template-call template-param (i.e. //x:call[@template]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
@@ -2285,21 +2285,21 @@
 	<case name="Static param is allowed only with run-as external (XSLT)">
     call :run ..\bin\xspec.bat static-param\disallowed_stylesheet.xspec
     call :verify_retval 2
-    call :verify_line  5 x "Enabling @static in x:param is supported only when /x:description has @run-as='external'."
+    call :verify_line  4 x "Enabling @static in x:param is supported only when /x:description has @run-as='external'."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Static param not allowed (XQuery)">
     call :run ..\bin\xspec.bat -q static-param\disallowed_query.xspec
     call :verify_retval 2
-    call :verify_line  5 x "Enabling @static in x:param is not supported for XQuery."
+    call :verify_line  4 x "Enabling @static in x:param is not supported for XQuery."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Static param not allowed (Schematron)">
     call :run ..\bin\xspec.bat -s static-param\disallowed_schematron.xspec
     call :verify_retval 2
-    call :verify_line  4 x "Enabling @static in x:param is not supported for Schematron."
+    call :verify_line  3 x "Enabling @static in x:param is not supported for Schematron."
     call :verify_line -1 x "*** Error converting Schematron into XSLT"
 	</case>
 
@@ -2310,14 +2310,14 @@
 	<case name="Duplicate @position (XSLT)">
     call :run ..\bin\xspec.bat bad-position\duplicate.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="Duplicate @position (XQuery)">
     call :run ..\bin\xspec.bat -q bad-position\duplicate.xspec
     call :verify_retval 2
-    call :verify_line  5 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call."
+    call :verify_line  4 x "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call."
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
@@ -2360,7 +2360,7 @@
 	<case name="Warning when x:call[@template] ignores x:context/x:param">
     call :run ..\bin\xspec.bat context-param.xspec
     call :verify_retval 0
-    call :verify_line 5 x "WARNING in x:scenario ('When x:context has x:param and another child node, setting up the context excludes x:param from the context nodes. So... When a template is called,'): x:context/x:param will have no effect on x:call"
+    call :verify_line 4 x "WARNING in x:scenario ('When x:context has x:param and another child node, setting up the context excludes x:param from the context nodes. So... When a template is called,'): x:context/x:param will have no effect on x:call"
 	</case>
 
 </collection>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -55,7 +55,7 @@ load bats-helper
     run ../bin/xspec.sh
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[2]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-e|-h] file" ]
+    [ "${lines[1]}" = "Usage: xspec [-t|-q|-s|-c|-j|-catalog file|-e|-h] file" ]
 }
 
 @test "invoking xspec without arguments prints usage even if Saxon environment variables are not defined" {
@@ -63,31 +63,31 @@ load bats-helper
     run ../bin/xspec.sh
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "SAXON_CP and SAXON_HOME both not set!" ]
-    assert_regex "${lines[3]}" '^Usage: xspec '
+    [ "${lines[0]}" = "SAXON_CP and SAXON_HOME both not set!" ]
+    assert_regex "${lines[2]}" '^Usage: xspec '
 }
 
 @test "invoking xspec with -h prints usage and does so even when it is 11th argument" {
     run ../bin/xspec.sh -t -t -t -t -t -t -t -t -t -t -h
     echo "$output"
     [ "$status" -eq 0 ]
-    assert_regex "${lines[1]}" '^Usage: xspec '
+    assert_regex "${lines[0]}" '^Usage: xspec '
 }
 
 @test "invoking xspec with unknown option prints usage" {
     run ../bin/xspec.sh -bogus ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Error: Unknown option: -bogus" ]
-    assert_regex "${lines[2]}" '^Usage: xspec '
+    [ "${lines[0]}" = "Error: Unknown option: -bogus" ]
+    assert_regex "${lines[1]}" '^Usage: xspec '
 }
 
 @test "invoking xspec with extra arguments prints usage" {
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec bogus
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Error: Extra option: bogus" ]
-    assert_regex "${lines[2]}" '^Usage: xspec '
+    [ "${lines[0]}" = "Error: Extra option: bogus" ]
+    assert_regex "${lines[1]}" '^Usage: xspec '
 }
 
 #
@@ -98,21 +98,21 @@ load bats-helper
     run ../bin/xspec.sh -s -t
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "-s and -t are mutually exclusive" ]
+    [ "${lines[0]}" = "-s and -t are mutually exclusive" ]
 }
 
 @test "invoking xspec with -s and -q prints error message" {
     run ../bin/xspec.sh -s -q
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "-s and -q are mutually exclusive" ]
+    [ "${lines[0]}" = "-s and -q are mutually exclusive" ]
 }
 
 @test "invoking xspec with -t and -q prints error message" {
     run ../bin/xspec.sh -t -q
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "-t and -q are mutually exclusive" ]
+    [ "${lines[0]}" = "-t and -q are mutually exclusive" ]
 }
 
 #
@@ -130,8 +130,8 @@ load bats-helper
     run ./my-xspec.sh "${XSPEC_HOME}/tutorial/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[19]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
-    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
+    [ "${lines[18]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
+    [ "${lines[19]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
 }
 
 @test "XSPEC_HOME is not a directory" {
@@ -141,7 +141,7 @@ load bats-helper
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "ERROR: XSPEC_HOME is not a directory: ${XSPEC_HOME}" ]
+    [ "${lines[0]}" = "ERROR: XSPEC_HOME is not a directory: ${XSPEC_HOME}" ]
 }
 
 @test "XSPEC_HOME seems to be corrupted" {
@@ -150,7 +150,7 @@ load bats-helper
     run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "ERROR: XSPEC_HOME seems to be corrupted: ${XSPEC_HOME}" ]
+    [ "${lines[0]}" = "ERROR: XSPEC_HOME seems to be corrupted: ${XSPEC_HOME}" ]
 }
 
 #
@@ -214,14 +214,14 @@ load bats-helper
     run ../bin/xspec.sh -c -q ../tutorial/xquery-tutorial.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Coverage is supported only for XSLT" ]
+    [ "${lines[0]}" = "Coverage is supported only for XSLT" ]
 }
 
 @test "invoking xspec -c -s prints error message" {
     run ../bin/xspec.sh -c -s ../tutorial/schematron/demo-01.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[1]}" = "Coverage is supported only for XSLT" ]
+    [ "${lines[0]}" = "Coverage is supported only for XSLT" ]
 }
 
 #
@@ -245,9 +245,9 @@ load bats-helper
     [ "$status" -eq 0 ]
 
     # Verify message
-    [ "${lines[13]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[14]}" = "Report available at ${test_copy}/xspec/function-result.html" ]
-    [ "${lines[15]}" = "Done." ]
+    [ "${lines[12]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[13]}" = "Report available at ${test_copy}/xspec/function-result.html" ]
+    [ "${lines[14]}" = "Done." ]
 
     # Verify report files
     # * XML report file is created
@@ -296,9 +296,9 @@ load bats-helper
     while IFS= read -r line; do
         mylines+=("$line")
     done <<< "$output"
-    [ "${mylines[20]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${mylines[23]}" = "Report available at ${test_copy}/xspec/function-coverage.html" ]
-    [ "${mylines[24]}" = "Done." ]
+    [ "${mylines[18]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${mylines[21]}" = "Report available at ${test_copy}/xspec/function-coverage.html" ]
+    [ "${mylines[22]}" = "Done." ]
 
     # Verify report files
     # * XML report file is created
@@ -333,9 +333,9 @@ load bats-helper
     [ "$status" -eq 0 ]
 
     # Verify message
-    [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[7]}" = "Report available at ${test_copy}/xspec/function-result.html" ]
-    [ "${lines[8]}" = "Done." ]
+    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[6]}" = "Report available at ${test_copy}/xspec/function-result.html" ]
+    [ "${lines[7]}" = "Done." ]
 
     # Verify report files
     # * XML report file is created
@@ -367,10 +367,10 @@ load bats-helper
 
     # Verify message
     # * No Schematron warnings #129 #131
-    [ "${lines[3]}"  = "Converting Schematron XSpec into XSLT XSpec..." ]
-    [ "${lines[15]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[16]}" = "Report available at ${test_copy}/xspec/schematron-result.html" ]
-    [ "${lines[17]}"  = "Done." ]
+    [ "${lines[ 2]}" = "Converting Schematron XSpec into XSLT XSpec..." ]
+    [ "${lines[14]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[15]}" = "Report available at ${test_copy}/xspec/schematron-result.html" ]
+    [ "${lines[16]}" = "Done." ]
 
     # Verify report files
     # * XML report file is created
@@ -394,27 +394,27 @@ load bats-helper
     run ../bin/xspec.sh -e some-failures/function.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[13]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[14]}" = "Report available at ${TEST_DIR}/function-result.html" ]
-    [ "${lines[15]}" = "*** Found a test failure" ]
+    [ "${lines[12]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[13]}" = "Report available at ${TEST_DIR}/function-result.html" ]
+    [ "${lines[14]}" = "*** Found a test failure" ]
 }
 
 @test "CLI -e with some failures (XQuery)" {
     run ../bin/xspec.sh -e -q some-failures/function.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[7]}" = "Report available at ${TEST_DIR}/function-result.html" ]
-    [ "${lines[8]}" = "*** Found a test failure" ]
+    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[6]}" = "Report available at ${TEST_DIR}/function-result.html" ]
+    [ "${lines[7]}" = "*** Found a test failure" ]
 }
 
 @test "CLI -e with some failures (Schematron)" {
     run ../bin/xspec.sh -e -s some-failures/schematron.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[15]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
-    [ "${lines[16]}" = "Report available at ${TEST_DIR}/schematron-result.html" ]
-    [ "${lines[17]}" = "*** Found a test failure" ]
+    [ "${lines[14]}" = "passed: 1 / pending: 0 / failed: 2 / total: 3" ]
+    [ "${lines[15]}" = "Report available at ${TEST_DIR}/schematron-result.html" ]
+    [ "${lines[16]}" = "*** Found a test failure" ]
 }
 
 #
@@ -425,27 +425,27 @@ load bats-helper
     run ../bin/xspec.sh -e xslt3.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[10]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
-    [ "${lines[11]}" = "Report available at ${TEST_DIR}/xslt3-result.html" ]
-    [ "${lines[12]}" = "Done." ]
+    [ "${lines[ 9]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[10]}" = "Report available at ${TEST_DIR}/xslt3-result.html" ]
+    [ "${lines[11]}" = "Done." ]
 }
 
 @test "CLI -e with no failures (XQuery)" {
     run ../bin/xspec.sh -e -q ../tutorial/xquery-tutorial.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-    [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
-    [ "${lines[8]}" = "Done." ]
+    [ "${lines[5]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[6]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
+    [ "${lines[7]}" = "Done." ]
 }
 
 @test "CLI -e with no failures (Schematron)" {
     run ../bin/xspec.sh -e -s ../tutorial/schematron/demo-01.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
-    [ "${lines[16]}" = "Report available at ${TEST_DIR}/demo-01-result.html" ]
-    [ "${lines[17]}" = "Done." ]
+    [ "${lines[14]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
+    [ "${lines[15]}" = "Report available at ${TEST_DIR}/demo-01-result.html" ]
+    [ "${lines[16]}" = "Done." ]
 }
 
 #
@@ -456,7 +456,7 @@ load bats-helper
     run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[21]}" = "Report available at ${TEST_DIR}/escape-for-regex-junit.xml" ]
+    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-junit.xml" ]
 
     # XML report file
     [ -f "${TEST_DIR}/escape-for-regex-result.xml" ]
@@ -476,14 +476,14 @@ load bats-helper
     run ../bin/xspec.sh issue-46.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    assert_regex "${lines[5]}" '^Testing with '
+    assert_regex "${lines[4]}" '^Testing with '
 }
 
 @test "x:resolve-EQName-ignoring-default-ns() with non-empty prefix does not raise a warning #826" {
     run ../bin/xspec.sh issue-826.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    assert_regex "${lines[5]}" '^Testing with '
+    assert_regex "${lines[4]}" '^Testing with '
 }
 
 #
@@ -580,7 +580,7 @@ load bats-helper
     run ../bin/xspec.sh "${special_chars_dir}/node-selection.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[29]}" = "Report available at ${expected_report}" ]
+    [ "${lines[28]}" = "Report available at ${expected_report}" ]
     [ -f "${expected_report}" ]
 }
 
@@ -596,7 +596,7 @@ load bats-helper
     run ../bin/xspec.sh -q "${special_chars_dir}/node-selection.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[7]}" = "Report available at ${expected_report}" ]
+    [ "${lines[6]}" = "Report available at ${expected_report}" ]
     [ -f "${expected_report}" ]
 }
 
@@ -615,7 +615,7 @@ load bats-helper
     run ../bin/xspec.sh -s "${special_chars_dir}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[31]}" = "Report available at ${expected_report}" ]
+    [ "${lines[30]}" = "Report available at ${expected_report}" ]
     [ -f "${expected_report}" ]
 }
 
@@ -642,7 +642,7 @@ load bats-helper
     run ../bin/xspec.sh -s schematron/schematron-param-001.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[19]}" = "passed: 9 / pending: 0 / failed: 0 / total: 9" ]
+    [ "${lines[18]}" = "passed: 9 / pending: 0 / failed: 0 / total: 9" ]
 }
 
 @test "Schematron phase/parameters are passed to Schematron compile (Ant)" {
@@ -674,7 +674,7 @@ load bats-helper
     run ../bin/xspec.sh -s schematron/schematron-xslt.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[11]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[10]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
 @test "invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (Ant)" {
@@ -711,7 +711,7 @@ load bats-helper
     run ../bin/xspec.sh "${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
+    [ "${lines[19]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -730,7 +730,7 @@ load bats-helper
     run "${parent_dir_abs}/bin/xspec.sh" "${tutorial_copy}/escape-for-regex.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[20]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
+    [ "${lines[19]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -761,7 +761,7 @@ load bats-helper
     while IFS= read -r line; do
         mylines+=("$line")
     done <<< "$output"
-    [ "${mylines[19]}" = "Report available at ${TEST_DIR}/demo-coverage.html" ]
+    [ "${mylines[17]}" = "Report available at ${TEST_DIR}/demo-coverage.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -787,7 +787,7 @@ load bats-helper
     while IFS= read -r line; do
         mylines+=("$line")
     done <<< "$output"
-    [ "${mylines[19]}" = "Report available at ${TEST_DIR}/demo-coverage.html" ]
+    [ "${mylines[17]}" = "Report available at ${TEST_DIR}/demo-coverage.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -811,7 +811,7 @@ load bats-helper
     run ../bin/xspec.sh -q "${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
+    [ "${lines[6]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -830,7 +830,7 @@ load bats-helper
     run "${parent_dir_abs}/bin/xspec.sh" -q "${tutorial_copy}/xquery-tutorial.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[7]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
+    [ "${lines[6]}" = "Report available at ${TEST_DIR}/xquery-tutorial-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -858,7 +858,7 @@ load bats-helper
     run ../bin/xspec.sh -s "${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[31]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
+    [ "${lines[30]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -879,7 +879,7 @@ load bats-helper
     run "${parent_dir_abs}/bin/xspec.sh" -s "${tutorial_copy}/demo-03.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[31]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
+    [ "${lines[30]}" = "Report available at ${TEST_DIR}/demo-03-result.html" ]
 
     # Verify files in specified TEST_DIR
     run ls "${TEST_DIR}"
@@ -1338,7 +1338,7 @@ load bats-helper
         "${space_dir}/catalog-01_stylesheet.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[14]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 @test "CLI with -catalog file path (XQuery)" {
@@ -1354,7 +1354,7 @@ load bats-helper
         "${space_dir}/catalog-01_query.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[5]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 @test "CLI with -catalog file path (Schematron)" {
@@ -1370,7 +1370,7 @@ load bats-helper
         "${space_dir}/catalog-01_schematron.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[17]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[16]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 #
@@ -1386,7 +1386,7 @@ load bats-helper
         catalog/catalog-01_stylesheet.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[14]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 @test "CLI with -catalog file URI (XQuery)" {
@@ -1397,7 +1397,7 @@ load bats-helper
         catalog/catalog-01_query.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[5]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 @test "CLI with -catalog file URI (Schematron)" {
@@ -1408,7 +1408,7 @@ load bats-helper
         catalog/catalog-01_schematron.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[17]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[16]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 #
@@ -1429,7 +1429,7 @@ load bats-helper
     run ../bin/xspec.sh "${space_dir}/catalog-01_stylesheet.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[14]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 @test "CLI with XML_CATALOG file path (XQuery)" {
@@ -1444,7 +1444,7 @@ load bats-helper
     run ../bin/xspec.sh -q "${space_dir}/catalog-01_query.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[5]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 @test "CLI with XML_CATALOG file path (Schematron)" {
@@ -1459,7 +1459,7 @@ load bats-helper
     run ../bin/xspec.sh -s "${space_dir}/catalog-01_schematron.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[17]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[16]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 #
@@ -1475,7 +1475,7 @@ load bats-helper
     run ../bin/xspec.sh "catalog/catalog-01_stylesheet.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[14]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 @test "CLI with XML_CATALOG file URI (XQuery)" {
@@ -1485,7 +1485,7 @@ load bats-helper
     run ../bin/xspec.sh -q "catalog/catalog-01_query.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[5]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 @test "CLI with XML_CATALOG file URI (Schematron)" {
@@ -1495,7 +1495,7 @@ load bats-helper
     run ../bin/xspec.sh -s "catalog/catalog-01_schematron.xspec"
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[17]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[16]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 #
@@ -1520,7 +1520,7 @@ load bats-helper
         catalog/catalog-01_stylesheet.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[15]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+    [ "${lines[14]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
 }
 
 #
@@ -1536,7 +1536,7 @@ load bats-helper
         catalog/catalog-02.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[9]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
+    [ "${lines[8]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
 }
 
 @test "Catalog Saxon bug 3025 (Ant)" {
@@ -1756,15 +1756,15 @@ load bats-helper
     run ../bin/xspec.sh issue-185/import-1.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}"  = "Scenario 1-1" ]
-    [ "${lines[7]}"  = "Scenario 1-2" ]
-    [ "${lines[8]}"  = "Scenario 1-3" ]
-    [ "${lines[9]}"  = "Scenario 2a-1" ]
-    [ "${lines[10]}" = "Scenario 2a-2" ]
-    [ "${lines[11]}" = "Scenario 2b-1" ]
-    [ "${lines[12]}" = "Scenario 2b-2" ]
-    [ "${lines[13]}" = "Scenario 3" ]
-    [ "${lines[14]}" = "Formatting Report..." ]
+    [ "${lines[ 5]}" = "Scenario 1-1" ]
+    [ "${lines[ 6]}" = "Scenario 1-2" ]
+    [ "${lines[ 7]}" = "Scenario 1-3" ]
+    [ "${lines[ 8]}" = "Scenario 2a-1" ]
+    [ "${lines[ 9]}" = "Scenario 2a-2" ]
+    [ "${lines[10]}" = "Scenario 2b-1" ]
+    [ "${lines[11]}" = "Scenario 2b-2" ]
+    [ "${lines[12]}" = "Scenario 3" ]
+    [ "${lines[13]}" = "Formatting Report..." ]
 }
 
 @test "Import order #185 (Ant)" {
@@ -1799,18 +1799,18 @@ load bats-helper
     run ../bin/xspec.sh issue-987_child.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}"  = "Scenario in child" ]
-    [ "${lines[8]}"  = "Scenario in parent" ]
-    [ "${lines[11]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[ 5]}" = "Scenario in child" ]
+    [ "${lines[ 7]}" = "Scenario in parent" ]
+    [ "${lines[10]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 
     # Use a fresh dir, to make the message line numbers predictable
     export TEST_DIR="${TEST_DIR}/parent ${RANDOM}"
     run ../bin/xspec.sh issue-987_parent.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}"  = "Scenario in parent" ]
-    [ "${lines[8]}"  = "Scenario in child" ]
-    [ "${lines[11]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
+    [ "${lines[ 5]}" = "Scenario in parent" ]
+    [ "${lines[ 7]}" = "Scenario in child" ]
+    [ "${lines[10]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 @test "Circular import #987 (Ant)" {
@@ -1869,7 +1869,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/boolean-test/as.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Boolean @test with @as should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1877,8 +1877,8 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/boolean-test/as.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @as should be error'\): Boolean @test must$"
-    [ "${lines[7]}" = "  not be accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @as should be error'\): Boolean @test must$"
+    [ "${lines[6]}" = "  not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1886,7 +1886,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/boolean-test/child-node.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Boolean @test with child node should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Boolean @test with child node should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1894,8 +1894,8 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/boolean-test/child-node.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with child node should be error'\): Boolean$"
-    [ "${lines[7]}" = "  @test must not be accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with child node should be error'\): Boolean$"
+    [ "${lines[6]}" = "  @test must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1903,7 +1903,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/boolean-test/href.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Boolean @test with @href should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1911,8 +1911,8 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/boolean-test/href.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @href should be error'\): Boolean @test$"
-    [ "${lines[7]}" = "  must not be accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @href should be error'\): Boolean @test$"
+    [ "${lines[6]}" = "  must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1920,7 +1920,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/boolean-test/select.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Boolean @test with @select should be error'): Boolean @test must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1928,8 +1928,8 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/boolean-test/select.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @select should be error'\): Boolean @test$"
-    [ "${lines[7]}" = "  must not be accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Boolean @test with @select should be error'\): Boolean @test$"
+    [ "${lines[6]}" = "  must not be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1941,7 +1941,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/non-boolean-test/empty.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Non-boolean @test (empty sequence) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1949,9 +1949,9 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/non-boolean-test/empty.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(empty sequence\) with no comparison$"
-    [ "${lines[7]}" = "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be" ]
-    [ "${lines[8]}" = "  accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(empty sequence\) with no comparison$"
+    [ "${lines[6]}" = "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be" ]
+    [ "${lines[7]}" = "  accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1959,7 +1959,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/non-boolean-test/multiple-boolean.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Non-boolean @test (multiple xs:boolean) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1967,9 +1967,9 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/non-boolean-test/multiple-boolean.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(multiple xs:boolean\) with no comparison$"
-    [ "${lines[7]}" = "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be" ]
-    [ "${lines[8]}" = "  accompanied by @as, @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(multiple xs:boolean\) with no comparison$"
+    [ "${lines[6]}" = "  factors should be error (even if child::x:label exists)'): Non-boolean @test must be" ]
+    [ "${lines[7]}" = "  accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1977,7 +1977,7 @@ load bats-helper
     run ../bin/xspec.sh bad-assertion/non-boolean-test/node.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[8]}" = "ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
+    [ "${lines[7]}" = "ERROR in x:expect ('Non-boolean @test (node) with no comparison factors should be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as, @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -1985,9 +1985,9 @@ load bats-helper
     run ../bin/xspec.sh -q bad-assertion/non-boolean-test/node.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    assert_regex "${lines[6]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(node\) with no comparison factors should$"
-    [ "${lines[7]}" = "  be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as," ]
-    [ "${lines[8]}" = "  @href, @select, or child node." ]
+    assert_regex "${lines[5]}" "^  FOER0000[: ] ERROR in x:expect \('Non-boolean @test \(node\) with no comparison factors should$"
+    [ "${lines[6]}" = "  be error (even if child::x:label exists)'): Non-boolean @test must be accompanied by @as," ]
+    [ "${lines[7]}" = "  @href, @select, or child node." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -2153,7 +2153,7 @@ load bats-helper
     run ../bin/xspec.sh do-nothing.xsl
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "Source document is not XSpec. /x:description is missing. Supplied source has /xsl:stylesheet instead." ]
+    [ "${lines[3]}" = "Source document is not XSpec. /x:description is missing. Supplied source has /xsl:stylesheet instead." ]
 }
 
 #
@@ -2164,14 +2164,14 @@ load bats-helper
     run ../bin/xspec.sh variable/reserved-uqname-in-local.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo, must not use the XSpec namespace." ]
+    [ "${lines[3]}" = "ERROR: User-defined XSpec variable, Q{http://www.jenitennison.com/xslt/xspec}foo, must not use the XSpec namespace." ]
 }
 
 @test "Error on user-defined variable in XSpec namespace (Lexical QName in global variable)" {
     run ../bin/xspec.sh variable/reserved-lexical-qname-in-global.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR: User-defined XSpec variable, u:foo, must not use the XSpec namespace." ]
+    [ "${lines[3]}" = "ERROR: User-defined XSpec variable, u:foo, must not use the XSpec namespace." ]
 }
 
 #
@@ -2184,13 +2184,13 @@ load bats-helper
     [ "$status" -eq 0 ]
 
     if [ "${SAXON_VERSION:0:4}" = "9.8." ]; then
-        [ "${lines[3]}" = "WARNING: Saxon version 9.8 is not recommended. Consider migrating to Saxon 9.9." ]
+        [ "${lines[2]}" = "WARNING: Saxon version 9.8 is not recommended. Consider migrating to Saxon 9.9." ]
     else
-        [ "${lines[3]}" = " " ]
+        [ "${lines[2]}" = " " ]
     fi
 
-    [ "${lines[4]}" = "Running Tests..." ]
-    assert_regex "${lines[5]}" '^Testing with SAXON [EHP]E [1-9][0-9]*\.[1-9][0-9]*'
+    [ "${lines[3]}" = "Running Tests..." ]
+    assert_regex "${lines[4]}" '^Testing with SAXON [EHP]E [1-9][0-9]*\.[1-9][0-9]*'
 }
 
 #
@@ -2402,21 +2402,21 @@ load bats-helper
     run ../bin/xspec.sh like/none.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:like: Scenario not found: 'none'" ]
+    [ "${lines[3]}" = "ERROR in x:like: Scenario not found: 'none'" ]
 }
 
 @test "x:like error (multiple scenarios)" {
     run ../bin/xspec.sh like/multiple.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:like: 2 scenarios found with same label: 'shared scenario'" ]
+    [ "${lines[3]}" = "ERROR in x:like: 2 scenarios found with same label: 'shared scenario'" ]
 }
 
 @test "x:like error (infinite loop)" {
     run ../bin/xspec.sh like/loop.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:like: Reference to ancestor scenario creates infinite loop: 'parent scenario'" ]
+    [ "${lines[3]}" = "ERROR in x:like: Reference to ancestor scenario creates infinite loop: 'parent scenario'" ]
 }
 
 #
@@ -2523,7 +2523,7 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/context-both-href-and-content.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2531,7 +2531,7 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/call-both-function-and-template.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2539,8 +2539,8 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/apply-with-context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "WARNING: The instruction x:apply is not supported yet!" ]
-    [ "${lines[5]}" = "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time" ]
+    [ "${lines[3]}" = "WARNING: The instruction x:apply is not supported yet!" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:apply with x:context'): Can't use x:apply and set a context at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2548,8 +2548,8 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/apply-with-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "WARNING: The instruction x:apply is not supported yet!" ]
-    [ "${lines[5]}" = "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time" ]
+    [ "${lines[3]}" = "WARNING: The instruction x:apply is not supported yet!" ]
+    [ "${lines[4]}" = "ERROR in x:scenario ('x:apply with x:call'): Can't use x:apply and x:call at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2557,7 +2557,7 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/function-with-context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:call[@function] with x:context'): Can't set a context and call a function at the same time" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2565,7 +2565,7 @@ load bats-helper
     run ../bin/xspec.sh error-compiling-scenario/expect-without-action.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:expect without action'): There are x:expect but no x:call, x:apply or x:context has been given" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2577,7 +2577,7 @@ load bats-helper
     run ../bin/xspec.sh -q error-compiling-scenario/xquery_context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:context'): x:context not supported for XQuery" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:context'): x:context not supported for XQuery" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2585,7 +2585,7 @@ load bats-helper
     run ../bin/xspec.sh -q error-compiling-scenario/xquery_template-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('x:call/@template'): x:call/@template not supported for XQuery" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2593,7 +2593,7 @@ load bats-helper
     run ../bin/xspec.sh -q error-compiling-scenario/xquery_no-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call" ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('No x:call'): There are x:expect but no x:call" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2605,7 +2605,7 @@ load bats-helper
     run ../bin/xspec.sh x-saxon-config/test.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[7]}" = "ERROR: \$Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration" ]
+    [ "${lines[6]}" = "ERROR: \$Q{http://www.jenitennison.com/xslt/xspec}saxon-config does not appear to be a Saxon configuration" ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error running the test suite" ]
 }
 
@@ -2617,7 +2617,7 @@ load bats-helper
     run ../bin/xspec.sh dup-param-name/function-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2625,7 +2625,7 @@ load bats-helper
     run ../bin/xspec.sh -q dup-param-name/function-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2633,7 +2633,7 @@ load bats-helper
     run ../bin/xspec.sh dup-param-name/context.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of context template-param (i.e. //x:context/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:context." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of context template-param (i.e. //x:context/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:context." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2641,7 +2641,7 @@ load bats-helper
     run ../bin/xspec.sh dup-param-name/template-call.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of template-call template-param (i.e. //x:call[@template]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of template-call template-param (i.e. //x:call[@template]/x:param) of the same name'): Duplicate parameter name, Q{}left, used in x:call." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2653,7 +2653,7 @@ load bats-helper
     run ../bin/xspec.sh static-param/disallowed_stylesheet.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "Enabling @static in x:param is supported only when /x:description has @run-as='external'." ]
+    [ "${lines[3]}" = "Enabling @static in x:param is supported only when /x:description has @run-as='external'." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2661,7 +2661,7 @@ load bats-helper
     run ../bin/xspec.sh -q static-param/disallowed_query.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "Enabling @static in x:param is not supported for XQuery." ]
+    [ "${lines[3]}" = "Enabling @static in x:param is not supported for XQuery." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2669,7 +2669,7 @@ load bats-helper
     run ../bin/xspec.sh -s static-param/disallowed_schematron.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[3]}" = "Enabling @static in x:param is not supported for Schematron." ]
+    [ "${lines[2]}" = "Enabling @static in x:param is not supported for Schematron." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error converting Schematron into XSLT" ]
 }
 
@@ -2681,7 +2681,7 @@ load bats-helper
     run ../bin/xspec.sh bad-position/duplicate.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2689,7 +2689,7 @@ load bats-helper
     run ../bin/xspec.sh -q bad-position/duplicate.xspec
     echo "$output"
     [ "$status" -eq 1 ]
-    [ "${lines[4]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call." ]
+    [ "${lines[3]}" = "ERROR in x:scenario ('Multiple instances of function-param (i.e. //x:call[@function]/x:param) of the same position'): Duplicate parameter position, 1, used in x:call." ]
     [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
 }
 
@@ -2737,5 +2737,5 @@ load bats-helper
     run ../bin/xspec.sh context-param.xspec
     echo "$output"
     [ "$status" -eq 0 ]
-    [ "${lines[4]}" = "WARNING in x:scenario ('When x:context has x:param and another child node, setting up the context excludes x:param from the context nodes. So... When a template is called,'): x:context/x:param will have no effect on x:call" ]
+    [ "${lines[3]}" = "WARNING in x:scenario ('When x:context has x:param and another child node, setting up the context excludes x:param from the context nodes. So... When a template is called,'): x:context/x:param will have no effect on x:call" ]
 }


### PR DESCRIPTION
By default, CLI prints "Saxon script not found, invoking JVM directly instead." This message helps little if any, because
- Using the script is not recommended. (XSpec has virtually no test for it. The script itself has apparently never been tested with Saxon 10+.)
- Without the message, you can still tell which mode you're in. (Another message is printed when the script is being used.)

This PR removes the message.

### Further work
Update console excerpts in Wiki.