### PR TITLE
build(oxygen): add-on v2.2.0

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,16 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.2.0</h3>
+				<ul>
+					<li>Initial development version of v2.2</li>
+					<li>feat(schematron): pending attribute on Schematron x:expect-* elements (<a
+							href="https://github.com/xspec/xspec/pull/1446">#1446</a>)</li>
+					<li>fix: pending variable declarations (<a
+							href="https://github.com/xspec/xspec/pull/1452">#1452</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.1.4</h3>
 				<ul>
 					<li>Official release of v2.1</li>
@@ -82,16 +92,6 @@
 							href="https://github.com/xspec/xspec/pull/1246">#1246</a>)</li>
 					<li><code>x:param[@position]</code> is designed more clearly (<a
 							href="https://github.com/xspec/xspec/pull/1267">#1267</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.0.5</h3>
-				<ul>
-					<li>fix(report): serialize text node report (<a
-							href="https://github.com/xspec/xspec/pull/1158">#1158</a>)</li>
-					<li>fix(xquery): fix issue 446 (x:pending may crash on XQuery) (<a
-							href="https://github.com/xspec/xspec/pull/1222">#1222</a>)</li>
-					<li>Reorganized compiler modules</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/a3b057f08372a93d5bb73cdcfb2d78f037162382.zip" />
+			href="https://github.com/xspec/xspec/archive/2827fabc1ea27e65ccf34906b2664e18e9d1f674.zip" />
 
-		<xt:version>2.1.4</xt:version>
+		<xt:version>2.2.0</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-a3b057f08372a93d5bb73cdcfb2d78f037162382/xspec.framework/XSpec</String>
+                                    <String>4/xspec-2827fabc1ea27e65ccf34906b2664e18e9d1f674/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 23.1 build 2021040908 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-2-0/oxygen-addon.xml`.