### PR TITLE
build: release v2.2.4

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,14 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.2.4</h3>
+				<ul>
+					<li>Official release of v2.2</li>
+					<li>Tested with Saxon 10.6</li>
+					<li>Tested with SchXslt 1.8.2</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.2.3</h3>
 				<ul>
 					<li>Release Candidate of the stable release</li>
@@ -83,13 +91,6 @@
 					<li>feat(schematron): skip step 1 and/or step 2 if <code>#none</code> (<a
 							href="https://github.com/xspec/xspec/pull/1371">#1371</a>)</li>
 					<li>Fully tested with SchXslt 1.6.2</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.1.1</h3>
-				<ul>
-					<li>Report more types</li>
-					<li>Constrain <code>x:param</code></li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/141220dee5eac694ccf831dee8a68e57bcaceb9b.zip" />
+			href="https://github.com/xspec/xspec/archive/25364653fdf4831a6d42e847f6ba55f7e474c29f.zip" />
 
-		<xt:version>2.2.3</xt:version>
+		<xt:version>2.2.4</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.2.4</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-141220dee5eac694ccf831dee8a68e57bcaceb9b/xspec.framework/XSpec</String>
+                                    <String>4/xspec-25364653fdf4831a6d42e847f6ba55f7e474c29f/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request increments the version numbers in `pom.xml` and `oxygen-addon.xml`, which makes the official stable release of `v2.2`. (technically `v2.2.4`, based on #940)

As for the file paths in `oxygen-addon.xml`, I used the last `master` SHA rather than the git tag `v2.2.4`, because we haven't had the actual tag yet and therefore cannot test it. I tested the Oxygen add-on on Oxygen 23.1 build 2021082307 using `https://github.com/AirQuick/xspec/raw/rel_2-2-4/oxygen-addon.xml`.