### PR TITLE
ci: skip codespell package-lock.json file

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,4 @@ quiet-level = 6
 
 # ".git" dir is not skipped by default: codespell-project/codespell#783
 # Skipping nested dirs needs "./": codespell-project/codespell#99
-skip = .git,./lib/*/*,node_modules
+skip = .git,./lib/*/*,node_modules,package-lock.json


### PR DESCRIPTION
Skip package-lock.json to avoid false positives

Part of "integrity" property value can look like an incorrectly
spelled word, but it is not meant as a word.

This change is motivated by the spell checking failure mentioned in https://github.com/xspec/xspec/pull/1640#issuecomment-1172408885.

### Testing Done
Without this change, manually added `vew` to the end of one of the integrity values in `package-lock.json` and checked that codespell found it.
```
C:\github\xspec>test\ci\run-codespell.cmd

C:\github\xspec>echo Install codespell
Install codespell

C:\github\xspec>pip3 install     --disable-pip-version-check     --requirement requirements-dev.txt
Requirement already satisfied: codespell==2.1.0 in C:\[...]\lib\site-packages (from -r requirements-dev.txt (line 1)) (2.1.0)

C:\github\xspec>echo Run codespell
Run codespell

C:\github\xspec>codespell
.\package-lock.json:10: vew ==> view
```
Then made this change and reran codespell. Now, codespell does not find that "word."
```
C:\github\xspec>test\ci\run-codespell.cmd

C:\github\xspec>echo Install codespell
Install codespell

C:\github\xspec>pip3 install     --disable-pip-version-check     --requirement requirements-dev.txt
Requirement already satisfied: codespell==2.1.0 in C:\[...]\lib\site-packages (from -r requirements-dev.txt (line 1)) (2.1.0)

C:\github\xspec>echo Run codespell
Run codespell

C:\github\xspec>codespell

C:\github\xspec>
```