### PR TITLE
build(oxygen): add-on v2.2.2

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.2.2</h3>
+				<ul>
+					<li>fix(schematron): handle location attribute not pointing to one node (<a
+							href="https://github.com/xspec/xspec/pull/1506">#1506</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.2.1</h3>
 				<ul>
 					<li>feat: multi-threading (<a href="https://github.com/xspec/xspec/pull/1497"
@@ -84,12 +91,6 @@
 					<li>Initial development version of v2.1</li>
 					<li>feat(schematron): support /x:description/attribute(run-as) (<a
 							href="https://github.com/xspec/xspec/pull/1294">#1294</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.0.7</h3>
-				<ul>
-					<li>Official release of v2.0</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/eb110b0df552b2890e745907cf318e2d6db79cc9.zip" />
+			href="https://github.com/xspec/xspec/archive/d84d3b3408a68f749795dcfbc8c7f793ee53d726.zip" />
 
-		<xt:version>2.2.1</xt:version>
+		<xt:version>2.2.2</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-eb110b0df552b2890e745907cf318e2d6db79cc9/xspec.framework/XSpec</String>
+                                    <String>4/xspec-d84d3b3408a68f749795dcfbc8c7f793ee53d726/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
Following #1506, this pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 23.1 build 2021061407 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-2-2/oxygen-addon.xml`.