### PR TITLE
ci: skip AppVeyor on schxslt branch or tags or branch with open pr

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,11 @@
+branches:
+  except:
+    - schxslt
+
+skip_tags: true
+
+skip_branch_with_pr: true
+
 environment:
   matrix:
     # Non-mainstream jobs are not included in favor of GitHub Actions and Azure Pipelines


### PR DESCRIPTION
For performance reasons, this pr skips AppVeyor on
- `schxslt` branch
- tag push
- branches with open pull request