### PR TITLE
revert(schematron): "co w/ GITHUB_TOKEN in rebase-schxslt.yml (#1463)"

### DIFF
--- a/.github/workflows/rebase-schxslt.yml
+++ b/.github/workflows/rebase-schxslt.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: schxslt
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: |
           set -ex


### PR DESCRIPTION
This reverts commit f4b86ec27598f119205449dc45d517d4e6788081 which didn't work. Looks like the token in this case must be a real personal access token which I'm reluctant to create.
Still, the `schxslt` branch is always tested by Azure Pipelines and sometimes (when pushed by a human) by GitHub Actions. That would be suffice for now.