### PR TITLE
ci: remove Saxon 9.8 from Azure Pipelines

### DIFF
--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -6,6 +6,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.jobName }}
+    timeoutInMinutes: 0
 
     pool:
       vmImage: windows-latest

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -14,6 +14,7 @@ jobs:
       maxParallel: 5
 
       matrix:
+        # saxon-9-8 not included in favor of GitHub Actions
         Saxon-10:
           XSPEC_TEST_ENV: saxon-10
 
@@ -22,9 +23,6 @@ jobs:
 
         Oxygen:
           XSPEC_TEST_ENV: oxygen
-
-        Saxon-9-8:
-          XSPEC_TEST_ENV: saxon-9-8
 
     steps:
       - task: JavaToolInstaller@0


### PR DESCRIPTION
Somehow Azure Pipelines is getting slower nowadays. This pull request removes deprecated Saxon 9.8 from Azure Pipelines and sets `timeoutInMinutes: 0`.