### PR TITLE
fix(report): recognize doctypes in stylesheets

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -152,12 +152,11 @@
    <xsl:variable name="group-comment" as="xs:integer" select="3"/>
    <xsl:variable name="group-pi" as="xs:integer" select="4"/>
    <xsl:variable name="group-cdata" as="xs:integer" select="5"/>
-   <xsl:variable name="group-doctype" as="xs:integer" select="6"/>
-   <xsl:variable name="group-close-tag" as="xs:integer" select="7"/>
-   <xsl:variable name="group-close-tag-name" as="xs:integer" select="8"/>
-   <xsl:variable name="group-open-tag" as="xs:integer" select="9"/>
-   <xsl:variable name="group-open-tag-name" as="xs:integer" select="10"/>
-   <xsl:variable name="group-empty-tag" as="xs:integer" select="11"/>
+   <xsl:variable name="group-close-tag" as="xs:integer" select="6"/>
+   <xsl:variable name="group-close-tag-name" as="xs:integer" select="7"/>
+   <xsl:variable name="group-open-tag" as="xs:integer" select="8"/>
+   <xsl:variable name="group-open-tag-name" as="xs:integer" select="9"/>
+   <xsl:variable name="group-empty-tag" as="xs:integer" select="10"/>
 
    <xsl:variable name="construct-regex" as="xs:string">
       <xsl:value-of xml:space="preserve">
@@ -176,7 +175,7 @@
                (?:[^\]]|\][^\]]|\]\][^>])*   <!-- ?: the content of the CDATA section -->
              \]\]>)
             |
-            (&lt;!DOCTYPE                    <!-- 6: a DOCTYPE declaration -->
+            (?:&lt;!DOCTYPE                  <!-- ?: a DOCTYPE declaration -->
                \s+
                (?:[^\[>])*                   <!-- ?: the content of the DOCTYPE -->
                (?:                           <!-- ?: the entity declarations -->
@@ -192,19 +191,19 @@
                &gt;
             )
             |
-            (&lt;/                           <!-- 7: a close tag -->
-               ([^>]+)                       <!-- 8: the name of the element being closed -->
+            (&lt;/                           <!-- 6: a close tag -->
+               ([^>]+)                       <!-- 7: the name of the element being closed -->
              >)
             |
-            (&lt;                            <!-- 9: an open tag -->
-               ([^>/\s]+)                    <!-- 10: the name of the element being opened -->
+            (&lt;                            <!-- 8: an open tag -->
+               ([^>/\s]+)                    <!-- 9: the name of the element being opened -->
                (?:                           <!-- ?: the attributes of the element -->
                   (?:                        <!-- ?: wrapper for the attribute regex -->
                      <xsl:value-of select="$attribute-regex" />
                   )*
                )
                \s*
-               (/?)                          <!-- 11: empty element tag flag -->
+               (/?)                          <!-- 10: empty element tag flag -->
                >
             )
          )
@@ -233,7 +232,9 @@
                </xsl:map>
             </xsl:matching-substring>
             <xsl:non-matching-substring>
-               <xsl:message terminate="yes" expand-text="yes">ERROR: unmatched string: {.}</xsl:message>
+               <xsl:message terminate="yes">
+                  <xsl:text expand-text="yes">ERROR: unmatched string: {.}</xsl:text>
+               </xsl:message>
             </xsl:non-matching-substring>
          </xsl:analyze-string>
       </xsl:variable>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-coverage.html
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for issue-1411_entity.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../issue-1411_entity.xsl">issue-1411_entity.xsl</a></p>
+      <h2>module: issue-1411_entity.xsl; 12 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+02: <span class="ignored"></span><span class="ignored">&lt;!DOCTYPE xsl:stylesheet [</span>
+03: <span class="ignored">    &lt;!ENTITY nbsp "&amp;#160;"&gt;</span>
+04: <span class="ignored">]&gt;</span><span class="ignored"></span>
+05: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+06: <span class="ignored">                version="3.0"&gt;</span><span class="ignored"></span>
+07: <span class="ignored"></span>
+08: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span><span class="ignored"></span>
+09: <span class="ignored">      </span><span class="hit">&lt;dummy&gt;</span><span class="hit">&amp;nbsp;</span><span class="hit">&lt;/dummy&gt;</span><span class="ignored"></span>
+10: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
+11: <span class="ignored"></span>
+12: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="issue-1411_entity.xspec">
+   <testsuite name="When converting a dummy element" tests="1" failures="0">
+      <testcase name="it should return a dummy element with an entity" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for issue-1411_entity.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../issue-1411_entity.xsl">issue-1411_entity.xsl</a></p>
+      <p>XSpec: <a href="../../issue-1411_entity.xspec">issue-1411_entity.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">When converting a dummy element</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">When converting a dummy element<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>When converting a dummy element</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it should return a dummy element with an entity</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-result.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-1411_entity.xspec"
+        stylesheet="../../issue-1411_entity.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../issue-1411_entity.xspec">
+      <label>When converting a dummy element</label>
+      <input-wrap xmlns="">
+         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <dummy/>
+         </x:context>
+      </input-wrap>
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <dummy> </dummy>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="true">
+         <label>it should return a dummy element with an entity</label>
+         <expect select="/element()">
+            <content-wrap xmlns="">
+               <dummy xmlns:x="http://www.jenitennison.com/xslt/xspec"> </dummy>
+            </content-wrap>
+         </expect>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-coverage.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for issue-1411_no-entity.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../issue-1411_no-entity.xsl">issue-1411_no-entity.xsl</a></p>
+      <h2>module: issue-1411_no-entity.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
+02: <span class="ignored"></span><span class="ignored">&lt;!DOCTYPE xsl:stylesheet&gt;</span><span class="ignored"></span>
+03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+04: <span class="ignored">                version="3.0"&gt;</span><span class="ignored"></span>
+05: <span class="ignored"></span>
+06: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span><span class="ignored"></span>
+07: <span class="ignored">      </span><span class="hit">&lt;dummy/&gt;</span><span class="ignored"></span>
+08: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
+09: <span class="ignored"></span>
+10: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="issue-1411_no-entity.xspec">
+   <testsuite name="When converting a dummy element" tests="1" failures="0">
+      <testcase name="it should return an empty dummy element" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for issue-1411_no-entity.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../issue-1411_no-entity.xsl">issue-1411_no-entity.xsl</a></p>
+      <p>XSpec: <a href="../../issue-1411_no-entity.xspec">issue-1411_no-entity.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">When converting a dummy element</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">When converting a dummy element<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>When converting a dummy element</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it should return an empty dummy element</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-result.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-1411_no-entity.xspec"
+        stylesheet="../../issue-1411_no-entity.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../issue-1411_no-entity.xspec">
+      <label>When converting a dummy element</label>
+      <input-wrap xmlns="">
+         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <dummy/>
+         </x:context>
+      </input-wrap>
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <dummy/>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="true">
+         <label>it should return an empty dummy element</label>
+         <expect select="/element()">
+            <content-wrap xmlns="">
+               <dummy xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+            </content-wrap>
+         </expect>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/issue-1411_entity.xsl
+++ b/test/end-to-end/cases/issue-1411_entity.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY nbsp "&#160;">
+]>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0">
+
+   <xsl:template match="dummy" as="element(dummy)">
+      <dummy>&nbsp;</dummy>
+   </xsl:template>
+
+</xsl:stylesheet>

--- a/test/end-to-end/cases/issue-1411_entity.xspec
+++ b/test/end-to-end/cases/issue-1411_entity.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="issue-1411_entity.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+    <x:scenario label="When converting a dummy element">
+        <x:context>
+            <dummy/>
+        </x:context>
+        <x:expect label="it should return a dummy element with an entity">
+            <dummy>&#160;</dummy>
+        </x:expect>
+    </x:scenario>
+
+</x:description>

--- a/test/end-to-end/cases/issue-1411_no-entity.xsl
+++ b/test/end-to-end/cases/issue-1411_no-entity.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsl:stylesheet>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0">
+
+   <xsl:template match="dummy" as="element(dummy)">
+      <dummy/>
+   </xsl:template>
+
+</xsl:stylesheet>

--- a/test/end-to-end/cases/issue-1411_no-entity.xspec
+++ b/test/end-to-end/cases/issue-1411_no-entity.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="issue-1411_no-entity.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+    <x:scenario label="When converting a dummy element">
+        <x:context>
+            <dummy/>
+        </x:context>
+        <x:expect label="it should return an empty dummy element">
+            <dummy/>
+        </x:expect>
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
This should resolve the issue that doctypes are not recognized (at least for the way I use them in my stylesheets).