### PR TITLE
refactor(schematron): disable SchXslt metadata generation in SVRL

### DIFF
--- a/src/schematron/generate-step3-wrapper.xsl
+++ b/src/schematron/generate-step3-wrapper.xsl
@@ -67,6 +67,13 @@
 					<!-- Resolve x:import and gather only the user-provided global params and
 						variables -->
 					<xsl:sequence select="x:resolve-import(.)" />
+
+					<!-- Always disable SchXslt metadata generation in SVRL -->
+					<xsl:element name="{x:xspec-name('param', .)}" namespace="{$x:xspec-namespace}">
+						<xsl:attribute name="as" select="x:known-UQName('xs:boolean')" />
+						<xsl:attribute name="name" select="'schxslt.compile.metadata'" />
+						<xsl:attribute name="select" select="'false()'" />
+					</xsl:element>
 				</xsl:element>
 			</xsl:variable>
 

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -135,12 +135,6 @@
 			Example (SchXslt):
 				in:  <svrl:active-pattern documents="file:/.../demo-02-compiled.xsl"
 				out: <svrl:active-pattern documents="demo-02-compiled.xsl"
-				
-				in:  <dct:created>2021-03-03T21:34:06.276+01:00</dct:created>
-				out: <dct:created>2000-01-01T00:00:00Z</dct:created>
-				
-				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
 	-->
 	<xsl:template as="text()" match="pre[contains-token(@class, 'svrl')]/text()"
 		mode="normalizer:normalize">
@@ -178,37 +172,9 @@
 				<xsl:variable as="xs:string" name="regex">
 					<xsl:text>
 						^
-						<!-- There are multiple dct:created. Identify the one by its leading spaces. -->
-						[ ]{6}&lt;dct:created>
-						(\S+?)					<!-- group 1 -->
-						&lt;/dct:created>
-						$
-					</xsl:text>
-				</xsl:variable>
-				<xsl:variable as="element(fn:analyze-string-result)" name="analyzed"
-					select="analyze-string(parent::pre, $regex, 'mx')" />
-				<xsl:variable as="element(fn:group)" name="normalized-dct-created"
-					select="$analyzed/fn:match/fn:group[@nr = 1]" />
-
-				<xsl:variable as="xs:string" name="regex">
-					<xsl:text>
-						^
-						(?:
-							([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
-							(\S+?)												<!-- group 2 -->
-							("[ ]/>)											<!-- group 3 -->
-							|
-							<!-- There are multiple dct:created. Identify the one by its leading spaces. -->
-							([ ]{12}&lt;dct:created>)							<!-- group 4 -->
-							\S+?
-							(&lt;/dct:created>)									<!-- group 5 -->
-							|
-							([ ]+&lt;skos:prefLabel>SchXslt/)					<!-- group 6 -->
-							[0-9.]+
-							([ ]SAXON/)											<!-- group 7 -->
-							[^/]+?
-							(&lt;/skos:prefLabel>)								<!-- group 8 -->
-						)
+						([ ]+(?:&lt;svrl:active-pattern[ ])?documents=")	<!-- group 1 -->
+						(\S+?)												<!-- group 2 -->
+						("[ ]/>)											<!-- group 3 -->
 						$
 					</xsl:text>
 				</xsl:variable>
@@ -216,31 +182,10 @@
 				<xsl:value-of>
 					<xsl:analyze-string flags="mx" regex="{$regex}" select=".">
 						<xsl:matching-substring>
-							<xsl:choose>
-								<xsl:when test="regex-group(1)">
-									<xsl:sequence select="
-											regex-group(1),
-											x:filename-and-extension(regex-group(2)),
-											regex-group(3)" />
-								</xsl:when>
-								<xsl:when test="regex-group(4)">
-									<xsl:sequence select="
-											regex-group(4),
-											$normalized-dct-created,
-											regex-group(5)" />
-								</xsl:when>
-								<xsl:when test="regex-group(6)">
-									<xsl:sequence select="
-											regex-group(6),
-											'version',
-											regex-group(7),
-											'product-version',
-											regex-group(8)" />
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:message terminate="yes" />
-								</xsl:otherwise>
-							</xsl:choose>
+							<xsl:sequence select="
+									regex-group(1),
+									x:filename-and-extension(regex-group(2)),
+									regex-group(3)" />
 						</xsl:matching-substring>
 
 						<xsl:non-matching-substring>
@@ -301,20 +246,16 @@
 		<xsl:if test="$svrl-pre">
 			<!-- parse-xml() may fail to handle control characters when the serialized SVRL is XML
 				1.1. Inspect the literal string instead of parsing it as XML. -->
-			<xsl:variable as="xs:string" name="schxslt-xmlns"
-				>xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"</xsl:variable>
-			<xsl:variable as="xs:string" name="schxslt-agent"><![CDATA[<dct:Agent>
-                  <skos:prefLabel>SchXslt/]]></xsl:variable>
+			<xsl:variable as="xs:string" name="schold-xmlns"
+				>xmlns:schold="http://www.ascc.net/xml/schematron"</xsl:variable>
 			<xsl:choose>
-				<xsl:when test="
-						$svrl-pre/span[contains-token(@class, 'xmlns')][. eq $schxslt-xmlns]
-						and $svrl-pre/text()[contains(., $schxslt-agent)]">
-					<xsl:sequence select="'schxslt'" />
+				<xsl:when test="$svrl-pre/span[contains-token(@class, 'xmlns')][. eq $schold-xmlns]">
+					<xsl:sequence select="'skeleton'" />
 				</xsl:when>
 
 				<xsl:otherwise>
-					<!-- Assume the "skeleton" Schematron implementation -->
-					<xsl:sequence select="'skeleton'" />
+					<!-- Assume SchXslt -->
+					<xsl:sequence select="'schxslt'" />
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:if>

--- a/test/end-to-end/processor/xml/_normalizer.xsl
+++ b/test/end-to-end/processor/xml/_normalizer.xsl
@@ -46,56 +46,6 @@
 	</xsl:template>
 
 	<!--
-		Normalizes dct:created by copying another element text
-	-->
-	<xsl:template as="text()" match="
-			/x:report[local:svrl-creator(.) eq 'schxslt']//x:scenario/x:result/content-wrap
-			/svrl:schematron-output/svrl:metadata/dct:source/rdf:Description/dct:created/text()
-			[. castable as xs:dateTimeStamp]" mode="normalizer:normalize">
-		<xsl:value-of select="ancestor::svrl:metadata[1]/dct:created cast as xs:dateTimeStamp" />
-	</xsl:template>
-
-	<!--
-		Normalizes skos:prefLabel
-			Example:
-				in:  <skos:prefLabel>SchXslt/1.6.2 SAXON/EE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SchXslt/version SAXON/product-version</skos:prefLabel>
-				
-				in:  <skos:prefLabel>SAXON/HE 9.9.1.7</skos:prefLabel>
-				out: <skos:prefLabel>SAXON/product-version</skos:prefLabel>
-	-->
-	<xsl:template as="text()" match="
-			/x:report[local:svrl-creator(.) eq 'schxslt']//x:scenario/x:result/content-wrap
-			/svrl:schematron-output/svrl:metadata//dct:creator/dct:Agent/skos:prefLabel[. ne 'Unknown']/text()"
-		mode="normalizer:normalize">
-		<xsl:variable as="xs:string" name="regex">
-			<xsl:text>
-				^
-					(?:
-						(SchXslt/)	<!-- group 1 -->
-						[0-9.]+
-						([ ])		<!-- group 2 -->
-					)?
-					(SAXON/)		<!-- group 3 -->
-					[^/]+
-				$
-			</xsl:text>
-		</xsl:variable>
-
-		<!-- Use analyze-string() so that the transformation will fail when nothing matches -->
-		<xsl:analyze-string flags="x" regex="{$regex}" select=".">
-			<xsl:matching-substring>
-				<xsl:value-of>
-					<xsl:if test="regex-group(1)">
-						<xsl:value-of select="regex-group(1) || 'version' || regex-group(2)" />
-					</xsl:if>
-					<xsl:value-of select="regex-group(3) || 'product-version'" />
-				</xsl:value-of>
-			</xsl:matching-substring>
-		</xsl:analyze-string>
-	</xsl:template>
-
-	<!--
 		Normalizes the link to the files created dynamically by XSpec
 	-->
 	<xsl:template as="attribute(href)" match="
@@ -131,16 +81,14 @@
 				=> head()" />
 		<xsl:if test="$svrl">
 			<xsl:choose>
-				<xsl:when test="
-						$svrl/svrl:metadata/dct:source
-						/rdf:Description/dct:creator/dct:Agent/skos:prefLabel
-						=> starts-with('SchXslt/')">
-					<xsl:sequence select="'schxslt'" />
+				<xsl:when
+					test="namespace-uri-for-prefix('schold', $svrl) eq 'http://www.ascc.net/xml/schematron'">
+					<xsl:sequence select="'skeleton'" />
 				</xsl:when>
 
 				<xsl:otherwise>
-					<!-- Assume the "skeleton" Schematron implementation -->
-					<xsl:sequence select="'skeleton'" />
+					<!-- Assume SchXslt -->
+					<xsl:sequence select="'schxslt'" />
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:if>

--- a/test/generate-step3-wrapper_custom.xspec
+++ b/test/generate-step3-wrapper_custom.xspec
@@ -10,6 +10,7 @@
 			<x:label><![CDATA[
 				- $ACTUAL-PREPROCESSOR-URI should be imported in place of the built-in one.
 				- /x:description/x:param should be transformed into /xsl:stylesheet/xsl:param.
+				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -20,6 +21,8 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:param name="Q{{}}phase" select="..." />
+				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
+					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>
 		</x:expect>
 	</x:scenario>

--- a/test/generate-step3-wrapper_default.xspec
+++ b/test/generate-step3-wrapper_default.xspec
@@ -8,6 +8,7 @@
 			<x:label><![CDATA[
 				- The built-in preprocessor, not $ACTUAL-PREPROCESSOR-URI, should be imported.
 				- /x:description/x:param should be transformed into /xsl:stylesheet/xsl:param.
+				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -18,6 +19,8 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:param name="Q{{}}phase" select="..." />
+				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
+					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>
 		</x:expect>
 	</x:scenario>


### PR DESCRIPTION
Disable `schxslt.compile.metadata` (schxslt/schxslt#206) so that we can simplify not only the test result report HTML but also the end-to-end test normalizers.

This change is a backport from `schxslt` branch.