### PR TITLE
refactor: pass handled variable declarations

### DIFF
--- a/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
@@ -81,7 +81,7 @@
       Handle variable declarations if they are not handled while compiling x:description or
       x:scenario
    -->
-   <xsl:template match="x:variable" as="node()*"
+   <xsl:template match="x:param | x:variable" as="node()*"
       mode="local:invoke-compiled-scenarios-or-expects">
       <!-- x:param and/or x:variable that have been already handled while compiling
          parent::x:description in x:main template or while compiling parent::x:scenario in

--- a/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
@@ -78,24 +78,19 @@
    </xsl:template>
 
    <!--
-      Handle local variable declarations if they are not preceding-siblings of x:call or x:context
+      Handle variable declarations if they are not handled while compiling x:description or
+      x:scenario
    -->
    <xsl:template match="x:variable" as="node()*"
       mode="local:invoke-compiled-scenarios-or-expects">
-      <xsl:choose>
-         <xsl:when test="parent::x:description">
-            <!-- This global variable declaration is handled in x:main template -->
-         </xsl:when>
+      <!-- x:param and/or x:variable that have been already handled while compiling
+         parent::x:description in x:main template or while compiling parent::x:scenario in
+         x:compile-scenario template. -->
+      <xsl:param name="tunnel_handled-vardecls" as="element()*" required="yes" tunnel="yes" />
 
-         <xsl:when test="following-sibling::x:call or following-sibling::x:context">
-            <!-- This local variable declaration is handled in x:compile-scenario template -->
-         </xsl:when>
-
-         <xsl:otherwise>
-            <!-- Declare now -->
-            <xsl:apply-templates select="." mode="x:declare-variable" />
-         </xsl:otherwise>
-      </xsl:choose>
+      <xsl:if test="not(. intersect $tunnel_handled-vardecls)">
+         <xsl:apply-templates select="." mode="x:declare-variable" />
+      </xsl:if>
    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -140,8 +140,7 @@
          </xsl:if>
 
          <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
-            <xsl:with-param name="tunnel_handled-vardecls" select="$local-preceding-vardecls"
-               tunnel="yes" />
+            <xsl:with-param name="handled-child-vardecls" select="$local-preceding-vardecls" />
             <xsl:with-param name="tunnel_variable-name-of-actual-result-report"
                select="$variable-name-of-actual-result-report" tunnel="yes" />
          </xsl:call-template>

--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -140,6 +140,8 @@
          </xsl:if>
 
          <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
+            <xsl:with-param name="tunnel_handled-vardecls" select="$local-preceding-vardecls"
+               tunnel="yes" />
             <xsl:with-param name="tunnel_variable-name-of-actual-result-report"
                select="$variable-name-of-actual-result-report" tunnel="yes" />
          </xsl:call-template>

--- a/src/compiler/xquery/main.xsl
+++ b/src/compiler/xquery/main.xsl
@@ -93,8 +93,8 @@
          </xsl:with-param>
       </xsl:call-template>
 
-      <!-- Compile global params and global variables. -->
-      <xsl:variable name="global-vardecls" as="element()*" select="x:param | x:variable" />
+      <!-- Compile global variables. (Global params are not supported: xspec/xspec#1325) -->
+      <xsl:variable name="global-vardecls" as="element(x:variable)*" select="x:variable" />
       <xsl:apply-templates select="$global-vardecls" mode="x:declare-variable" />
 
       <!-- Compile the top-level scenarios. -->

--- a/src/compiler/xquery/main.xsl
+++ b/src/compiler/xquery/main.xsl
@@ -127,7 +127,7 @@
       <!-- Generate invocations of the compiled top-level scenarios. -->
       <xsl:text>(: invoke each compiled top-level x:scenario :)&#x0A;</xsl:text>
       <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
-         <xsl:with-param name="tunnel_handled-vardecls" select="$global-vardecls" tunnel="yes" />
+         <xsl:with-param name="handled-child-vardecls" select="$global-vardecls" />
       </xsl:call-template>
 
       <!-- </x:report> -->

--- a/src/compiler/xquery/main.xsl
+++ b/src/compiler/xquery/main.xsl
@@ -94,7 +94,8 @@
       </xsl:call-template>
 
       <!-- Compile global params and global variables. -->
-      <xsl:apply-templates select="x:param | x:variable" mode="x:declare-variable" />
+      <xsl:variable name="global-vardecls" as="element()*" select="x:param | x:variable" />
+      <xsl:apply-templates select="$global-vardecls" mode="x:declare-variable" />
 
       <!-- Compile the top-level scenarios. -->
       <xsl:call-template name="x:compile-child-scenarios-or-expects" />
@@ -125,7 +126,9 @@
 
       <!-- Generate invocations of the compiled top-level scenarios. -->
       <xsl:text>(: invoke each compiled top-level x:scenario :)&#x0A;</xsl:text>
-      <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects" />
+      <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
+         <xsl:with-param name="tunnel_handled-vardecls" select="$global-vardecls" tunnel="yes" />
+      </xsl:call-template>
 
       <!-- </x:report> -->
       <xsl:text>}&#x0A;</xsl:text>

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -340,8 +340,7 @@
             </xsl:if>
 
             <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
-               <xsl:with-param name="tunnel_handled-vardecls" select="$local-preceding-vardecls"
-                  tunnel="yes" />
+               <xsl:with-param name="handled-child-vardecls" select="$local-preceding-vardecls" />
             </xsl:call-template>
 
          <!-- </x:scenario> -->

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -339,7 +339,10 @@
                <xsl:comment> invoke each compiled x:expect </xsl:comment>
             </xsl:if>
 
-            <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects" />
+            <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
+               <xsl:with-param name="tunnel_handled-vardecls" select="$local-preceding-vardecls"
+                  tunnel="yes" />
+            </xsl:call-template>
 
          <!-- </x:scenario> -->
          </xsl:element>

--- a/src/compiler/xslt/main.xsl
+++ b/src/compiler/xslt/main.xsl
@@ -69,7 +69,8 @@
          </variable>
 
          <!-- Compile global params and global variables. -->
-         <xsl:apply-templates select="x:param | x:variable" mode="x:declare-variable" />
+         <xsl:variable name="global-vardecls" as="element()*" select="x:param | x:variable" />
+         <xsl:apply-templates select="$global-vardecls" mode="x:declare-variable" />
 
          <xsl:if test="$is-external">
             <!-- If no $x:saxon-config is provided by global x:variable, declare a dummy one so that
@@ -160,7 +161,10 @@
 
                   <!-- Generate invocations of the compiled top-level scenarios. -->
                   <xsl:text>&#10;            </xsl:text><xsl:comment> invoke each compiled top-level x:scenario </xsl:comment>
-                  <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects" />
+                  <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
+                     <xsl:with-param name="tunnel_handled-vardecls" select="$global-vardecls"
+                        tunnel="yes" />
+                  </xsl:call-template>
                </xsl:element>
             </xsl:element>
          </xsl:element>

--- a/src/compiler/xslt/main.xsl
+++ b/src/compiler/xslt/main.xsl
@@ -162,8 +162,7 @@
                   <!-- Generate invocations of the compiled top-level scenarios. -->
                   <xsl:text>&#10;            </xsl:text><xsl:comment> invoke each compiled top-level x:scenario </xsl:comment>
                   <xsl:call-template name="x:invoke-compiled-child-scenarios-or-expects">
-                     <xsl:with-param name="tunnel_handled-vardecls" select="$global-vardecls"
-                        tunnel="yes" />
+                     <xsl:with-param name="handled-child-vardecls" select="$global-vardecls" />
                   </xsl:call-template>
                </xsl:element>
             </xsl:element>


### PR DESCRIPTION
Pass the handled `x:param | x:variable` to the `x:invoke-compiled-child-scenarios-or-expects` template so that the `local:invoke-compiled-scenarios-or-expects` mode can forget about the logic behind selecting `x:param | x:variable`.

This change is partly in preparation for #991.