### PR TITLE
test(basex): set admin password before starting BaseX server

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -772,9 +772,15 @@
     rem BaseX dir
     set "BASEX_HOME=%BASEX_JAR%\.."
 
+    rem Set BaseX password
+    rem Run the batch file in a child process in order to localize various environment changes
+    set BASEX_PASSWORD=%RANDOM%
+    call :run ""%BASEX_HOME%\bin\basex.bat" -c"PASSWORD %BASEX_PASSWORD%""
+    call :verify_retval 0
+
     rem Start BaseX server
     rem Run the batch file in a child process in order to localize various environment changes
-    call :run "%BASEX_HOME%\bin\basexhttp.bat" -S -U admin -c PASSWORD -h 8080
+    call :run "%BASEX_HOME%\bin\basexhttp.bat" -S
     call :verify_retval 0
 
     rem HTML report file
@@ -786,7 +792,7 @@
         -o result="file:///%EXPECTED_REPORT:\=/%" ^
         -p auth-method=Basic ^
         -p endpoint=http://localhost:8080/rest ^
-        -p password=admin ^
+        -p password="%BASEX_PASSWORD%" ^
         -p username=admin ^
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -869,8 +869,12 @@ load bats-helper
     # BaseX dir
     basex_home=$(dirname -- "${BASEX_JAR}")
 
+    # Set BaseX password
+    basex_password=${RANDOM}
+    "${basex_home}/bin/basex" -c"PASSWORD ${basex_password}"
+
     # Start BaseX server
-    "${basex_home}/bin/basexhttp" -S -U admin -c PASSWORD -h 8080
+    "${basex_home}/bin/basexhttp" -S
 
     # HTML report file
     expected_report="${work_dir}/report-sequence-result_${RANDOM}.html"
@@ -881,7 +885,7 @@ load bats-helper
         -o result="file:${expected_report}" \
         -p auth-method=Basic \
         -p endpoint=http://localhost:8080/rest \
-        -p password=admin \
+        -p password="${basex_password}" \
         -p username=admin \
         -p xspec-home="file:${parent_dir_abs}/" \
         ../src/harnesses/basex/basex-server-xquery-harness.xproc


### PR DESCRIPTION
- The BaseX server test is failing sporadically, with instances like [this](https://github.com/xspec/xspec/actions/runs/4924146975/jobs/8796830718#step:5:656) and [this](https://xspec.visualstudio.com/xspec/_build/results?buildId=4211&view=logs&j=8fbce2c9-ab2f-5e7d-502a-a98808b3c0e0&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=9df97ce0-6fa5-55fe-becc-6ec8a2275b4d&l=336). It appears to be an authentication failure caused by a timing issue.

- With the current test configuration, the BaseX server seems to accept any password regardless of its spelling. As a result, the `password` parameter of `basex-server-xquery-harness.xproc` is not being tested.

To address both issues, this pull request sets a random password before starting the BaseX server.