### PR TITLE
feat(schematron): bump built-in SchXslt to v1.7.3

### DIFF
--- a/lib/schxslt/1.0/compile/compile-1.0.xsl
+++ b/lib/schxslt/1.0/compile/compile-1.0.xsl
@@ -256,7 +256,7 @@
 
   <xsl:template match="@*" mode="schxslt:variable-content">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
-      <value-of select="."/>
+      <xsl:value-of select="."/>
     </attribute>
   </xsl:template>
 

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.7.2 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.7.3 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/templates.xsl
+++ b/lib/schxslt/2.0/compile/templates.xsl
@@ -59,7 +59,7 @@
 
   <xsl:template match="@*" mode="schxslt:variable-content schxslt:message-template">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
-      <value-of select="."/>
+      <xsl:value-of select="."/>
     </attribute>
   </xsl:template>
 

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.2</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.3</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -203,7 +203,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -255,7 +255,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -307,7 +307,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -359,7 +359,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -411,7 +411,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -463,7 +463,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -520,7 +520,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -572,7 +572,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -624,7 +624,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -676,7 +676,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -728,7 +728,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -780,7 +780,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -67,7 +67,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -182,7 +182,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -96,7 +96,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -36,7 +36,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -172,7 +172,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -224,7 +224,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -276,7 +276,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -328,7 +328,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -380,7 +380,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -432,7 +432,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -120,7 +120,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -181,7 +181,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -123,7 +123,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -214,7 +214,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -38,7 +38,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -111,7 +111,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -179,7 +179,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -35,7 +35,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -129,7 +129,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -233,7 +233,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -86,7 +86,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -137,7 +137,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -191,7 +191,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -242,7 +242,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -94,7 +94,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.2 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -33,7 +33,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.2 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>


### PR DESCRIPTION
Replace the built-in SchXslt v1.7.2 with v1.7.3.

Note that the base branch of this pull request is not `master` but `schxslt`.