### PR TITLE
test: bats_require_minimum_version 1.5.0

### DIFF
--- a/test/bats-helper.bash
+++ b/test/bats-helper.bash
@@ -47,6 +47,8 @@ assert_leaf_dir_not_exist() {
 }
 
 myrun() {
+    # run's non command parameters like --keep-empty-lines are only available since 1.5.0
+    bats_require_minimum_version 1.5.0
     run --keep-empty-lines -- "$@"
     # To print $output, use --print-output-on-failure and/or --verbose-run Bats command line flags
 


### PR DESCRIPTION
This pr addresses `BW02` warnings from Bats:
https://github.com/xspec/xspec/actions/runs/4262150688/jobs/7417307594#step:3:28
> BW02: Using flags on `run` requires at least BATS_VERSION=1.5.0. Use `bats_require_minimum_version 1.5.0` to fix this message.`

Details are in https://bats-core.readthedocs.io/en/stable/warnings/BW02.html