### PR TITLE
test: exclude /node_modules/ from shellcheck

### DIFF
--- a/test/ci/run-shellcheck.sh
+++ b/test/ci/run-shellcheck.sh
@@ -13,5 +13,7 @@ find . \
     -or \
     \( -path './misc/archive/*' -prune \) \
     -or \
+    \( -path './node_modules/*' -prune \) \
+    -or \
     \( -type f \( -name '*.bash' -or -name '*.bats' -or -name '*.sh' \) -print0 \) \
     | xargs -0 -t shellcheck


### PR DESCRIPTION
Just exclude `/node_modules/` directory from `shellcheck` (executed by `.github/workflows/lint.yml`).