### PR TITLE
refactor: use predicate for selecting $local-preceding-vardecls

### DIFF
--- a/src/compiler/xquery/compile/compile-scenario.xsl
+++ b/src/compiler/xquery/compile/compile-scenario.xsl
@@ -21,7 +21,7 @@
       <xsl:param name="run-sut-now" as="xs:boolean" required="yes" />
 
       <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
-         select="x:call/preceding-sibling::x:variable" />
+         select="x:variable[following-sibling::x:call]" />
 
       <xsl:if test="$context">
          <xsl:call-template name="x:diag-compiling-scenario">

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -22,8 +22,8 @@
       <xsl:param name="pending-p" as="xs:boolean" required="yes" />
       <xsl:param name="run-sut-now" as="xs:boolean" required="yes" />
 
-      <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*"
-         select="(x:call | x:context)/preceding-sibling::x:variable" />
+      <xsl:variable name="local-preceding-vardecls" as="element(x:variable)*" select="
+            x:variable[following-sibling::x:call or following-sibling::x:context]" />
 
       <!-- We have to create these error messages at this stage because before now
          we didn't have merged versions of the environment -->

--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -147,10 +147,9 @@
                   </xsl:when>
 
                   <xsl:when test=". intersect $local-preceding-vardecls">
-                     <!-- Handle local variable declarations that are preceding-siblings of x:call
-                        or x:context. The other local variable declarations are handled in
-                        mode="local:invoke-compiled-scenarios-or-expects" in
-                        invoke-compiled-child-scenarios-or-expects.xsl. -->
+                     <!-- Handle local preceding variable declarations. The other local variable
+                        declarations are handled in mode="local:invoke-compiled-scenarios-or-expects"
+                        in invoke-compiled-child-scenarios-or-expects.xsl. -->
                      <xsl:apply-templates select="." mode="x:declare-variable" />
                   </xsl:when>
 


### PR DESCRIPTION
Small refactoring about `$local-preceding-vardecls` in `compile-scenario.xsl`.
This is meant to reduce noise in the upcoming pr for #991.