### PR TITLE
feat(schematron): bump built-in SchXslt to v1.9.3

### DIFF
--- a/lib/schxslt/1.0/compile/compile-1.0.xsl
+++ b/lib/schxslt/1.0/compile/compile-1.0.xsl
@@ -12,8 +12,8 @@
   <xsl:output indent="yes"/>
   <xsl:namespace-alias stylesheet-prefix="#default" result-prefix="xsl"/>
 
-  <xsl:key name="schxslt:diagnostics" match="sch:diagnostic" use="@id"/>
-  <xsl:key name="schxslt:properties" match="sch:property" use="@id"/>
+  <xsl:key name="schxslt:diagnostics" match="sch:schema/sch:diagnostics/sch:diagnostic" use="@id"/>
+  <xsl:key name="schxslt:properties" match="sch:schema/sch:properties/sch:property" use="@id"/>
 
   <xsl:param name="phase">#DEFAULT</xsl:param>
   <xsl:param name="schxslt.compile.metadata" select="true()"/>
@@ -226,6 +226,10 @@
     <element namespace="{namespace-uri(.)}" name="{local-name(.)}">
       <xsl:apply-templates select="node() | @*" mode="schxslt:message-template"/>
     </element>
+  </xsl:template>
+
+  <xsl:template match="xsl:copy-of[ancestor::sch:property]" mode="schxslt:message-template">
+    <xsl:copy-of select="."/>
   </xsl:template>
 
   <xsl:template match="@*" mode="schxslt:message-template">

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.8.6 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.9.3 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -109,7 +109,7 @@
         <xsl:with-param name="typed-variables" as="xs:boolean" select="$schxslt.compile.typed-variables"/>
       </xsl:call-template>
 
-      <template match="/">
+      <template match="root()">
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
 
         <variable name="metadata" as="element()?">
@@ -336,17 +336,17 @@
             <schxslt:document>
               <xsl:for-each select="current-group()">
                 <schxslt:pattern id="{generate-id()}">
-                  <if test="exists(base-uri(/))">
-                    <attribute name="documents" select="base-uri(/)"/>
+                  <if test="exists(base-uri(root()))">
+                    <attribute name="documents" select="base-uri(root())"/>
                   </if>
-                  <for-each select="/">
+                  <for-each select="root()">
                     <xsl:call-template name="schxslt-api:active-pattern">
                       <xsl:with-param name="pattern" as="element(sch:pattern)" select="."/>
                     </xsl:call-template>
                   </for-each>
                 </schxslt:pattern>
               </xsl:for-each>
-              <apply-templates mode="{$mode}" select="/"/>
+              <apply-templates mode="{$mode}" select="root()"/>
             </schxslt:document>
           </xsl:otherwise>
         </xsl:choose>

--- a/lib/schxslt/2.0/expand.xsl
+++ b/lib/schxslt/2.0/expand.xsl
@@ -33,7 +33,13 @@
 
   <!-- Instantiate an abstract rule -->
   <xsl:template match="sch:extends[@rule]" mode="schxslt:expand">
+    <xsl:if test="empty(ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule])">
+      <xsl:message terminate="yes">
+        The current pattern defines no abstract rule named '<xsl:value-of select="@rule"/>'.
+      </xsl:message>
+    </xsl:if>
     <xsl:sequence select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()"/>
+    <xsl:apply-templates select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/sch:extends" mode="#current"/>
   </xsl:template>
 
   <!-- Instantiate an abstract pattern -->
@@ -45,11 +51,29 @@
       <xsl:apply-templates select="(if (not(@documents)) then $is-a/@documents else (), $is-a/node())" mode="schxslt:expand">
         <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
       </xsl:apply-templates>
+      <xsl:if test="$is-a/sch:rule/sch:*/@properties">
+        <xsl:variable name="ids" as="xs:string*"
+                      select="for $prop in $is-a/sch:rule/sch:*/@properties return tokenize($prop, '\s+')"/>
+        <sch:properties>
+          <xsl:apply-templates select="../sch:properties/sch:property[@id = $ids]" mode="schxslt:expand">
+            <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
+          </xsl:apply-templates>
+        </sch:properties>
+      </xsl:if>
+      <xsl:if test="$is-a/sch:rule/sch:*/@diagnostics">
+        <xsl:variable name="ids" as="xs:string*"
+                      select="for $diag in $is-a/sch:rule/sch:*/@diagnostics return tokenize($diag, '\s+')"/>
+        <sch:diagnostics>
+          <xsl:apply-templates select="../sch:diagnostics/sch:diagnostic[@id = $ids]" mode="schxslt:expand">
+            <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
+          </xsl:apply-templates>
+        </sch:diagnostics>
+      </xsl:if>
     </xsl:copy>
   </xsl:template>
 
   <!-- Replace placeholders in abstract pattern instance -->
-  <xsl:template match="sch:assert/@test | sch:report/@test | sch:rule/@context | sch:value-of/@select | sch:pattern/@documents | sch:name/@path | sch:let/@value" mode="schxslt:expand">
+  <xsl:template match="sch:assert/@test | sch:report/@test | sch:rule/@context | sch:value-of/@select | sch:pattern/@documents | sch:name/@path | sch:let/@value | xsl:copy-of[ancestor::sch:property]/@select" mode="schxslt:expand">
     <xsl:param name="schxslt:params" as="element(sch:param)*" tunnel="yes"/>
     <xsl:attribute name="{name()}" select="schxslt:replace-params(., $schxslt:params)"/>
   </xsl:template>
@@ -63,9 +87,16 @@
         <xsl:value-of select="$src"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:variable name="value" select="replace(replace($params[1]/@value, '\\', '\\\\'), '\$', '\\\$')"/>
-        <xsl:variable name="src" select="replace($src, concat('(\W*)\$', $params[1]/@name, '(\W*)'), concat('$1', $value, '$2'))"/>
-        <xsl:value-of select="schxslt:replace-params($src, $params[position() > 1])"/>
+        <xsl:variable name="paramsSorted" as="element(sch:param)*">
+          <xsl:for-each select="$params">
+            <xsl:sort select="string-length(@name)" order="descending"/>
+            <xsl:sequence select="."/>
+          </xsl:for-each>
+        </xsl:variable>
+
+        <xsl:variable name="value" select="replace(replace($paramsSorted[1]/@value, '\\', '\\\\'), '\$', '\\\$')"/>
+        <xsl:variable name="src" select="replace($src, concat('(\W*)\$', $paramsSorted[1]/@name, '(\W*)'), concat('$1', $value, '$2'))"/>
+        <xsl:value-of select="schxslt:replace-params($src, $paramsSorted[position() > 1])"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.8.6</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.3</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.8.6 with v1.9.3.

Note that the base branch of this pull request is not `master` but `schxslt`.
