### PR TITLE
test: consolidate x:call/attribute(function) in line-number_*abled.xspec

### DIFF
--- a/test/line-number_disabled.xspec
+++ b/test/line-number_disabled.xspec
@@ -1,43 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test additional-classpath=${xspec.project.dir}/java?>
 <?xspec-test saxon-custom-options=-config:"${xspec.project.dir}/test/line-number/disabled-config.xml"?>
-<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm"
-	stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm" stylesheet="do-nothing.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:import href="line-number/common.xspec" />
 
 	<x:scenario label="Scenarios for testing x:line-number() with lineNumbering disabled">
+		<x:call function="x:line-number" />
 
 		<x:scenario label="processing instruction">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/processing-instruction()" />
 			</x:call>
 			<x:expect label="-1" select="-1" />
 		</x:scenario>
 
 		<x:scenario label="element">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem" />
 			</x:call>
 			<x:expect label="-1" select="-1" />
 		</x:scenario>
 
 		<x:scenario label="attribute">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem/@attr" />
 			</x:call>
 			<x:expect label="-1" select="-1" />
 		</x:scenario>
 
 		<x:scenario label="child element">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem/child" />
 			</x:call>
 			<x:expect label="-1" select="-1" />
 		</x:scenario>
 
 		<x:scenario label="comment">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/comment()" />
 			</x:call>
 			<x:expect label="-1" select="-1" />

--- a/test/line-number_enabled.xspec
+++ b/test/line-number_enabled.xspec
@@ -2,43 +2,44 @@
 <?xspec-test require-saxon-bug-3543-fixed?>
 <?xspec-test additional-classpath=${xspec.project.dir}/java?>
 <?xspec-test saxon-custom-options=-config:"${xspec.project.dir}/src/reporter/coverage-report-config.xml"?>
-<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm"
-	stylesheet="do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+<x:description query="x-urn:test:do-nothing" query-at="do-nothing.xqm" stylesheet="do-nothing.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:import href="line-number/common.xspec" />
 
 	<x:scenario label="Scenarios for testing x:line-number() with lineNumbering enabled">
+		<x:call function="x:line-number" />
 
 		<x:scenario label="processing instruction">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/processing-instruction()" />
 			</x:call>
 			<x:expect label="line number" select="2" />
 		</x:scenario>
 
 		<x:scenario label="element">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem" />
 			</x:call>
 			<x:expect label="line number" select="3" />
 		</x:scenario>
 
 		<x:scenario label="attribute">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem/@attr" />
 			</x:call>
 			<x:expect label="line number" select="3" />
 		</x:scenario>
 
 		<x:scenario label="child element">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/elem/child" />
 			</x:call>
 			<x:expect label="line number" select="4" />
 		</x:scenario>
 
 		<x:scenario label="comment">
-			<x:call function="x:line-number">
+			<x:call>
 				<x:param select="$doc/comment()" />
 			</x:call>
 			<x:expect label="line number" select="6" />


### PR DESCRIPTION
Remove verbose `x:call/@function` from `test/line-number_*abled.xspec`.