### PR TITLE
ci: test with Java 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [8, 11]
+        java: [8, 17]
         env: [saxon-10, saxon-9-9, oxygen]
         exclude:
           - os: macos-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ jobs:
 
   - template: test/ci/azure-pipelines_windows.yml
     parameters:
-      jobName: Win_Java11
-      javaVersion: 11
+      jobName: Win_Java17
+      javaVersion: 17
 
   - job: macOS
 

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -39,7 +39,6 @@ jobs:
           versionSpec: ${{ parameters.javaVersion }}
           jdkArchitectureOption: x64
           jdkSourceOption: PreInstalled
-          cleanDestinationDirectory: false
 
       - task: BatchScript@1
         displayName: Install test dependencies

--- a/test/ci/compile-java.cmd
+++ b/test/ci/compile-java.cmd
@@ -2,7 +2,7 @@ echo Compile Java
 
 setlocal
 
-javac -version 2>&1 | "%SYSTEMROOT%\system32\find" " 11."
+javac -version 2>&1 | "%SYSTEMROOT%\system32\find" " 17."
 if not errorlevel 1 (
     echo Skip compiling with incompatible JDK
     exit /b 0

--- a/test/ci/compile-java.sh
+++ b/test/ci/compile-java.sh
@@ -2,7 +2,7 @@
 
 echo "Compile Java"
 
-if javac -version 2>&1 | grep -F ' 11.'; then
+if javac -version 2>&1 | grep -F ' 17.'; then
     echo "Skip compiling with incompatible JDK"
     exit
 fi


### PR DESCRIPTION
This pull request replaces Java 11 with Java 17 in the test matrix of GitHub Actions and Azure Pipelines.
While working on this, I noticed `cleanDestinationDirectory` was no longer necessary. (Probably fixed by microsoft/azure-pipelines-tasks#13657.) 60b46b0fa349931443afb8c5354ae5b66683d583 removes it.

## Why

The latest version of Java LTS is 17.
Also, Oxygen 24+ is shipped with 17.

## Further work

Update [Wiki](https://github.com/xspec/xspec/wiki/Requirements#java).