### PR TITLE
test: use $myv:test-data in variable.xspec

### DIFF
--- a/test/variable.xspec
+++ b/test/variable.xspec
@@ -19,8 +19,13 @@
 
 	<!-- Variables used only in this test file are in a dedicated namespace to prevent conflict with
 	 global parameters or global variables in the file to be tested. -->
+
 	<x:variable name="myv:test-data" href="variable.xml"/>
-	<x:variable name="myv:test-string" select="'global'"/>
+	<x:variable name="myv:test-string" select="
+			if ((:Global variables can use preceding-sibling variables:) $myv:test-data) then
+				'global'
+			else
+				()" />
 
 	<x:scenario label="Variables can be defined in different ways.">
 		<x:scenario label="@select by itself">


### PR DESCRIPTION
`$myv:test-data` in `test/variable.xspec` is not used.
In its initial commit (76c9ac59cafc54d5ca1b0baa0edb9a4b83d5e933), `$myv:test-data` seems to test referencing a global variable from another global variable. So this pull request just adds a reference from `$myv:test-string` to `$myv:test-data`.