### PR TITLE
test(schematron): normalize SchXslt attribute(documents) in a new line

### DIFF
--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -184,21 +184,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -222,21 +236,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -260,21 +288,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -298,21 +340,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -336,21 +392,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -374,21 +444,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -417,21 +501,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -455,21 +553,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -493,21 +605,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -531,21 +657,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -569,21 +709,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -607,21 +761,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -49,20 +49,34 @@
          <result select="/element()">
             <content-wrap xmlns="">
                <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:saxon="http://saxon.sf.net/"
-                                       xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-                                       xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                       title=""
-                                       schemaVersion=""><!--   
-		   
-		   
-		 -->
-                  <svrl:active-pattern document=""
-                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                                       name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+                                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+                                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                       xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+                                       xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
+                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                     <dct:creator>
+                        <dct:Agent>
+                           <skos:prefLabel>Unknown</skos:prefLabel>
+                        </dct:Agent>
+                     </dct:creator>
+                     <dct:created>2000-01-01T00:00:00Z</dct:created>
+                     <dct:source>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                           <dct:creator>
+                              <dct:Agent>
+                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
+                              </dct:Agent>
+                           </dct:creator>
+                           <dct:created>2000-01-01T00:00:00Z</dct:created>
+                        </rdf:Description>
+                     </dct:source>
+                  </svrl:metadata>
+                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
          </result>
@@ -150,20 +164,34 @@
          <result select="/element()">
             <content-wrap xmlns="">
                <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:saxon="http://saxon.sf.net/"
-                                       xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-                                       xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                       title=""
-                                       schemaVersion=""><!--   
-		   
-		   
-		 -->
-                  <svrl:active-pattern document=""
-                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                                       name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+                                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+                                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                       xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+                                       xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
+                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                     <dct:creator>
+                        <dct:Agent>
+                           <skos:prefLabel>Unknown</skos:prefLabel>
+                        </dct:Agent>
+                     </dct:creator>
+                     <dct:created>2000-01-01T00:00:00Z</dct:created>
+                     <dct:source>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                           <dct:creator>
+                              <dct:Agent>
+                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
+                              </dct:Agent>
+                           </dct:creator>
+                           <dct:created>2000-01-01T00:00:00Z</dct:created>
+                        </rdf:Description>
+                     </dct:source>
+                  </svrl:metadata>
+                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
          </result>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -153,21 +153,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -191,21 +205,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -229,21 +257,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -267,21 +309,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -305,21 +361,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>
@@ -343,21 +413,35 @@
                      <tr>
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
-                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:iso="http://purl.oclc.org/dsdl/schematron"</span>
-                        <span class="xmlns">xmlns:saxon="http://saxon.sf.net/"</span>
-                        <span class="xmlns">xmlns:schold="http://www.ascc.net/xml/schematron"</span>
+                           <pre class="svrl">&lt;svrl:schematron-output <span class="xmlns">xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"</span>
+                        <span class="xmlns">xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"</span>
+                        <span class="xmlns">xmlns:sch="http://purl.oclc.org/dsdl/schematron"</span>
+                        <span class="xmlns">xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</span>
+                        <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
-                        <span class="xmlns">xmlns:xhtml="http://www.w3.org/1999/xhtml"</span>
-                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-                        <span class="xmlns trivial">xmlns:xsd="http://www.w3.org/2001/XMLSchema"</span>
-                        title=""
-                        schemaVersion=""&gt;&lt;!--   
-		   
-		   
-		 --&gt;
-   &lt;svrl:active-pattern document=""
-                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                        name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME" /&gt;
+                        <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
+   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
+                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
+      &lt;dct:creator&gt;
+         &lt;dct:Agent&gt;
+            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
+         &lt;/dct:Agent&gt;
+      &lt;/dct:creator&gt;
+      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+      &lt;dct:source&gt;
+         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
+            &lt;dct:creator&gt;
+               &lt;dct:Agent&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
+               &lt;/dct:Agent&gt;
+            &lt;/dct:creator&gt;
+            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
+         &lt;/rdf:Description&gt;
+      &lt;/dct:source&gt;
+   &lt;/svrl:metadata&gt;
+   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
                         <td>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -17,20 +17,34 @@
          <result select="/element()">
             <content-wrap xmlns="">
                <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:saxon="http://saxon.sf.net/"
-                                       xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-                                       xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                       title=""
-                                       schemaVersion=""><!--   
-		   
-		   
-		 -->
-                  <svrl:active-pattern document=""
-                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                                       name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+                                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+                                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                       xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+                                       xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
+                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                     <dct:creator>
+                        <dct:Agent>
+                           <skos:prefLabel>Unknown</skos:prefLabel>
+                        </dct:Agent>
+                     </dct:creator>
+                     <dct:created>2000-01-01T00:00:00Z</dct:created>
+                     <dct:source>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                           <dct:creator>
+                              <dct:Agent>
+                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
+                              </dct:Agent>
+                           </dct:creator>
+                           <dct:created>2000-01-01T00:00:00Z</dct:created>
+                        </rdf:Description>
+                     </dct:source>
+                  </svrl:metadata>
+                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
          </result>
@@ -88,20 +102,34 @@
          <result select="/element()">
             <content-wrap xmlns="">
                <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:saxon="http://saxon.sf.net/"
-                                       xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-                                       xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                       title=""
-                                       schemaVersion=""><!--   
-		   
-		   
-		 -->
-                  <svrl:active-pattern document=""
-                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                                       name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+                                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+                                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                       xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+                                       xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
+                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                     <dct:creator>
+                        <dct:Agent>
+                           <skos:prefLabel>Unknown</skos:prefLabel>
+                        </dct:Agent>
+                     </dct:creator>
+                     <dct:created>2000-01-01T00:00:00Z</dct:created>
+                     <dct:source>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                           <dct:creator>
+                              <dct:Agent>
+                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
+                              </dct:Agent>
+                           </dct:creator>
+                           <dct:created>2000-01-01T00:00:00Z</dct:created>
+                        </rdf:Description>
+                     </dct:source>
+                  </svrl:metadata>
+                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
          </result>
@@ -135,20 +163,34 @@
          <result select="/element()">
             <content-wrap xmlns="">
                <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:saxon="http://saxon.sf.net/"
-                                       xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
-                                       xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                       title=""
-                                       schemaVersion=""><!--   
-		   
-		   
-		 -->
-                  <svrl:active-pattern document=""
-                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
-                                       name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+                                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+                                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                       xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+                                       xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
+                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+                     <dct:creator>
+                        <dct:Agent>
+                           <skos:prefLabel>Unknown</skos:prefLabel>
+                        </dct:Agent>
+                     </dct:creator>
+                     <dct:created>2000-01-01T00:00:00Z</dct:created>
+                     <dct:source>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                           <dct:creator>
+                              <dct:Agent>
+                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
+                              </dct:Agent>
+                           </dct:creator>
+                           <dct:created>2000-01-01T00:00:00Z</dct:created>
+                        </rdf:Description>
+                     </dct:source>
+                  </svrl:metadata>
+                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
          </result>

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -195,7 +195,7 @@
 					<xsl:text>
 						^
 						(?:
-							([ ]+&lt;svrl:active-pattern[ ]documents=")			<!-- group 1 -->
+							([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
 							(\S+?)												<!-- group 2 -->
 							("[ ]/>)											<!-- group 3 -->
 							|


### PR DESCRIPTION
#1446 needs an adjustment in normalizing the test result HTML generated with SchXslt. This pull request updates `test/end-to-end/processor/html/_normalizer.xsl` and regenerates the expected results of #1446 for SchXslt.

Note that the base branch of this pull request is not `master` but `schxslt`.