### PR TITLE
test(basex): test report-sequence.xqm with BaseX

### DIFF
--- a/src/common/report-sequence.xsl
+++ b/src/common/report-sequence.xsl
@@ -7,6 +7,11 @@
                 exclude-result-prefixes="#all"
                 version="3.0">
 
+   <!--
+      This template can't be a function, because it contains xsl:result-document. Invoking
+      xsl:result-document directly or indirectly in a function results in an error:
+      "XTDE1480: Cannot execute xsl:result-document while evaluating xsl:function"
+   -->
    <xsl:template name="rep:report-sequence" as="element()">
       <xsl:context-item use="absent" />
 

--- a/test/report-sequence.xspec
+++ b/test/report-sequence.xspec
@@ -13,9 +13,6 @@
       or @query-at.
    -->
 
-   <!--
-       Function rep:report-atomic-value
-   -->
    <t:scenario label="rep:report-atomic-value">
       <t:call function="rep:report-atomic-value" />
 
@@ -32,11 +29,11 @@
 
       <t:scenario label="xs:integer">
 
-         <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
+         <t:scenario label="Max supported by BaseX 9.4.5">
             <t:call>
-               <t:param select="xs:integer(18446744073709551615)" />
+               <t:param select="xs:integer(9223372036854775807)" />
             </t:call>
-            <t:expect label="Numeric literal" select="'18446744073709551615'" />
+            <t:expect label="Numeric literal" select="'9223372036854775807'" />
          </t:scenario>
 
          <t:scenario label="0">
@@ -46,11 +43,11 @@
             <t:expect label="Numeric literal" select="'0'" />
          </t:scenario>
 
-         <t:scenario label="-1">
+         <t:scenario label="Min supported by BaseX 9.4.5">
             <t:call>
-               <t:param select="xs:integer(-1)" />
+               <t:param select="xs:integer(-9223372036854775807)" />
             </t:call>
-            <t:expect label="Numeric literal" select="'-1'" />
+            <t:expect label="Numeric literal" select="'-9223372036854775807'" />
          </t:scenario>
 
       </t:scenario>
@@ -191,12 +188,12 @@
 
    </t:scenario>
 
-   <!--
-       Function rep:atom-type
-           http://www.w3.org/TR/xslt20/#built-in-types
-   -->
    <t:scenario label="rep:atom-type">
       <t:call function="rep:atom-type" />
+
+      <!--
+         http://www.w3.org/TR/xslt20/#built-in-types
+      -->
 
       <t:scenario label="All the primitive atomic types defined in [XML Schema Part 2], with the exception of xs:NOTATION">
 

--- a/test/report-sequence_stylesheet.xspec
+++ b/test/report-sequence_stylesheet.xspec
@@ -11,9 +11,6 @@
       compiler. You don't need to specify it in /t:description/@stylesheet.
    -->
 
-   <!--
-       Template rep:report-sequence
-   -->
    <t:scenario label="rep:report-sequence" xml:base="report-sequence/">
       <t:call template="rep:report-sequence" />
 
@@ -80,6 +77,23 @@
             </t:call>
             <t:expect label="t:result containing attributes and content"
                href="attributes-and-content.xml?strip-space=yes" select="t:result" />
+         </t:scenario>
+
+      </t:scenario>
+
+   </t:scenario>
+
+   <t:scenario label="rep:report-atomic-value">
+      <t:call function="rep:report-atomic-value" />
+
+      <t:scenario label="xs:integer">
+
+         <!-- FOAR0002 'Value out of range' on BaseX 9.4.5 -->
+         <t:scenario label="Max of xs:unsignedLong (a subtype of xs:integer)">
+            <t:call>
+               <t:param select="xs:integer(18446744073709551615)" />
+            </t:call>
+            <t:expect label="Numeric literal" select="'18446744073709551615'" />
          </t:scenario>
 
       </t:scenario>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -760,11 +760,11 @@
     call :verify_retval 0
 
     rem HTML report file
-    set "EXPECTED_REPORT=%WORK_DIR%\issue-1020-result_%RANDOM%.html"
+    set "EXPECTED_REPORT=%WORK_DIR%\report-sequence-result_%RANDOM%.html"
 
-    rem Run (also test with special characters in expression #1020)
+    rem Run (also test with various types in report)
     call :run java -cp "%XMLCALABASH_JAR%;%SAXON_JAR%" com.xmlcalabash.drivers.Main ^
-        -i source=issue-1020.xspec ^
+        -i source=report-sequence.xspec ^
         -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p auth-method=Basic ^
         -p endpoint=http://localhost:8984/rest ^
@@ -774,7 +774,7 @@
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
     call :verify_line_count 2
-    call :verify_line 2 r "..*:passed: 15 / pending: 0 / failed: 0 / total: 15"
+    call :verify_line 2 r "..*:passed: 55 / pending: 0 / failed: 0 / total: 55"
 
     rem HTML report file should be created and its charset should be UTF-8 #72
     call :run java -jar "%SAXON_JAR%" -s:"%EXPECTED_REPORT%" -xsl:check-html-charset.xsl

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -945,11 +945,11 @@ load bats-helper
     "${basex_home}/bin/basexhttp" -S
 
     # HTML report file
-    expected_report="${work_dir}/issue-1020-result_${RANDOM}.html"
+    expected_report="${work_dir}/report-sequence-result_${RANDOM}.html"
 
-    # Run (also test with special characters in expression #1020)
+    # Run (also test with various types in report)
     run java -cp "${XMLCALABASH_JAR}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
-        -i source=issue-1020.xspec \
+        -i source=report-sequence.xspec \
         -o result="file:${expected_report}" \
         -p auth-method=Basic \
         -p endpoint=http://localhost:8984/rest \
@@ -960,7 +960,7 @@ load bats-helper
     echo "$output"
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" = "2" ]
-    assert_regex "${lines[1]}" '.+:passed: 15 / pending: 0 / failed: 0 / total: 15'
+    assert_regex "${lines[1]}" '.+:passed: 55 / pending: 0 / failed: 0 / total: 55'
 
     # HTML report file should be created and its charset should be UTF-8 #72
     run java -jar "${SAXON_JAR}" -s:"${expected_report}" -xsl:check-html-charset.xsl


### PR DESCRIPTION
Different processors support different types. To make sure of compatibility, this pull request tests `src/common/report-sequence.xqm` with BaseX.