### PR TITLE
ci: add `workflow_dispatch` to GitHub Actions Lint and Test workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - 'dependabot/**'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   codespell:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - 'dependabot/**'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Add [`workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to `lint.yml` and `test.yml` in `.github/workflows/` so that we can trigger them in the `schxslt` branch (or any others) at any time.