### PR TITLE
test(schematron): remove SAXON_DOCUMENT_URI_FIXED

### DIFF
--- a/test/ci/env/oxygen.env
+++ b/test/ci/env/oxygen.env
@@ -7,4 +7,3 @@ SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
 XMLCALABASH_VERSION=1.5.3-110
 SEPARATE_XML_RESOLVER=
 BUNDLED_XML_RESOLVER=true
-SAXON_DOCUMENT_URI_FIXED=true

--- a/test/ci/env/saxon-10.env
+++ b/test/ci/env/saxon-10.env
@@ -6,4 +6,3 @@ SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/10/Java
 XMLCALABASH_VERSION=1.5.6-100
 SEPARATE_XML_RESOLVER=true
 BUNDLED_XML_RESOLVER=
-SAXON_DOCUMENT_URI_FIXED=false

--- a/test/ci/env/saxon-11.env
+++ b/test/ci/env/saxon-11.env
@@ -6,4 +6,3 @@ SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
 XMLCALABASH_VERSION=1.5.6-110
 SEPARATE_XML_RESOLVER=
 BUNDLED_XML_RESOLVER=true
-SAXON_DOCUMENT_URI_FIXED=true

--- a/test/ci/env/saxon-9-9.env
+++ b/test/ci/env/saxon-9-9.env
@@ -7,4 +7,3 @@ SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-Archive/main/Saxon-HE
 XMLCALABASH_VERSION=1.3.2-99
 SEPARATE_XML_RESOLVER=true
 BUNDLED_XML_RESOLVER=
-SAXON_DOCUMENT_URI_FIXED=false

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -535,12 +535,6 @@
 	-->
 
 	<case ifdef="SAXON_BUG_4696_FIXED" name="invoking xspec with Schematron XSLTs provided externally uses provided XSLTs for Schematron compile (CLI)">
-    if "%SAXON_DOCUMENT_URI_FIXED%"=="true" (
-        if exist ..\lib\iso-schematron (
-            call :skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-            goto :EOF
-        )
-    )
     set SCHEMATRON_XSLT_INCLUDE=schematron\schematron-xslt_include.xsl
     set SCHEMATRON_XSLT_EXPAND=schematron\schematron-xslt_expand.xsl
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt_compile.xsl
@@ -556,12 +550,6 @@
 
 	<!-- Ant is tested by schematron-xslt_skip-1.xspec -->
 	<case name="Skip Schematron Step 1 (CLI)">
-    if "%SAXON_DOCUMENT_URI_FIXED%"=="true" (
-        if exist ..\lib\iso-schematron (
-            call :skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-            goto :EOF
-        )
-    )
     set SCHEMATRON_XSLT_INCLUDE=#none
     set SCHEMATRON_XSLT_EXPAND=schematron\schematron-xslt_include-expand.xsl
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt_compile.xsl
@@ -573,12 +561,6 @@
 
 	<!-- Ant is tested by schematron-xslt_skip-2.xspec -->
 	<case name="Skip Schematron Step 2 (CLI)">
-    if "%SAXON_DOCUMENT_URI_FIXED%"=="true" (
-        if exist ..\lib\iso-schematron (
-            call :skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-            goto :EOF
-        )
-    )
     set SCHEMATRON_XSLT_INCLUDE=schematron\schematron-xslt_include.xsl
     set SCHEMATRON_XSLT_EXPAND=#none
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt_expand-compile.xsl
@@ -590,12 +572,6 @@
 
 	<!-- Ant is tested by schematron-xslt_skip-1-2.xspec -->
 	<case name="Skip Schematron Step 1 and 2 (CLI)">
-    if "%SAXON_DOCUMENT_URI_FIXED%"=="true" (
-        if exist ..\lib\iso-schematron (
-            call :skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-            goto :EOF
-        )
-    )
     set SCHEMATRON_XSLT_INCLUDE=#none
     set SCHEMATRON_XSLT_EXPAND=#none
     set SCHEMATRON_XSLT_COMPILE=schematron\schematron-xslt_include-expand-compile.xsl

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -605,11 +605,6 @@ load bats-helper
     if [ -z "${SAXON_BUG_4696_FIXED}" ]; then
         skip "Saxon bug 4696"
     fi
-    if [ "${SAXON_DOCUMENT_URI_FIXED}" = "true" ]; then
-        if [ -f "${parent_dir_abs}/lib/iso-schematron/readme.txt" ]; then
-            skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-        fi
-    fi
     export SCHEMATRON_XSLT_INCLUDE=schematron/schematron-xslt_include.xsl
     export SCHEMATRON_XSLT_EXPAND=schematron/schematron-xslt_expand.xsl
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt_compile.xsl
@@ -625,11 +620,6 @@ load bats-helper
 
 # Ant is tested by schematron-xslt_skip-1.xspec
 @test "Skip Schematron Step 1 (CLI)" {
-    if [ "${SAXON_DOCUMENT_URI_FIXED}" = "true" ]; then
-        if [ -f "${parent_dir_abs}/lib/iso-schematron/readme.txt" ]; then
-            skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-        fi
-    fi
     export SCHEMATRON_XSLT_INCLUDE="#none"
     export SCHEMATRON_XSLT_EXPAND=schematron/schematron-xslt_include-expand.xsl
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt_compile.xsl
@@ -641,11 +631,6 @@ load bats-helper
 
 # Ant is tested by schematron-xslt_skip-2.xspec
 @test "Skip Schematron Step 2 (CLI)" {
-    if [ "${SAXON_DOCUMENT_URI_FIXED}" = "true" ]; then
-        if [ -f "${parent_dir_abs}/lib/iso-schematron/readme.txt" ]; then
-            skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-        fi
-    fi
     export SCHEMATRON_XSLT_INCLUDE=schematron/schematron-xslt_include.xsl
     export SCHEMATRON_XSLT_EXPAND="#none"
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt_expand-compile.xsl
@@ -657,11 +642,6 @@ load bats-helper
 
 # Ant is tested by schematron-xslt_skip-1-2.xspec
 @test "Skip Schematron Step 1 and 2 (CLI)" {
-    if [ "${SAXON_DOCUMENT_URI_FIXED}" = "true" ]; then
-        if [ -f "${parent_dir_abs}/lib/iso-schematron/readme.txt" ]; then
-            skip "Schematron skeleton implementation relies on a document-uri bug that Saxon 11 fixes."
-        fi
-    fi
     export SCHEMATRON_XSLT_INCLUDE="#none"
     export SCHEMATRON_XSLT_EXPAND="#none"
     export SCHEMATRON_XSLT_COMPILE=schematron/schematron-xslt_include-expand-compile.xsl


### PR DESCRIPTION
With #1739, `SAXON_DOCUMENT_URI_FIXED` is no longer necessary. This PR removes it and re-enables the skipped tests.

The failures of the skipped tests were not caused by the *skeleton* Schematron implementation. They were caused by a breaking change in Saxon 11 where `document-uri()` had stopped working with the `+` command line parameter.
