### PR TITLE
refactor(oxygen): update xspec.xpr using Oxygen 23.0 build 2020121712

### DIFF
--- a/xspec.xpr
+++ b/xspec.xpr
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="22.1">
+<project>
     <meta>
         <filters directoryPatterns="node_modules" filePatterns="\Qxspec.xpr\E" positiveFilePatterns="" showHiddenFiles="false"/>
         <options>
-            <serialized version="22.1" xml:space="preserve">
+            <serialized xml:space="preserve">
                 <serializableOrderedMap>
                     <entry>
                         <String>additional.frameworks.directories</String>


### PR DESCRIPTION
Loading a project file in Oxygen 23.0 removes `@version` from it. This pull request reflects it.