### PR TITLE
ci(deps): bump BaseX from 9.5.1 to 9.5.2

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.10
 
 # Latest BaseX
-BASEX_VERSION=9.5.1
+BASEX_VERSION=9.5.2
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
https://github.com/BaseXdb/basex/blob/master/CHANGELOG
> VERSION 9.5.2 (May 27, 2021) -------------------------------------------
> 
>  - Performance tweaks, minor bug fixes

