### PR TITLE
test: test RECOGNIZE_URI_QUERY_PARAMETERS using XInclude

### DIFF
--- a/test/saxon-custom-options/test.xspec
+++ b/test/saxon-custom-options/test.xspec
@@ -10,12 +10,12 @@
 				test="normalize-space($x:result)" />
 		</x:scenario>
 
-		<x:scenario label="?strip-space=yes">
+		<x:scenario label="strip-space=yes and xinclude=yes">
 			<x:call function="exactly-one">
 				<!-- ws-only-text-copy.xml is identical to ws-only-text.xml. In Saxon 11,
 				the test fails if the same XML file is read with and without the URI
 				query parameter in the same test session.-->
-				<x:param href="ws-only-text-copy.xml?strip-space=yes" />
+				<x:param href="ws-only-text-copy.xml?strip-space=yes;xinclude=yes" />
 			</x:call>
 			<x:expect label="Whitespace-only text nodes are stripped" select="'AB'"
 				test="string($x:result)" />

--- a/test/saxon-custom-options/ws-only-text-copy.xml
+++ b/test/saxon-custom-options/ws-only-text-copy.xml
@@ -1,13 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<table>
-	<tgroup cols="1">
-		<tbody>
-			<row>
-				<entry>A</entry>
-			</row>
-			<row>
-				<entry>B</entry>
-			</row>
-		</tbody>
-	</tgroup>
-</table>
+<xi:include href="ws-only-text.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Just simplifies `test/saxon-custom-options/ws-only-text-copy.xml` using XInclude.