### PR TITLE
ci(deps): bump Ant from 1.10.10 to 1.10.11

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -3,7 +3,7 @@
 #
 
 # Latest Ant
-ANT_VERSION=1.10.10
+ANT_VERSION=1.10.11
 
 # Latest BaseX
 BASEX_VERSION=9.5.2


### PR DESCRIPTION
This pull request just updates the Ant version used for testing.