### PR TITLE
ci(schematron): set git user email and name when rebasing schxslt branch

### DIFF
--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -20,5 +20,7 @@ jobs:
 
       - run: |
           set -ex
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name  "github-actions[bot]"
           git rebase origin/master
           git push --force-with-lease


### PR DESCRIPTION
Fixes "Committer identity unknown" error in GitHub Actions `rebase-schxslt` workflow.