### PR TITLE
build(maven): bump Maven Assembly Plugin XSD from 2.0.0 to 2.1.1

### DIFF
--- a/assembly/enduser-files.xml
+++ b/assembly/enduser-files.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 http://maven.apache.org/xsd/assembly-2.1.1.xsd">
 
     <id>enduser-files</id>
 


### PR DESCRIPTION
We use [Maven Assembly Plugin 3.4.2](https://github.com/xspec/xspec/blob/a104cb1ef403881ff38c8821963a6c3dca0fbb3b/pom.xml#L172-L173) as of now and for that version, its schema should be 2.2.1:

https://maven.apache.org/plugins/maven-assembly-plugin/#assembly-and-component-descriptor-schemas-xsd
> Assembly and Component Descriptor Schemas (XSD)
> https://maven.apache.org/xsd/assembly-2.1.1.xsd, https://maven.apache.org/xsd/assembly-component-2.1.1.xsd (for version 3.4.0 and higher)

I verified that with this change, Oxygen 24.1 was able to perform validation.