### PR TITLE
feat(oxygen): add library jar files for Oxygen 25.1

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -795,6 +795,8 @@
 										<String>${oxygenHome}/lib/oxygen-editor-variables-parser.jar</String>
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
+										<String>${oxygenHome}/lib/xmlresolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*11*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
 										<String>${oxygenHome}/lib/oxygen-patched-slf4j.jar</String>
@@ -1189,6 +1191,8 @@
 										<String>${oxygenHome}/lib/oxygen-editor-variables-parser.jar</String>
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
+										<String>${oxygenHome}/lib/xmlresolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*11*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
 										<String>${oxygenHome}/lib/oxygen-patched-slf4j.jar</String>


### PR DESCRIPTION
This pull request adds some .jar files to xspec.framework so that the Ant transformation scenarios for XSpec work with Oxygen 25.1.

This change is based on https://github.com/xspec/oXygen-XML-editor-xspec-support/commit/cb9e3844feb8d39b3d17ef4351dd512c6bda3f04 and https://github.com/xspec/oXygen-XML-editor-xspec-support/commit/f619afaa4e69cc880b55a1b7de89add9d9fd9b7d .

With this change, I verified that the **Run XSpec Test** transformation scenario worked on Oxygen 25.1 build 2023031510.

About the the **XSLT Code Coverage** transformation scenario: Despite the fixes mentioned in #852, Oxygen 25.1 using Saxon 11.4 still shows the same symptom as in #1705. The sample file I used was `test/end-to-end/cases/custom-coverage-report.xspec`. I haven't looked into whether the Saxon fixes might be in Saxon 10.7 but not 11.4, or whether there is another explanation for code coverage continuing to be missing the relevant data.