### PR TITLE
ci: specify GitHub Actions minor patch version

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run: gpg --version
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v2.1.0
         with:
           java-version: 8
           distribution: zulu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v2.1.0
         with:
           java-version: ${{ matrix.java }}
           distribution: zulu
@@ -64,7 +64,7 @@ jobs:
           && call test\ci\last-git-status.cmd
           && call test\ci\test-maven-jar.cmd -silent
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v2.2.3
         if: env.MAVEN_PACKAGE_VERSION != ''
         with:
           name: maven-package_${{ env.MAVEN_PACKAGE_VERSION }}_${{ matrix.os }}_java-${{ matrix.java }}_${{ matrix.env }}


### PR DESCRIPTION
Specify minor and patch versions for `actions/setup-java` and `actions/upload-artifact`. That will make it easier to track changes of their releases.