### PR TITLE
build(oxygen): add-on v2.1.3

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,19 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.1.3</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>feat: <code>x:expect/@pending</code> (<a
+							href="https://github.com/xspec/xspec/issues/728">#728</a>)</li>
+					<li>feat: measure time (<a href="https://github.com/xspec/xspec/pull/1397"
+							>#1397</a>)</li>
+					<li>fix(report): recognize doctypes in stylesheets (<a
+							href="https://github.com/xspec/xspec/pull/1413">#1413</a>)</li>
+					<li>Fully tested with SchXslt 1.7.1</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.1.2</h3>
 				<ul>
 					<li>feat: scenario x:param<ul>
@@ -85,19 +98,6 @@
 					<li>feat: support XML 1.1 in Ant build (<a
 							href="https://github.com/xspec/xspec/pull/1141">#1141</a>)</li>
 					<li>Minor fixes in importing Schematron tests</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.0.3</h3>
-				<ul>
-					<li>feat: <code>x:helper</code> (<a
-							href="https://github.com/xspec/xspec/pull/1103">#1103</a>)</li>
-					<li>feat(report): report all namespaces in test result report HTML (<a
-							href="https://github.com/xspec/xspec/pull/1095">#1095</a>)</li>
-					<li>Improvements in handling namespaces<ul>
-							<li>See also <a href="https://github.com/xspec/xspec/issues/1121"
-									>Breaking changes in v2.0</a></li>
-						</ul></li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/23ab74823263b45b82e79643384001ad0ddae014.zip" />
+			href="https://github.com/xspec/xspec/archive/58bcc6489b01d0be6e5fd0af677f97fb9e21dcd9.zip" />
 
-		<xt:version>2.1.2</xt:version>
+		<xt:version>2.1.3</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-23ab74823263b45b82e79643384001ad0ddae014/xspec.framework/XSpec</String>
+                                    <String>4/xspec-58bcc6489b01d0be6e5fd0af677f97fb9e21dcd9/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.
The [changelog](https://htmlpreview.github.io/?https://github.com/AirQuick/xspec/blob/d847643/editors/oxygen/add-on/description/latest.xhtml) denotes this version as "Release Candidate of the stable release".

I tested this change on Oxygen 23.1 build 2021030206 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-1-3/oxygen-addon.xml`:

- All the 4 transformation scenarios work including **Run XSpec Test** with XSLT, XQuery, Schematron and the latest visible change (#1412).
- Loading `xspec.xpr` disables the add-on and enables its own framework.
