### PR TITLE
ci: skip Azure Pipelines on Dependabot push or any tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+trigger:
+  branches:
+    exclude:
+      - 'dependabot/*'
+  tags:
+    exclude:
+      - '*'
+
 jobs:
   - template: test/ci/azure-pipelines_windows.yml
     parameters:


### PR DESCRIPTION
For performance reasons, this pr skips Azure Pipelines on
- push in Dependabot branch; it's still triggered by pr event.
- tag push; it's still triggered by commit push.
