### PR TITLE
ci: use Eclipse Temurin distribution

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: zulu
+          distribution: temurin
           server-id: xspec-io.ossrh
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: zulu
+          distribution: temurin
 
       - name: Run tests for *nix
         if: runner.os != 'Windows'


### PR DESCRIPTION
GitHub Actions workflow currently employs the Azul Zulu distribution of Java with no strong reason, as stated in its [commit comment](https://github.com/xspec/xspec/pull/1466/commits/fd3392ef2f45963503ac8f4ec1e1a27ea5f10a27).

This pull request replaces it with the Eclipse Temurin distribution which comes bundled with Oxygen 25+ and therefore offers a more suitable alternative.