### PR TITLE
ci(deps): replace bats with bats-core on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo npm install -g bats
 
+      - name: Install Bats for macOS
+        if: runner.os == 'macOS'
+        run: >
+          brew uninstall bats
+          && brew install bats-core
+
       - name: Run tests for *nix
         if: runner.os != 'Windows'
         run: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,11 @@ jobs:
 
     steps:
       - script: >
+          brew uninstall bats
+          && brew install bats-core
+        displayName: Install Bats
+
+      - script: >
           source test/ci/install-deps.sh
           && test/ci/print-env.sh
           && test/ci/run-core-tests.sh


### PR DESCRIPTION
`bats` on macOS is stale (0.4.0) on both GitHub Actions and Azure Pipelines.
This pull request replaces it with the latest package (1.3.0 at the time of this writing).