### PR TITLE
test(schematron): safer attribute(location) in xspec-sch.xspec

### DIFF
--- a/test/xspec-sch.xspec
+++ b/test/xspec-sch.xspec
@@ -13,7 +13,7 @@
 		<x:scenario label="XSLT and XQuery">
 			<x:context href="ws-only-text.xspec" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="function-param"
-				location="/x:description/x:scenario[1]/x:scenario[1]/x:call/x:param/span/text()" />
+				location="/x:description/x:scenario[starts-with(@label, 'In function-param,')]/x:scenario[1]/x:call/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$myv:global-var-span-element"
 				location="/x:description/x:variable[@name eq 'myv:global-var-span-element']/span/text()" />
@@ -35,12 +35,12 @@
 		<x:scenario label="XSLT">
 			<x:context href="ws-only-text_stylesheet.xspec" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="context template-param"
-				location="/x:description/x:scenario[1]/x:scenario[1]/x:context/x:param/span/text()" />
+				location="/x:description/x:scenario[starts-with(@label, 'In context template-param,')]/x:scenario[1]/x:context/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="context"
-				location="/x:description/x:scenario[2]/x:scenario[1]/x:context/span/text()" />
+				location="/x:description/x:scenario[starts-with(@label, 'In context,')]/x:scenario[1]/x:context/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="template-call template-param"
-				location="/x:description/x:scenario[3]/x:scenario[1]/x:call/x:param/span/text()" />
+				location="/x:description/x:scenario[starts-with(@label, 'In template-call template-param,')]/x:scenario[1]/x:call/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$global-param-span-element"
 				location="/x:description/x:param[@name eq 'global-param-span-element']/span/text()" />

--- a/test/xspec-sch.xspec
+++ b/test/xspec-sch.xspec
@@ -16,10 +16,10 @@
 				location="/x:description[1]/x:scenario[1]/x:scenario[1]/x:call[1]/x:param[1]/span[1]/text()[1]" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$myv:global-var-span-element"
-				location="/x:description[1]/x:variable[1]/span[1]/text()[1]" />
+				location="/x:description[1]/x:variable[@name eq 'myv:global-var-span-element']/span[1]/text()[1]" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
-				label="myv:local-var-span-element"
-				location="/x:description[1]/x:scenario[starts-with(@label, 'In scenario-level variable,')]/x:variable[1]/span[1]/text()[1]" />
+				label="$myv:local-var-span-element"
+				location="//x:scenario/x:variable[@name eq 'myv:local-var-span-element']/span[1]/text()[1]" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="assertion"
 				location="/x:description[1]/x:scenario[starts-with(@label, 'In assertion,')]/x:scenario[1]/x:expect[1]/span[1]/text()[1]" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="grandchild"
@@ -43,7 +43,7 @@
 				location="/x:description[1]/x:scenario[3]/x:scenario[1]/x:call[1]/x:param[1]/span[1]/text()[1]" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$global-param-span-element"
-				location="/x:description[1]/x:param[1]/span[1]/text()[1]" />
+				location="/x:description[1]/x:param[@name eq 'global-param-span-element']/span[1]/text()[1]" />
 			<x:expect-assert count="4" />
 		</x:scenario>
 
@@ -51,7 +51,7 @@
 			<x:context href="external_ws-only-text_stylesheet.xspec" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$scenario-param-span-element"
-				location="//x:param[@name eq 'scenario-param-span-element']/span/text()" />
+				location="//x:scenario/x:param[@name eq 'scenario-param-span-element']/span/text()" />
 			<x:expect-assert count="1" />
 		</x:scenario>
 	</x:scenario>

--- a/test/xspec-sch.xspec
+++ b/test/xspec-sch.xspec
@@ -13,37 +13,37 @@
 		<x:scenario label="XSLT and XQuery">
 			<x:context href="ws-only-text.xspec" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="function-param"
-				location="/x:description[1]/x:scenario[1]/x:scenario[1]/x:call[1]/x:param[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[1]/x:scenario[1]/x:call/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$myv:global-var-span-element"
-				location="/x:description[1]/x:variable[@name eq 'myv:global-var-span-element']/span[1]/text()[1]" />
+				location="/x:description/x:variable[@name eq 'myv:global-var-span-element']/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$myv:local-var-span-element"
-				location="//x:scenario/x:variable[@name eq 'myv:local-var-span-element']/span[1]/text()[1]" />
+				location="//x:scenario/x:variable[@name eq 'myv:local-var-span-element']/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="assertion"
-				location="/x:description[1]/x:scenario[starts-with(@label, 'In assertion,')]/x:scenario[1]/x:expect[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[starts-with(@label, 'In assertion,')]/x:scenario[1]/x:expect/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="grandchild"
-				location="/x:description[1]/x:scenario[starts-with(@label, 'In user-content,')]/x:scenario[3]/x:call[1]/x:param[1]/pre[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[starts-with(@label, 'In user-content,')]/x:scenario[3]/x:call/x:param/pre/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="sibling node"
-				location="/x:description[1]/x:scenario[starts-with(@label, 'In user-content,')]/x:scenario[4]/x:call[1]/x:param[1]/p[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[starts-with(@label, 'In user-content,')]/x:scenario[4]/x:call/x:param/p/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="override ancestor scenario"
-				location="/x:description[1]/x:scenario[starts-with(x:label, 'When @xml:space=preserve ')]/x:scenario[2]/x:scenario[1]/x:call[1]/x:param[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[starts-with(x:label, 'When @xml:space=preserve ')]/x:scenario[2]/x:scenario/x:call/x:param/span/text()" />
 			<x:expect-assert count="7" />
 		</x:scenario>
 
 		<x:scenario label="XSLT">
 			<x:context href="ws-only-text_stylesheet.xspec" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="context template-param"
-				location="/x:description[1]/x:scenario[1]/x:scenario[1]/x:context[1]/x:param[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[1]/x:scenario[1]/x:context/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable" label="context"
-				location="/x:description[1]/x:scenario[2]/x:scenario[1]/x:context[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[2]/x:scenario[1]/x:context/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="template-call template-param"
-				location="/x:description[1]/x:scenario[3]/x:scenario[1]/x:call[1]/x:param[1]/span[1]/text()[1]" />
+				location="/x:description/x:scenario[3]/x:scenario[1]/x:call/x:param/span/text()" />
 			<x:expect-assert id="text-node-should-be-non-ignorable"
 				label="$global-param-span-element"
-				location="/x:description[1]/x:param[@name eq 'global-param-span-element']/span[1]/text()[1]" />
+				location="/x:description/x:param[@name eq 'global-param-span-element']/span/text()" />
 			<x:expect-assert count="4" />
 		</x:scenario>
 


### PR DESCRIPTION
`@location` in `test/xspec-sch.xspec` has predicates in an older form. (Every expression step has a positional predicate.)
This pr removes or replaces them with less context-dependent ones.