### PR TITLE
test: normalize SchXslt version in result report XML and HTML

### DIFF
--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -203,7 +203,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -255,7 +255,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -307,7 +307,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -359,7 +359,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -411,7 +411,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -463,7 +463,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -520,7 +520,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -572,7 +572,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -624,7 +624,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -676,7 +676,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -728,7 +728,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -780,7 +780,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -67,7 +67,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -182,7 +182,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -96,7 +96,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -36,7 +36,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -172,7 +172,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -224,7 +224,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -276,7 +276,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -328,7 +328,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -380,7 +380,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -432,7 +432,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -120,7 +120,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -181,7 +181,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -123,7 +123,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;
@@ -214,7 +214,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -38,7 +38,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -111,7 +111,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -179,7 +179,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -35,7 +35,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -129,7 +129,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>
@@ -233,7 +233,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -35,7 +35,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -86,7 +86,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -137,7 +137,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -191,7 +191,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>
@@ -242,7 +242,7 @@
                         <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                            <dct:creator>
                               <dct:Agent>
-                                 <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                                  <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                               </dct:Agent>
                            </dct:creator>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -94,7 +94,7 @@
          &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
             &lt;dct:creator&gt;
                &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/1.7.3 SAXON/product-version&lt;/skos:prefLabel&gt;
+                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
                   &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
                &lt;/dct:Agent&gt;
             &lt;/dct:creator&gt;

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -33,7 +33,7 @@
                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                         <dct:creator>
                            <dct:Agent>
-                              <skos:prefLabel>SchXslt/1.7.3 SAXON/product-version</skos:prefLabel>
+                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
                               <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                            </dct:Agent>
                         </dct:creator>

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -141,7 +141,7 @@
 				out: <dct:created>2000-01-01T00:00:00Z</dct:created>
 				
 				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
 	-->
 	<xsl:template as="text()" match="pre[contains-token(@class, 'svrl')]/text()"
 		mode="normalizer:normalize">
@@ -204,9 +204,11 @@
 							\S+?
 							(&lt;/dct:created>)									<!-- group 5 -->
 							|
-							([ ]+&lt;skos:prefLabel>SchXslt/[0-9.]+[ ]SAXON/)	<!-- group 6 -->
+							([ ]+&lt;skos:prefLabel>SchXslt/)					<!-- group 6 -->
+							[0-9.]+
+							([ ]SAXON/)											<!-- group 7 -->
 							[^/]+?
-							(&lt;/skos:prefLabel>)								<!-- group 7 -->
+							(&lt;/skos:prefLabel>)								<!-- group 8 -->
 						)
 						$
 					</xsl:text>
@@ -231,8 +233,10 @@
 								<xsl:when test="regex-group(6)">
 									<xsl:sequence select="
 											regex-group(6),
+											'version',
+											regex-group(7),
 											'product-version',
-											regex-group(7)" />
+											regex-group(8)" />
 								</xsl:when>
 								<xsl:otherwise>
 									<xsl:message terminate="yes" />

--- a/test/end-to-end/processor/xml/_normalizer.xsl
+++ b/test/end-to-end/processor/xml/_normalizer.xsl
@@ -59,7 +59,7 @@
 		Normalizes skos:prefLabel
 			Example:
 				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/1.6.2 SAXON/product-version</skos:prefLabel>
+				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
 				
 				in:  <skos:prefLabel>SAXON/HE 9.9.1.7</skos:prefLabel>
 				out: <skos:prefLabel>SAXON/product-version</skos:prefLabel>
@@ -68,10 +68,29 @@
 			/x:report[local:svrl-creator(.) eq 'schxslt']//x:scenario/x:result/content-wrap
 			/svrl:schematron-output/svrl:metadata//dct:creator/dct:Agent/skos:prefLabel[. ne 'Unknown']/text()"
 		mode="normalizer:normalize">
+		<xsl:variable as="xs:string" name="regex">
+			<xsl:text>
+				^
+					(?:
+						(SchXslt/)	<!-- group 1 -->
+						[0-9.]+
+						([ ])		<!-- group 2 -->
+					)?
+					(SAXON/)		<!-- group 3 -->
+					[^/]+
+				$
+			</xsl:text>
+		</xsl:variable>
+
 		<!-- Use analyze-string() so that the transformation will fail when nothing matches -->
-		<xsl:analyze-string regex="^((?:SchXslt/[0-9.]+ )?SAXON/)[^/]+$" select=".">
+		<xsl:analyze-string flags="x" regex="{$regex}" select=".">
 			<xsl:matching-substring>
-				<xsl:value-of select="regex-group(1) || 'product-version'" />
+				<xsl:value-of>
+					<xsl:if test="regex-group(1)">
+						<xsl:value-of select="regex-group(1) || 'version' || regex-group(2)" />
+					</xsl:if>
+					<xsl:value-of select="regex-group(3) || 'product-version'" />
+				</xsl:value-of>
 			</xsl:matching-substring>
 		</xsl:analyze-string>
 	</xsl:template>


### PR DESCRIPTION
To reduce noise, this pull request normalizes SchXslt version numbers in the result report XML and HTML while performing end-to-end tests.

Note that the base branch of this pull request is not `master` but `schxslt`.