### PR TITLE
feat(schematron): bump built-in SchXslt to v1.9.4

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.9.3 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.9.4 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -122,21 +122,7 @@
         <dct:creator>
           <dct:Agent>
             <skos:prefLabel>
-              <xsl:choose>
-                <xsl:when test="$xslt-version eq '3.0'">
-                  <value-of separator="/" select="(system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-name'), system-property('Q{{http://www.w3.org/1999/XSL/Transform}}product-version'))"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <variable name="prefix" as="xs:string?" select="if (doc-available('')) then in-scope-prefixes(document('')/*[1])[namespace-uri-for-prefix(., document('')/*[1]) eq 'http://www.w3.org/1999/XSL/Transform'][1] else ()">
-                  </variable>
-                  <choose>
-                    <when test="empty($prefix)">Unknown</when>
-                    <otherwise>
-                      <value-of separator="/" select="(system-property(concat($prefix, ':product-name')), system-property(concat($prefix,':product-version')))"/>
-                    </otherwise>
-                  </choose>
-                </xsl:otherwise>
-              </xsl:choose>
+              <value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
             </skos:prefLabel>
           </dct:Agent>
         </dct:creator>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.3</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.4</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.9.3 with v1.9.4.

Note that the base branch of this pull request is not `master` but `schxslt`.
