### PR TITLE
test: default to Saxon 10, not Saxon 9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ skip_branch_with_pr: true
 environment:
   matrix:
     # Non-mainstream jobs are not included in favor of GitHub Actions and Azure Pipelines
-    - XSPEC_TEST_ENV: saxon-9-9
+    - XSPEC_TEST_ENV: saxon-10
 
 install:
   - cmd: test\ci\install-deps.cmd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
 
     variables:
       # Non-mainstream jobs are not included in favor of GitHub Actions
-      XSPEC_TEST_ENV: saxon-9-9
+      XSPEC_TEST_ENV: saxon-10
 
     steps:
       - script: >

--- a/test/ci/set-env.cmd
+++ b/test/ci/set-env.cmd
@@ -1,7 +1,7 @@
 rem
 rem Select the mainstream by default
 rem
-if not defined XSPEC_TEST_ENV set XSPEC_TEST_ENV=saxon-9-9
+if not defined XSPEC_TEST_ENV set XSPEC_TEST_ENV=saxon-10
 echo Setting up %XSPEC_TEST_ENV%
 
 rem

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -8,7 +8,7 @@
 # Select the mainstream by default
 #
 if [ -z "${XSPEC_TEST_ENV}" ]; then
-    export XSPEC_TEST_ENV=saxon-9-9
+    export XSPEC_TEST_ENV=saxon-10
 fi
 echo "Setting up ${XSPEC_TEST_ENV}"
 


### PR DESCRIPTION
Now that XSpec warns that Saxon 9.9 is not recommended, the default should be a newer version of Saxon.

This update should have been part of https://github.com/xspec/xspec/pull/1652, but I wasn't familiar with this bit of code at the time.