### PR TITLE
test(basex): start and stop BaseX server more safely

### DIFF
--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -37,6 +37,7 @@ java -cp "%BASEX_JAR%" org.basex.BaseX -h
 echo:
 echo === Check BaseX server start and stop
 call "%BASEX_JAR%\..\bin\basexhttp.bat" -S
+ping -n 6 localhost > NUL
 call "%BASEX_JAR%\..\bin\basexhttpstop.bat"
 
 echo:

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -36,6 +36,7 @@ echo
 echo "=== Check BaseX server start and stop"
 basex_home=$(dirname -- "${BASEX_JAR}")
 "${basex_home}/bin/basexhttp" -S
+sleep 5
 "${basex_home}/bin/basexhttpstop"
 
 echo

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -772,6 +772,10 @@
     rem BaseX dir
     set "BASEX_HOME=%BASEX_JAR%\.."
 
+    rem Stop BaseX server, in case it's running
+    rem Run the batch file in a child process in order to localize various environment changes
+    call :run "%BASEX_HOME%\bin\basexhttpstop.bat"
+
     rem Set BaseX password
     rem Run the batch file in a child process in order to localize various environment changes
     set BASEX_PASSWORD=%RANDOM%

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -783,6 +783,9 @@
     call :run "%BASEX_HOME%\bin\basexhttp.bat" -S
     call :verify_retval 0
 
+    rem Wait for the server to start up
+    ping -n 6 localhost > NUL
+
     rem HTML report file
     set "EXPECTED_REPORT=%WORK_DIR%\report-sequence-result_%RANDOM%.html"
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -869,6 +869,9 @@ load bats-helper
     # BaseX dir
     basex_home=$(dirname -- "${BASEX_JAR}")
 
+    # Stop BaseX server, in case it's running
+    myrun "${basex_home}/bin/basexhttpstop"
+
     # Set BaseX password
     basex_password=${RANDOM}
     "${basex_home}/bin/basex" -c"PASSWORD ${basex_password}"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -876,6 +876,9 @@ load bats-helper
     # Start BaseX server
     "${basex_home}/bin/basexhttp" -S
 
+    # Wait for the server to start up
+    sleep 5
+
     # HTML report file
     expected_report="${work_dir}/report-sequence-result_${RANDOM}.html"
 


### PR DESCRIPTION
Despite the changes made in #1730, the BaseX server test encountered an intermittent [failure](https://github.com/xspec/xspec/actions/runs/4950109318/jobs/8853269124#step:5:659).

Looking back its log, it was found that `basexhttpstop.bat` [failed](https://github.com/xspec/xspec/actions/runs/4950109318/jobs/8853269124#step:5:130) to stop the server long before initiating the entire test suite. This probably caused the subsequent test to fail, as the server was still running.

To mitigate this issue, this PR

- adds a 5-second delay before connecting to the server
- stops the server (as a precautionary measure), before starting it for test
