### PR TITLE
test(report): code coverage with single line stylesheet

### DIFF
--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-coverage.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for issue-1411_entity_single-line.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../issue-1411_entity_single-line.xsl">issue-1411_entity_single-line.xsl</a></p>
+      <h2>module: issue-1411_entity_single-line.xsl; 1 lines</h2>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span><span class="ignored">&lt;!DOCTYPE xsl:stylesheet [    &lt;!ENTITY nbsp "&amp;#160;"&gt;]&gt;</span><span class="hit">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"                version="3.0"&gt;</span><span class="ignored">   </span><span class="hit">&lt;xsl:template match="dummy" as="element(dummy)"&gt;</span><span class="ignored">      </span><span class="hit">&lt;dummy&gt;</span><span class="hit">&amp;nbsp;</span><span class="hit">&lt;/dummy&gt;</span><span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span><span class="hit">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="issue-1411_entity_single-line.xspec">
+   <testsuite name="When converting a dummy element" tests="1" failures="0">
+      <testcase name="it should return a dummy element with an entity" status="passed"/>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-result.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for issue-1411_entity_single-line.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../issue-1411_entity_single-line.xsl">issue-1411_entity_single-line.xsl</a></p>
+      <p>XSpec: <a href="../../issue-1411_entity_single-line.xspec">issue-1411_entity_single-line.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 1</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 0</th>
+               <th class="totals">total: 1</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="successful">
+               <th><a href="#top_scenario1">When converting a dummy element</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">When converting a dummy element<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>When converting a dummy element</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it should return a dummy element with an entity</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1411_entity_single-line-result.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../issue-1411_entity_single-line.xspec"
+        stylesheet="../../issue-1411_entity_single-line.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../issue-1411_entity.xspec">
+      <label>When converting a dummy element</label>
+      <input-wrap xmlns="">
+         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <dummy/>
+         </x:context>
+      </input-wrap>
+      <result select="/element()">
+         <content-wrap xmlns="">
+            <dummy> </dummy>
+         </content-wrap>
+      </result>
+      <test id="scenario1-expect1" successful="true">
+         <label>it should return a dummy element with an entity</label>
+         <expect select="/element()">
+            <content-wrap xmlns="">
+               <dummy xmlns:x="http://www.jenitennison.com/xslt/xspec"> </dummy>
+            </content-wrap>
+         </expect>
+      </test>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/issue-1411_entity_single-line.xsl
+++ b/test/end-to-end/cases/issue-1411_entity_single-line.xsl
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE xsl:stylesheet [    <!ENTITY nbsp "&#160;">]><xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"                version="3.0">   <xsl:template match="dummy" as="element(dummy)">      <dummy>&nbsp;</dummy>   </xsl:template></xsl:stylesheet>

--- a/test/end-to-end/cases/issue-1411_entity_single-line.xspec
+++ b/test/end-to-end/cases/issue-1411_entity_single-line.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description stylesheet="issue-1411_entity_single-line.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!-- issue-1411_entity_single-line.xsl is an exact copy of issue-1411_entity.xsl with all the
+		line endings removed -->
+
+	<x:import href="issue-1411_entity.xspec" />
+
+</x:description>


### PR DESCRIPTION
Test code coverage with a stylesheet that consists of a single line (no CR or LF).