### PR TITLE
build(oxygen): add-on v2.2.3

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.2.3</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>Tested with BaseX 9.6.1</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.2.2</h3>
 				<ul>
 					<li>fix(schematron): handle location attribute not pointing to one node (<a
@@ -83,14 +90,6 @@
 				<ul>
 					<li>Report more types</li>
 					<li>Constrain <code>x:param</code></li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.1.0</h3>
-				<ul>
-					<li>Initial development version of v2.1</li>
-					<li>feat(schematron): support /x:description/attribute(run-as) (<a
-							href="https://github.com/xspec/xspec/pull/1294">#1294</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/d84d3b3408a68f749795dcfbc8c7f793ee53d726.zip" />
+			href="https://github.com/xspec/xspec/archive/141220dee5eac694ccf831dee8a68e57bcaceb9b.zip" />
 
-		<xt:version>2.2.2</xt:version>
+		<xt:version>2.2.3</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-d84d3b3408a68f749795dcfbc8c7f793ee53d726/xspec.framework/XSpec</String>
+                                    <String>4/xspec-141220dee5eac694ccf831dee8a68e57bcaceb9b/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.
The [changelog](https://htmlpreview.github.io/?https://github.com/AirQuick/xspec/blob/6709444/editors/oxygen/add-on/description/latest.xhtml) denotes this version as "Release Candidate of the stable release".

I tested this change on Oxygen 23.1 build 2021082307 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-2-3/oxygen-addon.xml`:

- All the 4 transformation scenarios work including **Run XSpec Test** with XSLT, XQuery, Schematron and the latest visible change (#1506).
- Loading `xspec.xpr` disables the add-on and enables its own framework.
