### PR TITLE
fix(cli): support MSYS2 on Windows

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -101,8 +101,8 @@ fi
 #    OPEN=see
 #fi
 
-# the classpath delimiter (aka ':', except ';' on Cygwin)
-if uname | grep -i cygwin > /dev/null 2>&1; then
+# the classpath delimiter (aka ':', except ';' on Cygwin and MSYS)
+if uname | grep -i 'cygwin\|msys' > /dev/null 2>&1; then
     CP_DELIM=";"
 else
     CP_DELIM=":"


### PR DESCRIPTION
Detect [MSYS](https://www.msys2.org/) usage, in addition to cygwin, for Java classpath separators.

MSYS2 is pre-installed on Windows Github Action environments and is generally a lighter-weight alternative to cygwin.

For reference, the output of `uname` with MSYS looks like this:

```
$ uname
MSYS_NT-10.0-14393
```