### PR TITLE
feat(oxygen): add library jar files for Oxygen 24.1

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -795,8 +795,15 @@
 										<String>${oxygenHome}/lib/oxygen-editor-variables-parser.jar</String>
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
-										<String>${oxygenHome}/lib/*log4j*.jar</String>
+										<String>${oxygenHome}/lib/oxygen-patched-slf4j.jar</String>
+										<String>${oxygenHome}/lib/logback-classic-*.jar</String>
+										<String>${oxygenHome}/lib/logback-core-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-over-slf4j-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-to-slf4j-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-api-*.jar</String>
+										<String>${oxygenHome}/lib/log4j.jar</String>
 										<String>${oxygenHome}/lib/*xerces*.jar</String>
 										<String>${oxygenHome}/lib/guava-*.jar</String>
 									</String-array>
@@ -1182,8 +1189,15 @@
 										<String>${oxygenHome}/lib/oxygen-editor-variables-parser.jar</String>
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
-										<String>${oxygenHome}/lib/*log4j*.jar</String>
+										<String>${oxygenHome}/lib/oxygen-patched-slf4j.jar</String>
+										<String>${oxygenHome}/lib/logback-classic-*.jar</String>
+										<String>${oxygenHome}/lib/logback-core-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-over-slf4j-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-to-slf4j-*.jar</String>
+										<String>${oxygenHome}/lib/log4j-api-*.jar</String>
+										<String>${oxygenHome}/lib/log4j.jar</String>
 										<String>${oxygenHome}/lib/*xerces*.jar</String>
 										<String>${oxygenHome}/lib/guava-*.jar</String>
 									</String-array>


### PR DESCRIPTION
This pull request adds some `.jar` files to `xspec.framework` so that the Ant transformation scenarios for XSpec work on Oxygen 24.1.
This change is based on https://github.com/xspec/oXygen-XML-editor-xspec-support/commit/b9cf8cf3f74bbe3e9645416e82006b6a3c1840b2 and https://github.com/xspec/oXygen-XML-editor-xspec-support/commit/51b6e219574173ec2fbce8f4fa3573aa8be72037.

With this change, I verified that the **Run XSpec Test** transformation scenario worked on Oxygen 24.1 build 2022092207.

Note that the **XSLT Code Coverate** transformation scenario does not work correctly on Oxygen 24.1, as the code coverage feature doesn't support Saxon 10. Supporting the code coverage on Saxon 10 has been blocked by [a Saxon bug](https://saxonica.plan.io/issues/5112). The bug seems to be fixed on Saxon 10.7. Unfortunately Oxygen 24.1 has Saxon 10.6.