### PR TITLE
perf(schematron): preprocess Schematron in parallel on Ant

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -298,8 +298,8 @@
     </saxon-xslt>
   </target>
 
-  <!-- Converts Schematron into XSLT -->
-  <target name="preprocess-schematron-xslt"
+  <!-- Converts Schematron and Schematron XSpec into XSLT and XSLT XSpec -->
+  <target name="preprocess-schematron"
           if="${xspec.is.schematron}">
 
     <!-- Mark URI of preprocessors to be skipped -->
@@ -321,42 +321,41 @@
              file="${xspec.schematron.preprocessor.step3}"
              if:set="xspec.schematron.preprocessor.step3" />
 
-    <!-- Location of the generated XSLT file -->
+    <!-- Location and URI of the generated XSLT file -->
     <property name="xspec.schematron.preprocessed.xsl.file"
               value="${xspec.output.dir}/${xspec.xspecfile.name.without.ext}-sch-preprocessed.xsl" />
-
-    <saxon-xslt in="${xspec.xspecfile.original}"
-                out="${xspec.schematron.preprocessed.xsl.file}"
-                style="${xspec.project.dir}/src/schematron/schut-to-xslt.xsl">
-      <xslt-elements>
-        <param name="STEP1-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step1.url}"
-          if:set="xspec.schematron.preprocessor.step1.url" />
-        <param name="STEP2-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step2.url}"
-          if:set="xspec.schematron.preprocessor.step2.url" />
-        <param name="STEP3-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step3.url}"
-          if:set="xspec.schematron.preprocessor.step3.url" />
-      </xslt-elements>
-    </saxon-xslt>
-  </target>
-
-  <!-- Converts Schematron XSpec into XSLT XSpec -->
-  <target name="preprocess-schematron-xspec"
-          depends="preprocess-schematron-xslt"
-          if="${xspec.is.schematron}">
     <makeurl property="xspec.schematron.preprocessed.xsl.url"
-             file="${xspec.schematron.preprocessed.xsl.file}" />
+             file="${xspec.schematron.preprocessed.xsl.file}"
+             validate="false" />
 
-    <saxon-xslt in="${xspec.xspecfile.original}"
-                out="${xspec.xspecfile.preprocessed}"
-                style="${xspec.project.dir}/src/schematron/schut-to-xspec.xsl">
-      <xslt-elements>
-        <param name="stylesheet-uri" expression="${xspec.schematron.preprocessed.xsl.url}" />
-      </xslt-elements>
-    </saxon-xslt>
+    <parallel failonany="true" threadsPerProcessor="1">
+      <!-- Convert Schematron into XSLT -->
+      <saxon-xslt in="${xspec.xspecfile.original}"
+                  out="${xspec.schematron.preprocessed.xsl.file}"
+                  style="${xspec.project.dir}/src/schematron/schut-to-xslt.xsl">
+        <xslt-elements>
+          <param name="STEP1-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step1.url}"
+            if:set="xspec.schematron.preprocessor.step1.url" />
+          <param name="STEP2-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step2.url}"
+            if:set="xspec.schematron.preprocessor.step2.url" />
+          <param name="STEP3-PREPROCESSOR-URI" expression="${xspec.schematron.preprocessor.step3.url}"
+            if:set="xspec.schematron.preprocessor.step3.url" />
+        </xslt-elements>
+      </saxon-xslt>
+
+      <!-- Convert Schematron XSpec into XSLT XSpec -->
+      <saxon-xslt in="${xspec.xspecfile.original}"
+                  out="${xspec.xspecfile.preprocessed}"
+                  style="${xspec.project.dir}/src/schematron/schut-to-xspec.xsl">
+        <xslt-elements>
+          <param name="stylesheet-uri" expression="${xspec.schematron.preprocessed.xsl.url}" />
+        </xslt-elements>
+      </saxon-xslt>
+    </parallel>
   </target>
 
   <!-- Compiles the XSpec file into the test runner file written in XSLT or XQuery -->
-  <target name="compile" depends="init, generate-catalog, preprocess-schematron-xspec">
+  <target name="compile" depends="init, generate-catalog, preprocess-schematron">
     <property name="xspec.compiler.dir"
               value="${xspec.project.dir}/src/compiler" />
 


### PR DESCRIPTION
On Ant, these two steps in `build.xml` can be run at the same time.
- Convert Schematron into XSLT
- Convert Schematron XSpec into XSLT XSpec

This pull request puts them in `<parallel>`.

### Test

I ran `for /l %I in (1,1,30) do timeit -k master -s cmd /c ant -lib saxon9ee.jar -Dtest.type=s -Dxspec.xml=test\schematron-016.xspec` on the current `master` branch and `-k pr` on this PR branch.

```console
C:\xspec>timeit -t
Runs Name                      Elapsed Time   Process Time    System   Context    Page    Total I/O
                                                               Calls  Switches   Faults
24   master                     0:00:07.385   0:00:00.146
24   pr                         0:00:06.938   0:00:00.145
```