### PR TITLE
test: distinguish Apache XML Resolver from XMLResolver.org one

### DIFF
--- a/src/common/uri-utils.xsl
+++ b/src/common/uri-utils.xsl
@@ -5,7 +5,7 @@
 
 	<!--
 		Resolves URI (of an XML document) with the currently enabled catalog,
-		working around an XML resolver bug
+		working around an Apache XML Resolver bug
 	-->
 	<xsl:function as="xs:anyURI" name="x:resolve-xml-uri-with-catalog">
 		<xsl:param as="xs:string" name="xml-uri" />
@@ -21,9 +21,9 @@
 
 	<!--
 		Returns the document actual URI (i.e. resolved with the currently enabled catalog),
-		working around an XML resolver bug. This doesn't work in Saxon 11 or later, so
-                go back to base-uri() in that case. Saxon 11 and later use a different resolver
-                so perhaps the resolver bug is no longer present.
+		working around an Apache XML Resolver bug. This doesn't work in Saxon 11 or later, so
+		go back to base-uri() in that case. Saxon 11 and later use a different resolver
+		so perhaps the resolver bug is no longer present.
 	-->
 	<xsl:function use-when="system-property('xsl:product-name') = 'SAXON'
                                 and xs:integer(substring-before(substring-after(system-property('xsl:product-version'), ' '), '.')) gt 10"
@@ -47,7 +47,7 @@
 	</xsl:function>
 
 	<!--
-		Performs fn:base-uri(), working around an XML resolver bug
+		Performs fn:base-uri(), working around an Apache XML Resolver bug
 	-->
 	<xsl:function as="xs:anyURI" name="x:base-uri">
 		<xsl:param as="node()" name="node" />

--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -29,7 +29,7 @@
 		</loadresource>
 		<!--
 			Download Saxon from GitHub, not Maven repository. Starting with
-			version 11, Saxon needs xmlresolver*.jar on classpath. The
+			version 11, Saxon needs XMLResolver.org XML Resolver on classpath. The
 			GitHub download includes xmlresolver*.jar in the ZIP-file and
 			in the classpath part of the manifest. In the same-version jar
 			file from the Maven repository, the manifest does not include

--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -43,14 +43,14 @@
 		<unzip dest="${saxon.jar.dir}" src="${saxon.zip}" />
 	</target>
 
-	<target name="xml-resolver">
-		<echo message="Install XML Resolver ${env.XML_RESOLVER_VERSION}" />
+	<target name="apache-xmlresolver">
+		<echo message="Install Apache XML Resolver ${env.APACHE_XMLRESOLVER_VERSION}" />
 
-		<dirname file="${env.XML_RESOLVER_JAR}" property="xml-resolver.jar.dir" />
-		<mkdir dir="${xml-resolver.jar.dir}" />
+		<dirname file="${env.APACHE_XMLRESOLVER_JAR}" property="apache-xmlresolver.jar.dir" />
+		<mkdir dir="${apache-xmlresolver.jar.dir}" />
 
-		<download dest="${env.XML_RESOLVER_JAR}"
-			src="https://repo1.maven.org/maven2/xml-resolver/xml-resolver/${env.XML_RESOLVER_VERSION}/xml-resolver-${env.XML_RESOLVER_VERSION}.jar"
+		<download dest="${env.APACHE_XMLRESOLVER_JAR}"
+			src="https://repo1.maven.org/maven2/xml-resolver/xml-resolver/${env.APACHE_XMLRESOLVER_VERSION}/xml-resolver-${env.APACHE_XMLRESOLVER_VERSION}.jar"
 		 />
 	</target>
 
@@ -88,7 +88,8 @@
 		<!--<download dest="${env.SLF4J_DIR}/slf4j-api.jar"
 			src="https://repo1.maven.org/maven2/org/slf4j/slf4j-api/${env.SLF4J_VERSION}/slf4j-api-${env.SLF4J_VERSION}.jar" />-->
 		<download dest="${env.SLF4J_DIR}/slf4j-simple.jar"
-			src="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/${env.SLF4J_VERSION}/slf4j-simple-${env.SLF4J_VERSION}.jar" />
+			src="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/${env.SLF4J_VERSION}/slf4j-simple-${env.SLF4J_VERSION}.jar"
+		 />
 	</target>
 
 	<target if="env.BASEX_VERSION" name="basex">
@@ -118,7 +119,7 @@
 	<target name="install">
 		<parallel failonany="true">
 			<antcall target="saxon" />
-			<antcall target="xml-resolver" />
+			<antcall target="apache-xmlresolver" />
 			<antcall target="xml-calabash" />
 			<antcall target="basex" />
 		</parallel>

--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -5,6 +5,10 @@
 # Latest Ant
 ANT_VERSION=1.10.13
 
+# Latest Apache XML Resolver
+# Required by Ant, even when Saxon and XML Calabash have XMLResolver.org XML Resolver.
+APACHE_XMLRESOLVER_VERSION=1.2
+
 # Latest BaseX
 BASEX_VERSION=10.6
 
@@ -15,8 +19,5 @@ DO_MAVEN_PACKAGE=
 # XML Calabash has slf4j-api-1.7.x.jar (the older stable version of SLF4J, not the current stable 2.x version) in its lib directory.
 SLF4J_VERSION=1.7.36
 
-# XML Calabash is not always available depending on Saxon version
+# XML Calabash may not always available depending on Saxon version
 XMLCALABASH_VERSION=
-
-# Latest XML Resolver
-XML_RESOLVER_VERSION=1.2

--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -19,5 +19,5 @@ DO_MAVEN_PACKAGE=
 # XML Calabash has slf4j-api-1.7.x.jar (the older stable version of SLF4J, not the current stable 2.x version) in its lib directory.
 SLF4J_VERSION=1.7.36
 
-# XML Calabash may not always available depending on Saxon version
+# XML Calabash may not always be available depending on Saxon version
 XMLCALABASH_VERSION=

--- a/test/ci/env/oxygen.env
+++ b/test/ci/env/oxygen.env
@@ -2,8 +2,6 @@
 # Latest oXygen
 #
 ANT_VERSION=1.10.9
-SAXON_VERSION=11.4
 SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
+SAXON_VERSION=11.4
 XMLCALABASH_VERSION=1.5.3-110
-SEPARATE_XML_RESOLVER=
-BUNDLED_XML_RESOLVER=true

--- a/test/ci/env/saxon-10.env
+++ b/test/ci/env/saxon-10.env
@@ -1,8 +1,6 @@
 #
 # Latest Saxon 10
 #
-SAXON_VERSION=10.9
 SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/10/Java
+SAXON_VERSION=10.9
 XMLCALABASH_VERSION=1.5.6-100
-SEPARATE_XML_RESOLVER=true
-BUNDLED_XML_RESOLVER=

--- a/test/ci/env/saxon-11.env
+++ b/test/ci/env/saxon-11.env
@@ -1,8 +1,6 @@
 #
 # Latest Saxon 11
 #
-SAXON_VERSION=11.5
 SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
+SAXON_VERSION=11.5
 XMLCALABASH_VERSION=1.5.6-110
-SEPARATE_XML_RESOLVER=
-BUNDLED_XML_RESOLVER=true

--- a/test/ci/env/saxon-9-9.env
+++ b/test/ci/env/saxon-9-9.env
@@ -2,8 +2,6 @@
 # Latest Saxon 9.9
 #
 DO_MAVEN_PACKAGE=true
-SAXON_VERSION=9.9.1-8
 SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-Archive/main/Saxon-HE/9/9.9
+SAXON_VERSION=9.9.1-8
 XMLCALABASH_VERSION=1.3.2-99
-SEPARATE_XML_RESOLVER=true
-BUNDLED_XML_RESOLVER=

--- a/test/ci/print-env.cmd
+++ b/test/ci/print-env.cmd
@@ -27,8 +27,8 @@ echo === Check XML Calabash
 java -cp "%XMLCALABASH_CP%" com.xmlcalabash.drivers.Main 2> NUL
 
 echo:
-echo === Print XML Resolver version
-java -cp "%XML_RESOLVER_JAR%" org.apache.xml.resolver.Version
+echo === Print Apache XML Resolver version
+java -cp "%APACHE_XMLRESOLVER_JAR%" org.apache.xml.resolver.Version
 
 echo:
 echo === Check BaseX

--- a/test/ci/print-env.sh
+++ b/test/ci/print-env.sh
@@ -25,8 +25,8 @@ echo "=== Check XML Calabash"
 java -cp "${XMLCALABASH_CP}" com.xmlcalabash.drivers.Main 2> /dev/null
 
 echo
-echo "=== Print XML Resolver version"
-java -cp "${XML_RESOLVER_JAR}" org.apache.xml.resolver.Version
+echo "=== Print Apache XML Resolver version"
+java -cp "${APACHE_XMLRESOLVER_JAR}" org.apache.xml.resolver.Version
 
 echo
 echo "=== Check BaseX"

--- a/test/ci/set-env.cmd
+++ b/test/ci/set-env.cmd
@@ -56,9 +56,9 @@ if "%SAXON_VERSION:~0,2%"=="9." (
 )
 
 rem
-rem XML Resolver
+rem Apache XML Resolver
 rem
-set "XML_RESOLVER_JAR=%XSPEC_TEST_DEPS%\xml-resolver-%XML_RESOLVER_VERSION%\resolver.jar"
+set "APACHE_XMLRESOLVER_JAR=%XSPEC_TEST_DEPS%\apache-xmlresolver-%APACHE_XMLRESOLVER_VERSION%\resolver.jar"
 
 rem
 rem XML Calabash jar

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -77,9 +77,9 @@ else
 fi
 
 #
-# XML Resolver
+# Apache XML Resolver
 #
-export XML_RESOLVER_JAR="${XSPEC_TEST_DEPS}/xml-resolver-${XML_RESOLVER_VERSION}/resolver.jar"
+export APACHE_XMLRESOLVER_JAR="${XSPEC_TEST_DEPS}/apache-xmlresolver-${APACHE_XMLRESOLVER_VERSION}/resolver.jar"
 
 #
 # XML Calabash jar

--- a/test/run-bats.cmd
+++ b/test/run-bats.cmd
@@ -25,8 +25,8 @@ if "%SAXON_VERSION%"=="10.0" set SAXON_BUG_4696_FIXED=
 if "%SAXON_VERSION%"=="10.1" set SAXON_BUG_4696_FIXED=
 if "%SAXON_VERSION%"=="10.2" set SAXON_BUG_4696_FIXED=
 
-set XMLRESOLVER_BUG_FIXED_IN_4_5_2=1
-if "%SAXON_VERSION%"=="11.4" set XMLRESOLVER_BUG_FIXED_IN_4_5_2=
+set XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED=1
+if "%SAXON_VERSION%"=="11.4" set XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED=
 
 java -cp "%SAXON_JAR%" net.sf.saxon.Version 2>&1 | "%SYSTEMROOT%\system32\find" "SAXON-EE " > NUL
 if not errorlevel 1 set XSLT_SUPPORTS_THREADS=1
@@ -35,7 +35,7 @@ rem Unset Ant environment variables
 set ANT_ARGS=
 set ANT_OPTS=
 
-rem Unset XML Resolver (of XML Calabash) environment variable
+rem Unset XMLResolver.org XML Resolver environment variable
 set XMLRESOLVER_PROPERTIES=
 
 rem Reset public environment variables

--- a/test/run-bats.sh
+++ b/test/run-bats.sh
@@ -28,10 +28,10 @@ case "${SAXON_VERSION}" in
         ;;
 esac
 
-export XMLRESOLVER_BUG_FIXED_IN_4_5_2=1
+export XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED=1
 case "${SAXON_VERSION}" in
     "11.4")
-        unset XMLRESOLVER_BUG_FIXED_IN_4_5_2
+        unset XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED
         ;;
 esac
 
@@ -47,7 +47,7 @@ unset JAVA_TOOL_OPTIONS
 unset ANT_ARGS
 unset ANT_OPTS
 
-# Unset XML Resolver (of XML Calabash) environment variable
+# Unset XMLResolver.org XML Resolver environment variable
 unset XMLRESOLVER_PROPERTIES
 
 # Reset public environment variables

--- a/test/schut-to-xslt.xspec
+++ b/test/schut-to-xslt.xspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test additional-classpath=${env.XML_RESOLVER_JAR}?>
+<?xspec-test additional-classpath=${env.APACHE_XMLRESOLVER_JAR}?>
 <?xspec-test saxon-custom-options=-catalog:"${xspec.project.dir}/test/catalog/01/catalog-public.xml;${xspec.project.dir}/test/catalog/01/catalog-rewriteURI.xml"?>
 <x:description stylesheet="../src/schematron/schut-to-xslt.xsl"
 	xmlns:local="urn:x-xspec:schematron:schut-to-xslt:local"

--- a/test/uri-utils.xspec
+++ b/test/uri-utils.xspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test additional-classpath=${env.XML_RESOLVER_JAR}?>
+<?xspec-test additional-classpath=${env.APACHE_XMLRESOLVER_JAR}?>
 <?xspec-test saxon-custom-options=-catalog:"${xspec.project.dir}/test/catalog/01/catalog-public.xml;${xspec.project.dir}/test/catalog/01/catalog-rewriteURI.xml"?>
 <x:description stylesheet="../src/common/uri-utils.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -947,7 +947,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test\catalog\01\catalog-public.xml;%CD%\catalog\01\catalog-rewriteURI.xml" ^
         -Dxspec.xml="%CD%\catalog\catalog-01_stylesheet.xspec"
     call :verify_retval 0
@@ -959,7 +959,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test\catalog\01\catalog-public.xml;%CD%\catalog\01\catalog-rewriteURI.xml" ^
         -Dtest.type=q ^
         -Dxspec.xml="%CD%\catalog\catalog-01_query.xspec"
@@ -972,7 +972,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test\catalog\01\catalog-public.xml;%CD%\catalog\01\catalog-rewriteURI.xml" ^
         -Dtest.type=s ^
         -Dxspec.xml="%CD%\catalog\catalog-01_schematron.xspec"
@@ -991,7 +991,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -Dcatalog.is.uri=true ^
         -Dxspec.xml="%CD%\catalog\catalog-01_stylesheet.xspec"
@@ -1004,7 +1004,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -Dcatalog.is.uri=true ^
         -Dtest.type=q ^
@@ -1018,7 +1018,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="test/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -Dcatalog.is.uri=true ^
         -Dtest.type=s ^
@@ -1155,13 +1155,13 @@
 			Test -catalog specifying multiple file paths (relative and absolute)
 	-->
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with -catalog file path (XSLT)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with -catalog file path (XSLT)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         "%SPACE_DIR%\catalog-01_stylesheet.xspec"
@@ -1169,13 +1169,13 @@
     call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with -catalog file path (XQuery)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with -catalog file path (XQuery)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         -q ^
@@ -1184,13 +1184,13 @@
     call :verify_line 9 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with -catalog file path (Schematron)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with -catalog file path (Schematron)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         -s ^
@@ -1206,7 +1206,7 @@
 	-->
 
 	<case name="CLI with -catalog file URI (XSLT)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
@@ -1215,7 +1215,7 @@
 	</case>
 
 	<case name="CLI with -catalog file URI (XQuery)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -q ^
@@ -1225,7 +1225,7 @@
 	</case>
 
 	<case name="CLI with -catalog file URI (Schematron)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -s ^
@@ -1240,13 +1240,13 @@
 			Test XML_CATALOG containing multiple file paths (relative and absolute)
 	-->
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with XML_CATALOG file path (XSLT)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with XML_CATALOG file path (XSLT)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01_stylesheet.xspec"
@@ -1254,13 +1254,13 @@
     call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
 	</case>
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with XML_CATALOG file path (XQuery)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with XML_CATALOG file path (XQuery)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -q "%SPACE_DIR%\catalog-01_query.xspec"
@@ -1268,13 +1268,13 @@
     call :verify_line 9 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
-	<case ifdef="XMLRESOLVER_BUG_FIXED_IN_4_5_2" name="CLI with XML_CATALOG file path (Schematron)">
+	<case ifdef="XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED" name="CLI with XML_CATALOG file path (Schematron)">
     set "SPACE_DIR=%WORK_DIR%\cat a log %RANDOM%"
     call :mkdir "%SPACE_DIR%\01"
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "%SPACE_DIR%\catalog-01_schematron.xspec"
@@ -1289,7 +1289,7 @@
 	-->
 
 	<case name="CLI with XML_CATALOG file URI (XSLT)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat "catalog\catalog-01_stylesheet.xspec"
@@ -1298,7 +1298,7 @@
 	</case>
 
 	<case name="CLI with XML_CATALOG file URI (XQuery)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -q "catalog\catalog-01_query.xspec"
@@ -1307,7 +1307,7 @@
 	</case>
 
 	<case name="CLI with XML_CATALOG file URI (Schematron)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "catalog\catalog-01_schematron.xspec"
@@ -1317,40 +1317,38 @@
 
 	<!--
 		Catalog resolver and SAXON_HOME (CLI)
-		Saxon 10 and earlier versions use resolver.jar in same directory as Saxon jar file.
-		Saxon 11 and later versions use xmlresolver*.jar in lib/ subdirectory.
+		
+			After setting up the test environment, Saxon should use these resolvers:
+			* Saxon 10 and earlier: Apache XML Resolver jar in same directory as Saxon jar file
+			* Saxon 11 and later: XMLResolver.org XML Resolver jar in lib/ subdirectory
 	-->
 
-	<case ifdef="SEPARATE_XML_RESOLVER" name="Saxon 10 and earlier: invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar">
+	<case name="invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar">
+    rem Dir of source Saxon jar
+    set SAXON_JAR_DIR=%SAXON_JAR%\..
+
+    rem Set up SAXON_HOME
     set "SAXON_HOME=%WORK_DIR%\saxon %RANDOM%"
     call :mkdir "%SAXON_HOME%"
-    call :copy "%SAXON_JAR%"        "%SAXON_HOME%"
-    call :copy "%XML_RESOLVER_JAR%" "%SAXON_HOME%\xml-resolver-1.2.jar"
+    call :copy "%SAXON_JAR%" "%SAXON_HOME%"
+
+    rem Copy all required dependencies to SAXON_HOME location, too.
+    if not "%SAXON_VERSION:~0,2%"=="9." if not "%SAXON_VERSION:~0,3%"=="10." set APACHE_XMLRESOLVER_JAR=
+    if defined APACHE_XMLRESOLVER_JAR (
+        call :copy "%APACHE_XMLRESOLVER_JAR%" "%SAXON_HOME%\xml-resolver-1.2.jar"
+    ) else (
+        call :mkdir "%SAXON_HOME%\lib"
+        call :copy "%SAXON_JAR_DIR%\lib" "%SAXON_HOME%\lib"
+    )
+
+    rem Unset SAXON_CP, otherwise SAXON_HOME is ignored.
     set SAXON_CP=
 
     rem To avoid "No license file found" warning on commercial Saxon
-    set "SAXON_LICENSE=%SAXON_JAR%\..\saxon-license.lic"
+    set "SAXON_LICENSE=%SAXON_JAR_DIR%\saxon-license.lic"
     if exist "%SAXON_LICENSE%" call :copy "%SAXON_LICENSE%" "%SAXON_HOME%"
 
-    call :run ..\bin\xspec.bat ^
-        -catalog "catalog\01\catalog-public.xml;catalog\01\catalog-rewriteURI.xml" ^
-        catalog\catalog-01_stylesheet.xspec
-    call :verify_retval 0
-    call :verify_line 18 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
-	</case>
-
-	<case ifdef="BUNDLED_XML_RESOLVER" name="Saxon 11 and later: invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar">
-    set "SAXON_HOME=%WORK_DIR%\saxon %RANDOM%"
-    call :mkdir "%SAXON_HOME%\lib"
-    call :copy "%SAXON_JAR%"        "%SAXON_HOME%"
-	rem Copy all required dependencies to SAXON_HOME location, too
-    call :copy "%SAXON_JAR%\..\lib" "%SAXON_HOME%\lib"
-    set SAXON_CP=
-
-    rem To avoid "No license file found" warning on commercial Saxon
-    set "SAXON_LICENSE=%SAXON_JAR%\..\saxon-license.lic"
-    if exist "%SAXON_LICENSE%" call :copy "%SAXON_LICENSE%" "%SAXON_HOME%"
-
+    rem Run
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;catalog\01\catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
@@ -1365,7 +1363,7 @@
 	-->
 
 	<case name="Catalog Saxon bug 3025 (CLI)">
-    set "SAXON_CP=%SAXON_JAR%;%XML_RESOLVER_JAR%"
+    set "SAXON_CP=%SAXON_JAR%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "%CD%\catalog\02\catalog.xml" ^
         catalog\catalog-02.xspec
@@ -1377,7 +1375,7 @@
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_JAR%" ^
-        -lib "%XML_RESOLVER_JAR%" ^
+        -lib "%APACHE_XMLRESOLVER_JAR%" ^
         -Dcatalog="%CD%\catalog\02\catalog.xml" ^
         -Dxspec.xml="%CD%\catalog\catalog-02.xspec"
     call :verify_retval 0

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -159,7 +159,7 @@ rem
     set ANT_ARGS=-Dxspec.dir="%TEST_DIR%"
 
     rem
-    rem Invalidate XML Resolver (of XML Calabash) cache
+    rem Invalidate XMLResolver.org XML Resolver cache
     rem
     set "XMLRESOLVER_PROPERTIES=%WORK_DIR%\xmlresolver.properties"
     echo cache=%WORK_DIR:\=\\%\\xmlcatalog-cache_%RANDOM% > "%XMLRESOLVER_PROPERTIES%"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -37,7 +37,7 @@ setup() {
     export TEST_DIR="${work_dir}/output_${RANDOM}"
     export ANT_ARGS="-Dxspec.dir=${TEST_DIR}"
 
-    # Invalidate XML Resolver (of XML Calabash) cache
+    # Invalidate XMLResolver.org XML Resolver cache
     XMLRESOLVER_PROPERTIES="${work_dir}/xmlresolver.properties"
     echo "cache=${work_dir}/xmlcatalog-cache_${RANDOM}" > "${XMLRESOLVER_PROPERTIES}"
     export XMLRESOLVER_PROPERTIES="file:${XMLRESOLVER_PROPERTIES}"
@@ -1047,7 +1047,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dxspec.xml="${PWD}/catalog/catalog-01_stylesheet.xspec"
     [ "$status" -eq 0 ]
@@ -1059,7 +1059,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dtest.type=q \
         -Dxspec.xml="${PWD}/catalog/catalog-01_query.xspec"
@@ -1072,7 +1072,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dtest.type=s \
         -Dxspec.xml="${PWD}/catalog/catalog-01_schematron.xspec"
@@ -1091,7 +1091,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dcatalog.is.uri=true \
         -Dxspec.xml="${PWD}/catalog/catalog-01_stylesheet.xspec"
@@ -1104,7 +1104,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dcatalog.is.uri=true \
         -Dtest.type=q \
@@ -1118,7 +1118,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="test/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dcatalog.is.uri=true \
         -Dtest.type=s \
@@ -1260,15 +1260,15 @@ load bats-helper
 #
 
 @test "CLI with -catalog file path (XSLT)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
     space_dir="${work_dir}/cat a log ${RANDOM}"
     mkdir -p "${space_dir}/01"
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         "${space_dir}/catalog-01_stylesheet.xspec"
@@ -1277,15 +1277,15 @@ load bats-helper
 }
 
 @test "CLI with -catalog file path (XQuery)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
     space_dir="${work_dir}/cat a log ${RANDOM}"
     mkdir -p "${space_dir}/01"
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         -q \
@@ -1295,15 +1295,15 @@ load bats-helper
 }
 
 @test "CLI with -catalog file path (Schematron)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
     space_dir="${work_dir}/cat a log ${RANDOM}"
     mkdir -p "${space_dir}/01"
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         -s \
@@ -1319,7 +1319,7 @@ load bats-helper
 #
 
 @test "CLI with -catalog file URI (XSLT)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_stylesheet.xspec
@@ -1328,7 +1328,7 @@ load bats-helper
 }
 
 @test "CLI with -catalog file URI (XQuery)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -q \
@@ -1338,7 +1338,7 @@ load bats-helper
 }
 
 @test "CLI with -catalog file URI (Schematron)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -s \
@@ -1354,8 +1354,8 @@ load bats-helper
 #
 
 @test "CLI with XML_CATALOG file path (XSLT)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
 
     space_dir="${work_dir}/cat a log ${RANDOM}"
@@ -1363,7 +1363,7 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh "${space_dir}/catalog-01_stylesheet.xspec"
@@ -1372,15 +1372,15 @@ load bats-helper
 }
 
 @test "CLI with XML_CATALOG file path (XQuery)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
     space_dir="${work_dir}/cat a log ${RANDOM}"
     mkdir -p "${space_dir}/01"
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -q "${space_dir}/catalog-01_query.xspec"
@@ -1389,15 +1389,15 @@ load bats-helper
 }
 
 @test "CLI with XML_CATALOG file path (Schematron)" {
-    if [ -z "${XMLRESOLVER_BUG_FIXED_IN_4_5_2}" ]; then
-        skip "Saxon uses XML Resolver with a bug that is fixed in 4.5.2"
+    if [ -z "${XMLRESOLVERORG_XMLRESOLVER_BUG_117_FIXED}" ]; then
+        skip "Saxon uses XMLResolver.org XML Resolver with bug #117"
     fi
     space_dir="${work_dir}/cat a log ${RANDOM}"
     mkdir -p "${space_dir}/01"
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -s "${space_dir}/catalog-01_schematron.xspec"
@@ -1412,7 +1412,7 @@ load bats-helper
 #
 
 @test "CLI with XML_CATALOG file URI (XSLT)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh "catalog/catalog-01_stylesheet.xspec"
@@ -1421,7 +1421,7 @@ load bats-helper
 }
 
 @test "CLI with XML_CATALOG file URI (XQuery)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -q "catalog/catalog-01_query.xspec"
@@ -1430,7 +1430,7 @@ load bats-helper
 }
 
 @test "CLI with XML_CATALOG file URI (Schematron)" {
-    export SAXON_CP="$SAXON_JAR:$XML_RESOLVER_JAR"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -s "catalog/catalog-01_schematron.xspec"
@@ -1440,46 +1440,38 @@ load bats-helper
 
 #
 # Catalog resolver and SAXON_HOME (CLI)
-# Saxon 10 and earlier versions use resolver.jar in same directory as Saxon jar file.
-# Saxon 11 and later versions use xmlresolver*.jar in lib/ subdirectory.
+#
+#     After setting up the test environment, Saxon should use these resolvers:
+#     * Saxon 10 and earlier: Apache XML Resolver jar in same directory as Saxon jar file
+#     * Saxon 11 and later: XMLResolver.org XML Resolver jar in lib/ subdirectory
 #
 
-@test "Saxon 10 and earlier: invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
-    if [ -z "${SEPARATE_XML_RESOLVER}" ]; then
-        skip "Saxon 10 and earlier only"
-    fi
+@test "invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
+    # Dir of source Saxon jar
+    saxon_jar_dir="$(dirname -- "${SAXON_JAR}")"
+
+    # Set up SAXON_HOME
     export SAXON_HOME="${work_dir}/saxon ${RANDOM}"
     mkdir "${SAXON_HOME}"
     cp "${SAXON_JAR}" "${SAXON_HOME}"
-    cp "${XML_RESOLVER_JAR}" "${SAXON_HOME}/xml-resolver-1.2.jar"
-    unset SAXON_CP
 
-    # To avoid "No license file found" warning on commercial Saxon
-    saxon_license="$(dirname -- "${SAXON_JAR}")/saxon-license.lic"
-    if [ -f "${saxon_license}" ]; then
-        cp "${saxon_license}" "${SAXON_HOME}"
-    fi
-
-    myrun ../bin/xspec.sh \
-        -catalog "catalog/01/catalog-public.xml;catalog/01/catalog-rewriteURI.xml" \
-        catalog/catalog-01_stylesheet.xspec
-    [ "$status" -eq 0 ]
-    [ "${lines[17]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
-}
-
-@test "Saxon 11 and later: invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar" {
-    if [ -z "${BUNDLED_XML_RESOLVER}" ]; then
-        skip "Saxon 11 and later only"
-    fi
-    export SAXON_HOME="${work_dir}/saxon ${RANDOM}"
-    mkdir -p "${SAXON_HOME}/lib"
-    cp "${SAXON_JAR}" "${SAXON_HOME}"
-    saxon_jar_dir="$(dirname -- "${SAXON_JAR}")"
     # Copy all required dependencies to SAXON_HOME location, too.
-    # ls command is for troubleshooting in case cp command ever
-    # fails due to future Saxon restructuring or other reason.
-    ls "${saxon_jar_dir}"/lib
-    cp "${saxon_jar_dir}"/lib/* "${SAXON_HOME}/lib/"
+    if [ "${SAXON_VERSION:0:2}" != "9." ] && [ "${SAXON_VERSION:0:3}" != "10." ]; then
+        unset APACHE_XMLRESOLVER_JAR
+    fi
+    if [ -n "${APACHE_XMLRESOLVER_JAR}" ]; then
+        cp "${APACHE_XMLRESOLVER_JAR}" "${SAXON_HOME}/xml-resolver-1.2.jar"
+    else
+        mkdir "${SAXON_HOME}/lib"
+
+        # ls command is for troubleshooting in case cp command ever
+        # fails due to future Saxon restructuring or other reason.
+        ls "${saxon_jar_dir}"/lib
+
+        cp "${saxon_jar_dir}"/lib/* "${SAXON_HOME}/lib/"
+    fi
+
+    # Unset SAXON_CP, otherwise SAXON_HOME is ignored.
     unset SAXON_CP
 
     # To avoid "No license file found" warning on commercial Saxon
@@ -1488,6 +1480,7 @@ load bats-helper
         cp "${saxon_license}" "${SAXON_HOME}"
     fi
 
+    # Run
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_stylesheet.xspec
@@ -1502,7 +1495,7 @@ load bats-helper
 #
 
 @test "Catalog Saxon bug 3025 (CLI)" {
-    export SAXON_CP="${SAXON_JAR}:${XML_RESOLVER_JAR}"
+    export SAXON_CP="${SAXON_JAR}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "${PWD}/catalog/02/catalog.xml" \
         catalog/catalog-02.xspec
@@ -1514,7 +1507,7 @@ load bats-helper
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_JAR}" \
-        -lib "${XML_RESOLVER_JAR}" \
+        -lib "${APACHE_XMLRESOLVER_JAR}" \
         -Dcatalog="${PWD}/catalog/02/catalog.xml" \
         -Dxspec.xml="${PWD}/catalog/catalog-02.xspec"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
There are two implementations of XML resolver. Now it's unclear what "XML Resolver" is and what the catalog test facilities are dealing with.

This PR
- Calls the traditional Apache resolver "Apache XML Resolver"
- Calls the new xmlresolver.org resolver "XMLResolver.org XML Resolver"
- Renames the environment variables
- Consolidates two `invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar` Bats tests into one
