### PR TITLE
refactor: remove unused branch from deep-equal-v1()

### DIFF
--- a/src/common/deep-equal.xqm
+++ b/src/common/deep-equal.xqm
@@ -39,7 +39,6 @@ declare %private function deq:deep-equal-v1(
           case xs:string  return $seq2-string
           case xs:double  return $seq2-string[. castable as xs:double]  => xs:double()
           case xs:decimal return $seq2-string[. castable as xs:decimal] => xs:decimal()
-          case xs:integer return $seq2-string[. castable as xs:integer] => xs:integer()
           default         return ()
     else
       ()

--- a/src/common/deep-equal.xsl
+++ b/src/common/deep-equal.xsl
@@ -108,9 +108,6 @@
                <xsl:when test="$seq1 instance of xs:decimal">
                   <xsl:sequence select="$seq2-string[. castable as xs:decimal] => xs:decimal()" />
                </xsl:when>
-               <xsl:when test="$seq1 instance of xs:integer">
-                  <xsl:sequence select="$seq2-string[. castable as xs:integer] => xs:integer()" />
-               </xsl:when>
             </xsl:choose>
          </xsl:if>
       </xsl:variable>


### PR DESCRIPTION
The 4th branch in `deep-equal-v1()` is never fired, because `$seq1[. instance of xs:integer]` enters the 3rd branch (`xs:decimal`). This pull request removes the unused 4th branch.