### PR TITLE
build(maven): bump pom.xml to 2.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>2.2.4</version>
+  <version>2.3-SNAPSHOT</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
As per our [workflow](https://github.com/xspec/xspec/wiki/Release-Workflow), this pull request increases the version of the XSpec release and adds the snapshot suffix. 

As usual, this should be the first pull request to be merged into `master` in order to start the development of XSpec v2.3.