### PR TITLE
fix: search only x:scenario for attribute(focus)

### DIFF
--- a/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
@@ -14,7 +14,8 @@
       <!-- Context item is x:description or x:scenario -->
       <xsl:context-item as="element()" use="required" />
 
-      <xsl:param name="pending" as="node()?" select="(.//@focus)[1]" tunnel="yes"/>
+      <xsl:param name="pending" as="node()?"
+         select="descendant-or-self::x:scenario[@focus][1]/@focus" tunnel="yes" />
 
       <xsl:variable name="this" select="." as="element()"/>
       <xsl:if test="empty($this[self::x:description|self::x:scenario])">
@@ -189,7 +190,7 @@
          <xsl:with-param name="pending" select="($pending, ancestor::x:scenario/@pending)[1]"
             tunnel="yes" />
          <xsl:with-param name="param-uqnames" as="xs:string*">
-            <xsl:if test="empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus)">
+            <xsl:if test="empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::x:scenario/@focus)">
                <xsl:sequence select="$context ! x:known-UQName('x:context')" />
                <xsl:sequence select="x:known-UQName('x:result')" />
             </xsl:if>

--- a/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/invoke-compiled/invoke-compiled-child-scenarios-or-expects.xsl
@@ -18,7 +18,8 @@
 
       <!-- Default value of $pending does not affect compiler output but is here if needed in the
          future -->
-      <xsl:param name="pending" select="(.//@focus)[1]" tunnel="yes" as="node()?"/>
+      <xsl:param name="pending" as="node()?"
+         select="descendant-or-self::x:scenario[@focus][1]/@focus" tunnel="yes" />
 
       <xsl:variable name="this" select="." as="element()"/>
       <xsl:if test="empty($this[self::x:description|self::x:scenario])">
@@ -68,7 +69,7 @@
       <!-- Dispatch to a language-specific (XSLT or XQuery) worker template -->
       <xsl:call-template name="x:invoke-compiled-current-scenario-or-expect">
          <xsl:with-param name="with-param-uqnames" as="xs:string*">
-            <xsl:if test="empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus)">
+            <xsl:if test="empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::x:scenario/@focus)">
                <xsl:sequence select="$context ! x:known-UQName('x:context')" />
                <xsl:sequence select="x:known-UQName('x:result')" />
             </xsl:if>

--- a/src/compiler/base/util/compiler-misc-utils.xsl
+++ b/src/compiler/base/util/compiler-misc-utils.xsl
@@ -16,6 +16,7 @@
    </xsl:function>
 
    <xsl:function name="x:pending-attribute-from-pending-node" as="attribute(pending)">
+      <!-- @pending, x:pending or @focus -->
       <xsl:param name="pending-node" as="node()" />
 
       <xsl:attribute name="pending" select="$pending-node" />

--- a/src/compiler/xquery/compile/compile-expect.xsl
+++ b/src/compiler/xquery/compile/compile-expect.xsl
@@ -23,7 +23,7 @@
       <xsl:param name="param-uqnames" as="xs:string*" required="yes" />
 
       <xsl:variable name="pending-p" as="xs:boolean"
-         select="exists($pending) and empty(ancestor::*/@focus)" />
+         select="exists($pending) and empty(ancestor::x:scenario/@focus)" />
 
       <!--
         declare function local:...($t:result as item()*)

--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -21,7 +21,7 @@
       <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
          select="x:call/preceding-sibling::x:variable" />
       <xsl:variable name="pending-p" as="xs:boolean"
-         select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
+         select="exists($pending) and empty(ancestor-or-self::x:scenario/@focus)" />
       <xsl:variable name="run-sut-now" as="xs:boolean" select="not($pending-p) and x:expect" />
 
       <xsl:if test="$context">

--- a/src/compiler/xquery/declare-variable/declare-variable.xsl
+++ b/src/compiler/xquery/declare-variable/declare-variable.xsl
@@ -17,7 +17,7 @@
    <xsl:mode name="x:declare-variable" on-multiple-match="fail" on-no-match="fail" />
 
    <xsl:template match="element()" as="node()+" mode="x:declare-variable">
-      <!-- Reflects @pending or x:pending -->
+      <!-- Reflects @pending, x:pending or @focus -->
       <xsl:param name="pending" as="node()?" tunnel="yes" />
 
       <xsl:param name="comment" as="xs:string?" />

--- a/src/compiler/xquery/declare-variable/declare-variable.xsl
+++ b/src/compiler/xquery/declare-variable/declare-variable.xsl
@@ -31,7 +31,7 @@
       <!-- True if the variable being declared is considered pending -->
       <xsl:variable name="is-pending" as="xs:boolean"
          select="self::x:variable
-            and not(empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus))" />
+            and not(empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::x:scenario/@focus))" />
 
       <!-- Child nodes to be excluded -->
       <xsl:variable name="exclude" as="element(x:label)?"

--- a/src/compiler/xslt/compile/compile-expect.xsl
+++ b/src/compiler/xslt/compile/compile-expect.xsl
@@ -23,7 +23,7 @@
       <xsl:param name="param-uqnames" as="xs:string*" required="yes" />
 
       <xsl:variable name="pending-p" as="xs:boolean"
-         select="exists($pending) and empty(ancestor::*/@focus)" />
+         select="exists($pending) and empty(ancestor::x:scenario/@focus)" />
 
       <xsl:element name="xsl:template" namespace="{$x:xsl-namespace}">
          <xsl:attribute name="name" select="x:known-UQName('x:' || @id)" />

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -23,7 +23,7 @@
       <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
          select="(x:call | x:context)/preceding-sibling::x:variable" />
       <xsl:variable name="pending-p" as="xs:boolean"
-         select="exists($pending) and empty(ancestor-or-self::*/@focus)" />
+         select="exists($pending) and empty(ancestor-or-self::x:scenario/@focus)" />
       <xsl:variable name="run-sut-now" as="xs:boolean" select="not($pending-p) and x:expect" />
 
       <!-- We have to create these error messages at this stage because before now

--- a/src/compiler/xslt/declare-variable/declare-variable.xsl
+++ b/src/compiler/xslt/declare-variable/declare-variable.xsl
@@ -30,7 +30,7 @@
       <!-- True if the variable being declared is considered pending -->
       <xsl:variable name="is-pending" as="xs:boolean"
          select="self::x:variable
-            and not(empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::*/@focus))" />
+            and not(empty($pending|ancestor::x:scenario/@pending) or exists(ancestor::x:scenario/@focus))" />
 
       <!-- Child nodes to be excluded -->
       <xsl:variable name="exclude" as="element()*"

--- a/src/compiler/xslt/declare-variable/declare-variable.xsl
+++ b/src/compiler/xslt/declare-variable/declare-variable.xsl
@@ -19,7 +19,7 @@
    <xsl:mode name="x:declare-variable" on-multiple-match="fail" on-no-match="fail" />
 
    <xsl:template match="element()" as="element()+" mode="x:declare-variable">
-      <!-- Reflects @pending or x:pending -->
+      <!-- Reflects @pending, x:pending or @focus -->
       <xsl:param name="pending" as="node()?" tunnel="yes" />
 
       <xsl:param name="comment" as="xs:string?" />

--- a/test/end-to-end/cases/expected/query/issue-1340-junit.xml
+++ b/test/end-to-end/cases/expected/query/issue-1340-junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="issue-1340.xspec">
+   <testsuite name="Scenario containing no @focus whatsoever"
+              tests="1"
+              failures="0">
+      <testcase name="should be active" status="skipped">
+         <skipped>bar</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="Scenario containing @focus in user-content"
+              tests="1"
+              failures="0">
+      <testcase name="should be active" status="skipped">
+         <skipped>bar</skipped>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/issue-1340-junit.xml
+++ b/test/end-to-end/cases/expected/query/issue-1340-junit.xml
@@ -2,16 +2,16 @@
 <testsuites name="issue-1340.xspec">
    <testsuite name="Scenario containing no @focus whatsoever"
               tests="1"
-              failures="0">
-      <testcase name="should be active" status="skipped">
-         <skipped>bar</skipped>
+              failures="1">
+      <testcase name="should be active" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
       </testcase>
    </testsuite>
    <testsuite name="Scenario containing @focus in user-content"
               tests="1"
-              failures="0">
-      <testcase name="should be active" status="skipped">
-         <skipped>bar</skipped>
+              failures="1">
+      <testcase name="should be active" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
       </testcase>
    </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: x-urn:test:do-nothing</p>
+      <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
+      <p>XSpec: <a href="../../issue-1340.xspec">issue-1340.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 2</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 2</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="pending">
+               <th>(<strong>bar</strong>) <a>Scenario containing no @focus whatsoever</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="pending">
+               <th>(<strong>bar</strong>) <a>Scenario containing @focus in user-content</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,27 +23,118 @@
             <tr>
                <th></th>
                <th class="totals">passed: 0</th>
-               <th class="totals">pending: 2</th>
-               <th class="totals">failed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 2</th>
                <th class="totals">total: 2</th>
             </tr>
          </thead>
          <tbody>
-            <tr class="pending">
-               <th>(<strong>bar</strong>) <a>Scenario containing no @focus whatsoever</a></th>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Scenario containing no @focus whatsoever</a></th>
+               <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
-               <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
-            <tr class="pending">
-               <th>(<strong>bar</strong>) <a>Scenario containing @focus in user-content</a></th>
+            <tr class="failed">
+               <th><a href="#top_scenario2">Scenario containing @focus in user-content</a></th>
+               <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
-               <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
          </tbody>
       </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Scenario containing no @focus whatsoever<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Scenario containing no @focus whatsoever</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">should be active</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Scenario containing no @focus whatsoever</h3>
+            <div id="scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">should be active</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">Scenario containing @focus in user-content<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Scenario containing @focus in user-content</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">should be active</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>Scenario containing @focus in user-content</h3>
+            <div id="scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">should be active</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
+     <span class="diff">focus</span>=<span class="diff">"bar"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.xml
@@ -4,7 +4,7 @@
         query="x-urn:test:do-nothing"
         query-at="../../../../do-nothing.xqm"
         date="2000-01-01T00:00:00Z">
-   <scenario id="scenario1" xspec="../../issue-1340.xspec" pending="bar">
+   <scenario id="scenario1" xspec="../../issue-1340.xspec">
       <label>Scenario containing no @focus whatsoever</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
@@ -13,11 +13,17 @@
             </x:param>
          </x:call>
       </input-wrap>
-      <test id="scenario1-expect1" pending="bar">
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <foo xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="false">
          <label>should be active</label>
+         <expect select="()"/>
       </test>
    </scenario>
-   <scenario id="scenario2" xspec="../../issue-1340.xspec" pending="bar">
+   <scenario id="scenario2" xspec="../../issue-1340.xspec">
       <label>Scenario containing @focus in user-content</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
@@ -26,8 +32,14 @@
             </x:param>
          </x:call>
       </input-wrap>
-      <test id="scenario2-expect1" pending="bar">
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" focus="bar"/>
+         </content-wrap>
+      </result>
+      <test id="scenario2-expect1" successful="false">
          <label>should be active</label>
+         <expect select="()"/>
       </test>
    </scenario>
 </report>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-1340.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../issue-1340.xspec" pending="bar">
+      <label>Scenario containing no @focus whatsoever</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
+            <x:param>
+               <foo/>
+            </x:param>
+         </x:call>
+      </input-wrap>
+      <test id="scenario1-expect1" pending="bar">
+         <label>should be active</label>
+      </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../issue-1340.xspec" pending="bar">
+      <label>Scenario containing @focus in user-content</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
+            <x:param>
+               <foo focus="bar"/>
+            </x:param>
+         </x:call>
+      </input-wrap>
+      <test id="scenario2-expect1" pending="bar">
+         <label>should be active</label>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="issue-1340.xspec">
+   <testsuite name="Scenario containing no @focus whatsoever"
+              tests="1"
+              failures="0">
+      <testcase name="should be active" status="skipped">
+         <skipped>bar</skipped>
+      </testcase>
+   </testsuite>
+   <testsuite name="Scenario containing @focus in user-content"
+              tests="1"
+              failures="0">
+      <testcase name="should be active" status="skipped">
+         <skipped>bar</skipped>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-junit.xml
@@ -2,16 +2,16 @@
 <testsuites name="issue-1340.xspec">
    <testsuite name="Scenario containing no @focus whatsoever"
               tests="1"
-              failures="0">
-      <testcase name="should be active" status="skipped">
-         <skipped>bar</skipped>
+              failures="1">
+      <testcase name="should be active" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
       </testcase>
    </testsuite>
    <testsuite name="Scenario containing @focus in user-content"
               tests="1"
-              failures="0">
-      <testcase name="should be active" status="skipped">
-         <skipped>bar</skipped>
+              failures="1">
+      <testcase name="should be active" status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
       </testcase>
    </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -22,27 +22,118 @@
             <tr>
                <th></th>
                <th class="totals">passed: 0</th>
-               <th class="totals">pending: 2</th>
-               <th class="totals">failed: 0</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 2</th>
                <th class="totals">total: 2</th>
             </tr>
          </thead>
          <tbody>
-            <tr class="pending">
-               <th>(<strong>bar</strong>) <a>Scenario containing no @focus whatsoever</a></th>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Scenario containing no @focus whatsoever</a></th>
+               <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
-               <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
-            <tr class="pending">
-               <th>(<strong>bar</strong>) <a>Scenario containing @focus in user-content</a></th>
+            <tr class="failed">
+               <th><a href="#top_scenario2">Scenario containing @focus in user-content</a></th>
+               <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
-               <th class="totals">0</th>
                <th class="totals">1</th>
             </tr>
          </tbody>
       </table>
+      <div id="top_scenario1">
+         <h2 class="failed">Scenario containing no @focus whatsoever<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Scenario containing no @focus whatsoever</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-expect1">should be active</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1">
+            <h3>Scenario containing no @focus whatsoever</h3>
+            <div id="scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">should be active</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="failed">Scenario containing @focus in user-content<span class="scenario-totals">passed: 0 / pending: 0 / failed: 1 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="failed">
+                  <th>Scenario containing @focus in user-content</th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-expect1">should be active</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2">
+            <h3>Scenario containing @focus in user-content</h3>
+            <div id="scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">should be active</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <p>XPath <code class="diff">/element()</code> from:</p>
+                           <pre>&lt;<span class="diff">foo</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>
+     <span class="diff">focus</span>=<span class="diff">"bar"</span> /&gt;</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>XSpec: <a href="../../issue-1340.xspec">issue-1340.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 0</th>
+               <th class="totals">pending: 2</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 2</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="pending">
+               <th>(<strong>bar</strong>) <a>Scenario containing no @focus whatsoever</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="pending">
+               <th>(<strong>bar</strong>) <a>Scenario containing @focus in user-content</a></th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-1340.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../issue-1340.xspec" pending="bar">
+      <label>Scenario containing no @focus whatsoever</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
+            <x:param>
+               <foo/>
+            </x:param>
+         </x:call>
+      </input-wrap>
+      <test id="scenario1-expect1" pending="bar">
+         <label>should be active</label>
+      </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../issue-1340.xspec" pending="bar">
+      <label>Scenario containing @focus in user-content</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
+            <x:param>
+               <foo focus="bar"/>
+            </x:param>
+         </x:call>
+      </input-wrap>
+      <test id="scenario2-expect1" pending="bar">
+         <label>should be active</label>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.xml
@@ -3,7 +3,7 @@
         xspec="../../issue-1340.xspec"
         stylesheet="../../../../do-nothing.xsl"
         date="2000-01-01T00:00:00Z">
-   <scenario id="scenario1" xspec="../../issue-1340.xspec" pending="bar">
+   <scenario id="scenario1" xspec="../../issue-1340.xspec">
       <label>Scenario containing no @focus whatsoever</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
@@ -12,11 +12,17 @@
             </x:param>
          </x:call>
       </input-wrap>
-      <test id="scenario1-expect1" pending="bar">
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <foo xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="false">
          <label>should be active</label>
+         <expect select="()"/>
       </test>
    </scenario>
-   <scenario id="scenario2" xspec="../../issue-1340.xspec" pending="bar">
+   <scenario id="scenario2" xspec="../../issue-1340.xspec">
       <label>Scenario containing @focus in user-content</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="exactly-one">
@@ -25,8 +31,14 @@
             </x:param>
          </x:call>
       </input-wrap>
-      <test id="scenario2-expect1" pending="bar">
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" focus="bar"/>
+         </content-wrap>
+      </result>
+      <test id="scenario2-expect1" successful="false">
          <label>should be active</label>
+         <expect select="()"/>
       </test>
    </scenario>
 </report>

--- a/test/end-to-end/cases/issue-1340.xspec
+++ b/test/end-to-end/cases/issue-1340.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm" stylesheet="do-nothing.xsl"
+	xml:base="../../" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="Scenario containing no @focus whatsoever">
+		<x:call function="exactly-one">
+			<x:param>
+				<foo />
+			</x:param>
+		</x:call>
+		<x:expect label="should be active" />
+	</x:scenario>
+
+	<x:scenario label="Scenario containing @focus in user-content">
+		<x:call function="exactly-one">
+			<x:param>
+				<foo focus="bar" />
+			</x:param>
+		</x:call>
+		<x:expect label="should be active" />
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Fixes #1340 

XSpec compiler searches any elements for `@focus` when it should have searched only `x:scenario`. This pull request fixes it.