### PR TITLE
fix(cli): properly detect XSPEC_HOME

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -111,7 +111,7 @@ fi
 # set XSPEC_HOME if it has not been set by the user (set it to the
 # parent dir of this script)
 if test -z "$XSPEC_HOME"; then
-    XSPEC_HOME=$(dirname "$0")
+    XSPEC_HOME="$(cd "$(dirname "$0")" && pwd)"
     XSPEC_HOME=$(dirname "$XSPEC_HOME")
 fi
 # safety checks

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -96,6 +96,14 @@
     call :verify_line 1 x "ERROR: XSPEC_HOME seems to be corrupted: %XSPEC_HOME%"
 	</case>
 
+	<case name="cd to bin dir and run CLI from there using implicit XSPEC_HOME #1568">
+    cd ..\bin
+    call :run xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :verify_retval 0
+    call :verify_line 22 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
+    call :verify_line 23 x "Report available at %TEST_DIR%\escape-for-regex-result.html"
+	</case>
+
 	<!--
 		SAXON_CP has precedence over SAXON_HOME
 	-->

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -141,6 +141,14 @@ load bats-helper
     [ "${lines[0]}" = "ERROR: XSPEC_HOME seems to be corrupted: ${XSPEC_HOME}" ]
 }
 
+@test "cd to bin dir and run CLI from there using implicit XSPEC_HOME #1568" {
+    cd ../bin
+    myrun ./xspec.sh ../tutorial/escape-for-regex.xspec
+    [ "$status" -eq 0 ]
+    [ "${lines[21]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
+    [ "${lines[22]}" = "Report available at ${TEST_DIR}/escape-for-regex-result.html" ]
+}
+
 #
 # SAXON_CP has precedence over SAXON_HOME
 #


### PR DESCRIPTION
Using `$(dirname "$0")` is not a safe way to get the location of a running script. 

For example, if you run:
```
cd ~/xspec/bin
./xspec.sh -h
```
the value of `XSPEC_HOME` will be `.`. Not what you want. More reliable to `cd && pwd` 