### PR TITLE
feat: report serialized form of unknown type

### DIFF
--- a/src/common/report-sequence.xqm
+++ b/src/common/report-sequence.xqm
@@ -148,7 +148,7 @@ declare %private function rep:report-pseudo-item(
     else
       element
         { QName($report-namespace, ($local-name-prefix || 'other')) }
-        {}
+        { rep:serialize-adaptive($item) }
   )
 };
 

--- a/src/common/report-sequence.xsl
+++ b/src/common/report-sequence.xsl
@@ -194,7 +194,9 @@
          </xsl:when>
 
          <xsl:otherwise>
-            <xsl:element name="{$local-name-prefix}other" namespace="{$report-namespace}" />
+            <xsl:element name="{$local-name-prefix}other" namespace="{$report-namespace}">
+               <xsl:value-of select="local:serialize-adaptive($item)" />
+            </xsl:element>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:function>

--- a/src/common/report-sequence.xsl
+++ b/src/common/report-sequence.xsl
@@ -194,6 +194,12 @@
          </xsl:when>
 
          <xsl:otherwise>
+            <!--
+               Wrapped Java objects will fall here.
+               https://www.saxonica.com/documentation/#!extensibility/functions/converting-args/converting-wrapped-java:
+               > wrapped objects are a fourth subtype of item(), at the same level in the type
+               > hierarchy as nodes, atomic values, and function items
+            -->
             <xsl:element name="{$local-name-prefix}other" namespace="{$report-namespace}">
                <xsl:value-of select="local:serialize-adaptive($item)" />
             </xsl:element>

--- a/test/ant/build.xml
+++ b/test/ant/build.xml
@@ -40,6 +40,17 @@
 		</condition>
 		<echo message="xslt.supports.hof=${xslt.supports.hof}" />
 
+		<!-- Checks to see if XSLT processor supports Java type -->
+		<java classname="net.sf.saxon.Transform" classpath="${java.class.path}" fork="true"
+			resultproperty="xslt.jref.compile.result">
+			<arg value="-nogo" />
+			<arg value="-xsl:${run-xspec-tests.basedir}/../caps/java-reflexive-ext-fn.xsl" />
+		</java>
+		<condition else="false" property="xslt.supports.jref">
+			<equals arg1="${xslt.jref.compile.result}" arg2="0" />
+		</condition>
+		<echo message="xslt.supports.jref=${xslt.supports.jref}" />
+
 		<!-- Checks to see if XQuery processor can be schema-aware ('-sa') -->
 		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
 			resultproperty="xquery.schema-aware.run.result">
@@ -60,6 +71,16 @@
 			<equals arg1="${xquery.hof.run.result}" arg2="0" />
 		</condition>
 		<echo message="xquery.supports.hof=${xquery.supports.hof}" />
+
+		<!-- Checks to see if XQuery processor supports Java type -->
+		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
+			resultproperty="xquery.jref.run.result">
+			<arg value="-q:${run-xspec-tests.basedir}/../caps/java-reflexive-ext-fn.xq" />
+		</java>
+		<condition else="false" property="xquery.supports.jref">
+			<equals arg1="${xquery.jref.run.result}" arg2="0" />
+		</condition>
+		<echo message="xquery.supports.jref=${xquery.supports.jref}" />
 	</target>
 
 	<!-- Generates the worker -->
@@ -76,9 +97,11 @@
 			<param expression="${xspecfiles.dir.url.query}" name="XSPECFILES-DIR-URI-QUERY" />
 			<param expression="${xslt.supports.schema}" name="XSLT-SUPPORTS-SCHEMA" type="BOOLEAN" />
 			<param expression="${xslt.supports.hof}" name="XSLT-SUPPORTS-HOF" type="BOOLEAN" />
+			<param expression="${xslt.supports.jref}" name="XSLT-SUPPORTS-JREF" type="BOOLEAN" />
 			<param expression="${xquery.supports.schema}" name="XQUERY-SUPPORTS-SCHEMA"
 				type="BOOLEAN" />
 			<param expression="${xquery.supports.hof}" name="XQUERY-SUPPORTS-HOF" type="BOOLEAN" />
+			<param expression="${xquery.supports.jref}" name="XQUERY-SUPPORTS-JREF" type="BOOLEAN" />
 			<param expression="${run-xspec-tests.now}" if="run-xspec-tests.now" name="NOW" />
 			<param expression="${thread.count}" if="thread.count" name="THREAD-COUNT" type="INT" />
 		</xslt>

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -23,10 +23,12 @@
 	<!-- XSLT processor capabilities -->
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-SCHEMA" required="yes" />
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-HOF" required="yes" />
+	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-JREF" required="yes" />
 
 	<!-- XQuery processor capabilities -->
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-SCHEMA" required="yes" />
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-HOF" required="yes" />
+	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-JREF" required="yes" />
 
 	<!-- Saxon -now option -->
 	<xsl:param as="xs:string?" name="NOW" />
@@ -116,84 +118,87 @@
 
 			<xsl:variable as="xs:string?" name="skip">
 				<xsl:choose>
-					<xsl:when
-						test="
+					<xsl:when test="
 							($test-type eq 't')
 							and $enable-coverage
 							and ($x:saxon-version ge x:pack-version(10))">
 						<xsl:text>XSLT Code Coverage requires Saxon version less than 10 (xspec/xspec#852)</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($test-type eq 't')
 							and ($pis = 'require-xslt-to-support-schema')
 							and not($XSLT-SUPPORTS-SCHEMA)">
 						<xsl:text>Requires schema-aware XSLT processor</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($test-type eq 't')
 							and ($pis = 'require-xslt-to-support-hof')
 							and not($XSLT-SUPPORTS-HOF)">
 						<xsl:text>Requires XSLT processor to support higher-order functions</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
+							($test-type eq 't')
+							and ($pis = 'require-xslt-to-support-jref')
+							and not($XSLT-SUPPORTS-JREF)">
+						<xsl:text>Requires XSLT processor to support Java reflexive extension functions</xsl:text>
+					</xsl:when>
+
+					<xsl:when test="
 							($test-type eq 'q')
 							and ($pis = 'require-xquery-to-support-schema')
 							and not($XQUERY-SUPPORTS-SCHEMA)">
 						<xsl:text>Requires schema-aware XQuery processor</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($test-type eq 'q')
 							and ($pis = 'require-xquery-to-support-hof')
 							and not($XQUERY-SUPPORTS-HOF)">
 						<xsl:text>Requires XQuery processor to support higher-order functions</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
+							($test-type eq 'q')
+							and ($pis = 'require-xquery-to-support-jref')
+							and not($XQUERY-SUPPORTS-JREF)">
+						<xsl:text>Requires XQuery processor to support Java reflexive extension functions</xsl:text>
+					</xsl:when>
+
+					<xsl:when test="
 							($pis = 'require-saxon-bug-3543-fixed')
 							and ($x:saxon-version lt x:pack-version((9, 8, 0, 7)))">
 						<xsl:text>Requires Saxon bug #3543 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4315-fixed')
 							and ($x:saxon-version ge x:pack-version((9, 9)))
 							and ($x:saxon-version le x:pack-version((9, 9, 1, 6)))">
 						<xsl:text>Requires Saxon bug #4315 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4376-fixed')
 							and ($x:saxon-version le x:pack-version((9, 9, 1, 5)))">
 						<xsl:text>Requires Saxon bug #4376 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4471-fixed')
 							and ($x:saxon-version lt x:pack-version((9, 9, 1, 7)))">
 						<xsl:text>Requires Saxon bug #4471 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4483-fixed')
 							and ($x:saxon-version eq x:pack-version((10, 0)))">
 						<xsl:text>Requires Saxon bug #4483 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4621-fixed')
 							and
 							(
@@ -208,23 +213,20 @@
 						<xsl:text>Requires Saxon bug #4621 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4696-fixed')
 							and ($x:saxon-version ge x:pack-version((10, 0)))
 							and ($x:saxon-version le x:pack-version((10, 2)))">
 						<xsl:text>Requires Saxon bug #4696 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-saxon-bug-4835-fixed')
 							and ($x:saxon-version le x:pack-version((10, 3)))">
 						<xsl:text>Requires Saxon bug #4835 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($pis = 'require-xspec-issue-1156-fixed')
 							and
 							(
@@ -239,8 +241,7 @@
 						<xsl:text>Requires xspec/xspec#1156 to have been fixed</xsl:text>
 					</xsl:when>
 
-					<xsl:when
-						test="
+					<xsl:when test="
 							($test-type eq 't')
 							and $run-as-external
 							and ($x:saxon-version lt x:pack-version((9, 8, 0, 8)))">
@@ -274,19 +275,16 @@
 								<xsl:sequence select="'-now:' || $NOW" />
 							</xsl:if>
 
-							<xsl:sequence
-								select="
+							<xsl:sequence select="
 									$pis[starts-with(., 'saxon-custom-options=')]
-									/substring-after(., 'saxon-custom-options=')"
-							 />
+									/substring-after(., 'saxon-custom-options=')" />
 						</xsl:variable>
 						<xsl:if test="exists($saxon-custom-options)">
 							<xsl:attribute name="saxon-custom-options"
 								select="$saxon-custom-options" />
 						</xsl:if>
 
-						<xsl:for-each
-							select="
+						<xsl:for-each select="
 								'additional-classpath',
 								'compiler-saxon-config',
 								'coverage-reporter',

--- a/test/caps/java-reflexive-ext-fn.xq
+++ b/test/caps/java-reflexive-ext-fn.xq
@@ -1,0 +1,2 @@
+(: This file is just for checking to see if the XQuery processor supports Java reflexive extension functions :)
+Q{java:java.lang.Runtime}getRuntime()

--- a/test/caps/java-reflexive-ext-fn.xsl
+++ b/test/caps/java-reflexive-ext-fn.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file is just for checking to see if the XSLT processor supports Java reflexive extension functions -->
+<xsl:stylesheet version="3.0" xmlns:jt="http://saxon.sf.net/java-type"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:template as="jt:java.lang.Runtime" name="xsl:initial-template">
+		<xsl:sequence select="Q{java:java.lang.Runtime}getRuntime()" />
+	</xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -79,7 +79,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">xs:integer#1</span>&lt;/pseudo-other&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>
@@ -124,7 +124,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">(anonymous-function)#1</span>&lt;/pseudo-other&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>

--- a/test/end-to-end/cases/expected/query/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-355-result.xml
@@ -15,7 +15,7 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec">xs:integer#1</pseudo-other>
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="false">
@@ -34,7 +34,7 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec">(anonymous-function)#1</pseudo-other>
          </content-wrap>
       </result>
       <test id="scenario2-expect1" successful="false">

--- a/test/end-to-end/cases/expected/query/report_java-object-junit.xml
+++ b/test/end-to-end/cases/expected/query/report_java-object-junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="report_java-object.xspec">
+   <testsuite name="Java type" tests="1" failures="1">
+      <testcase name="[Result] must be an empty 'pseudo-other' element" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/report_java-object-result.html
+++ b/test/end-to-end/cases/expected/query/report_java-object-result.html
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: x-urn:test:do-nothing</p>
+      <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
+      <p>XSpec: <a href="../../report_java-object.xspec">report_java-object.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Java type</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Java type<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Java type</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">[Result] must be an empty 'pseudo-other' element</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Java type</h3>
+            <div id="scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">[Result] must be an empty 'pseudo-other' element</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/report_java-object-result.xml
+++ b/test/end-to-end/cases/expected/query/report_java-object-result.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report_java-object.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../report_java-object.xspec">
+      <label>Java type</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="Q{java:java.lang.Runtime}getRuntime"/>
+      </input-wrap>
+      <result select="/*">
+         <content-wrap xmlns="">
+            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="false">
+         <label>[Result] must be an empty 'pseudo-other' element</label>
+         <expect select="()"/>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/report_java-object-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report_java-object-junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="report_java-object.xspec">
+   <testsuite name="Java type" tests="1" failures="1">
+      <testcase name="[Result] must be an empty 'pseudo-other' element" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/report_java-object-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report_java-object-result.html
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>XSpec: <a href="../../report_java-object.xspec">report_java-object.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 1</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Java type</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Java type<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Java type</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">[Result] must be an empty 'pseudo-other' element</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Java type</h3>
+            <div id="scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">[Result] must be an empty 'pseudo-other' element</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/*</code> from:</p>
+                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/report_java-object-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report_java-object-result.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../report_java-object.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../report_java-object.xspec">
+      <label>Java type</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="Q{java:java.lang.Runtime}getRuntime"/>
+      </input-wrap>
+      <result select="/*">
+         <content-wrap xmlns="">
+            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec"/>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="false">
+         <label>[Result] must be an empty 'pseudo-other' element</label>
+         <expect select="()"/>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/report_java-object.xspec
+++ b/test/end-to-end/cases/report_java-object.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-xquery-to-support-jref?>
+<?xspec-test require-xslt-to-support-jref?>
+<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xqm"
+	stylesheet="../../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="Java type">
+		<x:call function="Q{java:java.lang.Runtime}getRuntime" />
+		<x:expect>
+			<x:label>[Result] must be an empty 'pseudo-other' element</x:label>
+		</x:expect>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Use the adaptive output method of serialization, when the type of an item cannot be identified.
With this change, XQuery report for functions is slightly improved:
- [old](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/5d0080032d479190acf2e6c38112ef096929f941/test/end-to-end/cases/expected/query/issue-355-result.html)
- [new](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/1d92fe3b61958e7f08c8fa4fec5db19dc426cbe1/test/end-to-end/cases/expected/query/issue-355-result.html)