### PR TITLE
test: make three-dots.xspec less language-dependent

### DIFF
--- a/test/end-to-end/cases/expected/query/three-dots-junit.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-junit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="three-dots.xspec">
    <testsuite name="For resultant element (simple)" tests="7" failures="2">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -23,11 +23,11 @@
    <testsuite name="For resultant element (with attribute)"
               tests="3"
               failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -35,31 +35,31 @@
    <testsuite name="For resultant element (with mixed content)"
               tests="5"
               failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant attribute" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -95,73 +95,73 @@
       </testcase>
    </testsuite>
    <testsuite name="For resultant comment" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!----&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!----&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant processing instruction" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant document node" tests="7" failures="3">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting document node containing ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing nothing expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing nothing expecting document node containing ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is document node containing ... expecting document node containing ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing ... expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;text&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing ... expecting document node containing usual text node should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant namespace node" tests="7" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -169,19 +169,19 @@
    <testsuite name="For resultant sequence of multiple nodes"
               tests="5"
               failures="3">
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  ...&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  ...&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of two ... should be Success"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of two ... should be Success"
                 status="passed"/>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ...... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ...... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of three ... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of three ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -213,15 +213,23 @@
          <failure message="expect assertion failed">Expected Result: 'string'</failure>
       </testcase>
    </testsuite>
-   <testsuite name="For any resultant item" tests="4" failures="4">
+   <testsuite name="For any resultant item" tests="6" failures="6">
       <testcase name="expecting .... (four dots) should be Failure" status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="expecting ...x (three dots with extra character) should be Failure"
+      <testcase name="expecting x... (three dots with extra leading character) should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="expecting ... with surrounding whitespace should be Failure"
+      <testcase name="expecting ...x (three dots with extra trailing character) should be Failure"
+                status="failed">
+         <failure message="expect assertion failed"/>
+      </testcase>
+      <testcase name="expecting ... with leading whitespace should be Failure"
+                status="failed">
+         <failure message="expect assertion failed"/>
+      </testcase>
+      <testcase name="expecting ... with trailing whitespace should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>

--- a/test/end-to-end/cases/expected/query/three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/three-dots-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:three-dots (passed: 44 / pending: 0 / failed: 28 / total: 72)</title>
+      <title>Test Report for x-urn:test:three-dots (passed: 44 / pending: 0 / failed: 30 / total: 74)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -24,8 +24,8 @@
                <th></th>
                <th class="totals">passed: 44</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 28</th>
-               <th class="totals">total: 72</th>
+               <th class="totals">failed: 30</th>
+               <th class="totals">total: 74</th>
             </tr>
          </thead>
          <tbody>
@@ -117,8 +117,8 @@
                <th><a href="#top_scenario13">For any resultant item</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
-               <th class="totals">4</th>
-               <th class="totals">4</th>
+               <th class="totals">6</th>
+               <th class="totals">6</th>
             </tr>
          </tbody>
       </table>
@@ -818,11 +818,11 @@
                   <th>passed: 4 / pending: 0 / failed: 3 / total: 7</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;</a></th>
+                  <th><a href="#scenario8-scenario1">When result is document node containing &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario1-expect1">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario1-expect1">expecting document node containing ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -830,7 +830,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt;</a></th>
+                  <th><a href="#scenario8-scenario2">When result is document node containing nothing</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -838,15 +838,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario2-expect2">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario2-expect2">expecting document node containing ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</a></th>
+                  <th><a href="#scenario8-scenario3">When result is document node containing ...</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
-                  <td>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Success</td>
+                  <td>expecting document node containing ... should be Success</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -854,16 +854,16 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario3-expect3">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario3-expect3">expecting document node containing usual text node should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
          <div id="scenario8-scenario1">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt;</h3>
+            <h3>For resultant document node When result is document node containing &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
+               /&gt;</h3>
             <div id="scenario8-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing ... should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -877,7 +877,8 @@
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
                            <pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
-&lt;<span class="diff">elem</span> /&gt;</pre>
+&lt;<span class="diff">elem</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
+      <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span> /&gt;</pre>
                         </td>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
@@ -889,9 +890,9 @@
             </div>
          </div>
          <div id="scenario8-scenario2">
-            <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
+            <h3>For resultant document node When result is document node containing nothing</h3>
             <div id="scenario8-scenario2-expect2" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing ... should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -916,9 +917,9 @@
             </div>
          </div>
          <div id="scenario8-scenario3">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
+            <h3>For resultant document node When result is document node containing ...</h3>
             <div id="scenario8-scenario3-expect3" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing usual text node should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1340,7 +1341,7 @@
          </div>
       </div>
       <div id="top_scenario13">
-         <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 4 / total: 4</span></h2>
+         <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
          <table class="xspec" id="table_scenario13">
             <colgroup>
                <col style="width:75%" />
@@ -1349,22 +1350,30 @@
             <tbody>
                <tr class="failed">
                   <th>For any resultant item</th>
-                  <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
+                  <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
                   <td><a href="#scenario13-expect1">expecting .... (four dots) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect2">expecting ...x (three dots with extra character) should be Failure</a></td>
+                  <td><a href="#scenario13-expect2">expecting x... (three dots with extra leading character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect3">expecting ... with surrounding whitespace should be Failure</a></td>
+                  <td><a href="#scenario13-expect3">expecting ...x (three dots with extra trailing character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect4">expecting '...' (xs:string) should be Failure</a></td>
+                  <td><a href="#scenario13-expect4">expecting ... with leading whitespace should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario13-expect5">expecting ... with trailing whitespace should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario13-expect6">expecting '...' (xs:string) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -1396,7 +1405,31 @@
                </table>
             </div>
             <div id="scenario13-expect2" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting ...x (three dots with extra character) should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting x... (three dots with extra leading character) should be Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">x...</span></pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="scenario13-expect3" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ...x (three dots with extra trailing character) should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1419,8 +1452,8 @@
                   </tbody>
                </table>
             </div>
-            <div id="scenario13-expect3" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting ... with surrounding whitespace should be Failure</h4>
+            <div id="scenario13-expect4" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ... with leading whitespace should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1443,7 +1476,31 @@
                   </tbody>
                </table>
             </div>
-            <div id="scenario13-expect4" class="xTestReport">
+            <div id="scenario13-expect5" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ... with trailing whitespace should be Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">... </span></pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="scenario13-expect6" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' (xs:string) should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -8,7 +8,7 @@
       <label>For resultant element (simple)</label>
       <scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem&gt;text&lt;/elem&gt;
+					&lt;elem&gt;text&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -45,7 +45,7 @@
       </scenario>
       <scenario id="scenario1-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem /&gt;
+					&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -88,7 +88,7 @@
       </scenario>
       <scenario id="scenario1-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem&gt;...&lt;/elem&gt;
+					&lt;elem&gt;...&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -139,7 +139,7 @@
       <label>For resultant element (with attribute)</label>
       <scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem attrib="val" /&gt;
+					&lt;elem attrib="val" /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -192,7 +192,7 @@
       <label>For resultant element (with mixed content)</label>
       <scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
+					&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -244,7 +244,7 @@
       </scenario>
       <scenario id="scenario3-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
+					&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -294,7 +294,7 @@
       <label>For resultant attribute</label>
       <scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib="val"
+						 @attrib="val"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -329,7 +329,7 @@
       </scenario>
       <scenario id="scenario4-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib=""
+						 @attrib=""
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -358,7 +358,7 @@
       </scenario>
       <scenario id="scenario4-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib="..."
+						 @attrib="..."
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -410,7 +410,7 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_usual"/>
+               <x:param as="text()">text</x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -433,7 +433,8 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_whitespace-only"/>
+               <x:param as="text()">	
+&#xD; </x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -488,7 +489,7 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_three-dots"/>
+               <x:param as="text()">...</x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -516,7 +517,7 @@
       <label>For resultant comment</label>
       <scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!--comment--&gt;
+					&lt;!--comment--&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -545,7 +546,7 @@
       </scenario>
       <scenario id="scenario6-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!----&gt;
+					&lt;!----&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -568,7 +569,7 @@
       </scenario>
       <scenario id="scenario6-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!--...--&gt;
+					&lt;!--...--&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -608,7 +609,7 @@
       <label>For resultant processing instruction</label>
       <scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi data?&gt;
+					&lt;?pi data?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -637,7 +638,7 @@
       </scenario>
       <scenario id="scenario7-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi?&gt;
+					&lt;?pi?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -660,7 +661,7 @@
       </scenario>
       <scenario id="scenario7-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi ...?&gt;
+					&lt;?pi ...?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -699,26 +700,26 @@
    <scenario id="scenario8" xspec="../../three-dots.xspec">
       <label>For resultant document node</label>
       <scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;
+         <label>When result is document node containing
+														 &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="document-node()"
-                        select="$Q{x-urn:test:three-dots}document-node_multiple-nodes"/>
+               <x:param as="document-node()" select="/"><?pi?><!--comment-->
+                  <elem/>
+               </x:param>
             </x:call>
          </input-wrap>
          <result select="/self::document-node()">
             <content-wrap xmlns=""><?pi?><!--comment-->
-               <elem/>
+               <elem xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
             </content-wrap>
          </result>
          <test id="scenario8-scenario1-expect1" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing ... should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
@@ -731,9 +732,7 @@
          </test>
       </scenario>
       <scenario id="scenario8-scenario2" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document /&gt;
-				</label>
+         <label>When result is document node containing nothing</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -752,33 +751,26 @@
             </expect>
          </test>
          <test id="scenario8-scenario2-expect2" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing ... should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
          </test>
       </scenario>
       <scenario id="scenario8-scenario3" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-				</label>
+         <label>When result is document node containing ...</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="document-node()"
-                        select="$Q{x-urn:test:three-dots}document-node_three-dots"/>
+               <x:param as="document-node()" select="/">...</x:param>
             </x:call>
          </input-wrap>
          <result select="/self::document-node()">
             <content-wrap xmlns="">...</content-wrap>
          </result>
          <test id="scenario8-scenario3-expect1" successful="true">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Success</label>
+            <label>expecting document node containing ... should be Success</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
@@ -790,9 +782,7 @@
             </expect>
          </test>
          <test id="scenario8-scenario3-expect3" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;text&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing usual text node should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">text</content-wrap>
             </expect>
@@ -803,7 +793,7 @@
       <label>For resultant namespace node</label>
       <scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns:prefix="namespace-uri"
+				xmlns:prefix="namespace-uri"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -820,7 +810,7 @@
          </result>
          <test id="scenario9-scenario1-expect1" successful="true">
             <label>expecting
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -837,7 +827,7 @@
       </scenario>
       <scenario id="scenario9-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns="namespace-uri"
+				xmlns="namespace-uri"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -854,7 +844,7 @@
          </result>
          <test id="scenario9-scenario2-expect1" successful="true">
             <label>expecting
-					  xmlns="..."
+					xmlns="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -871,7 +861,7 @@
       </scenario>
       <scenario id="scenario9-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns:prefix="..."
+				xmlns:prefix="..."
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -888,7 +878,7 @@
          </result>
          <test id="scenario9-scenario3-expect1" successful="true">
             <label>expecting
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -904,7 +894,7 @@
          </test>
          <test id="scenario9-scenario3-expect3" successful="false">
             <label>expecting
-					  xmlns:prefix="namespace-uri"
+					xmlns:prefix="namespace-uri"
 					should be Failure</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -918,7 +908,7 @@
       <label>For resultant sequence of multiple nodes</label>
       <scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <label>When result is sequence of
-				&lt;elem1 /&gt;&lt;elem2 /&gt;
+					&lt;elem1 /&gt;&lt;elem2 /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -980,7 +970,7 @@
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
                  function="zero-or-one">
-            <x:param select="()"/>
+            <x:param as="empty-sequence()"/>
          </x:call>
       </input-wrap>
       <result select="()"/>
@@ -1063,18 +1053,30 @@
          </expect>
       </test>
       <test id="scenario13-expect2" successful="false">
-         <label>expecting ...x (three dots with extra character) should be Failure</label>
+         <label>expecting x... (three dots with extra leading character) should be Failure</label>
+         <expect select="/text()">
+            <content-wrap xmlns="">x...</content-wrap>
+         </expect>
+      </test>
+      <test id="scenario13-expect3" successful="false">
+         <label>expecting ...x (three dots with extra trailing character) should be Failure</label>
          <expect select="/text()">
             <content-wrap xmlns="">...x</content-wrap>
          </expect>
       </test>
-      <test id="scenario13-expect3" successful="false">
-         <label>expecting ... with surrounding whitespace should be Failure</label>
+      <test id="scenario13-expect4" successful="false">
+         <label>expecting ... with leading whitespace should be Failure</label>
          <expect select="/text()">
             <content-wrap xmlns=""> ...</content-wrap>
          </expect>
       </test>
-      <test id="scenario13-expect4" successful="false">
+      <test id="scenario13-expect5" successful="false">
+         <label>expecting ... with trailing whitespace should be Failure</label>
+         <expect select="/text()">
+            <content-wrap xmlns="">... </content-wrap>
+         </expect>
+      </test>
+      <test id="scenario13-expect6" successful="false">
          <label>expecting '...' (xs:string) should be Failure</label>
          <expect select="'...'"/>
       </test>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-junit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="three-dots.xspec">
    <testsuite name="For resultant element (simple)" tests="7" failures="2">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;text&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -23,11 +23,11 @@
    <testsuite name="For resultant element (with attribute)"
               tests="3"
               failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;...&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem attrib=&#34;val&#34; /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem&gt;...&lt;/elem&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -35,31 +35,31 @@
    <testsuite name="For resultant element (with mixed content)"
               tests="5"
               failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner1 /&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;outer&gt;...&lt;inner /&gt;&lt;/outer&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant attribute" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9; @attrib=&#34;val&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -95,73 +95,73 @@
       </testcase>
    </testsuite>
    <testsuite name="For resultant comment" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!----&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!----&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;!--...--&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;!--comment--&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant processing instruction" tests="6" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?pi ...?&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&lt;?pi data?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant document node" tests="7" failures="3">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting document node containing ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9; &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing nothing expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing nothing expecting document node containing ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is document node containing ... expecting document node containing ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is document node containing ... expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;...&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;xsl:document&gt;text&lt;/xsl:document&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is document node containing ... expecting document node containing usual text node should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
    </testsuite>
    <testsuite name="For resultant namespace node" tests="7" failures="1">
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Success"
                 status="passed"/>
-      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
+      <testcase name="When result is&#xA;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;...&#34;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;xmlns:prefix=&#34;namespace-uri&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -169,19 +169,19 @@
    <testsuite name="For resultant sequence of multiple nodes"
               tests="5"
               failures="3">
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  ...&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;  ...&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;should be Success"
                 status="passed"/>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of two ... should be Success"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of two ... should be Success"
                 status="passed"/>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ...... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting ...... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of three ... should be Failure"
+      <testcase name="When result is sequence of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;elem1 /&gt;&lt;elem2 /&gt;&#xA;&#x9;&#x9;&#x9;&#x9; expecting sequence of three ... should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -213,15 +213,23 @@
          <failure message="expect assertion failed">Expected Result: 'string'</failure>
       </testcase>
    </testsuite>
-   <testsuite name="For any resultant item" tests="4" failures="4">
+   <testsuite name="For any resultant item" tests="6" failures="6">
       <testcase name="expecting .... (four dots) should be Failure" status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="expecting ...x (three dots with extra character) should be Failure"
+      <testcase name="expecting x... (three dots with extra leading character) should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="expecting ... with surrounding whitespace should be Failure"
+      <testcase name="expecting ...x (three dots with extra trailing character) should be Failure"
+                status="failed">
+         <failure message="expect assertion failed"/>
+      </testcase>
+      <testcase name="expecting ... with leading whitespace should be Failure"
+                status="failed">
+         <failure message="expect assertion failed"/>
+      </testcase>
+      <testcase name="expecting ... with trailing whitespace should be Failure"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for three-dots.xsl (passed: 44 / pending: 0 / failed: 28 / total: 72)</title>
+      <title>Test Report for three-dots.xsl (passed: 44 / pending: 0 / failed: 30 / total: 74)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,8 +23,8 @@
                <th></th>
                <th class="totals">passed: 44</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 28</th>
-               <th class="totals">total: 72</th>
+               <th class="totals">failed: 30</th>
+               <th class="totals">total: 74</th>
             </tr>
          </thead>
          <tbody>
@@ -116,8 +116,8 @@
                <th><a href="#top_scenario13">For any resultant item</a></th>
                <th class="totals">0</th>
                <th class="totals">0</th>
-               <th class="totals">4</th>
-               <th class="totals">4</th>
+               <th class="totals">6</th>
+               <th class="totals">6</th>
             </tr>
          </tbody>
       </table>
@@ -817,11 +817,11 @@
                   <th>passed: 4 / pending: 0 / failed: 3 / total: 7</th>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario1">When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;</a></th>
+                  <th><a href="#scenario8-scenario1">When result is document node containing &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario1-expect1">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario1-expect1">expecting document node containing ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="successful">
@@ -829,7 +829,7 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario2">When result is &lt;xsl:document /&gt;</a></th>
+                  <th><a href="#scenario8-scenario2">When result is document node containing nothing</a></th>
                   <th>passed: 1 / pending: 0 / failed: 1 / total: 2</th>
                </tr>
                <tr class="successful">
@@ -837,15 +837,15 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario2-expect2">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario2-expect2">expecting document node containing ... should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <th><a href="#scenario8-scenario3">When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</a></th>
+                  <th><a href="#scenario8-scenario3">When result is document node containing ...</a></th>
                   <th>passed: 2 / pending: 0 / failed: 1 / total: 3</th>
                </tr>
                <tr class="successful">
-                  <td>expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Success</td>
+                  <td>expecting document node containing ... should be Success</td>
                   <td>Success</td>
                </tr>
                <tr class="successful">
@@ -853,16 +853,16 @@
                   <td>Success</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario8-scenario3-expect3">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</a></td>
+                  <td><a href="#scenario8-scenario3-expect3">expecting document node containing usual text node should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
          </table>
          <div id="scenario8-scenario1">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
-               /&gt;&lt;/xsl:document&gt;</h3>
+            <h3>For resultant document node When result is document node containing &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem
+               /&gt;</h3>
             <div id="scenario8-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing ... should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -876,7 +876,8 @@
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
                            <pre>&lt;?<span class="same">pi</span> <span class="same"></span>?&gt;<span class="diff">&lt;!--comment--&gt;</span>
-&lt;<span class="diff">elem</span> /&gt;</pre>
+&lt;<span class="diff">elem</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
+      <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span> /&gt;</pre>
                         </td>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
@@ -888,9 +889,9 @@
             </div>
          </div>
          <div id="scenario8-scenario2">
-            <h3>For resultant document node When result is &lt;xsl:document /&gt;</h3>
+            <h3>For resultant document node When result is document node containing nothing</h3>
             <div id="scenario8-scenario2-expect2" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;...&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing ... should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -915,9 +916,9 @@
             </div>
          </div>
          <div id="scenario8-scenario3">
-            <h3>For resultant document node When result is &lt;xsl:document&gt;...&lt;/xsl:document&gt;</h3>
+            <h3>For resultant document node When result is document node containing ...</h3>
             <div id="scenario8-scenario3-expect3" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting &lt;xsl:document&gt;text&lt;/xsl:document&gt; should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting document node containing usual text node should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1339,7 +1340,7 @@
          </div>
       </div>
       <div id="top_scenario13">
-         <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 4 / total: 4</span></h2>
+         <h2 class="failed">For any resultant item<span class="scenario-totals">passed: 0 / pending: 0 / failed: 6 / total: 6</span></h2>
          <table class="xspec" id="table_scenario13">
             <colgroup>
                <col style="width:75%" />
@@ -1348,22 +1349,30 @@
             <tbody>
                <tr class="failed">
                   <th>For any resultant item</th>
-                  <th>passed: 0 / pending: 0 / failed: 4 / total: 4</th>
+                  <th>passed: 0 / pending: 0 / failed: 6 / total: 6</th>
                </tr>
                <tr class="failed">
                   <td><a href="#scenario13-expect1">expecting .... (four dots) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect2">expecting ...x (three dots with extra character) should be Failure</a></td>
+                  <td><a href="#scenario13-expect2">expecting x... (three dots with extra leading character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect3">expecting ... with surrounding whitespace should be Failure</a></td>
+                  <td><a href="#scenario13-expect3">expecting ...x (three dots with extra trailing character) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario13-expect4">expecting '...' (xs:string) should be Failure</a></td>
+                  <td><a href="#scenario13-expect4">expecting ... with leading whitespace should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario13-expect5">expecting ... with trailing whitespace should be Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario13-expect6">expecting '...' (xs:string) should be Failure</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -1395,7 +1404,31 @@
                </table>
             </div>
             <div id="scenario13-expect2" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting ...x (three dots with extra character) should be Failure</h4>
+               <h4 class="xTestReportTitle">expecting x... (three dots with extra leading character) should be Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">x...</span></pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="scenario13-expect3" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ...x (three dots with extra trailing character) should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1418,8 +1451,8 @@
                   </tbody>
                </table>
             </div>
-            <div id="scenario13-expect3" class="xTestReport">
-               <h4 class="xTestReportTitle">expecting ... with surrounding whitespace should be Failure</h4>
+            <div id="scenario13-expect4" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ... with leading whitespace should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1442,7 +1475,31 @@
                   </tbody>
                </table>
             </div>
-            <div id="scenario13-expect4" class="xTestReport">
+            <div id="scenario13-expect5" class="xTestReport">
+               <h4 class="xTestReportTitle">expecting ... with trailing whitespace should be Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">item</span></pre>
+                        </td>
+                        <td>
+                           <p>XPath <code class="same">/text()</code> from:</p>
+                           <pre><span class="diff">... </span></pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div id="scenario13-expect6" class="xTestReport">
                <h4 class="xTestReportTitle">expecting '...' (xs:string) should be Failure</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
@@ -7,7 +7,7 @@
       <label>For resultant element (simple)</label>
       <scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem&gt;text&lt;/elem&gt;
+					&lt;elem&gt;text&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -44,7 +44,7 @@
       </scenario>
       <scenario id="scenario1-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem /&gt;
+					&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -87,7 +87,7 @@
       </scenario>
       <scenario id="scenario1-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem&gt;...&lt;/elem&gt;
+					&lt;elem&gt;...&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -138,7 +138,7 @@
       <label>For resultant element (with attribute)</label>
       <scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;elem attrib="val" /&gt;
+					&lt;elem attrib="val" /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -191,7 +191,7 @@
       <label>For resultant element (with mixed content)</label>
       <scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
+					&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -243,7 +243,7 @@
       </scenario>
       <scenario id="scenario3-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
+					&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -293,7 +293,7 @@
       <label>For resultant attribute</label>
       <scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib="val"
+						 @attrib="val"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -328,7 +328,7 @@
       </scenario>
       <scenario id="scenario4-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib=""
+						 @attrib=""
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -357,7 +357,7 @@
       </scenario>
       <scenario id="scenario4-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-					 @attrib="..."
+						 @attrib="..."
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -409,7 +409,7 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_usual"/>
+               <x:param as="text()">text</x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -432,7 +432,8 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_whitespace-only"/>
+               <x:param as="text()">	
+&#xD; </x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -487,7 +488,7 @@
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_three-dots"/>
+               <x:param as="text()">...</x:param>
             </x:call>
          </input-wrap>
          <result select="/text()">
@@ -515,7 +516,7 @@
       <label>For resultant comment</label>
       <scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!--comment--&gt;
+					&lt;!--comment--&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -544,7 +545,7 @@
       </scenario>
       <scenario id="scenario6-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!----&gt;
+					&lt;!----&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -567,7 +568,7 @@
       </scenario>
       <scenario id="scenario6-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;!--...--&gt;
+					&lt;!--...--&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -607,7 +608,7 @@
       <label>For resultant processing instruction</label>
       <scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi data?&gt;
+					&lt;?pi data?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -636,7 +637,7 @@
       </scenario>
       <scenario id="scenario7-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi?&gt;
+					&lt;?pi?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -659,7 +660,7 @@
       </scenario>
       <scenario id="scenario7-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-				&lt;?pi ...?&gt;
+					&lt;?pi ...?&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -698,26 +699,26 @@
    <scenario id="scenario8" xspec="../../three-dots.xspec">
       <label>For resultant document node</label>
       <scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document&gt;&lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;&lt;/xsl:document&gt;
+         <label>When result is document node containing
+														 &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="document-node()"
-                        select="$Q{x-urn:test:three-dots}document-node_multiple-nodes"/>
+               <x:param as="document-node()" select="/"><?pi?><!--comment-->
+                  <elem/>
+               </x:param>
             </x:call>
          </input-wrap>
          <result select="/self::document-node()">
             <content-wrap xmlns=""><?pi?><!--comment-->
-               <elem/>
+               <elem xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                     xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
             </content-wrap>
          </result>
          <test id="scenario8-scenario1-expect1" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing ... should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
@@ -730,9 +731,7 @@
          </test>
       </scenario>
       <scenario id="scenario8-scenario2" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document /&gt;
-				</label>
+         <label>When result is document node containing nothing</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -751,33 +750,26 @@
             </expect>
          </test>
          <test id="scenario8-scenario2-expect2" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing ... should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
          </test>
       </scenario>
       <scenario id="scenario8-scenario3" xspec="../../three-dots.xspec">
-         <label>When result is
-				&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-				</label>
+         <label>When result is document node containing ...</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
                     function="exactly-one">
-               <x:param as="document-node()"
-                        select="$Q{x-urn:test:three-dots}document-node_three-dots"/>
+               <x:param as="document-node()" select="/">...</x:param>
             </x:call>
          </input-wrap>
          <result select="/self::document-node()">
             <content-wrap xmlns="">...</content-wrap>
          </result>
          <test id="scenario8-scenario3-expect1" successful="true">
-            <label>expecting
-					&lt;xsl:document&gt;...&lt;/xsl:document&gt;
-					should be Success</label>
+            <label>expecting document node containing ... should be Success</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">...</content-wrap>
             </expect>
@@ -789,9 +781,7 @@
             </expect>
          </test>
          <test id="scenario8-scenario3-expect3" successful="false">
-            <label>expecting
-					&lt;xsl:document&gt;text&lt;/xsl:document&gt;
-					should be Failure</label>
+            <label>expecting document node containing usual text node should be Failure</label>
             <expect select="/self::document-node()">
                <content-wrap xmlns="">text</content-wrap>
             </expect>
@@ -802,7 +792,7 @@
       <label>For resultant namespace node</label>
       <scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns:prefix="namespace-uri"
+				xmlns:prefix="namespace-uri"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -819,7 +809,7 @@
          </result>
          <test id="scenario9-scenario1-expect1" successful="true">
             <label>expecting
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -836,7 +826,7 @@
       </scenario>
       <scenario id="scenario9-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns="namespace-uri"
+				xmlns="namespace-uri"
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -853,7 +843,7 @@
          </result>
          <test id="scenario9-scenario2-expect1" successful="true">
             <label>expecting
-					  xmlns="..."
+					xmlns="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -870,7 +860,7 @@
       </scenario>
       <scenario id="scenario9-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
-						  xmlns:prefix="..."
+				xmlns:prefix="..."
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -887,7 +877,7 @@
          </result>
          <test id="scenario9-scenario3-expect1" successful="true">
             <label>expecting
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -903,7 +893,7 @@
          </test>
          <test id="scenario9-scenario3-expect3" successful="false">
             <label>expecting
-					  xmlns:prefix="namespace-uri"
+					xmlns:prefix="namespace-uri"
 					should be Failure</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
@@ -917,7 +907,7 @@
       <label>For resultant sequence of multiple nodes</label>
       <scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <label>When result is sequence of
-				&lt;elem1 /&gt;&lt;elem2 /&gt;
+					&lt;elem1 /&gt;&lt;elem2 /&gt;
 				</label>
          <input-wrap xmlns="">
             <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -979,7 +969,7 @@
          <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
                  function="zero-or-one">
-            <x:param select="()"/>
+            <x:param as="empty-sequence()"/>
          </x:call>
       </input-wrap>
       <result select="()"/>
@@ -1062,18 +1052,30 @@
          </expect>
       </test>
       <test id="scenario13-expect2" successful="false">
-         <label>expecting ...x (three dots with extra character) should be Failure</label>
+         <label>expecting x... (three dots with extra leading character) should be Failure</label>
+         <expect select="/text()">
+            <content-wrap xmlns="">x...</content-wrap>
+         </expect>
+      </test>
+      <test id="scenario13-expect3" successful="false">
+         <label>expecting ...x (three dots with extra trailing character) should be Failure</label>
          <expect select="/text()">
             <content-wrap xmlns="">...x</content-wrap>
          </expect>
       </test>
-      <test id="scenario13-expect3" successful="false">
-         <label>expecting ... with surrounding whitespace should be Failure</label>
+      <test id="scenario13-expect4" successful="false">
+         <label>expecting ... with leading whitespace should be Failure</label>
          <expect select="/text()">
             <content-wrap xmlns=""> ...</content-wrap>
          </expect>
       </test>
-      <test id="scenario13-expect4" successful="false">
+      <test id="scenario13-expect5" successful="false">
+         <label>expecting ... with trailing whitespace should be Failure</label>
+         <expect select="/text()">
+            <content-wrap xmlns="">... </content-wrap>
+         </expect>
+      </test>
+      <test id="scenario13-expect6" successful="false">
          <label>expecting '...' (xs:string) should be Failure</label>
          <expect select="'...'"/>
       </test>

--- a/test/end-to-end/cases/three-dots.xqm
+++ b/test/end-to-end/cases/three-dots.xqm
@@ -1,50 +1,16 @@
 module namespace three-dots = "x-urn:test:three-dots";
 
-(:
-	Document node
-:)
-declare variable $three-dots:document-node_multiple-nodes as document-node() := (
-document {
-	<?pi?>,
-	<!--comment-->,
-	<elem/>
-}
-);
-
+(: Empty document node :)
 declare variable $three-dots:document-node_empty as document-node() := (
 document {()}
 );
 
-declare variable $three-dots:document-node_three-dots as document-node() := (
-document {"..."}
-);
-
-declare variable $three-dots:document-node_text as document-node() := (
-document {"text"}
-);
-
-(:
-	Text node
-:)
-declare variable $three-dots:text-node_usual as text() := (
-text {"text"}
-);
-
-declare variable $three-dots:text-node_whitespace-only as text() := (
-text {"&#x09;&#x0A;&#x0D;&#x20;"}
-);
-
+(: Zero-length text node :)
 declare variable $three-dots:text-node_zero-length as text() := (
 text {""}
 );
 
-declare variable $three-dots:text-node_three-dots as text() := (
-text {"..."}
-);
-
-(:
-	Namespace node
-:)
+(: Namespace node generator :)
 declare function three-dots:namespace-node(
 $prefix as xs:string,
 $namespace-uri as xs:string

--- a/test/end-to-end/cases/three-dots.xsl
+++ b/test/end-to-end/cases/three-dots.xsl
@@ -3,55 +3,22 @@
 	xmlns:three-dots="x-urn:test:three-dots" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-	<!--
-		Document node
-	-->
-	<xsl:variable as="document-node()" name="three-dots:document-node_multiple-nodes">
-		<xsl:document>
-			<xsl:processing-instruction name="pi" />
-			<xsl:comment>comment</xsl:comment>
-			<xsl:element name="elem" />
-		</xsl:document>
-	</xsl:variable>
-
+	<!-- Empty document node -->
 	<xsl:variable as="document-node()" name="three-dots:document-node_empty">
 		<xsl:document />
 	</xsl:variable>
 
-	<xsl:variable as="document-node()" name="three-dots:document-node_three-dots">
-		<xsl:document>...</xsl:document>
-	</xsl:variable>
-
-	<xsl:variable as="document-node()" name="three-dots:document-node_text">
-		<xsl:document>text</xsl:document>
-	</xsl:variable>
-
-	<!--
-		Text node
-	-->
-	<xsl:variable as="text()" name="three-dots:text-node_usual">
-		<xsl:text>text</xsl:text>
-	</xsl:variable>
-
-	<xsl:variable as="text()" name="three-dots:text-node_whitespace-only">
-		<xsl:text>&#x09;&#x0A;&#x0D;&#x20;</xsl:text>
-	</xsl:variable>
-
+	<!-- Zero-length text node -->
 	<xsl:variable as="text()" name="three-dots:text-node_zero-length">
 		<xsl:text />
 	</xsl:variable>
 
-	<xsl:variable as="text()" name="three-dots:text-node_three-dots">
-		<xsl:text>...</xsl:text>
-	</xsl:variable>
-
-	<!--
-		Namespace node
-	-->
+	<!-- Namespace node generator -->
 	<xsl:function as="namespace-node()" name="three-dots:namespace-node">
 		<xsl:param as="xs:string" name="prefix" />
 		<xsl:param as="xs:string" name="namespace-uri" />
 
 		<xsl:namespace name="{$prefix}" select="$namespace-uri" />
 	</xsl:function>
+
 </xsl:stylesheet>

--- a/test/end-to-end/cases/three-dots.xspec
+++ b/test/end-to-end/cases/three-dots.xspec
@@ -4,39 +4,39 @@
 	<x:scenario label="For resultant element (simple)">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<elem>text</elem>
+					<elem>text</elem>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(elem)">
 					<elem>text</elem>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem>...</elem>
 				]]>should be Success</x:label>
 				<elem>...</elem>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<elem />
+					<elem />
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(elem)">
 					<elem />
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem>...</elem>
 				]]>should be Success</x:label>
 				<elem>...</elem>
 			</x:expect>
 
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem attrib="..." />
 				]]>should be Failure</x:label>
@@ -46,22 +46,22 @@
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<elem>...</elem>
+					<elem>...</elem>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(elem)">
 					<elem>...</elem>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem>...</elem>
 				]]>should be Success</x:label>
 				<elem>...</elem>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem>text</elem>
 				]]>should be Failure</x:label>
@@ -73,22 +73,22 @@
 	<x:scenario label="For resultant element (with attribute)">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<elem attrib="val" />
+					<elem attrib="val" />
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(elem)">
 					<elem attrib="val" />
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem attrib="..." />
 				]]>should be Success</x:label>
 				<elem attrib="..." />
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect>
+			<x:expect as="element(elem)">
 				<x:label>expecting<![CDATA[
 				<elem>...</elem>
 				]]>should be Failure</x:label>
@@ -100,45 +100,45 @@
 	<x:scenario label="For resultant element (with mixed content)">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<outer>text<inner1 /><inner2 /></outer>
+					<outer>text<inner1 /><inner2 /></outer>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(outer)">
 					<outer>text<inner1 /><inner2 /></outer>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(outer)">
 				<x:label>expecting<![CDATA[
 				<outer>...</outer>
 				]]>should be Success</x:label>
 				<outer>...</outer>
 			</x:expect>
-			<x:expect>
+			<x:expect as="element(outer)">
 				<x:label>expecting<![CDATA[
 				<outer>...<inner1 />...</outer>
 				]]>should be Success</x:label>
 				<outer>...<inner1 />...</outer>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<outer><inner /></outer>
+					<outer><inner /></outer>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="element(outer)">
 					<outer><inner /></outer>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="element(outer)">
 				<x:label>expecting<![CDATA[
 				<outer>...</outer>
 				]]>should be Success</x:label>
 				<outer>...</outer>
 			</x:expect>
 
-			<x:expect>
+			<x:expect as="element(outer)">
 				<x:label>expecting<![CDATA[
 				<outer>...<inner /></outer>
 				]]>should be Failure</x:label>
@@ -150,32 +150,32 @@
 	<x:scenario label="For resultant attribute">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-					 @attrib="val"
+						 @attrib="val"
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="attribute(attrib)" select="elem/@*">
 					<elem attrib="val" />
 				</x:param>
 			</x:call>
-			<x:expect select="elem/@*" as="attribute(attrib)">
+			<x:expect as="attribute(attrib)" select="elem/@*">
 				<x:label>expecting<![CDATA[
 					 @attrib="..."
 					]]>should be Success</x:label>
 				<elem attrib="..." />
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-					 @attrib=""
+						 @attrib=""
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="attribute(attrib)" select="elem/@*">
 					<elem attrib="" />
 				</x:param>
 			</x:call>
-			<x:expect select="elem/@*" as="attribute(attrib)">
+			<x:expect as="attribute(attrib)" select="elem/@*">
 				<x:label>expecting<![CDATA[
 					 @attrib="..."
 					]]>should be Success</x:label>
@@ -185,22 +185,22 @@
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-					 @attrib="..."
+						 @attrib="..."
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="attribute(attrib)" select="elem/@*">
 					<elem attrib="..." />
 				</x:param>
 			</x:call>
-			<x:expect select="elem/@*" as="attribute(attrib)">
+			<x:expect as="attribute(attrib)" select="elem/@*">
 				<x:label>expecting<![CDATA[
 					 @attrib="..."
 					]]>should be Success</x:label>
 				<elem attrib="..." />
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect select="elem/@*" as="attribute(attrib)">
+			<x:expect as="attribute(attrib)" select="elem/@*">
 				<x:label>expecting<![CDATA[
 					 @attrib="val"
 					]]>should be Failure</x:label>
@@ -212,74 +212,76 @@
 	<x:scenario label="For resultant text node">
 		<x:scenario label="When result is usual text node">
 			<x:call function="exactly-one">
-				<x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_usual" />
+				<x:param as="text()">text</x:param>
 			</x:call>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect label="expecting '...' should be Failure" select="'...'" />
+			<x:expect as="xs:string" label="expecting '...' should be Failure" select="'...'" />
 		</x:scenario>
 
 		<x:scenario label="When result is whitespace-only text node">
 			<x:call function="exactly-one">
-				<x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_whitespace-only" />
+				<x:param as="text()">
+					<x:text>&#x09;&#x0A;&#x0D;&#x20;</x:text>
+				</x:param>
 			</x:call>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect label="expecting usual text node should be Failure"
-				select="$Q{x-urn:test:three-dots}text-node_usual" />
+			<x:expect as="text()" label="expecting usual text node should be Failure"
+				>text</x:expect>
 		</x:scenario>
 
 		<x:scenario label="When result is zero-length text node">
 			<x:call function="exactly-one">
 				<x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_zero-length" />
 			</x:call>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect label="expecting usual text node should be Failure"
-				select="$Q{x-urn:test:three-dots}text-node_usual" />
+			<x:expect as="text()" label="expecting usual text node should be Failure"
+				>text</x:expect>
 		</x:scenario>
 
 		<x:scenario label="When result is three-dot text node">
 			<x:call function="exactly-one">
-				<x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_three-dots" />
+				<x:param as="text()">...</x:param>
 			</x:call>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect label="expecting usual text node should be Failure"
-				select="$Q{x-urn:test:three-dots}text-node_usual" />
-			<x:expect label="expecting '...' should be Failure" select="'...'" />
+			<x:expect as="text()" label="expecting usual text node should be Failure"
+				>text</x:expect>
+			<x:expect as="xs:string" label="expecting '...' should be Failure" select="'...'" />
 		</x:scenario>
 	</x:scenario>
 
 	<x:scenario label="For resultant comment">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<!--comment-->
+					<!--comment-->
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="comment()">
 					<!--comment-->
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="comment()">
 				<x:label>expecting<![CDATA[
 				<!--...-->
 				]]>should be Success</x:label>
 				<!--...-->
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<!---->
+					<!---->
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="comment()">
 					<!---->
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="comment()">
 				<x:label>expecting<![CDATA[
 				<!--...-->
 				]]>should be Success</x:label>
@@ -289,22 +291,22 @@
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<!--...-->
+					<!--...-->
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="comment()">
 					<!--...-->
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="comment()">
 				<x:label>expecting<![CDATA[
 				<!--...-->
 				]]>should be Success</x:label>
 				<!--...-->
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect>
+			<x:expect as="comment()">
 				<x:label>expecting<![CDATA[
 				<!--comment-->
 				]]>should be Failure</x:label>
@@ -316,32 +318,32 @@
 	<x:scenario label="For resultant processing instruction">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<?pi data?>
+					<?pi data?>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="processing-instruction(pi)">
 					<?pi data?>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="processing-instruction(pi)">
 				<x:label>expecting<![CDATA[
 				<?pi ...?>
 				]]>should be Success</x:label>
 				<?pi ...?>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<?pi?>
+					<?pi?>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="processing-instruction(pi)">
 					<?pi?>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="processing-instruction(pi)">
 				<x:label>expecting<![CDATA[
 				<?pi ...?>
 				]]>should be Success</x:label>
@@ -351,22 +353,22 @@
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-				<?pi ...?>
+					<?pi ...?>
 				]]></x:label>
 			<x:call function="exactly-one">
 				<x:param as="processing-instruction(pi)">
 					<?pi ...?>
 				</x:param>
 			</x:call>
-			<x:expect>
+			<x:expect as="processing-instruction(pi)">
 				<x:label>expecting<![CDATA[
 				<?pi ...?>
 				]]>should be Success</x:label>
 				<?pi ...?>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect>
+			<x:expect as="processing-instruction(pi)">
 				<x:label>expecting<![CDATA[
 				<?pi data?>
 				]]>should be Failure</x:label>
@@ -377,112 +379,102 @@
 
 	<x:scenario label="For resultant document node">
 		<x:scenario>
-			<x:label>When result is<![CDATA[
-				<xsl:document><?pi?><!--comment--><elem /></xsl:document>
+			<x:label>When result is document node containing<![CDATA[
+														 <?pi?><!--comment--><elem />
 				]]></x:label>
 			<x:call function="exactly-one">
-				<x:param as="document-node()"
-					select="$Q{x-urn:test:three-dots}document-node_multiple-nodes" />
+				<x:param as="document-node()" select="/"><?pi?><!--comment--><elem /></x:param>
 			</x:call>
-			<x:expect select="$Q{x-urn:test:three-dots}document-node_three-dots">
-				<x:label>expecting<![CDATA[
-					<xsl:document>...</xsl:document>
-					]]>should be Failure</x:label>
-			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="document-node()"
+				label="expecting document node containing ... should be Failure" select="/"
+				>...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
-			<x:label>When result is<![CDATA[
-				<xsl:document />
-				]]></x:label>
+			<x:label>When result is document node containing nothing</x:label>
 			<x:call function="exactly-one">
 				<x:param as="document-node()" select="$Q{x-urn:test:three-dots}document-node_empty"
 				 />
 			</x:call>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect select="$Q{x-urn:test:three-dots}document-node_three-dots">
-				<x:label>expecting<![CDATA[
-					<xsl:document>...</xsl:document>
-					]]>should be Failure</x:label>
-			</x:expect>
+			<x:expect as="document-node()"
+				label="expecting document node containing ... should be Failure" select="/"
+				>...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
-			<x:label>When result is<![CDATA[
-				<xsl:document>...</xsl:document>
-				]]></x:label>
+			<x:label>When result is document node containing ...</x:label>
 			<x:call function="exactly-one">
-				<x:param as="document-node()"
-					select="$Q{x-urn:test:three-dots}document-node_three-dots" />
+				<x:param as="document-node()" select="/">...</x:param>
 			</x:call>
-			<x:expect select="$Q{x-urn:test:three-dots}document-node_three-dots">
-				<x:label>expecting<![CDATA[
-					<xsl:document>...</xsl:document>
-					]]>should be Success</x:label>
-			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="document-node()"
+				label="expecting document node containing ... should be Success" select="/"
+				>...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect select="$Q{x-urn:test:three-dots}document-node_text">
-				<x:label>expecting<![CDATA[
-					<xsl:document>text</xsl:document>
-					]]>should be Failure</x:label>
-			</x:expect>
+			<x:expect as="document-node()"
+				label="expecting document node containing usual text node should be Failure"
+				select="/">text</x:expect>
 		</x:scenario>
 	</x:scenario>
 
 	<x:scenario label="For resultant namespace node">
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-						  xmlns:prefix="namespace-uri"
+				xmlns:prefix="namespace-uri"
 				]]></x:label>
 			<x:call function="Q{x-urn:test:three-dots}namespace-node">
 				<x:param select="'prefix'" />
 				<x:param select="'namespace-uri'" />
 			</x:call>
-			<x:expect select="Q{x-urn:test:three-dots}namespace-node('prefix', '...')">
+			<x:expect as="namespace-node()"
+				select="Q{x-urn:test:three-dots}namespace-node('prefix', '...')">
 				<x:label>expecting<![CDATA[
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					]]>should be Success</x:label>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-						  xmlns="namespace-uri"
+				xmlns="namespace-uri"
 				]]></x:label>
 			<x:call function="Q{x-urn:test:three-dots}namespace-node">
 				<x:param select="''" />
 				<x:param select="'namespace-uri'" />
 			</x:call>
-			<x:expect select="Q{x-urn:test:three-dots}namespace-node('', '...')">
+			<x:expect as="namespace-node()"
+				select="Q{x-urn:test:three-dots}namespace-node('', '...')">
 				<x:label>expecting<![CDATA[
-					  xmlns="..."
+					xmlns="..."
 					]]>should be Success</x:label>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 		</x:scenario>
 
 		<x:scenario>
 			<x:label>When result is<![CDATA[
-						  xmlns:prefix="..."
+				xmlns:prefix="..."
 				]]></x:label>
 			<x:call function="Q{x-urn:test:three-dots}namespace-node">
 				<x:param select="'prefix'" />
 				<x:param select="'...'" />
 			</x:call>
-			<x:expect select="Q{x-urn:test:three-dots}namespace-node('prefix', '...')">
+			<x:expect as="namespace-node()"
+				select="Q{x-urn:test:three-dots}namespace-node('prefix', '...')">
 				<x:label>expecting<![CDATA[
-					  xmlns:prefix="..."
+					xmlns:prefix="..."
 					]]>should be Success</x:label>
 			</x:expect>
-			<x:expect label="expecting ... should be Success">...</x:expect>
+			<x:expect as="text()" label="expecting ... should be Success">...</x:expect>
 
-			<x:expect select="Q{x-urn:test:three-dots}namespace-node('prefix', 'namespace-uri')">
+			<x:expect as="namespace-node()"
+				select="Q{x-urn:test:three-dots}namespace-node('prefix', 'namespace-uri')">
 				<x:label>expecting<![CDATA[
-					  xmlns:prefix="namespace-uri"
+					xmlns:prefix="namespace-uri"
 					]]>should be Failure</x:label>
 			</x:expect>
 		</x:scenario>
@@ -491,29 +483,29 @@
 	<x:scenario label="For resultant sequence of multiple nodes">
 		<x:scenario>
 			<x:label>When result is sequence of<![CDATA[
-				<elem1 /><elem2 />
+					<elem1 /><elem2 />
 				]]></x:label>
 			<x:call function="one-or-more">
 				<x:param as="element()+">
 					<elem1 /><elem2 />
 				</x:param>
 			</x:call>
-			<x:expect select="wrap/node()" as="node()+">
+			<x:expect as="node()+" select="wrap/node()">
 				<x:label>expecting<![CDATA[
 					  ...<elem2 />
 					]]>should be Success</x:label>
 				<wrap>...<elem2 /></wrap>
 			</x:expect>
-			<x:expect label="expecting sequence of two ... should be Success"
-				select="wrap/text()" as="text()+">
+			<x:expect as="text()+" label="expecting sequence of two ... should be Success"
+				select="wrap/text()">
 				<wrap>...</wrap>
 				<wrap>...</wrap>
 			</x:expect>
 
-			<x:expect label="expecting ... should be Failure">...</x:expect>
-			<x:expect label="expecting ...... should be Failure">......</x:expect>
-			<x:expect label="expecting sequence of three ... should be Failure"
-				select="wrap/text()" as="text()+">
+			<x:expect as="text()" label="expecting ... should be Failure">...</x:expect>
+			<x:expect as="text()" label="expecting ...... should be Failure">......</x:expect>
+			<x:expect as="text()+" label="expecting sequence of three ... should be Failure"
+				select="wrap/text()">
 				<wrap>...</wrap>
 				<wrap>...</wrap>
 				<wrap>...</wrap>
@@ -523,9 +515,9 @@
 
 	<x:scenario label="When result is empty sequence">
 		<x:call function="zero-or-one">
-			<x:param select="()" />
+			<x:param as="empty-sequence()" />
 		</x:call>
-		<x:expect label="expecting ... should be Failure">...</x:expect>
+		<x:expect as="text()" label="expecting ... should be Failure">...</x:expect>
 	</x:scenario>
 
 	<x:scenario label="For resultant atomic value">
@@ -533,20 +525,21 @@
 			<x:call function="exactly-one">
 				<x:param as="xs:string" select="'string'" />
 			</x:call>
-			<x:expect label="expecting 'string' should be Success" select="'string'" />
+			<x:expect as="xs:string" label="expecting 'string' should be Success" select="'string'" />
 
-			<x:expect label="expecting ... should be Failure">...</x:expect>
-			<x:expect label="expecting '...' should be Failure" select="'...'" />
+			<x:expect as="text()" label="expecting ... should be Failure">...</x:expect>
+			<x:expect as="xs:string" label="expecting '...' should be Failure" select="'...'" />
 		</x:scenario>
 
 		<x:scenario label="When result is '...'">
 			<x:call function="exactly-one">
 				<x:param as="xs:string" select="'...'" />
 			</x:call>
-			<x:expect label="expecting '...' should be Success" select="'...'" />
+			<x:expect as="xs:string" label="expecting '...' should be Success" select="'...'" />
 
-			<x:expect label="expecting ... should be Failure">...</x:expect>
-			<x:expect label="expecting 'string' should be Failure" select="'string'" />
+			<x:expect as="text()" label="expecting ... should be Failure">...</x:expect>
+			<x:expect as="xs:string" label="expecting 'string' should be Failure" select="'string'"
+			 />
 		</x:scenario>
 	</x:scenario>
 
@@ -554,10 +547,18 @@
 		<x:call function="exactly-one">
 			<x:param as="text()">item</x:param>
 		</x:call>
-		<x:expect label="expecting .... (four dots) should be Failure">....</x:expect>
-		<x:expect label="expecting ...x (three dots with extra character) should be Failure"
+		<x:expect as="text()" label="expecting .... (four dots) should be Failure">....</x:expect>
+		<x:expect as="text()"
+			label="expecting x... (three dots with extra leading character) should be Failure"
+			>x...</x:expect>
+		<x:expect as="text()"
+			label="expecting ...x (three dots with extra trailing character) should be Failure"
 			>...x</x:expect>
-		<x:expect label="expecting ... with surrounding whitespace should be Failure" xml:space="preserve"> ...</x:expect>
-		<x:expect label="expecting '...' (xs:string) should be Failure" select="'...'" />
+		<x:expect as="text()" label="expecting ... with leading whitespace should be Failure"
+			>&#x20;...</x:expect>
+		<x:expect as="text()" label="expecting ... with trailing whitespace should be Failure"
+			>...&#x20;</x:expect>
+		<x:expect as="xs:string" label="expecting '...' (xs:string) should be Failure"
+			select="'...'" />
 	</x:scenario>
 </x:description>


### PR DESCRIPTION
Remove some dependency on `*.(xqm|xsl)` from `test/end-to-end/cases/three-dots.xspec`.