### PR TITLE
ci(deps): bump Log4j from 2.14.1 to 2.15.0

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -12,7 +12,7 @@ BASEX_VERSION=9.6.3
 DO_MAVEN_PACKAGE=
 
 # Log4j is for XML Calabash 1.3.2 or later
-LOG4J_VERSION=2.14.1
+LOG4J_VERSION=2.15.0
 
 # XML Calabash is not always available depending on Saxon version
 XMLCALABASH_VERSION=


### PR DESCRIPTION
This pull request just updates the Apache Log4j (for XML Calabash 1.3.2+) version used for testing.