### PR TITLE
refactor: remove unnecessary user-content templates from x:combine()

### DIFF
--- a/src/compiler/base/combine/mode/force-focus.xsl
+++ b/src/compiler/base/combine/mode/force-focus.xsl
@@ -6,13 +6,13 @@
 
    <!--
       mode="x:force-focus"
-      This mode enforces focus on specific instances of x:scenario
+      This mode enforces focus on specific instances of x:scenario and removes focus from the others
+      if $force-focus is specified.
    -->
    <xsl:mode name="x:force-focus" on-multiple-match="fail" on-no-match="shallow-copy" />
 
-   <!-- Force or remove focus -->
-   <xsl:template match="x:scenario[$force-focus]" as="element(x:scenario)"
-      mode="x:force-focus">
+   <!-- Enforce focus on or remove focus from x:scenario -->
+   <xsl:template match="x:scenario[$force-focus]" as="element(x:scenario)" mode="x:force-focus">
       <xsl:copy>
          <xsl:if test="contains-token($force-focus, @id)">
             <xsl:attribute name="focus" select="'force focus'" />

--- a/src/compiler/base/combine/mode/force-focus.xsl
+++ b/src/compiler/base/combine/mode/force-focus.xsl
@@ -10,12 +10,6 @@
    -->
    <xsl:mode name="x:force-focus" on-multiple-match="fail" on-no-match="shallow-copy" />
 
-   <!-- Leave user-content intact. This must be done in the highest priority. -->
-   <xsl:template match="node()[x:is-user-content(.)]" as="node()" mode="x:force-focus"
-      priority="1">
-      <xsl:sequence select="." />
-   </xsl:template>
-
    <!-- Force or remove focus -->
    <xsl:template match="x:scenario[$force-focus]" as="element(x:scenario)"
       mode="x:force-focus">

--- a/src/compiler/base/combine/mode/unshare-scenarios.xsl
+++ b/src/compiler/base/combine/mode/unshare-scenarios.xsl
@@ -11,12 +11,6 @@
    -->
    <xsl:mode name="x:unshare-scenarios" on-multiple-match="fail" on-no-match="shallow-copy" />
 
-   <!-- Leave user-content intact. This must be done in the highest priority. -->
-   <xsl:template match="node()[x:is-user-content(.)]" as="node()" mode="x:unshare-scenarios"
-      priority="1">
-      <xsl:sequence select="." />
-   </xsl:template>
-
    <!-- Discard @shared and shared x:scenario -->
    <xsl:template match="x:scenario/@shared | x:scenario[x:yes-no-synonym(@shared, false())]"
       as="empty-sequence()" mode="x:unshare-scenarios" />


### PR DESCRIPTION
`mode="x:force-focus"` and `mode="x:unshare-scenarios"` in `x:combine()` have templates for user-content. They were useful when some `test/**/*.xspec` files contained `x:*` elements in user-content for testing purposes. Now the `x:*` elements in user-content are basically gone, this pull request removes the unnecessary templates.