### PR TITLE
build(maven): remove `--pinentry-mode` gpg arg from maven-gpg-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,17 +238,6 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <!--
-                    Prevent `gpg` from using pinentry programs
-                    https://github.com/samuelmeuli/action-maven-publish/issues/1#issuecomment-555756718
-                    https://github.com/samuelmeuli/action-maven-publish/issues/10#issuecomment-589245121
-                  -->
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MGPG-59 suggests that a workaround configuration of maven-gpg-plugin is no longer necessary on 3.0.0 or later. This PR removes it.

I'm not entirely sure about the fix, so I'm just merging this PR and will see if it works. I'll revert it immediately on failure.