### PR TITLE
feat(schematron): bump built-in SchXslt to v1.7.4

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.7.3 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.7.4 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -219,25 +219,29 @@
         <xsl:with-param name="typed-variables" as="xs:boolean" select="$typed-variables"/>
       </xsl:call-template>
 
-      <schxslt:rule pattern="{generate-id(..)}">
-        <choose>
-          <when test="$schxslt:patterns-matched[. = '{generate-id(..)}']">
+      <choose>
+        <when test="$schxslt:patterns-matched[. = '{generate-id(..)}']">
+          <schxslt:rule pattern="{generate-id(..)}">
             <xsl:call-template name="schxslt-api:suppressed-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
             </xsl:call-template>
-          </when>
-          <otherwise>
+          </schxslt:rule>
+          <next-match>
+            <with-param name="schxslt:patterns-matched" as="xs:string*" select="$schxslt:patterns-matched"/>
+          </next-match>
+        </when>
+        <otherwise>
+          <schxslt:rule pattern="{generate-id(..)}">
             <xsl:call-template name="schxslt-api:fired-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
             </xsl:call-template>
             <xsl:apply-templates select="sch:assert | sch:report" mode="schxslt:compile"/>
-          </otherwise>
-        </choose>
-      </schxslt:rule>
-
-      <next-match>
-        <with-param name="schxslt:patterns-matched" as="xs:string*" select="($schxslt:patterns-matched, '{generate-id(..)}')"/>
-      </next-match>
+          </schxslt:rule>
+          <next-match>
+            <with-param name="schxslt:patterns-matched" as="xs:string*" select="($schxslt:patterns-matched, '{generate-id(..)}')"/>
+          </next-match>
+        </otherwise>
+      </choose>
     </template>
 
   </xsl:template>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.3</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.4</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.7.3 with v1.7.4.

Note that the base branch of this pull request is not `master` but `schxslt`.