### PR TITLE
test(schematron): backport e2e test HTML normalizer from schxslt branch

### DIFF
--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -195,7 +195,7 @@
 					<xsl:text>
 						^
 						(?:
-							([ ]+&lt;svrl:active-pattern[ ]documents=")			<!-- group 1 -->
+							([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
 							(\S+?)												<!-- group 2 -->
 							("[ ]/>)											<!-- group 3 -->
 							|


### PR DESCRIPTION
Backport `test/end-to-end/processor/html/_normalizer.xsl` from `schxslt` branch to `master` so that the end-to-end tests work with both SchXslt and the "skeleton" Schematron implementation.