### PR TITLE
refactor: generalize variable declaration stack

### DIFF
--- a/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
@@ -193,7 +193,7 @@
                <xsl:sequence select="$context ! x:known-UQName('x:context')" />
                <xsl:sequence select="x:known-UQName('x:result')" />
             </xsl:if>
-            <xsl:sequence select="accumulator-before('stacked-variables-distinct-uqnames')" />
+            <xsl:sequence select="accumulator-before('stacked-vardecls-distinct-uqnames')" />
          </xsl:with-param>
       </xsl:call-template>
    </xsl:template>

--- a/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
@@ -54,7 +54,7 @@
       <!-- Dispatch to a language-specific (XSLT or XQuery) worker template -->
       <xsl:call-template name="x:invoke-compiled-current-scenario-or-expect">
          <xsl:with-param name="with-param-uqnames"
-            select="accumulator-before('stacked-variables-distinct-uqnames')" />
+            select="accumulator-before('stacked-vardecls-distinct-uqnames')" />
       </xsl:call-template>
    </xsl:template>
 
@@ -72,22 +72,23 @@
                <xsl:sequence select="$context ! x:known-UQName('x:context')" />
                <xsl:sequence select="x:known-UQName('x:result')" />
             </xsl:if>
-            <xsl:sequence select="accumulator-before('stacked-variables-distinct-uqnames')" />
+            <xsl:sequence select="accumulator-before('stacked-vardecls-distinct-uqnames')" />
          </xsl:with-param>
       </xsl:call-template>
    </xsl:template>
 
    <!--
-      Declare local x:variable if they are not preceding-siblings of x:call or x:context.
+      Handle local variable declarations if they are not preceding-siblings of x:call or x:context
    -->
-   <xsl:template match="x:variable" as="node()*" mode="local:invoke-compiled-scenarios-or-expects">
+   <xsl:template match="x:variable" as="node()*"
+      mode="local:invoke-compiled-scenarios-or-expects">
       <xsl:choose>
          <xsl:when test="parent::x:description">
-            <!-- This global x:variable is declared in x:main template -->
+            <!-- This global variable declaration is handled in x:main template -->
          </xsl:when>
 
          <xsl:when test="following-sibling::x:call or following-sibling::x:context">
-            <!-- This local x:variable is declared in x:compile-scenario template -->
+            <!-- This local variable declaration is handled in x:compile-scenario template -->
          </xsl:when>
 
          <xsl:otherwise>

--- a/src/compiler/base/main.xsl
+++ b/src/compiler/base/main.xsl
@@ -29,34 +29,34 @@
       select="x:document-actual-uri($initial-document)" />
 
    <!--
-      Accumulators for local x:variable
+      Accumulators for local variable declarations (x:variable)
    -->
 
-   <!-- Push and pop x:variable based on node identity -->
-   <xsl:accumulator name="local:stacked-variables" as="element(x:variable)*" initial-value="()">
+   <!-- Push and pop variable declaration elements based on node identity -->
+   <xsl:accumulator name="local:stacked-vardecls" as="element(x:variable)*" initial-value="()">
       <xsl:accumulator-rule match="x:scenario/x:variable"
          select="
-            (: Append this local variable :)
+            (: Append this local variable declaration element :)
             $value, self::x:variable" />
       <xsl:accumulator-rule match="x:scenario" phase="end"
          select="
-            (: Remove variables declared as children of this scenario :)
+            (: Remove child variable declaration elements of this scenario :)
             $value except child::x:variable" />
    </xsl:accumulator>
 
-   <!-- Push and pop distinct URIQualifiedName of x:variable -->
-   <xsl:accumulator name="stacked-variables-distinct-uqnames" as="xs:string*" initial-value="()">
+   <!-- Push and pop distinct URIQualifiedName of variable declarations (x:variable) -->
+   <xsl:accumulator name="stacked-vardecls-distinct-uqnames" as="xs:string*" initial-value="()">
       <!-- Use x:distinct-strings-stable() instead of fn:distinct-values(). The x:compile-scenario
          template for XQuery requires the order to be stable. -->
       <xsl:accumulator-rule match="x:scenario/x:variable"
          select="
             x:distinct-strings-stable(
-               accumulator-before('local:stacked-variables') ! x:variable-UQName(.)
+               accumulator-before('local:stacked-vardecls') ! x:variable-UQName(.)
             )" />
       <xsl:accumulator-rule match="x:scenario" phase="end"
          select="
             x:distinct-strings-stable(
-               accumulator-after('local:stacked-variables') ! x:variable-UQName(.)
+               accumulator-after('local:stacked-vardecls') ! x:variable-UQName(.)
             )" />
    </xsl:accumulator>
 

--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -18,7 +18,7 @@
       <xsl:param name="context"   as="element(x:context)?"  tunnel="yes" />
       <xsl:param name="call"      as="element(x:call)?"     tunnel="yes" />
 
-      <xsl:variable name="local-preceding-variables" as="element(x:variable)*"
+      <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
          select="x:call/preceding-sibling::x:variable" />
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
@@ -59,7 +59,7 @@
       <xsl:text expand-text="yes">&#10;declare function local:{@id}(&#x0A;</xsl:text>
 
       <!-- Function parameters. Their order must be stable, because this is a function. -->
-      <xsl:for-each select="accumulator-before('stacked-variables-distinct-uqnames')">
+      <xsl:for-each select="accumulator-before('stacked-vardecls-distinct-uqnames')">
          <xsl:text expand-text="yes">${.}</xsl:text>
          <xsl:if test="position() ne last()">
             <xsl:text>,</xsl:text>
@@ -72,11 +72,12 @@
       <!-- Start of the function body -->
       <xsl:text>{&#x0A;</xsl:text>
 
-      <!-- If there are variables before x:call, declare them here followed by "return". The other
-         local variables are declared in mode="local:invoke-compiled-scenarios-or-expects" in
+      <!-- If there are variable declarations before x:call, handle them here followed by "return".
+         The other local variable declarations are handled in
+         mode="local:invoke-compiled-scenarios-or-expects" in
          invoke-compiled-child-scenarios-or-expects.xsl. -->
-      <xsl:if test="exists($local-preceding-variables)">
-         <xsl:apply-templates select="$local-preceding-variables" mode="x:declare-variable" />
+      <xsl:if test="exists($local-preceding-vardecls)">
+         <xsl:apply-templates select="$local-preceding-vardecls" mode="x:declare-variable" />
          <xsl:text>return&#x0A;</xsl:text>
       </xsl:if>
 

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -20,8 +20,8 @@
       <xsl:param name="call" as="element(x:call)?" tunnel="yes" />
       <xsl:param name="context" as="element(x:context)?" tunnel="yes" />
 
-      <xsl:variable name="local-preceding-variables" as="element(x:variable)*"
-         select="x:call/preceding-sibling::x:variable | x:context/preceding-sibling::x:variable" />
+      <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
+         select="(x:call | x:context)/preceding-sibling::x:variable" />
       <xsl:variable name="pending-p" as="xs:boolean"
          select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
       <xsl:variable name="run-sut-now" as="xs:boolean" select="not($pending-p) and x:expect" />
@@ -92,7 +92,7 @@
             <xsl:attribute name="use" select="'absent'" />
          </xsl:element>
 
-         <xsl:for-each select="accumulator-before('stacked-variables-distinct-uqnames')">
+         <xsl:for-each select="accumulator-before('stacked-vardecls-distinct-uqnames')">
             <param name="{.}" required="yes" />
          </xsl:for-each>
 
@@ -125,9 +125,9 @@
 
             <xsl:apply-templates select="x:label(.)" mode="x:node-constructor" />
 
-            <!-- Handle variables and apply/call/context in document order,
-               instead of apply/call/context first and variables second. -->
-            <xsl:for-each select="$local-preceding-variables | x:apply | x:call | x:context">
+            <!-- Handle local preceding variable declarations and apply/call/context in document
+               order, instead of apply/call/context first and variable declarations second. -->
+            <xsl:for-each select="$local-preceding-vardecls | x:apply | x:call | x:context">
                <xsl:choose>
                   <xsl:when test="self::x:apply or self::x:call or self::x:context">
                      <!-- Copy the input to the test result report XML -->
@@ -147,9 +147,10 @@
                      </xsl:if>
                   </xsl:when>
 
-                  <xsl:when test="self::x:variable">
-                     <!-- Declare local preceding variables. The other local variables are declared
-                        in mode="local:invoke-compiled-scenarios-or-expects" in
+                  <xsl:when test=". intersect $local-preceding-vardecls">
+                     <!-- Handle local variable declarations that are preceding-siblings of x:call
+                        or x:context. The other local variable declarations are handled in
+                        mode="local:invoke-compiled-scenarios-or-expects" in
                         invoke-compiled-child-scenarios-or-expects.xsl. -->
                      <xsl:apply-templates select="." mode="x:declare-variable" />
                   </xsl:when>


### PR DESCRIPTION
Right now the XSpec compiler assumes that only `x:variable` contributes to the stack of scenario variables.
In preparation for #991, this pr generalizes it a bit so that other elements (namely `x:param`) can be inserted to the stack smoothly.