### PR TITLE
build: release v2.1.4

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,12 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.1.4</h3>
+				<ul>
+					<li>Official release of v2.1</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.1.3</h3>
 				<ul>
 					<li>Release Candidate of the stable release</li>
@@ -86,18 +92,6 @@
 					<li>fix(xquery): fix issue 446 (x:pending may crash on XQuery) (<a
 							href="https://github.com/xspec/xspec/pull/1222">#1222</a>)</li>
 					<li>Reorganized compiler modules</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.0.4</h3>
-				<ul>
-					<li>feat(schematron): compare location based on node identity (<a
-							href="https://github.com/xspec/xspec/pull/1107">#1107</a>)</li>
-					<li>feat(xslt): static parameters (<a
-							href="https://github.com/xspec/xspec/pull/1120">#1120</a>)</li>
-					<li>feat: support XML 1.1 in Ant build (<a
-							href="https://github.com/xspec/xspec/pull/1141">#1141</a>)</li>
-					<li>Minor fixes in importing Schematron tests</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/58bcc6489b01d0be6e5fd0af677f97fb9e21dcd9.zip" />
+			href="https://github.com/xspec/xspec/archive/a3b057f08372a93d5bb73cdcfb2d78f037162382.zip" />
 
-		<xt:version>2.1.3</xt:version>
+		<xt:version>2.1.4</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>2.1-SNAPSHOT</version>
+  <version>2.1.4</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-58bcc6489b01d0be6e5fd0af677f97fb9e21dcd9/xspec.framework/XSpec</String>
+                                    <String>4/xspec-a3b057f08372a93d5bb73cdcfb2d78f037162382/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request increments the version numbers in `pom.xml` and `oxygen-addon.xml`, which makes the official stable release of `v2.1`. (technically `v2.1.4`, based on #940)

As for the file paths in `oxygen-addon.xml`, I used the last `master` SHA rather than the git tag `v2.1.4`, because we haven't had the actual tag yet and therefore cannot test it. I tested the Oxygen add-on on Oxygen 23.1 build 2021040908 using `https://github.com/AirQuick/xspec/raw/rel_2-1-4/oxygen-addon.xml`.