### PR TITLE
ci(deps): bump BaseX from 9.6 to 9.6.1

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.11
 
 # Latest BaseX
-BASEX_VERSION=9.6
+BASEX_VERSION=9.6.1
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
https://github.com/BaseXdb/basex/blob/master/CHANGELOG

> VERSION 9.6.1 (August 26, 2021) ----------------------------------------
> 
> - GUI bug fix, XQuery performance tweaks
