### PR TITLE
feat: do not allow x:variable to override x:param

### DIFF
--- a/test/variable-overriding-param/global-variable.xspec
+++ b/test/variable-overriding-param/global-variable.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:my="http://example.org/ns/my" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<!--
+		- /x:description/x:variable overriding /x:description/x:param
+		- URIQualifiedName overriding lexical QName
+	-->
+	<x:param name="my:foo" />
+	<x:variable name="Q{http://example.org/ns/my}foo" />
+</x:description>

--- a/test/variable-overriding-param/local-variable/description-param.xspec
+++ b/test/variable-overriding-param/local-variable/description-param.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:my="http://example.org/ns/my" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<!--
+		- x:scenario/x:variable overriding /x:description/x:param
+		- Lexical QName overriding URIQualifiedName
+	-->
+	<x:param name="Q{http://example.org/ns/my}foo" />
+	<x:scenario label="x:scenario/x:variable">
+		<x:variable name="my:foo" />
+	</x:scenario>
+</x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2366,6 +2366,24 @@
 	</case>
 
 	<!--
+		x:variable must not override x:param
+	-->
+
+	<case name="x:variable must not override x:param (global variable overriding description param)">
+    call :run ..\bin\xspec.bat variable-overriding-param\global-variable.xspec
+    call :verify_retval 2
+    call :verify_line  4 x "ERROR: x:variable (named Q{http://example.org/ns/my}foo) must not override x:param (named my:foo)"
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+
+	<case name="x:variable must not override x:param (local variable overriding description param)">
+    call :run ..\bin\xspec.bat variable-overriding-param\local-variable\description-param.xspec
+    call :verify_retval 2
+    call :verify_line  4 x "ERROR: x:variable (named my:foo) must not override x:param (named Q{http://example.org/ns/my}foo)"
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+
+	<!--
 		Duplicate @position
 	-->
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2741,6 +2741,26 @@ load bats-helper
 }
 
 #
+# x:variable must not override x:param
+#
+
+@test "x:variable must not override x:param (global variable overriding description param)" {
+    run ../bin/xspec.sh variable-overriding-param/global-variable.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[3]}" = "ERROR: x:variable (named Q{http://example.org/ns/my}foo) must not override x:param (named my:foo)" ]
+    [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
+}
+
+@test "x:variable must not override x:param (local variable overriding description param)" {
+    run ../bin/xspec.sh variable-overriding-param/local-variable/description-param.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    [ "${lines[3]}" = "ERROR: x:variable (named my:foo) must not override x:param (named Q{http://example.org/ns/my}foo)" ]
+    [ "${lines[${#lines[@]}-1]}" = "*** Error compiling the test suite" ]
+}
+
+#
 # Duplicate @position
 #
 


### PR DESCRIPTION
With `@run-as="external"`, only `/x:description/x:param` is supposed to take effect in SUT. `x:variable` is not.
However, `x:variable` can override `x:param` and effectively go into SUT. For example:

With this stylesheet
```xslt
<?xml version="1.0" encoding="UTF-8"?>
<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">

	<xsl:param name="p" />
	<xsl:template name="get-p">
		<xsl:sequence select="$p" />
	</xsl:template>

	<xsl:param name="v" />
	<xsl:template name="get-v">
		<xsl:sequence select="$v" />
	</xsl:template>

</xsl:stylesheet>
```
and this XSpec
```xspec
<?xml version="1.0" encoding="UTF-8"?>
<x:description run-as="external" stylesheet="test.xsl"
	xmlns:x="http://www.jenitennison.com/xslt/xspec">

	<x:param name="p">global-p</x:param>
	<x:variable name="v">global-v</x:variable>

	<x:scenario label="test">
		<x:variable name="p">local-p</x:variable>
		<x:variable name="v">local-v</x:variable>

		<x:scenario label="$p">
			<x:call template="get-p" />
			<x:expect label="test" />
		</x:scenario>

		<x:scenario label="$v">
			<x:call template="get-v" />
			<x:expect label="test" />
		</x:scenario>
	</x:scenario>

</x:description>

```
- `get-p` returns `local-p`, not `global-p`, because `x:variable` overrides the value of `$p`.
- `get-v` returns `''`, because `x:variable` by itself does not take effect in SUT.

This behavior could be considered as "by design". (In that sense, #991 is already partially possible. 😀)
But I think it's confusing. So this pull request prohibits `x:variable` from overriding `/x:description/x:param`. With this change, the example above is terminated with an error:
```console
C:\xspec\test>..\bin\xspec.bat test.xspec
Creating Test Stylesheet...

ERROR: x:variable (named p) must not override x:param (named p)
...
*** Error compiling the test suite
```

Upon implementing #991, I'll extend this rule and prohibit `x:variable` from overriding `//x:scenario/x:param` as well.