### PR TITLE
test(schematron): test bad attribute(location)

### DIFF
--- a/test/schematron/bad-location/atomic/expect-assert.xspec
+++ b/test/schematron/bad-location/atomic/expect-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-assert
+			label="x:expect-assert/@location selecting an atomic value should be a fatal error."
+			location="1" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/atomic/expect-not-assert.xspec
+++ b/test/schematron/bad-location/atomic/expect-not-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-not-assert
+			label="x:expect-not-assert/@location selecting an atomic value should be a fatal error."
+			location="1" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/atomic/expect-not-report.xspec
+++ b/test/schematron/bad-location/atomic/expect-not-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-not-report
+			label="x:expect-not-report/@location selecting an atomic value should be a fatal error."
+			location="1" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/atomic/expect-report.xspec
+++ b/test/schematron/bad-location/atomic/expect-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-report
+			label="x:expect-report/@location selecting an atomic value should be a fatal error."
+			location="1" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/context.xml
+++ b/test/schematron/bad-location/context.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo />

--- a/test/schematron/bad-location/empty/expect-assert.xspec
+++ b/test/schematron/bad-location/empty/expect-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-assert
+			label="x:expect-assert/@location selecting an empty sequence should be a fatal error."
+			location="()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/empty/expect-not-assert.xspec
+++ b/test/schematron/bad-location/empty/expect-not-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-not-assert
+			label="x:expect-not-assert/@location selecting an empty sequence should be a fatal error."
+			location="()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/empty/expect-not-report.xspec
+++ b/test/schematron/bad-location/empty/expect-not-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-not-report
+			label="x:expect-not-report/@location selecting an empty sequence should be a fatal error."
+			location="()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/empty/expect-report.xspec
+++ b/test/schematron/bad-location/empty/expect-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-report
+			label="x:expect-report/@location selecting an empty sequence should be a fatal error."
+			location="()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/multiple/expect-assert.xspec
+++ b/test/schematron/bad-location/multiple/expect-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-assert
+			label="x:expect-assert/@location selecting 2+ nodes should be a fatal error."
+			location="/descendant-or-self::node()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/multiple/expect-not-assert.xspec
+++ b/test/schematron/bad-location/multiple/expect-not-assert.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:assert is false">
+		<x:context href="../context.xml" />
+		<x:expect-not-assert
+			label="x:expect-not-assert/@location selecting 2+ nodes should be a fatal error."
+			location="/descendant-or-self::node()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/multiple/expect-not-report.xspec
+++ b/test/schematron/bad-location/multiple/expect-not-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-not-report
+			label="x:expect-not-report/@location selecting 2+ nodes should be a fatal error."
+			location="/descendant-or-self::node()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/multiple/expect-report.xspec
+++ b/test/schematron/bad-location/multiple/expect-report.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="../test.sch" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="When sch:report is true">
+		<x:context href="../context.xml" />
+		<x:expect-report
+			label="x:expect-report/@location selecting 2+ nodes should be a fatal error."
+			location="/descendant-or-self::node()" />
+	</x:scenario>
+
+</x:description>

--- a/test/schematron/bad-location/test.sch
+++ b/test/schematron/bad-location/test.sch
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+	<sch:pattern>
+		<sch:rule context="foo">
+			<sch:assert test="false()" />
+			<sch:report test="true()" />
+		</sch:rule>
+	</sch:pattern>
+</sch:schema>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2630,4 +2630,68 @@
     call :verify_line 8 r "  FOER0000[: ] /Q{http://www.jenitennison.com/xslt/xspec}description\[1\]/Q{http://www.jenitennison.com/xslt/xspec}scenario\[1\]/@threads is not an integer"
 	</case>
 
+	<!--
+		Bad Schematron @location
+	-->
+
+	<case name="@location selects an atomic value">
+    cd schematron\bad-location\atomic
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] ..* value in 'treat as' expression is node()"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] ..* value in 'treat as' expression is node()"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] ..* value in 'treat as' expression is node()"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] ..* value in 'treat as' expression is node()"
+	</case>
+
+	<case name="@location selects an empty sequence">
+    cd schematron\bad-location\empty
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] The value in 'treat as' expression does not satisfy the cardinality constraints$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] The value in 'treat as' expression does not satisfy the cardinality constraints$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] The value in 'treat as' expression does not satisfy the cardinality constraints$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] The value in 'treat as' expression does not satisfy the cardinality constraints$"
+	</case>
+
+	<case name="@location selects 2+ nodes">
+    cd schematron\bad-location\multiple
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] A sequence of more than one item is not allowed as the value in 'treat as'$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-assert.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] A sequence of more than one item is not allowed as the value in 'treat as'$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-not-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] A sequence of more than one item is not allowed as the value in 'treat as'$"
+
+    call :run ..\..\..\..\bin\xspec.bat -s expect-report.xspec
+    call :verify_retval 2
+    call :verify_line * r "  XPDY0050[: ] A sequence of more than one item is not allowed as the value in 'treat as'$"
+	</case>
+
 </collection>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -3016,3 +3016,79 @@ load bats-helper
     assert_regex "${lines[7]}" '^  FOER0000[: ] /Q\{http://www.jenitennison.com/xslt/xspec\}description\[1\]/Q\{http://www.jenitennison.com/xslt/xspec\}scenario\[1\]/@threads is not an integer'
 }
 
+#
+# Bad Schematron @location
+#
+
+@test "@location selects an atomic value" {
+    cd schematron/bad-location/atomic
+
+    run ../../../../bin/xspec.sh -s expect-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] .+ value in '\''treat as'\'' expression is node\(\)'
+
+    run ../../../../bin/xspec.sh -s expect-not-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] .+ value in '\''treat as'\'' expression is node\(\)'
+
+    run ../../../../bin/xspec.sh -s expect-not-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] .+ value in '\''treat as'\'' expression is node\(\)'
+
+    run ../../../../bin/xspec.sh -s expect-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] .+ value in '\''treat as'\'' expression is node\(\)'
+}
+
+@test "@location selects an empty sequence" {
+    cd schematron/bad-location/empty
+
+    run ../../../../bin/xspec.sh -s expect-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] The value in '\''treat as'\'' expression does not satisfy the cardinality constraints'$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-not-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] The value in '\''treat as'\'' expression does not satisfy the cardinality constraints'$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-not-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] The value in '\''treat as'\'' expression does not satisfy the cardinality constraints'$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] The value in '\''treat as'\'' expression does not satisfy the cardinality constraints'$'\n'
+}
+
+@test "@location selects 2+ nodes" {
+    cd schematron/bad-location/multiple
+
+    run ../../../../bin/xspec.sh -s expect-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] A sequence of more than one item is not allowed as the value in '\''treat as'\'''$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-not-assert.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] A sequence of more than one item is not allowed as the value in '\''treat as'\'''$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-not-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] A sequence of more than one item is not allowed as the value in '\''treat as'\'''$'\n'
+
+    run ../../../../bin/xspec.sh -s expect-report.xspec
+    echo "$output"
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''  XPDY0050[: ] A sequence of more than one item is not allowed as the value in '\''treat as'\'''$'\n'
+}
+


### PR DESCRIPTION
Related to https://github.com/xspec/xspec/pull/1506#issuecomment-882099608.
This pull request tests bad `@location` in Schematron `x:expect-*` where `@location` selects an atomic value, an empty sequence or multiple nodes.