### PR TITLE
test(xslt): verify stylesheet line ending in testing issue 793

### DIFF
--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-junit.xml
@@ -3,4 +3,18 @@
    <testsuite name="input" tests="1" failures="0">
       <testcase name="output" status="passed"/>
    </testsuite>
+   <testsuite name="verify line ending" tests="3" failures="3">
+      <testcase name="contains any CR (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains any LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains CR followed by LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for issue-793-cr.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <title>Test Report for issue-793-cr.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,8 +23,8 @@
                <th></th>
                <th class="totals">passed: 1</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 0</th>
-               <th class="totals">total: 1</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 4</th>
             </tr>
          </thead>
          <tbody>
@@ -34,6 +34,13 @@
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">verify line ending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">3</th>
+               <th class="totals">3</th>
             </tr>
          </tbody>
       </table>
@@ -55,6 +62,120 @@
                </tr>
             </tbody>
          </table>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="successful">verify line ending<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>verify line ending</th>
+                  <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario1">contains any CR</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario1-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario2">contains any LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario2-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario3">contains CR followed by LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario3-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2-scenario1">
+            <h3>verify line ending contains any CR</h3>
+            <div id="scenario2-scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario2">
+            <h3>verify line ending contains any LF</h3>
+            <div id="scenario2-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario3">
+            <h3>verify line ending contains CR followed by LF</h3>
+            <div id="scenario2-scenario3-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.xml
@@ -3,7 +3,7 @@
         xspec="../../issue-793-cr.xspec"
         stylesheet="../../issue-793-cr.xsl"
         date="2000-01-01T00:00:00Z">
-   <scenario id="scenario1" xspec="../../issue-793-cr.xspec">
+   <scenario id="scenario1" xspec="../../issue-793-lf.xspec">
       <label>input</label>
       <input-wrap xmlns="">
          <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -27,5 +27,52 @@ test
             </content-wrap>
          </expect>
       </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../issue-793-lf.xspec">
+      <label>verify line ending</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="matches">
+            <x:param select="     doc($x:xspec-uri)/x:description/resolve-uri(@stylesheet, base-uri())     =&gt; unparsed-text()"/>
+         </x:call>
+      </input-wrap>
+      <scenario id="scenario2-scenario1" xspec="../../issue-793-lf.xspec">
+         <label>contains any CR</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>
+         <test id="scenario2-scenario1-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario2" xspec="../../issue-793-lf.xspec">
+         <label>contains any LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+         <test id="scenario2-scenario2-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario3" xspec="../../issue-793-lf.xspec">
+         <label>contains CR followed by LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+         <test id="scenario2-scenario3-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
    </scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-junit.xml
@@ -3,4 +3,18 @@
    <testsuite name="input" tests="1" failures="0">
       <testcase name="output" status="passed"/>
    </testsuite>
+   <testsuite name="verify line ending" tests="3" failures="3">
+      <testcase name="contains any CR (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains any LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains CR followed by LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for issue-793-crlf.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <title>Test Report for issue-793-crlf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,8 +23,8 @@
                <th></th>
                <th class="totals">passed: 1</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 0</th>
-               <th class="totals">total: 1</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 4</th>
             </tr>
          </thead>
          <tbody>
@@ -34,6 +34,13 @@
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">verify line ending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">3</th>
+               <th class="totals">3</th>
             </tr>
          </tbody>
       </table>
@@ -55,6 +62,120 @@
                </tr>
             </tbody>
          </table>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="successful">verify line ending<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>verify line ending</th>
+                  <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario1">contains any CR</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario1-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario2">contains any LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario2-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario3">contains CR followed by LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario3-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2-scenario1">
+            <h3>verify line ending contains any CR</h3>
+            <div id="scenario2-scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario2">
+            <h3>verify line ending contains any LF</h3>
+            <div id="scenario2-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario3">
+            <h3>verify line ending contains CR followed by LF</h3>
+            <div id="scenario2-scenario3-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.xml
@@ -3,7 +3,7 @@
         xspec="../../issue-793-crlf.xspec"
         stylesheet="../../issue-793-crlf.xsl"
         date="2000-01-01T00:00:00Z">
-   <scenario id="scenario1" xspec="../../issue-793-crlf.xspec">
+   <scenario id="scenario1" xspec="../../issue-793-lf.xspec">
       <label>input</label>
       <input-wrap xmlns="">
          <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -27,5 +27,52 @@ test
             </content-wrap>
          </expect>
       </test>
+   </scenario>
+   <scenario id="scenario2" xspec="../../issue-793-lf.xspec">
+      <label>verify line ending</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="matches">
+            <x:param select="     doc($x:xspec-uri)/x:description/resolve-uri(@stylesheet, base-uri())     =&gt; unparsed-text()"/>
+         </x:call>
+      </input-wrap>
+      <scenario id="scenario2-scenario1" xspec="../../issue-793-lf.xspec">
+         <label>contains any CR</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>
+         <test id="scenario2-scenario1-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario2" xspec="../../issue-793-lf.xspec">
+         <label>contains any LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>
+         <test id="scenario2-scenario2-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario3" xspec="../../issue-793-lf.xspec">
+         <label>contains CR followed by LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>
+         <test id="scenario2-scenario3-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
    </scenario>
 </report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-junit.xml
@@ -3,4 +3,18 @@
    <testsuite name="input" tests="1" failures="0">
       <testcase name="output" status="passed"/>
    </testsuite>
+   <testsuite name="verify line ending" tests="3" failures="3">
+      <testcase name="contains any CR (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains any LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+      <testcase name="contains CR followed by LF (fail deliberately to see the result)"
+                status="failed">
+         <failure message="expect assertion failed">Expected Result: ()</failure>
+      </testcase>
+   </testsuite>
 </testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for issue-793-lf.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <title>Test Report for issue-793-lf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>
@@ -23,8 +23,8 @@
                <th></th>
                <th class="totals">passed: 1</th>
                <th class="totals">pending: 0</th>
-               <th class="totals">failed: 0</th>
-               <th class="totals">total: 1</th>
+               <th class="totals">failed: 3</th>
+               <th class="totals">total: 4</th>
             </tr>
          </thead>
          <tbody>
@@ -34,6 +34,13 @@
                <th class="totals">0</th>
                <th class="totals">0</th>
                <th class="totals">1</th>
+            </tr>
+            <tr class="failed">
+               <th><a href="#top_scenario2">verify line ending</a></th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">3</th>
+               <th class="totals">3</th>
             </tr>
          </tbody>
       </table>
@@ -55,6 +62,120 @@
                </tr>
             </tbody>
          </table>
+      </div>
+      <div id="top_scenario2">
+         <h2 class="successful">verify line ending<span class="scenario-totals">passed: 0 / pending: 0 / failed: 3 / total: 3</span></h2>
+         <table class="xspec" id="table_scenario2">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>verify line ending</th>
+                  <th>passed: 0 / pending: 0 / failed: 3 / total: 3</th>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario1">contains any CR</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario1-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario2">contains any LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario2-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario2-scenario3">contains CR followed by LF</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario2-scenario3-expect1">(fail deliberately to see the result)</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario2-scenario1">
+            <h3>verify line ending contains any CR</h3>
+            <div id="scenario2-scenario1-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario2">
+            <h3>verify line ending contains any LF</h3>
+            <div id="scenario2-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('true')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario2-scenario3">
+            <h3>verify line ending contains CR followed by LF</h3>
+            <div id="scenario2-scenario3-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">(fail deliberately to see the result)</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expected Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>Q{http://www.w3.org/2001/XMLSchema}boolean('false')</pre>
+                        </td>
+                        <td>
+                           <pre>()</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.xml
@@ -28,4 +28,51 @@ test
          </expect>
       </test>
    </scenario>
+   <scenario id="scenario2" xspec="../../issue-793-lf.xspec">
+      <label>verify line ending</label>
+      <input-wrap xmlns="">
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec" function="matches">
+            <x:param select="     doc($x:xspec-uri)/x:description/resolve-uri(@stylesheet, base-uri())     =&gt; unparsed-text()"/>
+         </x:call>
+      </input-wrap>
+      <scenario id="scenario2-scenario1" xspec="../../issue-793-lf.xspec">
+         <label>contains any CR</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+         <test id="scenario2-scenario1-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario2" xspec="../../issue-793-lf.xspec">
+         <label>contains any LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>
+         <test id="scenario2-scenario2-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario2-scenario3" xspec="../../issue-793-lf.xspec">
+         <label>contains CR followed by LF</label>
+         <input-wrap xmlns="">
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:param position="2" select="'\r\n'"/>
+            </x:call>
+         </input-wrap>
+         <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('false')"/>
+         <test id="scenario2-scenario3-expect1" successful="false">
+            <label>(fail deliberately to see the result)</label>
+            <expect select="()"/>
+         </test>
+      </scenario>
+   </scenario>
 </report>

--- a/test/end-to-end/cases/issue-793-cr.xspec
+++ b/test/end-to-end/cases/issue-793-cr.xspec
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test enable-coverage?>
 <x:description stylesheet="issue-793-cr.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="input">
-		<x:context>
-			<input />
-		</x:context>
-		<x:expect label="output">
-			<output><![CDATA[
-test
-]]></output>
-		</x:expect>
-	</x:scenario>
+	<x:import href="issue-793-lf.xspec" />
 </x:description>

--- a/test/end-to-end/cases/issue-793-crlf.xspec
+++ b/test/end-to-end/cases/issue-793-crlf.xspec
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test enable-coverage?>
 <x:description stylesheet="issue-793-crlf.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="input">
-		<x:context>
-			<input />
-		</x:context>
-		<x:expect label="output">
-			<output><![CDATA[
-test
-]]></output>
-		</x:expect>
-	</x:scenario>
+	<x:import href="issue-793-lf.xspec" />
 </x:description>

--- a/test/end-to-end/cases/issue-793-lf.xspec
+++ b/test/end-to-end/cases/issue-793-lf.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test enable-coverage?>
 <x:description stylesheet="issue-793-lf.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
 	<x:scenario label="input">
 		<x:context>
 			<input />
@@ -11,4 +12,34 @@ test
 ]]></output>
 		</x:expect>
 	</x:scenario>
+
+	<x:scenario label="verify line ending">
+		<x:call function="matches">
+			<x:param select="
+				doc($x:xspec-uri)/x:description/resolve-uri(@stylesheet, base-uri())
+				=> unparsed-text()" />
+		</x:call>
+
+		<x:scenario label="contains any CR">
+			<x:call>
+				<x:param position="2" select="'\r'" />
+			</x:call>
+			<x:expect label="(fail deliberately to see the result)" />
+		</x:scenario>
+
+		<x:scenario label="contains any LF">
+			<x:call>
+				<x:param position="2" select="'\n'" />
+			</x:call>
+			<x:expect label="(fail deliberately to see the result)" />
+		</x:scenario>
+
+		<x:scenario label="contains CR followed by LF">
+			<x:call>
+				<x:param position="2" select="'\r\n'" />
+			</x:call>
+			<x:expect label="(fail deliberately to see the result)" />
+		</x:scenario>
+	</x:scenario>
+
 </x:description>


### PR DESCRIPTION
`issue-793-cr.xsl` must have CR line ending, but Git sees the file as a binary file and therefore its line ending is prone to be broken.
This pr adds some scenarios for inspecting the line ending of the stylesheet being tested.
