### PR TITLE
feat(schematron): bump built-in SchXslt to v1.8.4

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.8.2 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.8.4 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -150,6 +150,9 @@
       </template>
 
       <template match="text() | @*" mode="#all" priority="-10"/>
+      <template match="/" mode="#all" priority="-10">
+        <apply-templates mode="#current" select="node()"/>
+      </template>
       <template match="*" mode="#all" priority="-10">
         <apply-templates mode="#current" select="@*"/>
         <apply-templates mode="#current" select="node()"/>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.2</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.4</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.8.2 with v1.8.4[^1].

Note that the base branch of this pull request is not `master` but `schxslt`.

[^1]: v1.8.3 should be skipped. It was an erroneous release.