### PR TITLE
ci(basex): do not download BaseX on Java 8

### DIFF
--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -36,8 +36,8 @@ java -cp "%BASEX_JAR%" org.basex.BaseX -h
 
 echo:
 echo === Check BaseX server start and stop
-call "%BASEX_JAR%\..\bin\basexhttp.bat" -S 2> NUL
-call "%BASEX_JAR%\..\bin\basexhttpstop.bat" 2> NUL
+call "%BASEX_JAR%\..\bin\basexhttp.bat" -S
+call "%BASEX_JAR%\..\bin\basexhttpstop.bat"
 
 echo:
 echo === Print environment variables

--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -32,7 +32,7 @@ java -cp "%XML_RESOLVER_JAR%" org.apache.xml.resolver.Version
 
 echo:
 echo === Check BaseX
-java -cp "%BASEX_JAR%" org.basex.BaseX -h 2> NUL
+java -cp "%BASEX_JAR%" org.basex.BaseX -h
 
 echo:
 echo === Check BaseX server start and stop

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -30,7 +30,7 @@ java -cp "${XML_RESOLVER_JAR}" org.apache.xml.resolver.Version
 
 echo
 echo "=== Check BaseX"
-java -cp "${BASEX_JAR}" org.basex.BaseX -h 2> /dev/null
+java -cp "${BASEX_JAR}" org.basex.BaseX -h
 
 echo
 echo "=== Check BaseX server start and stop"

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -35,8 +35,8 @@ java -cp "${BASEX_JAR}" org.basex.BaseX -h
 echo
 echo "=== Check BaseX server start and stop"
 basex_home=$(dirname -- "${BASEX_JAR}")
-"${basex_home}/bin/basexhttp" -S 2> /dev/null
-"${basex_home}/bin/basexhttpstop" 2> /dev/null
+"${basex_home}/bin/basexhttp" -S
+"${basex_home}/bin/basexhttpstop"
 
 echo
 echo "=== Print Bats version"

--- a/test/ci/set-env.cmd
+++ b/test/ci/set-env.cmd
@@ -96,6 +96,11 @@ if defined XMLCALABASH_CP if defined LOG4J_DIR (
 rem
 rem BaseX
 rem
+
+rem BaseX 10 requires Java 11
+java -version 2>&1 | "%SYSTEMROOT%\system32\find" " 1.8." > NUL
+if not errorlevel 1 set BASEX_VERSION=
+
 if defined BASEX_VERSION (
     rem Depends on the archive file structure
     set "BASEX_JAR=%XSPEC_TEST_DEPS%\basex-%BASEX_VERSION%\basex\BaseX.jar"

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -117,6 +117,12 @@ fi
 #
 # BaseX
 #
+
+# BaseX 10 requires Java 11
+if java -version 2>&1 | grep -F " 1.8." > /dev/null; then
+    unset BASEX_VERSION
+fi
+
 if [ -n "${BASEX_VERSION}" ]; then
     # Depends on the archive file structure
     export BASEX_JAR="${XSPEC_TEST_DEPS}/basex-${BASEX_VERSION}/basex/BaseX.jar"

--- a/test/run-bats.cmd
+++ b/test/run-bats.cmd
@@ -16,10 +16,6 @@ if not exist "%SAXON_JAR%" (
     exit /b 1
 )
 
-rem If Java 8, unset BASEX_JAR because Java 8 is incompatible with BaseX 10
-java -version 2>&1 | "%SYSTEMROOT%\system32\find" " 1.8." > NUL
-if not errorlevel 1 set BASEX_JAR=
-
 rem Check capabilities
 java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&1 | "%SYSTEMROOT%\system32\find" " 9." > NUL
 if not errorlevel 1 set XSLT_SUPPORTS_COVERAGE=1

--- a/test/run-bats.sh
+++ b/test/run-bats.sh
@@ -16,11 +16,6 @@ if [ ! -f "${SAXON_JAR}" ]; then
     exit 1
 fi
 
-# If Java 8, unset BASEX_JAR because Java 8 is incompatible with BaseX 10
-if java -version 2>&1 | grep -F " 1.8." > /dev/null; then
-    export BASEX_JAR=
-fi
-
 # Check capabilities
 if java -cp "${SAXON_JAR}" net.sf.saxon.Version 2>&1 | grep -F " 9." > /dev/null; then
     export XSLT_SUPPORTS_COVERAGE=1


### PR DESCRIPTION
Right now, BaseX is always downloaded although it is not tested on Java 8.
This pull request skips downloading it in the first place.