### PR TITLE
ci: no need to check and uninstall stale Bats on macOS 11 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: zulu
 
-      - name: Uninstall stale Bats for macOS
-        if: runner.os == 'macOS'
-        run: test/ci/uninstall-bats-macos.sh
-
       - name: Run tests for *nix
         if: runner.os != 'Windows'
         run: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,6 @@ jobs:
       XSPEC_TEST_ENV: saxon-9-9
 
     steps:
-      - script: test/ci/uninstall-bats-macos.sh
-        displayName: Uninstall stale Bats
-
       - script: >
           source test/ci/npm-ci.sh
           && source test/ci/install-deps.sh

--- a/test/ci/uninstall-bats-macos.sh
+++ b/test/ci/uninstall-bats-macos.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-if brew list bats; then
-    brew uninstall bats
-else
-    true
-fi


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/4060#issuecomment-1023546603
> The migration is completed — all the jobs on `macos-latest` now run on `macos-11`.

And `macos-11` doesn't seem to have Bats. We no longer have to uninstall it.

I guess that's also the case on Azure Pipelines.