### PR TITLE
ci(deps): add GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: ci
+      include: scope
   - package-ecosystem: maven
     directory: '/'
     schedule:


### PR DESCRIPTION
Closes #1019 

Following #1460, this pr adds `package-ecosystem: github-actions` to `.github/dependabot.yml`.