### PR TITLE
test(report): expect any line num when testing custom HTML reporter CLI

### DIFF
--- a/test/format-xspec-report-messaging.xsl
+++ b/test/format-xspec-report-messaging.xsl
@@ -32,15 +32,7 @@
 				<xsl:message select="string()" />
 			</xsl:for-each>
 			<xsl:for-each select="xhtml:pre">
-				<xsl:message>
-					<!--
-						copy-namespaces="false" is because Saxon 10 puts namespaces on one line
-						of the message, while Saxon 11 includes a line break between successive
-						namespace declarations. The namespace declarations are not relevant for
-						this test, so suppress them.
-					-->
-					<xsl:copy-of select="string() => parse-xml-fragment()" copy-namespaces="false"/>
-				</xsl:message>
+				<xsl:message select="string() => parse-xml-fragment()" />
 			</xsl:for-each>
 		</xsl:for-each>
 	</xsl:template>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2268,8 +2268,8 @@
     set HTML_REPORTER_XSL=format-xspec-report-messaging.xsl
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
-    call :verify_line -16 x "--- Actual Result ---"
-    call :verify_line  -9 x "--- Expected Result ---"
+    call :verify_line * x "--- Actual Result ---"
+    call :verify_line * x "--- Expected Result ---"
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2424,8 +2424,8 @@ load bats-helper
     export HTML_REPORTER_XSL=format-xspec-report-messaging.xsl
     myrun ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 16]}" = "--- Actual Result ---" ]
-    [ "${lines[${#lines[@]} - 9]}" = "--- Expected Result ---" ]
+    assert_regex "${output}" $'\n''--- Actual Result ---'$'\n'
+    assert_regex "${output}" $'\n''--- Expected Result ---'$'\n'
 }
 
 #


### PR DESCRIPTION
Since `test/format-xspec-report-messaging.xsl` is mentioned in https://github.com/xspec/xspec/pull/791#issuecomment-596095233, it would be nice if we could keep its original behavior.