### PR TITLE
test(xslt): remove verbose $x:result from attribute(test)

### DIFF
--- a/test/catch_stylesheet.xspec
+++ b/test/catch_stylesheet.xspec
@@ -4,19 +4,19 @@
 
 	<x:scenario label="expect-error" shared="yes">
 		<x:expect label="err:code and its type" select="xs:QName('error-code-of-my-template')"
-			test="$x:result?err?code treat as xs:QName" />
+			test="?err?code treat as xs:QName" />
 		<x:expect label="err:description and its type" select="'error description of my template'"
-			test="$x:result?err?description treat as xs:string" />
+			test="?err?description treat as xs:string" />
 		<x:expect label="err:value and its type" select="'error', 'object', 'of', 'my', 'template'"
-			test="$x:result?err?value treat as xs:string+" />
+			test="?err?value treat as xs:string+" />
 
 		<!-- The error is raised by fn:error() at a line in the stylesheet being tested -->
 		<x:expect label="err:module and its type" select="resolve-uri('catch.xsl', $x:xspec-uri)"
-			test="$x:result?err?module treat as xs:string" />
+			test="?err?module treat as xs:string" />
 		<x:expect label="err:line-number and its type" select="15"
-			test="$x:result?err?line-number treat as xs:integer" />
+			test="?err?line-number treat as xs:integer" />
 		<x:expect label="err:column-number and its type"
-			test="($x:result?err?column-number treat as xs:integer) ge 1" />
+			test="(?err?column-number treat as xs:integer) ge 1" />
 	</x:scenario>
 
 	<x:scenario label="expect-intact" shared="yes">

--- a/test/compiler-yes-no-utils.xspec
+++ b/test/compiler-yes-no-utils.xspec
@@ -117,7 +117,7 @@
 					<x:param select="true()" />
 				</x:call>
 				<x:expect label="Error without falling back on the default value"
-					select="xs:QName('err:XTTE0780')" test="$x:result?err?code" />
+					select="xs:QName('err:XTTE0780')" test="?err?code" />
 			</x:scenario>
 
 			<x:scenario label="Bogus">
@@ -126,7 +126,7 @@
 					<x:param select="true()" />
 				</x:call>
 				<x:expect label="Error without falling back on the default value"
-					select="xs:QName('err:XTTE0780')" test="$x:result?err?code" />
+					select="xs:QName('err:XTTE0780')" test="?err?code" />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>

--- a/test/external_tutorial_global-context-item_original.xspec
+++ b/test/external_tutorial_global-context-item_original.xspec
@@ -6,10 +6,10 @@
 	<x:scenario catch="yes" label="when no global context item is supplied">
 		<x:call template="test-me" />
 		<x:expect label="error code" select="QName('http://www.w3.org/2005/xqt-errors', 'XTDE3086')"
-			test="$x:result?err?code" />
+			test="?err?code" />
 		<x:expect label="error description"
 			select="'A global context item is required, but none has been supplied'"
-			test="$x:result?err?description" />
+			test="?err?description" />
 	</x:scenario>
 
 </x:description>

--- a/test/external_xslt-package_arith_private.xspec
+++ b/test/external_xslt-package_arith_private.xspec
@@ -28,10 +28,10 @@
 				}" />
 		</x:call>
 		<x:expect label="should be error XTDE0041" select="xs:QName('err:XTDE0041')"
-			test="$x:result?err?code" />
+			test="?err?code" />
 		<x:expect label="due to private visibility"
 			select="'Cannot invoke function f:real#1 externally, because it is not public'"
-			test="$x:result?err?description" />
+			test="?err?description" />
 	</x:scenario>
 
 </x:description>

--- a/test/issue-1029.xspec
+++ b/test/issue-1029.xspec
@@ -5,9 +5,8 @@
 
 	<x:scenario label="expectations" shared="yes">
 		<x:expect label="should catch err:XTMM9000"
-			select="QName('http://www.w3.org/2005/xqt-errors', 'XTMM9000')"
-			test="$x:result?err?code" />
-		<x:expect label="should catch its message body" test="$x:result?err?value/text()"
+			select="QName('http://www.w3.org/2005/xqt-errors', 'XTMM9000')" test="?err?code" />
+		<x:expect label="should catch its message body" test="?err?value/text()"
 			><![CDATA[my error message]]></x:expect>
 	</x:scenario>
 

--- a/test/issue-700.xspec
+++ b/test/issue-700.xspec
@@ -11,12 +11,12 @@
         </x:context>
         <x:expect
             label="err:code"
-            test="$x:result?err?code"
+            test="?err?code"
             select="QName('http://www.w3.org/2005/xqt-errors', 'XTMM9000')"
         />
         <x:expect
             label="err:value should contain xsl:message body preceded by Saxon-specific processing instruction"
-            test="$x:result?err?value"
+            test="?err?value"
             select="/"
             expand-text="yes"
             xml:space="preserve"

--- a/test/version-utils.xspec
+++ b/test/version-utils.xspec
@@ -50,24 +50,21 @@
 				<x:call>
 					<x:param select="1, 2, 3, 4, 5" />
 				</x:call>
-				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
-					test="$x:result?err?code" />
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')" test="?err?code" />
 			</x:scenario>
 
 			<x:scenario label="Greater than uint16">
 				<x:call>
 					<x:param select="65536" />
 				</x:call>
-				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
-					test="$x:result?err?code" />
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')" test="?err?code" />
 			</x:scenario>
 
 			<x:scenario label="Less than uint16">
 				<x:call>
 					<x:param select="-1" />
 				</x:call>
-				<x:expect label="Error" select="xs:QName('err:XTTE0780')"
-					test="$x:result?err?code" />
+				<x:expect label="Error" select="xs:QName('err:XTTE0780')" test="?err?code" />
 			</x:scenario>
 		</x:scenario>
 	</x:scenario>

--- a/test/xsl-result-document.xspec
+++ b/test/xsl-result-document.xspec
@@ -10,24 +10,24 @@
 	<x:helper stylesheet="../src/common/version-utils.xsl" />
 
 	<x:scenario label="should be err:XTDE1480 due to outer xsl:variable" shared="yes">
-		<x:expect label="code" select="xs:QName('err:XTDE1480')" test="$x:result?err?code" />
+		<x:expect label="code" select="xs:QName('err:XTDE1480')" test="?err?code" />
 		<x:expect label="description"
 			select="'Cannot execute xsl:result-document while evaluating xsl:variable'"
-			test="$x:result?err?description" />
+			test="?err?description" />
 	</x:scenario>
 
 	<x:scenario catch="yes" label="Calling a template containing xsl:result-document">
 		<x:scenario label="[@href]">
 			<x:call template="has-href" />
 			<x:like label="should be err:XTDE1480 due to outer xsl:variable" />
-			<x:expect label="line-number" select="7" test="$x:result?err?line-number" />
+			<x:expect label="line-number" select="7" test="?err?line-number" />
 		</x:scenario>
 
 		<x:scenario label="[empty(@href)]">
 			<x:call template="no-href" />
 			<x:like label="should be err:XTDE1480 due to outer xsl:variable" />
 			<x:expect label="line-number" select="21[$x:saxon-version ge x:pack-version((9, 9))]"
-				test="$x:result?err?line-number" />
+				test="?err?line-number" />
 		</x:scenario>
 	</x:scenario>
 

--- a/test/xspec-name.xspec
+++ b/test/xspec-name.xspec
@@ -111,10 +111,9 @@
 
 	<scenario label="Expect error in x:xspec-name()" shared="yes">
 		<expect label="Error (code)" select="QName('http://www.w3.org/2005/xqt-errors', 'XTTE0570')"
-			test="$Q{http://www.jenitennison.com/xslt/xspec}result?err?code" />
-		<expect label="Error (description)"
-			test="
-				$Q{http://www.jenitennison.com/xslt/xspec}result?err?description
+			test="?err?code" />
+		<expect label="Error (description)" test="
+				?err?description
 				=> starts-with('An empty sequence is not allowed as the value of variable $xspec-prefixes')"
 		 />
 	</scenario>


### PR DESCRIPTION
Just remove verbose `$x:result` from `$x:result?err` in `x:expect/@test` in `test/*.xspec`.

In essence, nothing has been changed by this removal.