### PR TITLE
test: unfocused param and variable

### DIFF
--- a/test/external_unfocused-param.xspec
+++ b/test/external_unfocused-param.xspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" stylesheet="external_mirror.xsl" xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		Test (/x:description|//x:scenario)/x:param when they are unfocused by @focus on an inner
+		scenario.
+	-->
+
+	<x:param name="description-param" select="'PARAM'" />
+
+	<x:scenario label="Outer scenario">
+		<x:param name="scenario-param" select="'param'" />
+
+		<x:scenario focus="focus" label="Focused scenario">
+			<x:call function="mirror:false" />
+			<x:expect label="Unfocused description-level param should hold its original value"
+				select="'PARAM'" test="$description-param" />
+			<x:expect label="Unfocused scenario-level param in an outer scenario should be empty"
+				select="()" test="$scenario-param" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/unfocused-param.xspec
+++ b/test/unfocused-param.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="do-nothing.sch" stylesheet="do-nothing.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		Test /x:description/x:param when it is unfocused by @focus.
+	-->
+
+	<x:param name="description-param" select="'PARAM'" />
+
+	<x:scenario focus="focus" label="Focused scenario">
+		<x:call function="false" />
+		<x:expect label="Unfocused description-level param should hold its original value"
+			select="'PARAM'" test="$description-param" />
+	</x:scenario>
+
+</x:description>

--- a/test/unfocused-variable.xspec
+++ b/test/unfocused-variable.xspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm" schematron="do-nothing.sch"
+	stylesheet="do-nothing.xsl" xmlns:myv="http://example.org/ns/my/variable"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		Test (/x:description|//x:scenario)/x:variable when they are unfocused by @focus on an inner
+		scenario.
+	-->
+
+	<x:variable name="myv:description-variable" select="'VARIABLE'" />
+
+	<x:scenario label="Outer scenario">
+		<x:variable name="myv:outer-scenario-variable" select="'variable'" />
+
+		<x:scenario focus="focus" label="Focused scenario">
+			<x:call function="false" />
+			<x:expect label="Unfocused description-level variable should hold its original value"
+				select="'VARIABLE'" test="$myv:description-variable" />
+			<x:expect label="Unfocused scenario-level variable in an outer scenario should be empty"
+				select="()" test="$myv:outer-scenario-variable" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Test `(/x:description|//x:scenario)/(x:param|x:variable)` when they are out of a focused scenario.