### PR TITLE
refactor(schematron): override skeleton impl for testing purposes only

### DIFF
--- a/src/schematron/step3.xsl
+++ b/src/schematron/step3.xsl
@@ -14,7 +14,6 @@
 		Import the original Schematron Step 3 preprocessor
 	-->
 	<xsl:import href="../../lib/iso-schematron/iso_svrl_for_xslt2.xsl" />
-	<xsl:include href="step3-override-process-assert.xsl"/>
 
 	<!--
 		Setting this parameter true activates the patch for @location containing text node

--- a/test/issue-1618.xspec
+++ b/test/issue-1618.xspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test schematron-preprocessor-step3=${xspec.project.dir}/test/issue-1618_step3.xsl?>
 <x:description
     schematron="issue-1618.sch"
     xmlns:x="http://www.jenitennison.com/xslt/xspec">

--- a/test/issue-1618_step3.xsl
+++ b/test/issue-1618_step3.xsl
@@ -12,6 +12,10 @@
         https://github.com/xspec/xspec/issues/1618
 -->
 
+    <xsl:include href="../src/schematron/preprocessor.xsl" />
+
+    <xsl:import _href="{$x:schematron-preprocessor?stylesheets?3}" />
+
     <!--
 Open Source Initiative OSI - The MIT License:Licensing
 [OSI Approved License]


### PR DESCRIPTION
As mentioned in https://github.com/xspec/xspec/issues/1618#issuecomment-1257168030 and https://github.com/xspec/xspec/issues/1618#issuecomment-1257185678, #1618 is just one of many bugs in the *skeleton* implementation. Fixing them is beyond the scope of XSpec.

That being said, testing #1618 is still beneficial as it ensures that XSpec can handle curly brackets in `sch:assert/@test`. This pull request enables the fix #1626 only when testing `test/issue-1618.xspec`.