### PR TITLE
feat(schematron): bump built-in SchXslt to v1.8.2

### DIFF
--- a/lib/schxslt/1.0/compile-for-svrl.xsl
+++ b/lib/schxslt/1.0/compile-for-svrl.xsl
@@ -194,18 +194,9 @@
     <svrl:property-reference property="{$head}">
       <xsl:copy-of select="key('schxslt:properties', $head)/@role"/>
       <xsl:copy-of select="key('schxslt:properties', $head)/@schema"/>
-      <xsl:for-each select="key('schxslt:properties', $head)/node()">
-        <xsl:choose>
-          <xsl:when test="self::text() and normalize-space(.)">
-            <svrl:text>
-              <xsl:apply-templates select="." mode="schxslt:message-template"/>
-            </svrl:text>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:copy-of select="."/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:for-each>
+      <svrl:text>
+        <xsl:apply-templates select="key('schxslt:properties', $head)/node()" mode="schxslt:message-template"/>
+      </svrl:text>
     </svrl:property-reference>
 
     <xsl:choose>

--- a/lib/schxslt/1.0/compile/compile-1.0.xsl
+++ b/lib/schxslt/1.0/compile/compile-1.0.xsl
@@ -16,6 +16,7 @@
   <xsl:key name="schxslt:properties" match="sch:property" use="@id"/>
 
   <xsl:param name="phase">#DEFAULT</xsl:param>
+  <xsl:param name="schxslt.compile.metadata" select="true()"/>
 
   <xsl:template match="/sch:schema">
 
@@ -93,12 +94,14 @@
       <template match="/">
 
         <variable name="schxslt:report">
-          <xsl:call-template name="schxslt-api:metadata">
-            <xsl:with-param name="schema" select="."/>
-            <xsl:with-param name="source">
-              <xsl:call-template name="schxslt:version"/>
-            </xsl:with-param>
-          </xsl:call-template>
+          <xsl:if test="$schxslt.compile.metadata">
+            <xsl:call-template name="schxslt-api:metadata">
+              <xsl:with-param name="schema" select="."/>
+              <xsl:with-param name="source">
+                <xsl:call-template name="schxslt:version"/>
+              </xsl:with-param>
+            </xsl:call-template>
+          </xsl:if>
           <xsl:choose>
             <xsl:when test="$effective-phase = '#ALL'">
               <xsl:for-each select="sch:pattern[sch:rule]">
@@ -215,11 +218,11 @@
   </xsl:template>
 
   <!-- Message templates -->
-  <xsl:template match="comment() | processing-instruction()" mode="schxslt:message-template">
+  <xsl:template match="comment() | processing-instruction()" mode="schxslt:message-template" priority="-10">
     <xsl:copy-of select="."/>
   </xsl:template>
 
-  <xsl:template match="*" mode="schxslt:message-template">
+  <xsl:template match="*" mode="schxslt:message-template" priority="-10">
     <element namespace="{namespace-uri(.)}" name="{local-name(.)}">
       <xsl:apply-templates select="node() | @*" mode="schxslt:message-template"/>
     </element>

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.8 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.8.2 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.7.4 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.8 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -133,9 +133,11 @@
         <!-- Unwrap the intermediary report -->
         <variable name="schxslt:report" as="node()*">
           <sequence select="$metadata"/>
-          <for-each select="$report/schxslt:pattern">
-            <sequence select="node()"/>
-            <sequence select="$report/schxslt:rule[@pattern = current()/@id]/node()"/>
+          <for-each select="$report/schxslt:document">
+            <for-each select="schxslt:pattern">
+              <sequence select="node()"/>
+              <sequence select="../schxslt:rule[@pattern = current()/@id]/node()"/>
+            </for-each>
           </for-each>
         </variable>
 
@@ -288,54 +290,60 @@
             <xsl:choose>
               <xsl:when test="$xslt-version = '3.0'">
                 <for-each select="{@documents}">
-                  <source-document href="{{.}}">
+                  <schxslt:document>
+                    <source-document href="{{.}}">
+                      <xsl:for-each select="current-group()">
+                        <schxslt:pattern id="{generate-id()}">
+                          <for-each select=".">
+                            <xsl:call-template name="schxslt-api:active-pattern">
+                              <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
+                            </xsl:call-template>
+                          </for-each>
+                        </schxslt:pattern>
+                        <apply-templates mode="{$mode}" select="."/>
+                      </xsl:for-each>
+                    </source-document>
+                  </schxslt:document>
+                </for-each>
+              </xsl:when>
+              <xsl:otherwise>
+                <for-each select="{@documents}">
+                  <schxslt:document>
+                    <variable name="document" as="item()" select="document(.)"/>
                     <xsl:for-each select="current-group()">
                       <schxslt:pattern id="{generate-id()}">
-                        <for-each select=".">
+                        <if test="exists(base-uri($document))">
+                          <attribute name="documents" select="base-uri($document)"/>
+                        </if>
+                        <for-each select="$document">
                           <xsl:call-template name="schxslt-api:active-pattern">
                             <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
                           </xsl:call-template>
                         </for-each>
                       </schxslt:pattern>
-                      <apply-templates mode="{$mode}" select="."/>
+                      <apply-templates mode="{$mode}" select="$document"/>
                     </xsl:for-each>
-                  </source-document>
-                </for-each>
-              </xsl:when>
-              <xsl:otherwise>
-                <for-each select="{@documents}">
-                  <variable name="document" as="item()" select="document(.)"/>
-                  <xsl:for-each select="current-group()">
-                    <schxslt:pattern id="{generate-id()}">
-                      <if test="exists(base-uri($document))">
-                        <attribute name="documents" select="base-uri($document)"/>
-                      </if>
-                      <for-each select="$document">
-                        <xsl:call-template name="schxslt-api:active-pattern">
-                          <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
-                        </xsl:call-template>
-                      </for-each>
-                    </schxslt:pattern>
-                    <apply-templates mode="{$mode}" select="$document"/>
-                  </xsl:for-each>
+                  </schxslt:document>
                 </for-each>
               </xsl:otherwise>
             </xsl:choose>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:for-each select="current-group()">
-              <schxslt:pattern id="{generate-id()}">
-                <if test="exists(base-uri(/))">
-                  <attribute name="documents" select="base-uri(/)"/>
-                </if>
-                <for-each select="/">
-                  <xsl:call-template name="schxslt-api:active-pattern">
-                    <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
-                  </xsl:call-template>
-                </for-each>
-              </schxslt:pattern>
-            </xsl:for-each>
-            <apply-templates mode="{$mode}" select="/"/>
+            <schxslt:document>
+              <xsl:for-each select="current-group()">
+                <schxslt:pattern id="{generate-id()}">
+                  <if test="exists(base-uri(/))">
+                    <attribute name="documents" select="base-uri(/)"/>
+                  </if>
+                  <for-each select="/">
+                    <xsl:call-template name="schxslt-api:active-pattern">
+                      <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
+                    </xsl:call-template>
+                  </for-each>
+                </schxslt:pattern>
+              </xsl:for-each>
+              <apply-templates mode="{$mode}" select="/"/>
+            </schxslt:document>
           </xsl:otherwise>
         </xsl:choose>
 

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -28,6 +28,7 @@
   <xsl:param name="phase" as="xs:string">#DEFAULT</xsl:param>
   <xsl:variable name="schxslt.compile.typed-variables" as="xs:boolean" select="true()"/>
   <xsl:param name="schxslt.compile.streamable" as="xs:boolean" select="false()"/>
+  <xsl:param name="schxslt.compile.metadata" as="xs:boolean" select="true()"/>
 
   <xsl:template match="/sch:schema">
     <xsl:call-template name="schxslt:compile">
@@ -112,11 +113,13 @@
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
 
         <variable name="metadata" as="element()?">
-          <xsl:call-template name="schxslt-api:metadata">
-            <xsl:with-param name="schema" as="element(sch:schema)" select="$schematron"/>
-            <xsl:with-param name="source" as="element(rdf:Description)" select="$version"/>
-            <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
-          </xsl:call-template>
+          <xsl:if test="$schxslt.compile.metadata">
+            <xsl:call-template name="schxslt-api:metadata">
+              <xsl:with-param name="schema" as="element(sch:schema)" select="$schematron"/>
+              <xsl:with-param name="source" as="element(rdf:Description)" select="$version"/>
+              <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
+            </xsl:call-template>
+          </xsl:if>
         </variable>
 
         <variable name="report" as="element(schxslt:report)">

--- a/lib/schxslt/2.0/compile/templates.xsl
+++ b/lib/schxslt/2.0/compile/templates.xsl
@@ -28,7 +28,7 @@
   </xsl:template>
 
   <!-- Message templates -->
-  <xsl:template match="node() | @*" mode="schxslt:message-template">
+  <xsl:template match="node() | @*" mode="schxslt:message-template" priority="-10">
     <xsl:copy>
       <xsl:apply-templates mode="#current"/>
     </xsl:copy>

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -9,6 +9,8 @@
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+  <xsl:param name="schxslt.svrl.compact" as="xs:boolean" select="false()"/>
+
   <xsl:template name="schxslt-api:report">
     <xsl:param name="schema" as="element(sch:schema)" required="yes"/>
     <xsl:param name="phase" as="xs:string" required="yes"/>
@@ -18,21 +20,24 @@
       <xsl:if test="$phase ne '#ALL'">
         <xsl:attribute name="phase" select="$phase"/>
       </xsl:if>
-      <xsl:if test="$schema/sch:title">
-        <xsl:attribute name="title" select="$schema/sch:title"/>
-      </xsl:if>
-      <xsl:for-each select="$schema/sch:p">
-        <svrl:text>
-          <xsl:sequence select="(@id, @class, @icon)"/>
-          <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
-        </svrl:text>
-      </xsl:for-each>
 
-      <xsl:for-each select="$schema/sch:ns">
-        <svrl:ns-prefix-in-attribute-values>
-          <xsl:sequence select="(@prefix, @uri)"/>
-        </svrl:ns-prefix-in-attribute-values>
-      </xsl:for-each>
+      <xsl:if test="$schxslt.svrl.compact eq false()">
+        <xsl:if test="$schema/sch:title">
+          <xsl:attribute name="title" select="$schema/sch:title"/>
+        </xsl:if>
+        <xsl:for-each select="$schema/sch:p">
+          <svrl:text>
+            <xsl:sequence select="(@id, @class, @icon)"/>
+            <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
+          </svrl:text>
+        </xsl:for-each>
+
+        <xsl:for-each select="$schema/sch:ns">
+          <svrl:ns-prefix-in-attribute-values>
+            <xsl:sequence select="(@prefix, @uri)"/>
+          </svrl:ns-prefix-in-attribute-values>
+        </xsl:for-each>
+      </xsl:if>
 
       <sequence select="$schxslt:report"/>
 
@@ -41,34 +46,40 @@
 
   <xsl:template name="schxslt-api:active-pattern">
     <xsl:param name="pattern" as="element(sch:pattern)" required="yes"/>
-    <svrl:active-pattern>
-      <xsl:sequence select="($pattern/@id, $pattern/@role)"/>
-      <attribute name="documents" select="base-uri(.)"/>
-    </svrl:active-pattern>
+    <xsl:if test="$schxslt.svrl.compact eq false()">
+      <svrl:active-pattern>
+        <xsl:sequence select="($pattern/@id, $pattern/@role)"/>
+        <attribute name="documents" select="base-uri(.)"/>
+      </svrl:active-pattern>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="schxslt-api:fired-rule">
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
-    <svrl:fired-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
-      <attribute name="context">
-        <xsl:value-of select="$rule/@context"/>
-      </attribute>
-    </svrl:fired-rule>
+    <xsl:if test="$schxslt.svrl.compact eq false()">
+      <svrl:fired-rule>
+        <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
+        <attribute name="context">
+          <xsl:value-of select="$rule/@context"/>
+        </attribute>
+      </svrl:fired-rule>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="schxslt-api:suppressed-rule">
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
-    <xsl:variable name="message">
-      WARNING: Rule <xsl:value-of select="normalize-space(@id)"/> for context "<xsl:value-of select="@context"/>" shadowed by preceding rule
-    </xsl:variable>
-    <comment> <xsl:sequence select="normalize-space($message)"/> </comment>
-    <svrl:suppressed-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
-      <attribute name="context">
-        <xsl:value-of select="$rule/@context"/>
-      </attribute>
-    </svrl:suppressed-rule>
+    <xsl:if test="$schxslt.svrl.compact eq false()">
+      <xsl:variable name="message">
+        WARNING: Rule <xsl:value-of select="normalize-space(@id)"/> for context "<xsl:value-of select="@context"/>" shadowed by preceding rule
+      </xsl:variable>
+      <comment> <xsl:sequence select="normalize-space($message)"/> </comment>
+      <svrl:suppressed-rule>
+        <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
+        <attribute name="context">
+          <xsl:value-of select="$rule/@context"/>
+        </attribute>
+      </svrl:suppressed-rule>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="schxslt-api:failed-assert">
@@ -103,33 +114,35 @@
     <xsl:param name="schema" as="element(sch:schema)" required="yes"/>
     <xsl:param name="source" as="element(rdf:Description)" required="yes"/>
     <xsl:param name="xslt-version" as="xs:string" required="yes" tunnel="yes"/>
-    <svrl:metadata xmlns:dct="http://purl.org/dc/terms/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-      <dct:creator>
-        <dct:Agent>
-          <skos:prefLabel>
-            <xsl:choose>
-              <xsl:when test="$xslt-version eq '3.0'">
-                <value-of separator="/" select="(system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-name'), system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-version'))"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <variable name="prefix" as="xs:string?" select="if (doc-available('')) then in-scope-prefixes(document('')/*[1])[namespace-uri-for-prefix(., document('')/*[1]) eq 'http://www.w3.org/1999/XSL/Transform'][1] else ()">
-                </variable>
-                <choose>
-                  <when test="empty($prefix)">Unknown</when>
-                  <otherwise>
-                    <value-of separator="/" select="(system-property(concat($prefix, ':product-name')), system-property(concat($prefix,':product-version')))"/>
-                  </otherwise>
-                </choose>
-              </xsl:otherwise>
-            </xsl:choose>
-          </skos:prefLabel>
-        </dct:Agent>
-      </dct:creator>
-      <dct:created><value-of select="current-dateTime()"/></dct:created>
-      <dct:source>
-        <xsl:sequence select="$source"/>
-      </dct:source>
-    </svrl:metadata>
+    <xsl:if test="$schxslt.svrl.compact eq false()">
+      <svrl:metadata xmlns:dct="http://purl.org/dc/terms/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <dct:creator>
+          <dct:Agent>
+            <skos:prefLabel>
+              <xsl:choose>
+                <xsl:when test="$xslt-version eq '3.0'">
+                  <value-of separator="/" select="(system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-name'), system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-version'))"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <variable name="prefix" as="xs:string?" select="if (doc-available('')) then in-scope-prefixes(document('')/*[1])[namespace-uri-for-prefix(., document('')/*[1]) eq 'http://www.w3.org/1999/XSL/Transform'][1] else ()">
+                  </variable>
+                  <choose>
+                    <when test="empty($prefix)">Unknown</when>
+                    <otherwise>
+                      <value-of separator="/" select="(system-property(concat($prefix, ':product-name')), system-property(concat($prefix,':product-version')))"/>
+                    </otherwise>
+                  </choose>
+                </xsl:otherwise>
+              </xsl:choose>
+            </skos:prefLabel>
+          </dct:Agent>
+        </dct:creator>
+        <dct:created><value-of select="current-dateTime()"/></dct:created>
+        <dct:source>
+          <xsl:sequence select="$source"/>
+        </dct:source>
+      </svrl:metadata>
+    </xsl:if>
   </xsl:template>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
@@ -151,20 +164,9 @@
     <xsl:param name="property" as="element(sch:property)"/>
     <svrl:property-reference property="{.}">
       <xsl:sequence select="($property/@role, $property/@scheme)"/>
-      <xsl:for-each select="$property/node()">
-        <xsl:choose>
-          <xsl:when test="self::text()">
-            <xsl:if test="normalize-space()">
-              <svrl:text>
-                <xsl:apply-templates select="." mode="schxslt:message-template"/>
-              </svrl:text>
-            </xsl:if>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:sequence select="."/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:for-each>
+      <svrl:text>
+        <xsl:apply-templates select="$property/node()" mode="schxslt:message-template"/>
+      </svrl:text>
     </svrl:property-reference>
   </xsl:template>
 

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.2</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.7.4</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/src/schematron/generate-step3-wrapper.xsl
+++ b/src/schematron/generate-step3-wrapper.xsl
@@ -67,6 +67,13 @@
 					<!-- Resolve x:import and gather only the user-provided global params and
 						variables -->
 					<xsl:sequence select="x:resolve-import(.)" />
+
+					<!-- Always disable SchXslt metadata generation in SVRL -->
+					<xsl:element name="{x:xspec-name('param', .)}" namespace="{$x:xspec-namespace}">
+						<xsl:attribute name="as" select="x:known-UQName('xs:boolean')" />
+						<xsl:attribute name="name" select="'schxslt.compile.metadata'" />
+						<xsl:attribute name="select" select="'false()'" />
+					</xsl:element>
 				</xsl:element>
 			</xsl:variable>
 

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -191,26 +191,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -243,26 +223,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -295,26 +255,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -347,26 +287,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -399,26 +319,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -451,26 +351,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -508,26 +388,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -560,26 +420,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -612,26 +452,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -664,26 +484,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -716,26 +516,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -768,26 +548,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -55,26 +55,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
@@ -170,26 +150,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -84,26 +84,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern documents="issue-693-compiled.xsl" /&gt;
    &lt;svrl:fired-rule context="foo" /&gt;
    &lt;svrl:successful-report location="/Q{}foo[1]"

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -24,26 +24,6 @@
                                     xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                     xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>Unknown</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern documents="issue-693-compiled.xsl"/>
                <svrl:fired-rule context="foo"/>
                <svrl:successful-report location="/Q{}foo[1]" id="bar-exists" test="bar">

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -160,26 +160,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -212,26 +192,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -264,26 +224,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -316,26 +256,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -368,26 +288,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
@@ -420,26 +320,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -23,26 +23,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
@@ -108,26 +88,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
@@ -169,26 +129,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -111,26 +111,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern documents="schematron-023-compiled.xsl" /&gt;
    &lt;svrl:fired-rule context="/" /&gt;
    &lt;svrl:fired-rule context="title" /&gt;
@@ -202,26 +182,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern documents="schematron-023-compiled.xsl" /&gt;
    &lt;svrl:fired-rule context="/" /&gt;
    &lt;svrl:failed-assert location="/"

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -26,26 +26,6 @@
                                     xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                     xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>Unknown</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern documents="schematron-023-compiled.xsl"/>
                <svrl:fired-rule context="/"/>
                <svrl:fired-rule context="title"/>
@@ -99,26 +79,6 @@
                                     xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                     xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>Unknown</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern documents="schematron-023-compiled.xsl"/>
                <svrl:fired-rule context="/"/>
                <svrl:fired-rule context="title"/>
@@ -167,26 +127,6 @@
                                     xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                     xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>Unknown</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern documents="schematron-023-compiled.xsl"/>
                <svrl:fired-rule context="/"/>
                <svrl:failed-assert location="/" role="FATAL" id="a0001" test="document">

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -23,26 +23,6 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>SAXON/product-version</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
@@ -117,26 +97,6 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>SAXON/product-version</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
@@ -221,26 +181,6 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>SAXON/product-version</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -23,26 +23,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern documents="tvt_label_schematron-compiled.xsl"/>
                   <svrl:fired-rule context="context-child"/>
                </svrl:schematron-output>
@@ -74,26 +54,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern documents="tvt_label_schematron-compiled.xsl"/>
                   <svrl:fired-rule context="context-child"/>
                </svrl:schematron-output>
@@ -125,26 +85,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern documents="tvt_label_schematron-compiled.xsl"/>
                   <svrl:fired-rule context="context-child"/>
                </svrl:schematron-output>
@@ -179,26 +119,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern documents="tvt_label_schematron-compiled.xsl"/>
                   <svrl:fired-rule context="context-child"/>
                </svrl:schematron-output>
@@ -230,26 +150,6 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                                 xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                     <dct:creator>
-                        <dct:Agent>
-                           <skos:prefLabel>Unknown</skos:prefLabel>
-                        </dct:Agent>
-                     </dct:creator>
-                     <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     <dct:source>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                           <dct:creator>
-                              <dct:Agent>
-                                 <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                                 <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                              </dct:Agent>
-                           </dct:creator>
-                           <dct:created>2000-01-01T00:00:00Z</dct:created>
-                        </rdf:Description>
-                     </dct:source>
-                  </svrl:metadata>
                   <svrl:active-pattern documents="tvt_label_schematron-compiled.xsl"/>
                   <svrl:fired-rule context="context-child"/>
                </svrl:schematron-output>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -82,26 +82,6 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:metadata <span class="xmlns">xmlns:dct="http://purl.org/dc/terms/"</span>
-                  <span class="xmlns">xmlns:skos="http://www.w3.org/2004/02/skos/core#"</span>&gt;
-      &lt;dct:creator&gt;
-         &lt;dct:Agent&gt;
-            &lt;skos:prefLabel&gt;Unknown&lt;/skos:prefLabel&gt;
-         &lt;/dct:Agent&gt;
-      &lt;/dct:creator&gt;
-      &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-      &lt;dct:source&gt;
-         &lt;rdf:Description <span class="xmlns">xmlns:dc="http://purl.org/dc/elements/1.1/"</span>&gt;
-            &lt;dct:creator&gt;
-               &lt;dct:Agent&gt;
-                  &lt;skos:prefLabel&gt;SchXslt/version SAXON/product-version&lt;/skos:prefLabel&gt;
-                  &lt;schxslt.compile.typed-variables <span class="xmlns">xmlns="https://doi.org/10.5281/zenodo.1495494#"</span>&gt;true&lt;/schxslt.compile.typed-variables&gt;
-               &lt;/dct:Agent&gt;
-            &lt;/dct:creator&gt;
-            &lt;dct:created&gt;2000-01-01T00:00:00Z&lt;/dct:created&gt;
-         &lt;/rdf:Description&gt;
-      &lt;/dct:source&gt;
-   &lt;/svrl:metadata&gt;
    &lt;svrl:active-pattern documents="xml-1-1_schematron-compiled.xsl" /&gt;
    &lt;svrl:fired-rule context="test" /&gt;
    &lt;svrl:successful-report location="/Q{}test[1]"

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -21,26 +21,6 @@
                                     xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                     xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-               <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
-                              xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-                  <dct:creator>
-                     <dct:Agent>
-                        <skos:prefLabel>Unknown</skos:prefLabel>
-                     </dct:Agent>
-                  </dct:creator>
-                  <dct:created>2000-01-01T00:00:00Z</dct:created>
-                  <dct:source>
-                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dct:creator>
-                           <dct:Agent>
-                              <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-                              <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
-                           </dct:Agent>
-                        </dct:creator>
-                        <dct:created>2000-01-01T00:00:00Z</dct:created>
-                     </rdf:Description>
-                  </dct:source>
-               </svrl:metadata>
                <svrl:active-pattern documents="xml-1-1_schematron-compiled.xsl"/>
                <svrl:fired-rule context="test"/>
                <svrl:successful-report location="/Q{}test[1]" id="U0007" test="string() eq '&#x7;'"/>

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -135,12 +135,6 @@
 			Example (SchXslt):
 				in:  <svrl:active-pattern documents="file:/.../demo-02-compiled.xsl"
 				out: <svrl:active-pattern documents="demo-02-compiled.xsl"
-				
-				in:  <dct:created>2021-03-03T21:34:06.276+01:00</dct:created>
-				out: <dct:created>2000-01-01T00:00:00Z</dct:created>
-				
-				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
 	-->
 	<xsl:template as="text()" match="pre[contains-token(@class, 'svrl')]/text()"
 		mode="normalizer:normalize">
@@ -178,37 +172,9 @@
 				<xsl:variable as="xs:string" name="regex">
 					<xsl:text>
 						^
-						<!-- There are multiple dct:created. Identify the one by its leading spaces. -->
-						[ ]{6}&lt;dct:created>
-						(\S+?)					<!-- group 1 -->
-						&lt;/dct:created>
-						$
-					</xsl:text>
-				</xsl:variable>
-				<xsl:variable as="element(fn:analyze-string-result)" name="analyzed"
-					select="analyze-string(parent::pre, $regex, 'mx')" />
-				<xsl:variable as="element(fn:group)" name="normalized-dct-created"
-					select="$analyzed/fn:match/fn:group[@nr = 1]" />
-
-				<xsl:variable as="xs:string" name="regex">
-					<xsl:text>
-						^
-						(?:
-							([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
-							(\S+?)												<!-- group 2 -->
-							("[ ]/>)											<!-- group 3 -->
-							|
-							<!-- There are multiple dct:created. Identify the one by its leading spaces. -->
-							([ ]{12}&lt;dct:created>)							<!-- group 4 -->
-							\S+?
-							(&lt;/dct:created>)									<!-- group 5 -->
-							|
-							([ ]+&lt;skos:prefLabel>SchXslt/)					<!-- group 6 -->
-							[0-9.]+
-							([ ]SAXON/)											<!-- group 7 -->
-							[^/]+?
-							(&lt;/skos:prefLabel>)								<!-- group 8 -->
-						)
+						([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
+						(\S+?)												<!-- group 2 -->
+						("[ ]/>)											<!-- group 3 -->
 						$
 					</xsl:text>
 				</xsl:variable>
@@ -216,31 +182,10 @@
 				<xsl:value-of>
 					<xsl:analyze-string flags="mx" regex="{$regex}" select=".">
 						<xsl:matching-substring>
-							<xsl:choose>
-								<xsl:when test="regex-group(1)">
-									<xsl:sequence select="
-											regex-group(1),
-											x:filename-and-extension(regex-group(2)),
-											regex-group(3)" />
-								</xsl:when>
-								<xsl:when test="regex-group(4)">
-									<xsl:sequence select="
-											regex-group(4),
-											$normalized-dct-created,
-											regex-group(5)" />
-								</xsl:when>
-								<xsl:when test="regex-group(6)">
-									<xsl:sequence select="
-											regex-group(6),
-											'version',
-											regex-group(7),
-											'product-version',
-											regex-group(8)" />
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:message terminate="yes" />
-								</xsl:otherwise>
-							</xsl:choose>
+							<xsl:sequence select="
+									regex-group(1),
+									x:filename-and-extension(regex-group(2)),
+									regex-group(3)" />
 						</xsl:matching-substring>
 
 						<xsl:non-matching-substring>
@@ -301,20 +246,16 @@
 		<xsl:if test="$svrl-pre">
 			<!-- parse-xml() may fail to handle control characters when the serialized SVRL is XML
 				1.1. Inspect the literal string instead of parsing it as XML. -->
-			<xsl:variable as="xs:string" name="schxslt-xmlns"
-				>xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</xsl:variable>
-			<xsl:variable as="xs:string" name="schxslt-agent"><![CDATA[<dct:Agent>
-                  <skos:prefLabel>SchXslt/]]></xsl:variable>
+			<xsl:variable as="xs:string" name="schold-xmlns"
+				>xmlns:schold="http://www.ascc.net/xml/schematron"</xsl:variable>
 			<xsl:choose>
-				<xsl:when test="
-						$svrl-pre/span[contains-token(@class, 'xmlns')][. eq $schxslt-xmlns]
-						and $svrl-pre/text()[contains(., $schxslt-agent)]">
-					<xsl:sequence select="'schxslt'" />
+				<xsl:when test="$svrl-pre/span[contains-token(@class, 'xmlns')][. eq $schold-xmlns]">
+					<xsl:sequence select="'skeleton'" />
 				</xsl:when>
 
 				<xsl:otherwise>
-					<!-- Assume the "skeleton" Schematron implementation -->
-					<xsl:sequence select="'skeleton'" />
+					<!-- Assume SchXslt -->
+					<xsl:sequence select="'schxslt'" />
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:if>

--- a/test/end-to-end/processor/xml/_normalizer.xsl
+++ b/test/end-to-end/processor/xml/_normalizer.xsl
@@ -46,56 +46,6 @@
 	</xsl:template>
 
 	<!--
-		Normalizes dct:created by copying another element text
-	-->
-	<xsl:template as="text()" match="
-			/x:report[local:svrl-creator(.) eq 'schxslt']//x:scenario/x:result/content-wrap
-			/svrl:schematron-output/svrl:metadata/dct:source/rdf:Description/dct:created/text()
-			[. castable as xs:dateTimeStamp]" mode="normalizer:normalize">
-		<xsl:value-of select="ancestor::svrl:metadata[1]/dct:created cast as xs:dateTimeStamp" />
-	</xsl:template>
-
-	<!--
-		Normalizes skos:prefLabel
-			Example:
-				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-				
-				in:  <skos:prefLabel>SAXON/HE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SAXON/product-version</skos:prefLabel>
-	-->
-	<xsl:template as="text()" match="
-			/x:report[local:svrl-creator(.) eq 'schxslt']//x:scenario/x:result/content-wrap
-			/svrl:schematron-output/svrl:metadata//dct:creator/dct:Agent/skos:prefLabel[. ne 'Unknown']/text()"
-		mode="normalizer:normalize">
-		<xsl:variable as="xs:string" name="regex">
-			<xsl:text>
-				^
-					(?:
-						(SchXslt/)	<!-- group 1 -->
-						[0-9.]+
-						([ ])		<!-- group 2 -->
-					)?
-					(SAXON/)		<!-- group 3 -->
-					[^/]+
-				$
-			</xsl:text>
-		</xsl:variable>
-
-		<!-- Use analyze-string() so that the transformation will fail when nothing matches -->
-		<xsl:analyze-string flags="x" regex="{$regex}" select=".">
-			<xsl:matching-substring>
-				<xsl:value-of>
-					<xsl:if test="regex-group(1)">
-						<xsl:value-of select="regex-group(1) || 'version' || regex-group(2)" />
-					</xsl:if>
-					<xsl:value-of select="regex-group(3) || 'product-version'" />
-				</xsl:value-of>
-			</xsl:matching-substring>
-		</xsl:analyze-string>
-	</xsl:template>
-
-	<!--
 		Normalizes the link to the files created dynamically by XSpec
 	-->
 	<xsl:template as="attribute(href)" match="
@@ -131,16 +81,14 @@
 				=> head()" />
 		<xsl:if test="$svrl">
 			<xsl:choose>
-				<xsl:when test="
-						$svrl/svrl:metadata/dct:source
-						/rdf:Description/dct:creator/dct:Agent/skos:prefLabel
-						=> starts-with('SchXslt/')">
-					<xsl:sequence select="'schxslt'" />
+				<xsl:when
+					test="namespace-uri-for-prefix('schold', $svrl) eq 'http://www.ascc.net/xml/schematron'">
+					<xsl:sequence select="'skeleton'" />
 				</xsl:when>
 
 				<xsl:otherwise>
-					<!-- Assume the "skeleton" Schematron implementation -->
-					<xsl:sequence select="'skeleton'" />
+					<!-- Assume SchXslt -->
+					<xsl:sequence select="'schxslt'" />
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:if>

--- a/test/generate-step3-wrapper_custom.xspec
+++ b/test/generate-step3-wrapper_custom.xspec
@@ -10,6 +10,7 @@
 			<x:label><![CDATA[
 				- $ACTUAL-PREPROCESSOR-URI should be imported in place of the built-in one.
 				- /x:description/x:param should be transformed into /xsl:stylesheet/xsl:param.
+				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -20,6 +21,8 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:param name="Q{{}}phase" select="..." />
+				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
+					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>
 		</x:expect>
 	</x:scenario>

--- a/test/generate-step3-wrapper_default.xspec
+++ b/test/generate-step3-wrapper_default.xspec
@@ -8,6 +8,7 @@
 			<x:label><![CDATA[
 				- The built-in preprocessor, not $ACTUAL-PREPROCESSOR-URI, should be imported.
 				- /x:description/x:param should be transformed into /xsl:stylesheet/xsl:param.
+				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -18,6 +19,8 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:param name="Q{{}}phase" select="..." />
+				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
+					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>
 		</x:expect>
 	</x:scenario>


### PR DESCRIPTION
- Replace the built-in SchXslt v1.7.4 with v1.8.
- Disable `schxslt.compile.metadata` (schxslt/schxslt#206) so that we can simplify not only the test result report HTML but also the end-to-end test normalizers.

Note that the base branch of this pull request is not `master` but `schxslt`.

---

Although schxslt/schxslt@bba1f70e5f67e43cb4bf78111f5e59043b3b03ad is [tagged as v1.8](https://github.com/schxslt/schxslt/releases/tag/v1.8), I'm not sure if it's considered as an official release. That's why this pull request is still a draft.
