### PR TITLE
feat(schematron): bump built-in SchXslt to v1.8.5

### DIFF
--- a/lib/schxslt/1.0/expand.xsl
+++ b/lib/schxslt/1.0/expand.xsl
@@ -68,38 +68,40 @@
     <xsl:param name="source"/>
     <xsl:param name="params"/>
 
-    <xsl:variable name="param">
+    <xsl:if test="normalize-space($params) != ''">
+      <xsl:variable name="param">
+        <xsl:choose>
+          <xsl:when test="contains($params, ' ')">
+            <xsl:value-of select="substring-before($params, ' ')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$params"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+      <xsl:variable name="replacement" select="key('schxslt:params', $instanceId)[@name = substring($param, 2)]/@value"/>
+
+      <xsl:variable name="source-replaced">
+        <xsl:call-template name="schxslt:replace-single-param">
+          <xsl:with-param name="source" select="$source"/>
+          <xsl:with-param name="param" select="$param"/>
+          <xsl:with-param name="replacement" select="$replacement"/>
+        </xsl:call-template>
+      </xsl:variable>
+
       <xsl:choose>
         <xsl:when test="contains($params, ' ')">
-          <xsl:value-of select="substring-before($params, ' ')"/>
+          <xsl:call-template name="schxslt:replace-params">
+            <xsl:with-param name="instanceId" select="$instanceId"/>
+            <xsl:with-param name="source" select="$source-replaced"/>
+            <xsl:with-param name="params" select="substring-after($params, ' ')"/>
+          </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="$params"/>
+          <xsl:value-of select="$source-replaced"/>
         </xsl:otherwise>
       </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="replacement" select="key('schxslt:params', $instanceId)[@name = substring($param, 2)]/@value"/>
-
-    <xsl:variable name="source-replaced">
-      <xsl:call-template name="schxslt:replace-single-param">
-        <xsl:with-param name="source" select="$source"/>
-        <xsl:with-param name="param" select="$param"/>
-        <xsl:with-param name="replacement" select="$replacement"/>
-      </xsl:call-template>
-    </xsl:variable>
-
-    <xsl:choose>
-      <xsl:when test="contains($params, ' ')">
-        <xsl:call-template name="schxslt:replace-params">
-          <xsl:with-param name="instanceId" select="$instanceId"/>
-          <xsl:with-param name="source" select="$source-replaced"/>
-          <xsl:with-param name="params" select="substring-after($params, ' ')"/>
-        </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$source-replaced"/>
-      </xsl:otherwise>
-    </xsl:choose>
+    </xsl:if>
 
   </xsl:template>
 

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.8.4 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.8.5 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -290,11 +290,12 @@
 
         <xsl:choose>
           <xsl:when test="@documents">
+            <variable name="base-uri" as="xs:string" select="string(base-uri())"/>
             <xsl:choose>
               <xsl:when test="$xslt-version = '3.0'">
                 <for-each select="{@documents}">
                   <schxslt:document>
-                    <source-document href="{{.}}">
+                    <source-document href="{{resolve-uri(., $base-uri)}}">
                       <xsl:for-each select="current-group()">
                         <schxslt:pattern id="{generate-id()}">
                           <for-each select=".">
@@ -312,7 +313,7 @@
               <xsl:otherwise>
                 <for-each select="{@documents}">
                   <schxslt:document>
-                    <variable name="document" as="item()" select="document(.)"/>
+                    <variable name="document" as="item()" select="document(resolve-uri(., $base-uri))"/>
                     <xsl:for-each select="current-group()">
                       <schxslt:pattern id="{generate-id()}">
                         <if test="exists(base-uri($document))">

--- a/lib/schxslt/2.0/compile/templates.xsl
+++ b/lib/schxslt/2.0/compile/templates.xsl
@@ -57,6 +57,18 @@
     </element>
   </xsl:template>
 
+  <xsl:template match="xsl:copy-of" mode="schxslt:message-template">
+    <xsl:param name="allow-xsl-copy-of" tunnel="yes" as="xs:boolean" select="false()"/>
+    <xsl:choose>
+      <xsl:when test="$allow-xsl-copy-of">
+        <xsl:sequence select="."/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="@*" mode="schxslt:variable-content schxslt:message-template">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
       <xsl:value-of select="."/>

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -165,7 +165,9 @@
     <svrl:property-reference property="{.}">
       <xsl:sequence select="($property/@role, $property/@scheme)"/>
       <svrl:text>
-        <xsl:apply-templates select="$property/node()" mode="schxslt:message-template"/>
+        <xsl:apply-templates select="$property/node()" mode="schxslt:message-template">
+          <xsl:with-param name="allow-xsl-copy-of" tunnel="yes" as="xs:boolean" select="true()"/>
+        </xsl:apply-templates>
       </svrl:text>
     </svrl:property-reference>
   </xsl:template>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.4</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.5</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/lib/schxslt/README.md
+++ b/lib/schxslt/README.md
@@ -49,7 +49,7 @@ externalize abstract rules for them to be used.
 This proposal extends Schematron with a top-level ```rules``` element to hold abstract rules that are globally
 referencable by the ```@rule``` attribute of ```extends```.
 
-### Addition XSLT elements
+### Additional XSLT elements
 
 [Proposal 4](https://github.com/Schematron/schematron-enhancement-proposals/issues/4)
 


### PR DESCRIPTION
Replace the built-in SchXslt v1.8.4 with v1.8.5.

Note that the base branch of this pull request is not `master` but `schxslt`.
