### PR TITLE
fix(schematron): construct $STEP3-PREPROCESSOR-URI using base-uri()

### DIFF
--- a/src/schematron/schut-to-xslt.xsl
+++ b/src/schematron/schut-to-xslt.xsl
@@ -19,7 +19,7 @@
 	<xsl:param as="xs:string" name="STEP2-PREPROCESSOR-URI"
 		select="$x:schematron-preprocessor?stylesheets?2" />
 	<xsl:param as="xs:string?" name="STEP3-PREPROCESSOR-URI"
-		select="document-uri($STEP3-PREPROCESSOR-DOC)" />
+		select="base-uri($STEP3-PREPROCESSOR-DOC)" />
 
 	<xsl:param as="xs:boolean" name="CACHE" select="false()" />
 


### PR DESCRIPTION
`src/schematron/schut-to-xslt.xsl` fails to obtain the Step 3 XSLT URI, when the Step 3 XSLT document is provided by the `+` command line parameter. (probably related to https://saxonica.plan.io/issues/4837)

This pr fixes it.