### PR TITLE
ci(schematron): rebase schxslt branch onto master branch

### DIFF
--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -3,8 +3,7 @@ name: Rebase schxslt branch
 on:
   push:
     branches:
-      # TODO: Change this to `master`
-      - gha-rebase-schxslt
+      - master
 
 jobs:
   rebase-schxslt:

--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 10 # greater than the number of commits made specifically on schxslt branch
           ref: schxslt
 
-      - uses: imba-tjd/rebase-upstream-action@d5dc619947399c040b31fe6c0bff1b072dc6ad92
-        with:
-          upstream: ${{ github.repository }}
+      - run: |
+          set -ex
+          git rebase master
+          git push --force-with-lease

--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -3,7 +3,8 @@ name: Rebase schxslt branch
 on:
   push:
     branches:
-      - master
+      # TODO: Change this to `master`
+      - gha-rebase-schxslt
 
 jobs:
   rebase-schxslt:

--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -21,5 +21,5 @@ jobs:
 
       - run: |
           set -ex
-          git rebase master
+          git rebase origin/master
           git push --force-with-lease

--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -1,0 +1,23 @@
+name: Rebase schxslt branch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  rebase-schxslt:
+    runs-on: ubuntu-latest
+
+    # Do not disturb forks
+    if: github.repository == 'xspec/xspec'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 10 # greater than the number of commits made specifically on schxslt branch
+          ref: schxslt
+
+      - uses: imba-tjd/rebase-upstream-action@d5dc619947399c040b31fe6c0bff1b072dc6ad92
+        with:
+          upstream: ${{ github.repository }}

--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 10 # greater than the number of commits made specifically on schxslt branch
+          fetch-depth: 0
           ref: schxslt
 
       - run: |


### PR DESCRIPTION
Add a GitHub Actions workflow that keeps rebasing `schxslt` branch onto `master` branch. See #1380 for the purpose.

[A test run](https://github.com/xspec/xspec/actions/runs/660524515) worked successfully on this pr branch. So I presume it will also work after merging this into `master`.

Anticipating this pr and #1380, I created a branch protection rule for `schxslt` branch at the [repository settings](https://github.com/xspec/xspec/settings/branches).