### PR TITLE
feat(schematron): bump built-in SchXslt to v1.8.6

### DIFF
--- a/lib/schxslt/1.0/compile-for-svrl.xsl
+++ b/lib/schxslt/1.0/compile-for-svrl.xsl
@@ -47,6 +47,14 @@
       <xsl:if test="$pattern/@documents">
         <attribute name="documents"><value-of select="normalize-space()"/></attribute>
       </xsl:if>
+      <xsl:choose>
+        <xsl:when test="$pattern/sch:title">
+          <xsl:attribute name="name" select="$pattern/sch:title"/>
+        </xsl:when>
+        <xsl:when test="$pattern/@id">
+          <xsl:attribute name="name" select="$pattern/@id"/>
+        </xsl:when>
+      </xsl:choose>
     </svrl:active-pattern>
 
   </xsl:template>

--- a/lib/schxslt/1.0/expand.xsl
+++ b/lib/schxslt/1.0/expand.xsl
@@ -68,40 +68,45 @@
     <xsl:param name="source"/>
     <xsl:param name="params"/>
 
-    <xsl:if test="normalize-space($params) != ''">
-      <xsl:variable name="param">
+    <xsl:choose>
+      <xsl:when test="normalize-space($params) != ''">
+        <xsl:variable name="param">
+          <xsl:choose>
+            <xsl:when test="contains($params, ' ')">
+              <xsl:value-of select="substring-before($params, ' ')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$params"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="replacement" select="key('schxslt:params', $instanceId)[@name = substring($param, 2)]/@value"/>
+
+        <xsl:variable name="source-replaced">
+          <xsl:call-template name="schxslt:replace-single-param">
+            <xsl:with-param name="source" select="$source"/>
+            <xsl:with-param name="param" select="$param"/>
+            <xsl:with-param name="replacement" select="$replacement"/>
+          </xsl:call-template>
+        </xsl:variable>
+
         <xsl:choose>
           <xsl:when test="contains($params, ' ')">
-            <xsl:value-of select="substring-before($params, ' ')"/>
+            <xsl:call-template name="schxslt:replace-params">
+              <xsl:with-param name="instanceId" select="$instanceId"/>
+              <xsl:with-param name="source" select="$source-replaced"/>
+              <xsl:with-param name="params" select="substring-after($params, ' ')"/>
+            </xsl:call-template>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="$params"/>
+            <xsl:value-of select="$source-replaced"/>
           </xsl:otherwise>
         </xsl:choose>
-      </xsl:variable>
-      <xsl:variable name="replacement" select="key('schxslt:params', $instanceId)[@name = substring($param, 2)]/@value"/>
-
-      <xsl:variable name="source-replaced">
-        <xsl:call-template name="schxslt:replace-single-param">
-          <xsl:with-param name="source" select="$source"/>
-          <xsl:with-param name="param" select="$param"/>
-          <xsl:with-param name="replacement" select="$replacement"/>
-        </xsl:call-template>
-      </xsl:variable>
-
-      <xsl:choose>
-        <xsl:when test="contains($params, ' ')">
-          <xsl:call-template name="schxslt:replace-params">
-            <xsl:with-param name="instanceId" select="$instanceId"/>
-            <xsl:with-param name="source" select="$source-replaced"/>
-            <xsl:with-param name="params" select="substring-after($params, ' ')"/>
-          </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$source-replaced"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:if>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$source"/>
+      </xsl:otherwise>
+    </xsl:choose>
 
   </xsl:template>
 

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.8.5 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.8.6 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -48,6 +48,9 @@
     <xsl:param name="pattern" as="element(sch:pattern)" required="yes"/>
     <xsl:if test="$schxslt.svrl.compact eq false()">
       <svrl:active-pattern>
+        <xsl:if test="exists($pattern/sch:title | $pattern/@id)">
+          <xsl:attribute name="name" select="($pattern/sch:title, $pattern/@id)[1]"/>
+        </xsl:if>
         <xsl:sequence select="($pattern/@id, $pattern/@role)"/>
         <attribute name="documents" select="base-uri(.)"/>
       </svrl:active-pattern>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.5</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.6</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -191,7 +191,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -223,7 +224,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -255,7 +257,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -287,7 +290,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -319,7 +323,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -351,7 +356,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -388,7 +394,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -420,7 +427,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -452,7 +460,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -484,7 +493,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -516,7 +526,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -548,7 +559,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="focus-vs-pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -55,7 +55,8 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                  <svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
@@ -150,7 +151,8 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                  <svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="focus-vs-pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -160,7 +160,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -192,7 +193,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -224,7 +226,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -256,7 +259,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -288,7 +292,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>
@@ -320,7 +325,8 @@
                         <span class="xmlns">xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"</span>
                         <span class="xmlns">xmlns:svrl="http://purl.oclc.org/dsdl/svrl"</span>
                         <span class="xmlns trivial">xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>&gt;
-   &lt;svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+   &lt;svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                        id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                         documents="pending_schematron-compiled.xsl" /&gt;
 &lt;/svrl:schematron-output&gt;</pre>
                         </td>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -23,7 +23,8 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                  <svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
@@ -88,7 +89,8 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                  <svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>
@@ -129,7 +131,8 @@
                                        xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                                        xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                  <svrl:active-pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                  <svrl:active-pattern name="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
+                                       id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"
                                        documents="pending_schematron-compiled.xsl"/>
                </svrl:schematron-output>
             </content-wrap>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -23,7 +23,7 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern2" id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -35,7 +35,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern3" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern3" id="Pattern3" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -46,7 +46,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern4" id="Pattern4" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -97,7 +97,7 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern2" id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -109,7 +109,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern3" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern3" id="Pattern3" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -120,7 +120,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern4" id="Pattern4" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -181,7 +181,7 @@
                                     xmlns:local="local"
                                     phase="PhaseB">
                <svrl:ns-prefix-in-attribute-values prefix="local" uri="local"/>
-               <svrl:active-pattern id="Pattern2" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern2" id="Pattern2" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -193,7 +193,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern3" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern3" id="Pattern3" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:failed-assert location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"
@@ -204,7 +204,7 @@
             </svrl:text>
                </svrl:failed-assert>
                <svrl:fired-rule context="sec"/>
-               <svrl:active-pattern id="Pattern4" documents="demo-02.xml"/>
+               <svrl:active-pattern name="Pattern4" id="Pattern4" documents="demo-02.xml"/>
                <svrl:fired-rule context="sec"/>
                <svrl:fired-rule context="sec"/>
                <svrl:successful-report location="/Q{}article[1]/Q{}body[1]/Q{}sec[2]"


### PR DESCRIPTION
Replace the built-in SchXslt v1.8.5 with v1.8.6.

Note that the base branch of this pull request is not `master` but `schxslt`.
