### PR TITLE
ci(schematron): checkout action with GITHUB_TOKEN in rebase-schxslt.yml

### DIFF
--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: schxslt
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: |
           set -ex


### PR DESCRIPTION
Looks like the automated rebasing of `schxslt` branch is not triggering GitHub Actions in that branch. (Azure Pipelines and AppVeyor are triggered.)

As per https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854 , this pr tries fixing it by adding `token` to `checkout` action.