### PR TITLE
feat(xslt): report xs:dateTimeStamp

### DIFF
--- a/src/common/report-sequence.xqm
+++ b/src/common/report-sequence.xqm
@@ -255,6 +255,10 @@ declare function rep:atom-type(
       (:    * All other built-in types defined in [XML Schema Part 2] :)
       (: Requires schema-aware processor :)
 
+      (: https://www.w3.org/TR/xslt-30/#built-in-types:
+        XSD 1.1 ... adds one new type: xs:dateTimeStamp :)
+      (: xs:dateTimeStamp: Not supported by BaseX 9.4.5 :)
+
       (: Every XSLT 2.0 processor includes the following named type definitions in the in-scope schema components: :)
 
       (:    * The following types defined in [XPath 2.0] :)

--- a/src/common/report-sequence.xsl
+++ b/src/common/report-sequence.xsl
@@ -357,6 +357,14 @@
             <xsl:when test="$value instance of xs:nonNegativeInteger" use-when="type-available('xs:nonNegativeInteger')">nonNegativeInteger</xsl:when>
             <!-- xs:NOTATION: Abstract -->
 
+            <!-- https://www.w3.org/TR/xslt-30/#built-in-types:
+               XSD 1.1 ... adds one new type: xs:dateTimeStamp -->
+            <!-- TODO: Remove system-property() condition from @use-when after
+               https://saxonica.plan.io/issues/4861 gets fixed. -->
+            <xsl:when test="$value instance of xs:dateTimeStamp" use-when="
+               type-available('xs:dateTimeStamp')
+               and (xs:decimal(system-property('xsl:xsd-version')) ge 1.1)">dateTimeStamp</xsl:when>
+
             <!-- Every XSLT 2.0 processor includes the following named type definitions in the in-scope schema components: -->
 
             <!--    * The following types defined in [XPath 2.0] -->

--- a/test/end-to-end/cases/expected/query/report-junit.xml
+++ b/test/end-to-end/cases/expected/query/report-junit.xml
@@ -58,4 +58,10 @@
 'bar'</failure>
       </testcase>
    </testsuite>
+   <testsuite name="Derived types" tests="1" failures="1">
+      <testcase name="Derived date/time types xs:dateTimeStamp [Result] must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#34;Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(XSLT) or&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#34;Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(XQuery)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/report-result.html
+++ b/test/end-to-end/cases/expected/query/report-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 9 / total: 9)</title>
+      <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 10 / total: 10)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -24,8 +24,8 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 9</th>
-               <th class="totals">total: 9</th>
+               <th class="totals">failed: 10</th>
+               <th class="totals">total: 10</th>
             </tr>
          </thead>
          <tbody>
@@ -73,6 +73,13 @@
             </tr>
             <tr class="failed">
                <th><a href="#top_scenario7">Sequence of multiple atomic values</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario8">Derived types</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -486,6 +493,56 @@
 1,
 2,
 'bar'</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario8">
+         <h2 class="successful">Derived types<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario8">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Derived types</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario8-scenario1-scenario1">Derived date/time types xs:dateTimeStamp</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario8-scenario1-scenario1-expect1">[Result] must be "Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+                        (XSLT) or "Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')" (XQuery)</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario8-scenario1-scenario1">
+            <h3>Derived types Derived date/time types xs:dateTimeStamp</h3>
+            <div id="scenario8-scenario1-scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">[Result] must be "Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+                  (XSLT) or "Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')" (XQuery)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/query/report-result.xml
+++ b/test/end-to-end/cases/expected/query/report-result.xml
@@ -196,4 +196,33 @@
          <expect select="QName('', 'foo'),&#xA;1,&#xA;2,&#xA;'bar'"/>
       </test>
    </scenario>
+   <scenario id="scenario8" xspec="../../report.xspec">
+      <label>Derived types</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="Q{x-urn:test:mirror}param-mirror"/>
+      </input-wrap>
+      <scenario id="scenario8-scenario1" xspec="../../report.xspec">
+         <label>Derived date/time types</label>
+         <scenario id="scenario8-scenario1-scenario1" xspec="../../report.xspec">
+            <label>xs:dateTimeStamp</label>
+            <input-wrap xmlns="">
+               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+                  <x:param select="xs:dateTimeStamp('1234-01-02T03:04:05Z')"/>
+               </x:call>
+            </input-wrap>
+            <result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')"/>
+            <test id="scenario8-scenario1-scenario1-expect1" successful="false">
+               <label>[Result] must be
+						"Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+						(XSLT) or
+						"Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')"
+						(XQuery)</label>
+               <expect select="()"/>
+            </test>
+         </scenario>
+      </scenario>
+   </scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/report-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report-junit.xml
@@ -58,4 +58,10 @@
 'bar'</failure>
       </testcase>
    </testsuite>
+   <testsuite name="Derived types" tests="1" failures="1">
+      <testcase name="Derived date/time types xs:dateTimeStamp [Result] must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#34;Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(XSLT) or&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#34;Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(XQuery)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 9 / total: 9)</title>
+      <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 10 / total: 10)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,8 +23,8 @@
                <th></th>
                <th class="totals">passed: 0</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 9</th>
-               <th class="totals">total: 9</th>
+               <th class="totals">failed: 10</th>
+               <th class="totals">total: 10</th>
             </tr>
          </thead>
          <tbody>
@@ -72,6 +72,13 @@
             </tr>
             <tr class="failed">
                <th><a href="#top_scenario7">Sequence of multiple atomic values</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario8">Derived types</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
@@ -485,6 +492,56 @@
 1,
 2,
 'bar'</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario8">
+         <h2 class="successful">Derived types<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario8">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Derived types</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario8-scenario1-scenario1">Derived date/time types xs:dateTimeStamp</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario8-scenario1-scenario1-expect1">[Result] must be "Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+                        (XSLT) or "Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')" (XQuery)</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario8-scenario1-scenario1">
+            <h3>Derived types Derived date/time types xs:dateTimeStamp</h3>
+            <div id="scenario8-scenario1-scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">[Result] must be "Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+                  (XSLT) or "Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')" (XQuery)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
                         </td>
                      </tr>
                   </tbody>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.xml
@@ -195,4 +195,33 @@
          <expect select="QName('', 'foo'),&#xA;1,&#xA;2,&#xA;'bar'"/>
       </test>
    </scenario>
+   <scenario id="scenario8" xspec="../../report.xspec">
+      <label>Derived types</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 function="Q{x-urn:test:mirror}param-mirror"/>
+      </input-wrap>
+      <scenario id="scenario8-scenario1" xspec="../../report.xspec">
+         <label>Derived date/time types</label>
+         <scenario id="scenario8-scenario1-scenario1" xspec="../../report.xspec">
+            <label>xs:dateTimeStamp</label>
+            <input-wrap xmlns="">
+               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+                  <x:param select="xs:dateTimeStamp('1234-01-02T03:04:05Z')"/>
+               </x:call>
+            </input-wrap>
+            <result select="Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"/>
+            <test id="scenario8-scenario1-scenario1-expect1" successful="false">
+               <label>[Result] must be
+						"Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+						(XSLT) or
+						"Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')"
+						(XQuery)</label>
+               <expect select="()"/>
+            </test>
+         </scenario>
+      </scenario>
+   </scenario>
 </report>

--- a/test/end-to-end/cases/report.xspec
+++ b/test/end-to-end/cases/report.xspec
@@ -69,9 +69,9 @@
 					<test />
 				</x:param>
 			</x:call>
-			<x:expect
+			<x:expect as="element()"
 				label="XPath should be colored as different. Serialized node should be colored as same."
-				select="element()" as="element()">
+				select="element()">
 				<test />
 			</x:expect>
 		</x:scenario>
@@ -82,9 +82,9 @@
 					<test />
 				</x:param>
 			</x:call>
-			<x:expect
+			<x:expect as="document-node()"
 				label="XPath should be colored as different. Serialized node should be colored as same."
-				select="/self::document-node()" as="document-node()">
+				select="/self::document-node()">
 				<test />
 			</x:expect>
 		</x:scenario>
@@ -97,6 +97,28 @@
 		<x:expect
 			label="Atomic values in [Result] and [Expected Result] are separated by comma and new line"
 			select="Q{http://www.w3.org/2001/XMLSchema}QName('foo'), 1, 2, 'bar'" />
+	</x:scenario>
+
+	<x:scenario label="Derived types" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+		<x:call function="Q{x-urn:test:mirror}param-mirror" />
+
+		<x:scenario label="Derived date/time types">
+
+			<x:scenario label="xs:dateTimeStamp">
+				<x:call>
+					<x:param select="xs:dateTimeStamp('1234-01-02T03:04:05Z')" />
+				</x:call>
+				<x:expect>
+					<x:label>[Result] must be
+						"Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp('1234-01-02T03:04:05Z')"
+						(XSLT) or
+						"Q{http://www.w3.org/2001/XMLSchema}dateTime('1234-01-02T03:04:05Z')"
+						(XQuery)</x:label>
+				</x:expect>
+			</x:scenario>
+
+		</x:scenario>
+
 	</x:scenario>
 
 </x:description>

--- a/test/report-sequence_stylesheet.xspec
+++ b/test/report-sequence_stylesheet.xspec
@@ -11,9 +11,6 @@
       compiler. You don't need to specify it in /t:description/@stylesheet.
    -->
 
-   <!--
-       Template rep:report-sequence
-   -->
    <t:scenario label="rep:report-sequence" xml:base="report-sequence/">
       <t:call template="rep:report-sequence" />
 
@@ -82,6 +79,20 @@
                href="attributes-and-content.xml?strip-space=yes" select="t:result" />
          </t:scenario>
 
+      </t:scenario>
+
+   </t:scenario>
+
+   <t:scenario label="rep:atom-type">
+      <t:call function="rep:atom-type" />
+
+      <!-- BaseX 9.4.5 does not support xs:dateTimeStamp -->
+      <t:scenario label="XSD 1.1 ... adds one new type: xs:dateTimeStamp">
+         <t:call>
+            <t:param select="xs:dateTimeStamp('1111-11-11T11:11:11Z')" />
+         </t:call>
+         <t:expect label="xs:dateTimeStamp" select="string()"
+            >Q{http://www.w3.org/2001/XMLSchema}dateTimeStamp</t:expect>
       </t:scenario>
 
    </t:scenario>


### PR DESCRIPTION
Report `xs:dateTimeStamp`. ([example](https://htmlpreview.github.io/?https://github.com/xspec/xspec/blob/ec80dbae5c9b9304af83789614dcb8daff547379/test/end-to-end/cases/expected/stylesheet/report-result.html#scenario8-scenario1-scenario1-expect1))

Not for XQuery, because BaseX [doesn't support](https://mailman.uni-konstanz.de/pipermail/basex-talk/2017-November/012690.html) `xs:dateTimeStamp`.