### PR TITLE
test(schematron): adapt external_scenario-param.sch to SchXslt

### DIFF
--- a/test/external_scenario-param.sch
+++ b/test/external_scenario-param.sch
@@ -2,7 +2,11 @@
 <sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-	<xsl:param name="phase" required="yes" />
+	<!--
+		SchXslt 1.6.2 discards xsl:param, while it allows xsl:include. (schxslt/schxslt#154)
+		Declare xsl:param indirectly via xsl:include.
+	-->
+	<xsl:include href="external_scenario-param.sch.included.xsl" />
 
 	<sch:phase id="A">
 		<sch:active pattern="pattern-A" />

--- a/test/external_scenario-param.sch.included.xsl
+++ b/test/external_scenario-param.sch.included.xsl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:param name="phase" required="yes" />
+</xsl:stylesheet>

--- a/test/external_scenario-param_schematron.xspec
+++ b/test/external_scenario-param_schematron.xspec
@@ -2,7 +2,7 @@
 <x:description run-as="external" schematron="external_scenario-param.sch"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<!-- Enable /sch:schema/xsl:param -->
+	<!-- Enable /sch:schema/xsl:include -->
 	<x:param name="allow-foreign">true</x:param>
 
 	<!-- This $phase (/x:description/x:param) takes effect at both compile time and run time -->


### PR DESCRIPTION
`test/external_scenario-param.sch` uses a foreign element `xsl:param`, but SchXslt 1.6.2 discards it.
This pr replaces `xsl:param` with `xsl:include` which is accepted by SchXslt. `xsl:param` is declared there.