### PR TITLE
refactor(report): do not emit empty span in coverage report

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -272,9 +272,11 @@
             <xsl:if test="position() != 1">
                <xsl:text expand-text="yes">&#x0A;{format-number($line-number + position(), $number-format)}: </xsl:text>
             </xsl:if>
-            <span class="{$coverage}">
-               <xsl:value-of select="." />
-            </span>
+            <xsl:where-populated>
+               <span class="{$coverage}">
+                  <xsl:value-of select="." />
+               </span>
+            </xsl:where-populated>
          </xsl:for-each>
 
          <xsl:next-iteration>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
@@ -8,60 +8,60 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../../../../tutorial/coverage/demo.xsl">demo.xsl</a></p>
       <h2>module: demo.xsl; 29 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
-05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span><span class="ignored"></span>
-06: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
+05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span>
+06: 
 07: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 08: <span class="ignored">		Makes &lt;iron&gt; into &lt;shield&gt;</span>
 09: <span class="ignored">			This template overrides an imported template.</span>
-10: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span><span class="ignored"></span>
-12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span><span class="ignored"></span>
-13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span><span class="ignored"></span>
-15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-16: <span class="ignored"></span>
+10: <span class="ignored">	--&gt;</span>
+11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span>
+12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span>
+13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span>
+15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
 17: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 18: <span class="ignored">		Makes &lt;iron&gt; into &lt;gold&gt;</span>
 19: <span class="ignored">			Only in alchemy mode.</span>
-20: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span><span class="ignored"></span>
-23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span><span class="ignored"></span>
-24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span><span class="ignored"></span>
-26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-27: <span class="ignored"></span>
-28: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-29: <span class="ignored"></span></pre>
+20: <span class="ignored">	--&gt;</span>
+21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span>
+23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span>
+24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span>
+26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+27: 
+28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+29: </pre>
       <h2>module: demo-imported.xsl; 25 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
 05: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 06: <span class="ignored">		Identity template</span>
-07: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span><span class="ignored"></span>
-09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span><span class="ignored"></span>
-10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span><span class="ignored"></span>
-12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-13: <span class="ignored"></span>
+07: <span class="ignored">	--&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span>
+09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span>
+10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span>
+12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+13: 
 14: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 15: <span class="ignored">		Makes &lt;iron&gt; into &lt;sword&gt;</span>
 16: <span class="ignored">			This template will be overridden.</span>
-17: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span><span class="ignored"></span>
-19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span><span class="ignored"></span>
-20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-23: <span class="ignored"></span>
-24: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-25: <span class="ignored"></span></pre>
+17: <span class="ignored">	--&gt;</span>
+18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span>
+19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span>
+20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+23: 
+24: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+25: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
@@ -8,29 +8,29 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../external_issue-1410.xsl">external_issue-1410.xsl</a></p>
       <h2>module: external_issue-1410.xsl; 24 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
-05: <span class="ignored">	</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:global-context-item --&gt;</span><span class="ignored"></span>
-06: <span class="ignored">	</span><span class="ignored">&lt;xsl:global-context-item as="document-node(element(foo))" use="required" /&gt;</span><span class="ignored"></span>
-07: <span class="ignored"></span>
-08: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing no elements but xsl:context-item --&gt;</span><span class="ignored"></span>
-09: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-10: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="empty-sequence()" match="foo" mode="empty"&gt;</span><span class="ignored"></span>
-11: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span><span class="ignored"></span>
-12: <span class="ignored">		</span><span class="hit">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span><span class="ignored"></span>
-13: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-14: <span class="ignored"></span>
-15: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing xsl:context-item and literal result elements --&gt;</span><span class="ignored"></span>
-16: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="not-empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-17: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(bar)" match="foo" mode="not-empty"&gt;</span><span class="ignored"></span>
-18: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span><span class="ignored"></span>
-19: <span class="ignored">		</span><span class="missed">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span><span class="ignored"></span>
-20: <span class="ignored">		</span><span class="missed">&lt;bar /&gt;</span><span class="ignored"></span>
-21: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-22: <span class="ignored"></span>
-23: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-24: <span class="ignored"></span></pre>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
+03: <span class="ignored">	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
+05: <span class="ignored">	</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:global-context-item --&gt;</span>
+06: <span class="ignored">	</span><span class="ignored">&lt;xsl:global-context-item as="document-node(element(foo))" use="required" /&gt;</span>
+07: 
+08: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing no elements but xsl:context-item --&gt;</span>
+09: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+10: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="empty-sequence()" match="foo" mode="empty"&gt;</span>
+11: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span>
+12: <span class="ignored">		</span><span class="hit">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span>
+13: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+14: 
+15: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing xsl:context-item and literal result elements --&gt;</span>
+16: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="not-empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+17: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(bar)" match="foo" mode="not-empty"&gt;</span>
+18: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span>
+19: <span class="ignored">		</span><span class="missed">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span>
+20: <span class="ignored">		</span><span class="missed">&lt;bar /&gt;</span>
+21: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+22: 
+23: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+24: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
@@ -8,29 +8,29 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../external_issue-1410.xsl">external_issue-1410.xsl</a></p>
       <h2>module: external_issue-1410.xsl; 24 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
-05: <span class="ignored">	</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:global-context-item --&gt;</span><span class="ignored"></span>
-06: <span class="ignored">	</span><span class="ignored">&lt;xsl:global-context-item as="document-node(element(foo))" use="required" /&gt;</span><span class="ignored"></span>
-07: <span class="ignored"></span>
-08: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing no elements but xsl:context-item --&gt;</span><span class="ignored"></span>
-09: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-10: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="empty-sequence()" match="foo" mode="empty"&gt;</span><span class="ignored"></span>
-11: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span><span class="ignored"></span>
-12: <span class="ignored">		</span><span class="missed">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span><span class="ignored"></span>
-13: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-14: <span class="ignored"></span>
-15: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing xsl:context-item and literal result elements --&gt;</span><span class="ignored"></span>
-16: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="not-empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-17: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(bar)" match="foo" mode="not-empty"&gt;</span><span class="ignored"></span>
-18: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span><span class="ignored"></span>
-19: <span class="ignored">		</span><span class="hit">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span><span class="ignored"></span>
-20: <span class="ignored">		</span><span class="hit">&lt;bar /&gt;</span><span class="ignored"></span>
-21: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-22: <span class="ignored"></span>
-23: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-24: <span class="ignored"></span></pre>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
+03: <span class="ignored">	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
+05: <span class="ignored">	</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:global-context-item --&gt;</span>
+06: <span class="ignored">	</span><span class="ignored">&lt;xsl:global-context-item as="document-node(element(foo))" use="required" /&gt;</span>
+07: 
+08: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing no elements but xsl:context-item --&gt;</span>
+09: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+10: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="empty-sequence()" match="foo" mode="empty"&gt;</span>
+11: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span>
+12: <span class="ignored">		</span><span class="missed">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span>
+13: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+14: 
+15: <span class="ignored">	</span><span class="ignored">&lt;!-- Template containing xsl:context-item and literal result elements --&gt;</span>
+16: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="not-empty" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+17: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(bar)" match="foo" mode="not-empty"&gt;</span>
+18: <span class="ignored">		</span><span class="ignored">&lt;!-- Test Code Coverage with this xsl:context-item --&gt;</span>
+19: <span class="ignored">		</span><span class="hit">&lt;xsl:context-item as="element(foo)" use="required" /&gt;</span>
+20: <span class="ignored">		</span><span class="hit">&lt;bar /&gt;</span>
+21: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+22: 
+23: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+24: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
@@ -8,60 +8,60 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../../../../tutorial/coverage/demo.xsl">demo.xsl</a></p>
       <h2>module: demo.xsl; 29 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
-05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span><span class="ignored"></span>
-06: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
+05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span>
+06: 
 07: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 08: <span class="ignored">		Makes &lt;iron&gt; into &lt;shield&gt;</span>
 09: <span class="ignored">			This template overrides an imported template.</span>
-10: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span><span class="ignored"></span>
-12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span><span class="ignored"></span>
-13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span><span class="ignored"></span>
-15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-16: <span class="ignored"></span>
+10: <span class="ignored">	--&gt;</span>
+11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span>
+12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span>
+13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span>
+15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
 17: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 18: <span class="ignored">		Makes &lt;iron&gt; into &lt;gold&gt;</span>
 19: <span class="ignored">			Only in alchemy mode.</span>
-20: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span><span class="ignored"></span>
-23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span><span class="ignored"></span>
-24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span><span class="ignored"></span>
-26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-27: <span class="ignored"></span>
-28: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-29: <span class="ignored"></span></pre>
+20: <span class="ignored">	--&gt;</span>
+21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span>
+23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span>
+24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span>
+26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+27: 
+28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+29: </pre>
       <h2>module: demo-imported.xsl; 25 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
 05: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 06: <span class="ignored">		Identity template</span>
-07: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span><span class="ignored"></span>
-09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span><span class="ignored"></span>
-10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span><span class="ignored"></span>
-12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-13: <span class="ignored"></span>
+07: <span class="ignored">	--&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span>
+09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span>
+10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span>
+12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+13: 
 14: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 15: <span class="ignored">		Makes &lt;iron&gt; into &lt;sword&gt;</span>
 16: <span class="ignored">			This template will be overridden.</span>
-17: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span><span class="ignored"></span>
-19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span><span class="ignored"></span>
-20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-23: <span class="ignored"></span>
-24: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-25: <span class="ignored"></span></pre>
+17: <span class="ignored">	--&gt;</span>
+18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span>
+19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span>
+20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+23: 
+24: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+25: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity-coverage.html
@@ -8,17 +8,17 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-1411_entity.xsl">issue-1411_entity.xsl</a></p>
       <h2>module: issue-1411_entity.xsl; 12 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;!DOCTYPE xsl:stylesheet [</span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;!DOCTYPE xsl:stylesheet [</span>
 03: <span class="ignored">    &lt;!ENTITY nbsp "&amp;#160;"&gt;</span>
-04: <span class="ignored">]&gt;</span><span class="ignored"></span>
-05: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
-06: <span class="ignored">                version="3.0"&gt;</span><span class="ignored"></span>
-07: <span class="ignored"></span>
-08: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span><span class="ignored"></span>
-09: <span class="ignored">      </span><span class="hit">&lt;dummy&gt;</span><span class="hit">&amp;nbsp;</span><span class="hit">&lt;/dummy&gt;</span><span class="ignored"></span>
-10: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-11: <span class="ignored"></span>
-12: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+04: <span class="ignored">]&gt;</span>
+05: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+06: <span class="ignored">                version="3.0"&gt;</span>
+07: 
+08: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;dummy&gt;</span><span class="hit">&amp;nbsp;</span><span class="hit">&lt;/dummy&gt;</span>
+10: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+11: 
+12: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_no-entity-coverage.html
@@ -8,15 +8,15 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-1411_no-entity.xsl">issue-1411_no-entity.xsl</a></p>
       <h2>module: issue-1411_no-entity.xsl; 10 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;!DOCTYPE xsl:stylesheet&gt;</span><span class="ignored"></span>
-03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
-04: <span class="ignored">                version="3.0"&gt;</span><span class="ignored"></span>
-05: <span class="ignored"></span>
-06: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span><span class="ignored"></span>
-07: <span class="ignored">      </span><span class="hit">&lt;dummy/&gt;</span><span class="ignored"></span>
-08: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-09: <span class="ignored"></span>
-10: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;!DOCTYPE xsl:stylesheet&gt;</span>
+03: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+04: <span class="ignored">                version="3.0"&gt;</span>
+05: 
+06: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span>
+07: <span class="ignored">      </span><span class="hit">&lt;dummy/&gt;</span>
+08: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+09: 
+10: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
@@ -8,14 +8,14 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-214.xsl">issue-214.xsl</a></p>
       <h2>module: issue-214.xsl; 9 lines</h2>
-      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-2: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-3: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span><span class="ignored"></span>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+2: <span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+3: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span>
 4: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
 5: <span class="hit">test</span>
-6: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
-7: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-8: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-9: <span class="ignored"></span></pre>
+6: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span>
+7: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+8: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+9: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
@@ -8,15 +8,15 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-793-cr.xsl">issue-793-cr.xsl</a></p>
       <h2>module: issue-793-cr.xsl; 10 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR line ending --&gt;</span><span class="ignored"></span>
-03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span><span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;!-- This file must be saved with CR line ending --&gt;</span>
+03: <span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span>
 05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
 06: <span class="hit">test</span>
-07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-10: <span class="ignored"></span></pre>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+09: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+10: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
@@ -8,15 +8,15 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-793-crlf.xsl">issue-793-crlf.xsl</a></p>
       <h2>module: issue-793-crlf.xsl; 10 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with CR LF line ending --&gt;</span><span class="ignored"></span>
-03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span><span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;!-- This file must be saved with CR LF line ending --&gt;</span>
+03: <span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span>
 05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
 06: <span class="hit">test</span>
-07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-10: <span class="ignored"></span></pre>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+09: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+10: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
@@ -8,15 +8,15 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../issue-793-lf.xsl">issue-793-lf.xsl</a></p>
       <h2>module: issue-793-lf.xsl; 10 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;!-- This file must be saved with LF line ending --&gt;</span><span class="ignored"></span>
-03: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span><span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;!-- This file must be saved with LF line ending --&gt;</span>
+03: <span class="ignored">&lt;xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(output)" match="input"&gt;</span>
 05: <span class="ignored">		</span><span class="hit">&lt;output&gt;</span><span class="hit">&lt;![CDATA[</span>
 06: <span class="hit">test</span>
-07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-09: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-10: <span class="ignored"></span></pre>
+07: <span class="hit">]]&gt;</span><span class="hit">&lt;/output&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+09: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+10: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
@@ -8,60 +8,60 @@
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../../../../tutorial/coverage/demo.xsl">demo.xsl</a></p>
       <h2>module: demo.xsl; 29 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
-05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span><span class="ignored"></span>
-06: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
+05: <span class="ignored">	</span><span class="ignored">&lt;xsl:import href="demo-imported.xsl" /&gt;</span>
+06: 
 07: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 08: <span class="ignored">		Makes &lt;iron&gt; into &lt;shield&gt;</span>
 09: <span class="ignored">			This template overrides an imported template.</span>
-10: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span><span class="ignored"></span>
-12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span><span class="ignored"></span>
-13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span><span class="ignored"></span>
-15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-16: <span class="ignored"></span>
+10: <span class="ignored">	--&gt;</span>
+11: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="element(shield)" match="iron"&gt;</span>
+12: <span class="ignored">		</span><span class="hit">&lt;shield&gt;</span>
+13: <span class="ignored">			</span><span class="hit">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+14: <span class="ignored">		</span><span class="hit">&lt;/shield&gt;</span>
+15: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
 17: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 18: <span class="ignored">		Makes &lt;iron&gt; into &lt;gold&gt;</span>
 19: <span class="ignored">			Only in alchemy mode.</span>
-20: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span><span class="ignored"></span>
-23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span><span class="ignored"></span>
-24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span><span class="ignored"></span>
-26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-27: <span class="ignored"></span>
-28: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-29: <span class="ignored"></span></pre>
+20: <span class="ignored">	--&gt;</span>
+21: <span class="ignored">	</span><span class="ignored">&lt;xsl:mode name="alchemy" on-multiple-match="fail" on-no-match="fail" /&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(gold)" match="iron" mode="alchemy"&gt;</span>
+23: <span class="ignored">		</span><span class="missed">&lt;gold&gt;</span>
+24: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+25: <span class="ignored">		</span><span class="missed">&lt;/gold&gt;</span>
+26: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+27: 
+28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+29: </pre>
       <h2>module: demo-imported.xsl; 25 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored"></span>
-02: <span class="ignored"></span><span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
-03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored"></span>
-04: <span class="ignored"></span>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="2.0"</span>
+03: <span class="ignored">	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+04: 
 05: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 06: <span class="ignored">		Identity template</span>
-07: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span><span class="ignored"></span>
-09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span><span class="ignored"></span>
-10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span><span class="ignored"></span>
-12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-13: <span class="ignored"></span>
+07: <span class="ignored">	--&gt;</span>
+08: <span class="ignored">	</span><span class="hit">&lt;xsl:template as="node()" match="@* | node()"&gt;</span>
+09: <span class="ignored">		</span><span class="hit">&lt;xsl:copy&gt;</span>
+10: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+11: <span class="ignored">		</span><span class="hit">&lt;/xsl:copy&gt;</span>
+12: <span class="ignored">	</span><span class="hit">&lt;/xsl:template&gt;</span>
+13: 
 14: <span class="ignored">	</span><span class="ignored">&lt;!--</span>
 15: <span class="ignored">		Makes &lt;iron&gt; into &lt;sword&gt;</span>
 16: <span class="ignored">			This template will be overridden.</span>
-17: <span class="ignored">	--&gt;</span><span class="ignored"></span>
-18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span><span class="ignored"></span>
-19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span><span class="ignored"></span>
-20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span><span class="ignored"></span>
-21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span><span class="ignored"></span>
-22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored"></span>
-23: <span class="ignored"></span>
-24: <span class="ignored"></span><span class="ignored">&lt;/xsl:stylesheet&gt;</span><span class="ignored"></span>
-25: <span class="ignored"></span></pre>
+17: <span class="ignored">	--&gt;</span>
+18: <span class="ignored">	</span><span class="missed">&lt;xsl:template as="element(sword)" match="iron"&gt;</span>
+19: <span class="ignored">		</span><span class="missed">&lt;sword&gt;</span>
+20: <span class="ignored">			</span><span class="missed">&lt;xsl:apply-templates select="@* | node()" /&gt;</span>
+21: <span class="ignored">		</span><span class="missed">&lt;/sword&gt;</span>
+22: <span class="ignored">	</span><span class="missed">&lt;/xsl:template&gt;</span>
+23: 
+24: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+25: </pre>
    </body>
 </html>


### PR DESCRIPTION
Just remove empty `<span>` from the coverage report HTML.