### PR TITLE
feat(schematron): bump built-in SchXslt to v1.9.5

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.9.4 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.9.5 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -274,7 +274,7 @@
       </mode>
     </xsl:if>
 
-    <xsl:for-each-group select="$patterns" group-by="string-join((base-uri(.), @documents), '~')">
+    <xsl:for-each-group select="$patterns" group-by="string(@documents)">
       <xsl:variable name="mode" as="xs:string" select="generate-id()"/>
 
       <xsl:if test="$xslt-version = '3.0'">

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.4</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.5</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.9.4 with v1.9.5, using download from https://github.com/schxslt/schxslt/releases/download/v1.9.5/schxslt-1.9.5-xslt-only.zip

Note that the base branch of this pull request is not `master` but `schxslt`.
