### PR TITLE
ci: codespell immediate child files of lib dir

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,4 @@ quiet-level = 6
 
 # ".git" dir is not skipped by default: codespell-project/codespell#783
 # Skipping nested dirs needs "./": codespell-project/codespell#99
-skip = .git,./lib,./node_modules
+skip = .git,./lib/*/*,node_modules


### PR DESCRIPTION
The current *codespell* configuration ignores everything in `lib/` including `lib/README.md`.

This pr fixes it so that only the subdirs of `lib/` are ignored.