### PR TITLE
test(schematron): remove SchXslt 1.6.2 test workaround

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -103,21 +103,6 @@
 			select="processing-instruction(xspec-test)" />
 		<xsl:variable as="xs:boolean" name="enable-coverage" select="$pis = 'enable-coverage'" />
 
-		<!-- Version of SchXslt. Empty sequence if not SchXslt.
-			This implementation is ad-hoc, because it depends on SchXslt internal structure. -->
-		<xsl:variable as="xs:integer?" name="schxslt-version">
-			<xsl:variable as="document-node(element(xsl:transform))?" name="version-xsl"
-				select="'../../../lib/schxslt/2.0/version.xsl'[doc-available(.)] ! doc(.)" />
-			<xsl:for-each select="$version-xsl">
-				<xsl:variable as="element(xsl:variable)" name="schxslt-ident"
-					select="descendant::xsl:variable[@name eq 'schxslt-ident']" />
-				<xsl:sequence select="
-						($schxslt-ident || '.0')
-						=> x:extract-version()
-						=> x:pack-version()" />
-			</xsl:for-each>
-		</xsl:variable>
-
 		<xsl:for-each select="x:description/(@query | @schematron | @stylesheet)">
 			<xsl:sort select="name()" />
 
@@ -237,12 +222,6 @@
 							($pis = 'require-saxon-bug-4835-fixed')
 							and ($x:saxon-version le x:pack-version((10, 3)))">
 						<xsl:text>Requires Saxon bug #4835 to have been fixed</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
-							($pis = 'require-schxslt-issue-178-fixed')
-							and ($schxslt-version le x:pack-version((1, 6, 2)))">
-						<xsl:text>Requires schxslt/schxslt#178 to have been fixed</xsl:text>
 					</xsl:when>
 
 					<xsl:when test="

--- a/test/schematron-020.xspec
+++ b/test/schematron-020.xspec
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test require-saxon-bug-4696-fixed?>
-<?xspec-test require-schxslt-issue-178-fixed?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
     schematron="schematron/schematron-020.sch">
     


### PR DESCRIPTION
SchXslt v1.7 no longer needs a test workaround. This pull request removes it.

This change is a backport from `schxslt` branch.