### PR TITLE
ci(deps): bump BaseX from 9.6.3 to 9.6.4

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -6,7 +6,7 @@
 ANT_VERSION=1.10.12
 
 # Latest BaseX
-BASEX_VERSION=9.6.3
+BASEX_VERSION=9.6.4
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
https://github.com/BaseXdb/basex/blob/master/CHANGELOG
> VERSION 9.6.4 (December 17, 2021) --------------------------------------
> 
>  - Performance tweaks, minor fixes