### PR TITLE
feat(schematron): bump built-in SchXslt from 1.6.2 to 1.7

### DIFF
--- a/lib/schxslt/1.0/compile-for-svrl.xsl
+++ b/lib/schxslt/1.0/compile-for-svrl.xsl
@@ -23,7 +23,7 @@
       <xsl:for-each select="$schema/sch:p">
         <svrl:text>
           <xsl:copy-of select="@id | @class | @icon"/>
-          <xsl:apply-templates select="node()" mode="schxslt:compile"/>
+          <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
         </svrl:text>
       </xsl:for-each>
 
@@ -55,7 +55,7 @@
     <xsl:param name="rule"/>
 
     <svrl:fired-rule>
-      <xsl:copy-of select="$rule/@id | $rule/@role | $rule/@flag"/>
+      <xsl:copy-of select="$rule/@id | $rule/@role | $rule/@flag | $rule/@see | $rule/@icon | $rule/@fpi"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -81,7 +81,7 @@
       </call-template>
     </variable>
     <svrl:failed-assert location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id"/>
+      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id | $assert/@see | $assert/@icon | $assert/@fpi"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -108,7 +108,7 @@
       </call-template>
     </variable>
     <svrl:successful-report location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id"/>
+      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id | $report/@see | $report/@icon | $report/@fpi"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>
@@ -140,7 +140,7 @@
     </xsl:if>
     <xsl:if test="text() | *">
       <svrl:text>
-        <xsl:apply-templates select="node()" mode="schxslt:compile"/>
+        <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
       </svrl:text>
     </xsl:if>
   </xsl:template>
@@ -162,7 +162,7 @@
     <svrl:diagnostic-reference diagnostic="{$head}">
       <svrl:text>
         <xsl:copy-of select="key('schxslt:diagnostics', $head)/@*"/>
-        <xsl:apply-templates select="key('schxslt:diagnostics', $head)/node()" mode="schxslt:compile"/>
+        <xsl:apply-templates select="key('schxslt:diagnostics', $head)/node()" mode="schxslt:message-template"/>
       </svrl:text>
     </svrl:diagnostic-reference>
 
@@ -198,7 +198,7 @@
         <xsl:choose>
           <xsl:when test="self::text() and normalize-space(.)">
             <svrl:text>
-              <xsl:apply-templates select="." mode="schxslt:compile"/>
+              <xsl:apply-templates select="." mode="schxslt:message-template"/>
             </svrl:text>
           </xsl:when>
           <xsl:otherwise>
@@ -253,6 +253,12 @@
     </xsl:variable>
 
     <xsl:value-of select="$path"/>
+  </xsl:template>
+
+  <xsl:template match="sch:dir | sch:emph | sch:span" mode="schxslt:message-template">
+    <xsl:element name="svrl:{local-name()}">
+      <xsl:apply-templates select="node() | @*" mode="schxslt:message-template"/>
+    </xsl:element>
   </xsl:template>
 
 </xsl:transform>

--- a/lib/schxslt/1.0/compile/compile-1.0.xsl
+++ b/lib/schxslt/1.0/compile/compile-1.0.xsl
@@ -101,12 +101,12 @@
           </xsl:call-template>
           <xsl:choose>
             <xsl:when test="$effective-phase = '#ALL'">
-              <xsl:for-each select="sch:pattern">
+              <xsl:for-each select="sch:pattern[sch:rule]">
                 <call-template name="{generate-id()}"/>
               </xsl:for-each>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:for-each select="sch:pattern[@id = current()/sch:phase[@id = $effective-phase]/sch:active/@pattern]">
+              <xsl:for-each select="sch:pattern[@id = current()/sch:phase[@id = $effective-phase]/sch:active/@pattern][sch:rule]">
                 <call-template name="{generate-id()}"/>
               </xsl:for-each>
             </xsl:otherwise>
@@ -208,22 +208,39 @@
     </if>
   </xsl:template>
 
-  <xsl:template match="sch:name[@path]" mode="schxslt:compile">
-    <value-of select="{@path}"/>
-  </xsl:template>
-
-  <xsl:template match="sch:name[not(@path)]" mode="schxslt:compile">
-    <value-of select="name()"/>
-  </xsl:template>
-
-  <xsl:template match="sch:value-of" mode="schxslt:compile">
-    <value-of select="{@select}"/>
-  </xsl:template>
-
   <xsl:template match="node() | @*" mode="schxslt:compile">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*" mode="schxslt:compile"/>
     </xsl:copy>
+  </xsl:template>
+
+  <!-- Message templates -->
+  <xsl:template match="comment() | processing-instruction()" mode="schxslt:message-template">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <xsl:template match="*" mode="schxslt:message-template">
+    <element namespace="{namespace-uri(.)}" name="{local-name(.)}">
+      <xsl:apply-templates select="node() | @*" mode="schxslt:message-template"/>
+    </element>
+  </xsl:template>
+
+  <xsl:template match="@*" mode="schxslt:message-template">
+    <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
+      <value-of select="."/>
+    </attribute>
+  </xsl:template>
+
+  <xsl:template match="sch:name[@path]" mode="schxslt:message-template">
+    <value-of select="{@path}"/>
+  </xsl:template>
+
+  <xsl:template match="sch:name[not(@path)]" mode="schxslt:message-template">
+    <value-of select="name()"/>
+  </xsl:template>
+
+  <xsl:template match="sch:value-of" mode="schxslt:message-template">
+    <value-of select="{@select}"/>
   </xsl:template>
 
   <!-- Copy variable content -->

--- a/lib/schxslt/1.0/expand.xsl
+++ b/lib/schxslt/1.0/expand.xsl
@@ -16,12 +16,12 @@
   <xsl:template match="sch:rule[@abstract = 'true']"/>
 
   <xsl:template match="sch:extends[@rule]">
-    <xsl:if test="not(ancestor::sch:pattern/sch:rule[@abstract = 'true'][@id = current()/@rule])">
+    <xsl:if test="not((ancestor::sch:pattern|ancestor::sch:schema/sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule])">
       <xsl:message terminate="yes">
         The current pattern defines no abstract rule named '<xsl:value-of select="@rule"/>'.
       </xsl:message>
     </xsl:if>
-    <xsl:copy-of select="ancestor::sch:pattern/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()"/>
+    <xsl:copy-of select="(ancestor::sch:pattern|ancestor::sch:schema/sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()"/>
   </xsl:template>
 
   <xsl:template match="sch:pattern[@is-a]">

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.6.2 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.7 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -26,7 +26,7 @@
   <xsl:include href="../version.xsl"/>
 
   <xsl:param name="phase" as="xs:string">#DEFAULT</xsl:param>
-  <xsl:param name="schxslt.compile.typed-variables" as="xs:boolean" select="true()"/>
+  <xsl:variable name="schxslt.compile.typed-variables" as="xs:boolean" select="true()"/>
   <xsl:param name="schxslt.compile.streamable" as="xs:boolean" select="false()"/>
 
   <xsl:template match="/sch:schema">
@@ -89,6 +89,7 @@
       <xsl:sequence select="$schematron/xsl:function[not(preceding-sibling::sch:pattern)]"/>
       <xsl:if test="$xslt-version eq '3.0'">
         <xsl:sequence select="$schematron/xsl:accumulator[not(preceding-sibling::sch:pattern)]"/>
+        <xsl:sequence select="$schematron/xsl:use-package[not(preceding-sibling::sch:pattern)]"/>
       </xsl:if>
 
       <!-- See https://github.com/dmj/schxslt/issues/25 -->
@@ -109,11 +110,6 @@
 
       <template match="/">
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
-
-        <xsl:call-template name="schxslt:let-variable">
-          <xsl:with-param name="bindings" select="$schematron/sch:phase[@id eq $effective-phase]/sch:let"/>
-          <xsl:with-param name="typed-variables" as="xs:boolean" select="$schxslt.compile.typed-variables"/>
-        </xsl:call-template>
 
         <variable name="metadata" as="element()?">
           <xsl:call-template name="schxslt-api:metadata">
@@ -258,16 +254,18 @@
     <xsl:param name="streamable" as="xs:boolean" required="yes"/>
     <xsl:param name="xslt-version" as="xs:string" tunnel="yes" required="yes"/>
 
+    <xsl:if test="$xslt-version = '3.0'">
+      <mode use-accumulators="#all">
+        <xsl:if test="$streamable">
+          <xsl:attribute name="streamable">yes</xsl:attribute>
+        </xsl:if>
+      </mode>
+    </xsl:if>
+
     <xsl:for-each-group select="$patterns" group-by="string-join((base-uri(.), @documents), '~')">
       <xsl:variable name="mode" as="xs:string" select="generate-id()"/>
-      <xsl:variable name="baseUri" as="xs:anyURI" select="base-uri(.)"/>
 
       <xsl:if test="$xslt-version = '3.0'">
-        <mode use-accumulators="#all">
-          <xsl:if test="$streamable">
-            <xsl:attribute name="streamable">yes</xsl:attribute>
-          </xsl:if>
-        </mode>
         <mode name="{$mode}" use-accumulators="#all">
           <xsl:if test="$streamable">
             <xsl:attribute name="streamable">yes</xsl:attribute>
@@ -283,12 +281,9 @@
             <xsl:choose>
               <xsl:when test="$xslt-version = '3.0'">
                 <for-each select="{@documents}">
-                  <source-document href="{{resolve-uri(., '{$baseUri}')}}">
+                  <source-document href="{{.}}">
                     <xsl:for-each select="current-group()">
                       <schxslt:pattern id="{generate-id()}">
-                        <if test="exists(base-uri(.))">
-                          <attribute name="documents" select="base-uri(.)"/>
-                        </if>
                         <for-each select=".">
                           <xsl:call-template name="schxslt-api:active-pattern">
                             <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
@@ -302,7 +297,7 @@
               </xsl:when>
               <xsl:otherwise>
                 <for-each select="{@documents}">
-                  <variable name="document" as="item()" select="document(resolve-uri(., '{$baseUri}'))"/>
+                  <variable name="document" as="item()" select="document(.)"/>
                   <xsl:for-each select="current-group()">
                     <schxslt:pattern id="{generate-id()}">
                       <if test="exists(base-uri($document))">

--- a/lib/schxslt/2.0/compile/functions.xsl
+++ b/lib/schxslt/2.0/compile/functions.xsl
@@ -51,10 +51,10 @@
 
     <xsl:choose>
       <xsl:when test="$phase eq '#ALL'">
-        <xsl:sequence select="$schema/sch:pattern"/>
+        <xsl:sequence select="$schema/sch:pattern[sch:rule]"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:sequence select="$schema/sch:pattern[@id = $schema/sch:phase[@id eq $phase]/sch:active/@pattern]"/>
+        <xsl:sequence select="$schema/sch:pattern[@id = $schema/sch:phase[@id eq $phase]/sch:active/@pattern][sch:rule]"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/lib/schxslt/2.0/compile/templates.xsl
+++ b/lib/schxslt/2.0/compile/templates.xsl
@@ -27,30 +27,37 @@
     </if>
   </xsl:template>
 
-  <xsl:template match="sch:name" mode="schxslt:compile">
+  <!-- Message templates -->
+  <xsl:template match="node() | @*" mode="schxslt:message-template">
+    <xsl:copy>
+      <xsl:apply-templates mode="#current"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="sch:name" mode="schxslt:message-template">
     <value-of select="{if (@path) then @path else 'name()'}">
       <xsl:sequence select="@xml:base"/>
     </value-of>
   </xsl:template>
 
-  <xsl:template match="sch:value-of" mode="schxslt:compile">
+  <xsl:template match="sch:value-of" mode="schxslt:message-template">
     <value-of select="{@select}">
       <xsl:sequence select="@xml:base"/>
     </value-of>
   </xsl:template>
 
   <!-- Copy variable content -->
-  <xsl:template match="comment() | processing-instruction()" mode="schxslt:variable-content">
+  <xsl:template match="comment() | processing-instruction()" mode="schxslt:variable-content schxslt:message-template">
     <xsl:sequence select="."/>
   </xsl:template>
 
-  <xsl:template match="*" mode="schxslt:variable-content">
+  <xsl:template match="*" mode="schxslt:variable-content schxslt:message-template">
     <element namespace="{namespace-uri(.)}" name="{local-name(.)}">
       <xsl:apply-templates select="node() | @*" mode="#current"/>
     </element>
   </xsl:template>
 
-  <xsl:template match="@*" mode="schxslt:variable-content">
+  <xsl:template match="@*" mode="schxslt:variable-content schxslt:message-template">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
       <value-of select="."/>
     </attribute>

--- a/lib/schxslt/2.0/expand.xsl
+++ b/lib/schxslt/2.0/expand.xsl
@@ -11,18 +11,11 @@
     </xsl:call-template>
   </xsl:template>
 
-  <!-- Copy the outermost element and preserve it's base URI -->
   <xsl:template name="schxslt:expand">
     <xsl:param name="schema" as="element(sch:schema)" required="yes"/>
-    <xsl:copy>
-      <xsl:if test="exists(base-uri())">
-        <xsl:attribute name="xml:base" select="base-uri()"/>
-      </xsl:if>
-      <xsl:sequence select="@* except @xml:base"/>
-      <xsl:apply-templates mode="schxslt:expand" select="$schema/node()">
-        <xsl:with-param name="abstract-patterns" as="element(sch:pattern)*" tunnel="yes" select="$schema/sch:pattern[@abstract = 'true']"/>
-      </xsl:apply-templates>
-    </xsl:copy>
+    <xsl:apply-templates select="$schema" mode="schxslt:expand">
+      <xsl:with-param name="abstract-patterns" as="element(sch:pattern)*" tunnel="yes" select="$schema/sch:pattern[@abstract = 'true']"/>
+    </xsl:apply-templates>
   </xsl:template>
 
   <!-- Copy all other elements -->
@@ -40,7 +33,8 @@
 
   <!-- Instantiate an abstract rule -->
   <xsl:template match="sch:extends[@rule]" mode="schxslt:expand">
-    <xsl:variable name="parent" as="element(sch:rule)?" select="ancestor::sch:pattern/sch:rule[@abstract = 'true'][@id = current()/@rule]"/>
+    <xsl:variable name="parent" as="element(sch:rule)?"
+                  select="(ancestor::sch:pattern|ancestor::sch:schema/sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]"/>
     <xsl:if test="empty($parent)">
       <xsl:variable name="message">
         The current pattern defines no abstract rule named '<xsl:value-of select="@rule"/>'.
@@ -83,4 +77,5 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
+
 </xsl:transform>

--- a/lib/schxslt/2.0/include.xsl
+++ b/lib/schxslt/2.0/include.xsl
@@ -14,75 +14,36 @@
   <!-- Recursive inclusion -->
   <xsl:template name="schxslt:include">
     <xsl:param name="schematron" as="element(sch:schema)" required="yes"/>
-    <xsl:variable name="result" as="element(sch:schema)">
-      <xsl:apply-templates select="$schematron" mode="schxslt:include"/>
-    </xsl:variable>
+    <xsl:apply-templates mode="schxslt:include" select="."/>
+  </xsl:template>
+
+  <xsl:template match="node() | @*" mode="schxslt:include">
+    <xsl:copy>
+      <xsl:sequence select="@*"/>
+      <xsl:apply-templates select="node()" mode="#current"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="sch:include | sch:extends[@href]" mode="schxslt:include">
+    <xsl:param name="base-uri" as="xs:string?" tunnel="yes"/>
+    <xsl:variable name="url" as="xs:string" select="if (contains(@href, '#')) then substring-before(@href, '#') else @href"/>
+    <xsl:variable name="fragment" as="xs:string?" select="substring-after(@href, '#')"/>
+    <xsl:variable name="document" select="document(if ($base-uri) then resolve-uri($url, $base-uri) else $url, @href)"/>
+    <xsl:variable name="element" select="if ($fragment) then ($document//sch:*[@id = $fragment], $document//sch:*[@xml:id = $fragment])[1] else $document/*[1]"/>
     <xsl:choose>
-      <xsl:when test="$result//sch:include or $result//sch:extends[@href]">
-        <xsl:call-template name="schxslt:include">
-          <xsl:with-param name="schematron" select="$result" as="element(sch:schema)"/>
-        </xsl:call-template>
+      <xsl:when test="self::sch:include">
+        <xsl:apply-templates select="$element" mode="schxslt:include">
+          <xsl:with-param name="base-uri" as="xs:string?" tunnel="yes" select="base-uri($element)"/>
+        </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:sequence select="$result"/>
+        <xsl:if test="(local-name($element) eq local-name(..)) and (namespace-uri($element) eq 'http://purl.oclc.org/dsdl/schematron')">
+          <xsl:apply-templates mode="schxslt:include" select="$element/*">
+            <xsl:with-param name="base-uri" as="xs:string?" tunnel="yes" select="base-uri($element)"/>
+          </xsl:apply-templates>
+        </xsl:if>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-
-  <!-- Copy outermost element and keep it's base URI -->
-  <xsl:template match="sch:schema" mode="schxslt:include">
-    <xsl:copy>
-      <xsl:if test="exists(schxslt:base-uri(.))">
-        <xsl:attribute name="xml:base" select="schxslt:base-uri(.)"/>
-      </xsl:if>
-      <xsl:sequence select="@* except @xml:base"/>
-      <xsl:apply-templates mode="schxslt:include"/>
-    </xsl:copy>
-  </xsl:template>
-
-  <!-- Copy all other elements -->
-  <xsl:template match="node() | @*" mode="schxslt:include">
-    <xsl:copy>
-      <xsl:apply-templates select="node() | @*" mode="#current"/>
-    </xsl:copy>
-  </xsl:template>
-
-  <!-- Replace with contents of external definition -->
-  <xsl:template match="sch:extends[@href]" mode="schxslt:include">
-    <xsl:variable name="extends" select="doc(if (exists(schxslt:base-uri(.))) then resolve-uri(@href, schxslt:base-uri(.)) else resolve-uri(@href))"/>
-    <xsl:variable name="element" select="if ($extends instance of element()) then $extends else $extends/*"/>
-    <xsl:if test="(local-name($element) eq local-name(..)) and (namespace-uri($element) eq 'http://purl.oclc.org/dsdl/schematron')">
-      <xsl:for-each select="$element/*">
-        <xsl:copy>
-          <xsl:sequence select="@* except @xml:base"/>
-          <xsl:if test="exists(schxslt:base-uri(.))">
-            <xsl:attribute name="xml:base" select="schxslt:base-uri(.)"/>
-          </xsl:if>
-          <xsl:sequence select="node()"/>
-        </xsl:copy>
-      </xsl:for-each>
-    </xsl:if>
-  </xsl:template>
-
-  <!-- Replace with external definition -->
-  <xsl:template match="sch:include" mode="schxslt:include">
-    <xsl:variable name="include" select="doc(if (exists(schxslt:base-uri(.))) then resolve-uri(@href, schxslt:base-uri(.)) else resolve-uri(@href))"/>
-    <xsl:variable name="element" select="if ($include instance of element()) then $include else $include/*"/>
-    <xsl:for-each select="$element">
-      <xsl:copy>
-        <xsl:sequence select="@* except @xml:base"/>
-        <xsl:if test="exists(schxslt:base-uri(.))">
-          <xsl:attribute name="xml:base" select="schxslt:base-uri(.)"/>
-        </xsl:if>
-        <xsl:sequence select="node()"/>
-      </xsl:copy>
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:function name="schxslt:base-uri" as="xs:string?">
-    <xsl:param name="node" as="node()"/>
-    <xsl:variable name="uri" as="xs:anyURI?" select="base-uri($node)"/>
-    <xsl:sequence select="if (matches($uri, '^[a-zA-Z.+-]+:/')) then string($uri) else ()"/>
-  </xsl:function>
 
 </xsl:transform>

--- a/lib/schxslt/2.0/pipeline.xsl
+++ b/lib/schxslt/2.0/pipeline.xsl
@@ -5,7 +5,7 @@
 
   <xsl:include href="compile/compile-2.0.xsl"/>
   <xsl:include href="include.xsl"/>
-  <xsl:include href="expand.xsl"/>
+  <xsl:import href="expand.xsl"/>
 
   <xsl:template match="/sch:schema" priority="100">
     <xsl:call-template name="schxslt:compile">

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -24,7 +24,7 @@
       <xsl:for-each select="$schema/sch:p">
         <svrl:text>
           <xsl:sequence select="(@id, @class, @icon)"/>
-          <xsl:apply-templates select="node()" mode="#current"/>
+          <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
         </svrl:text>
       </xsl:for-each>
 
@@ -50,7 +50,7 @@
   <xsl:template name="schxslt-api:fired-rule">
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
     <svrl:fired-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag)"/>
+      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -60,11 +60,11 @@
   <xsl:template name="schxslt-api:suppressed-rule">
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
     <xsl:variable name="message">
-      WARNING: Rule <xsl:value-of select="normalize-space(@id)"/> for context "<xsl:value-of select="@context"/>" shadowed by preceeding rule
+      WARNING: Rule <xsl:value-of select="normalize-space(@id)"/> for context "<xsl:value-of select="@context"/>" shadowed by preceding rule
     </xsl:variable>
     <comment> <xsl:sequence select="normalize-space($message)"/> </comment>
     <svrl:suppressed-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag)"/>
+      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -75,7 +75,7 @@
     <xsl:param name="assert" as="element(sch:assert)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:failed-assert location="{{{$location-function}({($assert/@subject, $assert/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id)"/>
+      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id, $assert/@see, $assert/@icon, $assert/@fpi)"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -89,7 +89,7 @@
     <xsl:param name="report" as="element(sch:report)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:successful-report location="{{{$location-function}({($report/@subject, $report/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($report/@role, $report/@flag, $report/@id)"/>
+      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi)"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>
@@ -142,7 +142,7 @@
     <xsl:call-template name="schxslt:copy-properties"/>
     <xsl:if test="text() | *">
       <svrl:text>
-        <xsl:apply-templates select="node()" mode="#current"/>
+        <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
       </svrl:text>
     </xsl:if>
   </xsl:template>
@@ -156,7 +156,7 @@
           <xsl:when test="self::text()">
             <xsl:if test="normalize-space()">
               <svrl:text>
-                <xsl:apply-templates select="." mode="#current"/>
+                <xsl:apply-templates select="." mode="schxslt:message-template"/>
               </svrl:text>
             </xsl:if>
           </xsl:when>
@@ -198,10 +198,16 @@
       <svrl:diagnostic-reference diagnostic="{.}">
         <svrl:text>
           <xsl:sequence select="$diagnostic/@*"/>
-          <xsl:apply-templates select="$diagnostic/node()" mode="#current"/>
+          <xsl:apply-templates select="$diagnostic/node()" mode="schxslt:message-template"/>
         </svrl:text>
       </svrl:diagnostic-reference>
     </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="sch:dir | sch:emph | sch:span" mode="schxslt:message-template">
+    <xsl:element name="svrl:{local-name()}">
+      <xsl:apply-templates select="node() | @*" mode="#current"/>
+    </xsl:element>
   </xsl:template>
 
 </xsl:transform>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.6.2</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/lib/schxslt/README.md
+++ b/lib/schxslt/README.md
@@ -7,14 +7,15 @@ license.
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1495494.svg)](https://doi.org/10.5281/zenodo.1495494)
 [![Build Status](https://travis-ci.org/schxslt/schxslt.svg?branch=master)](https://travis-ci.org/schxslt/schxslt)
 
-SchXslt is a Schematron processor implemented entirely in XSLT. It transforms a Schemtron schema document to an XSLT
+SchXslt is a Schematron processor implemented entirely in XSLT. It transforms a Schematron schema document into an XSLT
 stylesheet that you apply to the document(s) to be validated.
 
 Limitations
 --
 
-As of date SchXslt does not properly implement the scoping rules of pattern and phase variables (see
-[#135](https://github.com/schxslt/schxslt/issues/135) and [#136](https://github.com/schxslt/schxslt/issues/136)).
+As of date SchXslt does not properly implement the scoping rules of pattern (see
+[#135](https://github.com/schxslt/schxslt/issues/135)) and phase variables (see
+[#136](https://github.com/schxslt/schxslt/issues/136)).
 
 Schema, pattern, and phase variables are all implemented as global XSLT variables. As a consequence the name of a
 schema, pattern, or phase variable must be unique in the entire schema.
@@ -22,6 +23,48 @@ schema, pattern, or phase variable must be unique in the entire schema.
 Due to the constrains of XSLT 1.0 and the way rules are implemented it is not possible to use a variable inside a rule
 context expression of a Schematron using the XSLT 1.0 query binding (see
 [#138](https://github.com/schxslt/schxslt/issues/138)).
+
+Schematron enhancements
+--
+
+SchXslt implements the following Schematron enhancements:
+
+### Typed variables
+
+[Proposal 1](https://github.com/Schematron/schematron-enhancement-proposals/issues/1)
+
+The Schematron specification does not allow for annotating variables with the expected type of its value. Type
+annotations are helpful to make the most of XSLT 3.0. Using them is current best practice.
+
+This proposal adds support for an ```@as``` attribute on variable declarations.
+
+### Global abstract rules
+
+[Proposal 3](https://github.com/Schematron/schematron-enhancement-proposals/issues/3)
+
+The Schematron specification limits the the reuse of abstract rules to the current pattern element. The ```@href
+attribute``` on ```extends``` was introduced in 2016 to overcome this limitation but requires a schema author to
+externalize abstract rules for them to be used.
+
+This proposal extends Schematron with a top-level ```rules``` element to hold abstract rules that are globally
+referencable by the ```@rule``` attribute of ```extends```.
+
+### Addition XSLT elements
+
+[Proposal 4](https://github.com/Schematron/schematron-enhancement-proposals/issues/4)
+
+The Schematron specification allows the XSLT elements ```function``` and ```key``` to be used in a Schematron
+schema. This makes sense because both are required to set up the query language environment. The ```key``` element
+prepares data structures for the ```key()``` function and the ```function``` element allows the use of user defined
+functions.
+
+This proposal adds support for the following XSLT elements:
+
+* xsl:accumulator (XSLT 3.0)
+* xsl:import (XSLT 1.0, XSLT 2.0, XSLT 3.0)
+* xsl:import-schema (XSLT 2.0, XSLT 3.0)
+* xsl:include (XSLT 1.0, XSLT 2.0, XSLT 3.0)
+* xsl:use-package (XSLT 3.0)
 
 Installation
 --
@@ -45,7 +88,7 @@ Using SchXslt
 ### XSLT Stylesheets
 
 The simplest way to use SchXslt is to download the ZIP file with just the stylesheets from the
-[releaes](https://github.com/schxslt/schxslt/releases) page. To validate documents with your Schematron you first
+[releases](https://github.com/schxslt/schxslt/releases) page. To validate documents with your Schematron you first
 transform it with the ```pipeline-for-svrl.xsl``` stylesheet. This creates the XSL transformation that creates a
 validation report when applied to a document.
 

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -103,21 +103,6 @@
 			select="processing-instruction(xspec-test)" />
 		<xsl:variable as="xs:boolean" name="enable-coverage" select="$pis = 'enable-coverage'" />
 
-		<!-- Version of SchXslt. Empty sequence if not SchXslt.
-			This implementation is ad-hoc, because it depends on SchXslt internal structure. -->
-		<xsl:variable as="xs:integer?" name="schxslt-version">
-			<xsl:variable as="document-node(element(xsl:transform))?" name="version-xsl"
-				select="'../../../lib/schxslt/2.0/version.xsl'[doc-available(.)] ! doc(.)" />
-			<xsl:for-each select="$version-xsl">
-				<xsl:variable as="element(xsl:variable)" name="schxslt-ident"
-					select="descendant::xsl:variable[@name eq 'schxslt-ident']" />
-				<xsl:sequence select="
-						($schxslt-ident || '.0')
-						=> x:extract-version()
-						=> x:pack-version()" />
-			</xsl:for-each>
-		</xsl:variable>
-
 		<xsl:for-each select="x:description/(@query | @schematron | @stylesheet)">
 			<xsl:sort select="name()" />
 
@@ -237,12 +222,6 @@
 							($pis = 'require-saxon-bug-4835-fixed')
 							and ($x:saxon-version le x:pack-version((10, 3)))">
 						<xsl:text>Requires Saxon bug #4835 to have been fixed</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
-							($pis = 'require-schxslt-issue-178-fixed')
-							and ($schxslt-version le x:pack-version((1, 6, 2)))">
-						<xsl:text>Requires schxslt/schxslt#178 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when test="

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -96,7 +96,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.6.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -36,7 +36,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -123,7 +123,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.6.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -214,7 +214,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.6.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -38,7 +38,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -111,7 +111,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -179,7 +179,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -35,7 +35,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -193,7 +193,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -361,7 +361,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -86,7 +86,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -137,7 +137,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -191,7 +191,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -242,7 +242,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -94,7 +94,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.6.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -33,7 +33,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/schematron-020.xspec
+++ b/test/schematron-020.xspec
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test require-saxon-bug-4696-fixed?>
-<?xspec-test require-schxslt-issue-178-fixed?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
     schematron="schematron/schematron-020.sch">
     


### PR DESCRIPTION
Replace the built-in SchXslt v1.6.2 with v1.7.

Note that the base branch of this pull request is not `master` but `schxslt`.