### PR TITLE
refactor: required=yes for clarifying responsibility of some xsl:param

### DIFF
--- a/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
@@ -47,10 +47,10 @@
       Compile x:scenario.
    -->
    <xsl:template match="x:scenario" as="node()+" mode="local:compile-scenarios-or-expects">
-      <xsl:param name="pending" as="node()?" tunnel="yes" />
       <xsl:param name="apply" as="element(x:apply)?" tunnel="yes" />
-      <xsl:param name="call" as="element(x:call)?" tunnel="yes"/>
-      <xsl:param name="context" as="element(x:context)?" tunnel="yes"/>
+      <xsl:param name="call" as="element(x:call)?" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <!-- The new $pending. -->
       <xsl:variable name="new-pending" as="node()?" select="
@@ -167,10 +167,10 @@
 
       <!-- Dispatch to a language-specific (XSLT or XQuery) worker template -->
       <xsl:call-template name="x:compile-scenario">
-         <xsl:with-param name="pending"   select="$new-pending" tunnel="yes"/>
-         <xsl:with-param name="apply"     select="$new-apply"   tunnel="yes"/>
-         <xsl:with-param name="call"      select="$new-call"    tunnel="yes"/>
-         <xsl:with-param name="context"   select="$new-context" tunnel="yes"/>
+         <xsl:with-param name="apply" select="$new-apply" tunnel="yes" />
+         <xsl:with-param name="call" select="$new-call" tunnel="yes" />
+         <xsl:with-param name="context" select="$new-context" tunnel="yes" />
+         <xsl:with-param name="pending" select="$new-pending" tunnel="yes" />
       </xsl:call-template>
    </xsl:template>
 
@@ -178,16 +178,16 @@
       Compile x:expect.
    -->
    <xsl:template match="x:expect" as="node()+" mode="local:compile-scenarios-or-expects">
-      <xsl:param name="pending" as="node()?" tunnel="yes" />
-      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
       <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <!-- Dispatch to a language-specific (XSLT or XQuery) worker template -->
       <xsl:call-template name="x:compile-expect">
-         <xsl:with-param name="pending" tunnel="yes" select="
-             ( $pending, ancestor::x:scenario/@pending )[1]"/>
-         <xsl:with-param name="context" tunnel="yes" select="$context"/>
-         <xsl:with-param name="call"    tunnel="yes" select="$call"/>
+         <xsl:with-param name="call" select="$call" tunnel="yes" />
+         <xsl:with-param name="context" select="$context" tunnel="yes" />
+         <xsl:with-param name="pending" select="($pending, ancestor::x:scenario/@pending)[1]"
+            tunnel="yes" />
          <xsl:with-param name="param-uqnames" as="xs:string*">
             <xsl:if test="empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus)">
                <xsl:sequence select="$context ! x:known-UQName('x:context')" />

--- a/src/compiler/base/compile/compile-scenario.xsl
+++ b/src/compiler/base/compile/compile-scenario.xsl
@@ -24,7 +24,7 @@
    <xsl:template name="x:check-param-max-position" as="empty-sequence()">
       <xsl:context-item as="element(x:scenario)" use="required" />
 
-      <xsl:param name="call" as="element(x:call)?" tunnel="yes" />
+      <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
 
       <xsl:variable name="max-param-position" as="xs:integer?"
          select="max($call/x:param ! xs:integer(@position))" />

--- a/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
@@ -62,8 +62,8 @@
       Generate an invocation of the compiled x:expect
    -->
    <xsl:template match="x:expect" as="node()+" mode="local:invoke-compiled-scenarios-or-expects">
-      <xsl:param name="pending" as="node()?" tunnel="yes" />
-      <xsl:param name="context" as="element(x:context)?" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <!-- Dispatch to a language-specific (XSLT or XQuery) worker template -->
       <xsl:call-template name="x:invoke-compiled-current-scenario-or-expect">

--- a/src/compiler/xquery/compile/compile-expect.xsl
+++ b/src/compiler/xquery/compile/compile-expect.xsl
@@ -14,9 +14,9 @@
    <xsl:template name="x:compile-expect" as="node()+">
       <xsl:context-item as="element(x:expect)" use="required" />
 
-      <xsl:param name="pending" as="node()?"                         tunnel="yes" />
+      <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
       <!-- No $context for XQuery -->
-      <xsl:param name="call"    as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <!-- URIQualifiedNames of the parameters of the function being generated.
          Their order must be stable, because they are function parameters. -->

--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -13,10 +13,10 @@
    <xsl:template name="x:compile-scenario" as="node()+">
       <xsl:context-item as="element(x:scenario)" use="required" />
 
-      <xsl:param name="pending"   as="node()?"              tunnel="yes" />
       <!-- No $apply for XQuery -->
-      <xsl:param name="context"   as="element(x:context)?"  tunnel="yes" />
-      <xsl:param name="call"      as="element(x:call)?"     tunnel="yes" />
+      <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
          select="x:call/preceding-sibling::x:variable" />

--- a/src/compiler/xquery/invoke-compiled/invoke-compiled-current-scenario-or-expect.xsl
+++ b/src/compiler/xquery/invoke-compiled/invoke-compiled-current-scenario-or-expect.xsl
@@ -16,7 +16,7 @@
       <!-- URIQualifiedNames of the variables that will be passed as the parameters to the compiled
          x:scenario or x:expect being invoked.
          Their order must be stable, because they are passed to a function. -->
-      <xsl:param name="with-param-uqnames" as="xs:string*" />
+      <xsl:param name="with-param-uqnames" as="xs:string*" required="yes" />
 
       <xsl:param name="tunnel_variable-name-of-actual-result-report" as="xs:string?" tunnel="yes" />
 

--- a/src/compiler/xslt/compile/compile-expect.xsl
+++ b/src/compiler/xslt/compile/compile-expect.xsl
@@ -15,9 +15,9 @@
    <xsl:template name="x:compile-expect" as="element(xsl:template)">
       <xsl:context-item as="element(x:expect)" use="required" />
 
-      <xsl:param name="pending" as="node()?" tunnel="yes" />
-      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
       <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <!-- URIQualifiedNames of the (required) parameters of the template being generated -->
       <xsl:param name="param-uqnames" as="xs:string*" required="yes" />

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -15,10 +15,10 @@
    <xsl:template name="x:compile-scenario" as="element(xsl:template)+">
       <xsl:context-item as="element(x:scenario)" use="required" />
 
-      <xsl:param name="pending" as="node()?" tunnel="yes" />
-      <xsl:param name="apply" as="element(x:apply)?" tunnel="yes" />
-      <xsl:param name="call" as="element(x:call)?" tunnel="yes" />
-      <xsl:param name="context" as="element(x:context)?" tunnel="yes" />
+      <xsl:param name="apply" as="element(x:apply)?" required="yes" tunnel="yes" />
+      <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
+      <xsl:param name="pending" as="node()?" required="yes" tunnel="yes" />
 
       <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
          select="(x:call | x:context)/preceding-sibling::x:variable" />

--- a/src/compiler/xslt/external/transform-options.xsl
+++ b/src/compiler/xslt/external/transform-options.xsl
@@ -13,8 +13,8 @@
    <xsl:template name="x:transform-options" as="element(xsl:variable)">
       <xsl:context-item as="element(x:scenario)" use="required" />
 
-      <xsl:param name="call" as="element(x:call)?" tunnel="yes" />
-      <xsl:param name="context" as="element(x:context)?" tunnel="yes" />
+      <xsl:param name="call" as="element(x:call)?" required="yes" tunnel="yes" />
+      <xsl:param name="context" as="element(x:context)?" required="yes" tunnel="yes" />
 
       <variable name="{x:known-UQName('impl:transform-options')}" as="map({x:known-UQName('xs:string')}, item()*)">
          <map>

--- a/src/compiler/xslt/invoke-compiled/invoke-compiled-current-scenario-or-expect.xsl
+++ b/src/compiler/xslt/invoke-compiled/invoke-compiled-current-scenario-or-expect.xsl
@@ -15,7 +15,7 @@
       <!-- URIQualifiedNames of the variables that will be passed as the parameters to the compiled
          x:scenario or x:expect being invoked. Names and contents of the variables are passed
          through unchanged. -->
-      <xsl:param name="with-param-uqnames" as="xs:string*" />
+      <xsl:param name="with-param-uqnames" as="xs:string*" required="yes" />
 
       <xsl:element name="xsl:call-template" namespace="{$x:xsl-namespace}">
          <xsl:attribute name="name" select="x:known-UQName('x:' || @id)" />

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -420,8 +420,8 @@
    <xsl:template name="fmt:load-css" as="element()">
       <xsl:context-item use="absent" />
 
-      <xsl:param name="inline" as="xs:boolean" required="yes" />
-      <xsl:param name="uri" as="xs:string?" />
+      <xsl:param name="inline" as="xs:boolean" />
+      <xsl:param name="uri" as="xs:string?" required="yes" />
 
       <xsl:variable as="xs:string" name="uri" select="($uri, resolve-uri('test-report.css'))[1]" />
 

--- a/test/compile-xslt-tests.xspec
+++ b/test/compile-xslt-tests.xspec
@@ -31,7 +31,12 @@
 
    <t:scenario label="x:scenario[@label] transformed in x:compile-scenario template">
       <t:context href="compile-xslt-tests/compile-scenario.xspec" select="//t:scenario" />
-      <t:call template="t:compile-scenario" />
+      <t:call template="t:compile-scenario">
+         <t:param name="apply" as="empty-sequence()" tunnel="yes" />
+         <t:param name="call" as="empty-sequence()" tunnel="yes" />
+         <t:param name="context" as="empty-sequence()" tunnel="yes" />
+         <t:param name="pending" as="empty-sequence()" tunnel="yes" />
+      </t:call>
       <t:expect>
          <t:label>
             - is xsl:template
@@ -68,8 +73,9 @@
    <t:scenario label="x:expect[@test] transformed in x:compile-expect template">
       <t:context href="compile-xslt-tests/compile-expect.xspec" select="//t:expect" />
       <t:call template="t:compile-expect">
-         <t:param name="context" as="empty-sequence()" tunnel="yes" />
          <t:param name="call" as="empty-sequence()" tunnel="yes" />
+         <t:param name="context" as="empty-sequence()" tunnel="yes" />
+         <t:param name="pending" as="empty-sequence()" tunnel="yes" />
          <t:param name="param-uqnames" as="empty-sequence()" />
       </t:call>
       <t:expect label="is a template"


### PR DESCRIPTION
Add `required="yes"` to some `xsl:param` that may be empty. This clarifies who is responsible for creating the parameters.

This change is partly in preparation for #991.