### PR TITLE
Revert "build(deps): bump maven-assembly-plugin from 3.4.1 to 3.4.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.1</version>
         <configuration>
           <descriptors>
             <descriptor>assembly/enduser-files.xml</descriptor>


### PR DESCRIPTION
Reverts xspec/xspec#1644

#1610 and #1645 are failing the "Lint / shfmt (pull_request)" check since I  updated this plugin to 3.4.2. Reverting for now.