### PR TITLE
feat(schematron): bump built-in SchXslt to v1.7.1

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.7 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.7.1 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -327,8 +327,8 @@
                   </xsl:call-template>
                 </for-each>
               </schxslt:pattern>
-              <apply-templates mode="{$mode}" select="/"/>
             </xsl:for-each>
+            <apply-templates mode="{$mode}" select="/"/>
           </xsl:otherwise>
         </xsl:choose>
 

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.1</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -96,7 +96,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.1 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -36,7 +36,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -123,7 +123,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.1 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -214,7 +214,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.1 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -38,7 +38,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -111,7 +111,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -179,7 +179,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -35,7 +35,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -44,28 +44,6 @@
                   </dct:source>
                </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -88,49 +66,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -193,7 +129,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -202,28 +138,6 @@
                   </dct:source>
                </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -246,49 +160,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -361,7 +233,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -370,28 +242,6 @@
                   </dct:source>
                </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   role="error"
-                                   id="t2-1"
-                                   test="@sec-type">
-                  <svrl:text>
-                sec element should have a sec-type attribute.
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -414,49 +264,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                   id="t3-1"
-                                   test="title">
-                  <svrl:text>
-                section should have a title
-            </svrl:text>
-               </svrl:failed-assert>
-               <svrl:fired-rule context="sec"/>
                <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:fired-rule context="sec"/>
-               <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
-                                       role="warn"
-                                       id="t4-1"
-                                       test="count(p) = 1">
-                  <svrl:text>
-                Short section has only one paragraph.
-            </svrl:text>
-               </svrl:successful-report>
-               <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -86,7 +86,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -137,7 +137,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -191,7 +191,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -242,7 +242,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -94,7 +94,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.1 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -33,7 +33,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.1 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>


### PR DESCRIPTION
Replace the built-in SchXslt v1.7 with v1.7.1.

Note that the base branch of this pull request is not `master` but `schxslt`.