### PR TITLE
test(schematron): test with SchXslt v1.6.2

### DIFF
--- a/test/schxslt/base-uri.xsl
+++ b/test/schxslt/base-uri.xsl
@@ -3,6 +3,6 @@
 	xmlns:test-with-schxslt="x-urn:test:test-with-schxslt"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	<xsl:variable as="xs:string" name="test-with-schxslt:base-uri"
-		select="xs:anyURI('https://github.com/schxslt/schxslt/raw/v1.5.2/core/src/main/resources/xslt/2.0/')"
+		select="xs:anyURI('https://github.com/schxslt/schxslt/raw/v1.6.2/core/src/main/resources/xslt/2.0/')"
 		static="yes" />
 </xsl:stylesheet>


### PR DESCRIPTION
Just update the SchXslt version used for testing.

Skip v1.6 and v1.6.1 due to these bugs:
- schxslt/schxslt#157
- schxslt/schxslt#158