### PR TITLE
refactor: redirect x:document-actual-uri() to x:base-uri()

### DIFF
--- a/src/common/uri-utils.xsl
+++ b/src/common/uri-utils.xsl
@@ -10,27 +10,28 @@
 	<xsl:function as="xs:anyURI" name="x:resolve-xml-uri-with-catalog">
 		<xsl:param as="xs:string" name="xml-uri" />
 
-		<!-- https://sourceforge.net/p/saxon/mailman/message/36339785/
-			"document-uri() returns the (absolutized) requested URI, while base-uri() returns
-			the actual document location after catalog resolution." -->
 		<xsl:sequence select="
 				$xml-uri
 				=> doc()
-				=> x:base-uri()" />
+				=> x:document-actual-uri()" />
 	</xsl:function>
 
 	<!--
 		Returns the document actual URI (i.e. resolved with the currently enabled catalog),
-		working around an Apache XML Resolver bug
+		working around an Apache XML Resolver bug.
+		
+		This function is now just redirected to x:base-uri(). But this function is still here for
+		the purpose of clarifying the caller's intention. i.e. The caller of this function wants to
+		retrieve the document actual URI after catalog resolution (not some cryptic URI before
+		catalog resolution).
 	-->
 	<xsl:function as="xs:anyURI" name="x:document-actual-uri">
 		<xsl:param as="document-node()" name="doc" />
 
-		<xsl:sequence
-			select="
-				$doc
-				=> document-uri()
-				=> x:resolve-xml-uri-with-catalog()" />
+		<!-- https://sourceforge.net/p/saxon/mailman/message/36339785/
+			"document-uri() returns the (absolutized) requested URI, while base-uri() returns
+			the actual document location after catalog resolution." -->
+		<xsl:sequence select="x:base-uri($doc)" />
 	</xsl:function>
 
 	<!--
@@ -41,13 +42,11 @@
 
 		<!-- Fix invalid URI such as 'file:C:/dir/file'
 			https://issues.apache.org/jira/browse/XMLCOMMONS-24 -->
-		<xsl:sequence
-			select="
+		<xsl:sequence select="
 				$node
 				=> base-uri()
 				=> replace('^(file:)([^/])', '$1/$2')
-				=> xs:anyURI()"
-		 />
+				=> xs:anyURI()" />
 	</xsl:function>
 
 </xsl:stylesheet>

--- a/src/common/uri-utils.xsl
+++ b/src/common/uri-utils.xsl
@@ -21,22 +21,9 @@
 
 	<!--
 		Returns the document actual URI (i.e. resolved with the currently enabled catalog),
-		working around an Apache XML Resolver bug. This doesn't work in Saxon 11 or later, so
-		go back to base-uri() in that case. Saxon 11 and later use a different resolver
-		so perhaps the resolver bug is no longer present.
+		working around an Apache XML Resolver bug
 	-->
-	<xsl:function use-when="system-property('xsl:product-name') = 'SAXON'
-                                and xs:integer(substring-before(substring-after(system-property('xsl:product-version'), ' '), '.')) gt 10"
-                      as="xs:anyURI" name="x:document-actual-uri">
-		<xsl:param as="document-node()" name="doc" />
-
-		<xsl:sequence
-			select="base-uri($doc)" />
-	</xsl:function>
-
-	<xsl:function use-when="system-property('xsl:product-name') != 'SAXON'
-                                or xs:integer(substring-before(substring-after(system-property('xsl:product-version'), ' '), '.')) le 10"
-                      as="xs:anyURI" name="x:document-actual-uri">
+	<xsl:function as="xs:anyURI" name="x:document-actual-uri">
 		<xsl:param as="document-node()" name="doc" />
 
 		<xsl:sequence

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -13,7 +13,13 @@
     -->
     <xsl:param name="stylesheet-doc" as="document-node()?" />
 
-    <xsl:param name="stylesheet-uri" as="xs:string" select="document-uri($stylesheet-doc)" />
+    <!--
+        document-uri($stylesheet-doc) returns an empty sequence on Saxon 11 when $stylesheet-doc is
+        provided by the '+' command line parameter. (probably related to
+        https://saxonica.plan.io/issues/4837)
+        That's why base-uri() is used here in @select.
+    -->
+    <xsl:param name="stylesheet-uri" as="xs:string" select="base-uri($stylesheet-doc)" />
 
     <xsl:include href="../common/common-utils.xsl" />
     <xsl:include href="../common/namespace-vars.xsl" />

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -13,7 +13,7 @@
     -->
     <xsl:param name="stylesheet-doc" as="document-node()?" />
 
-    <xsl:param name="stylesheet-uri" as="xs:string" select="x:document-actual-uri($stylesheet-doc)" />
+    <xsl:param name="stylesheet-uri" as="xs:string" select="document-uri($stylesheet-doc)" />
 
     <xsl:include href="../common/common-utils.xsl" />
     <xsl:include href="../common/namespace-vars.xsl" />

--- a/test/catalog/01/example.dtd
+++ b/test/catalog/01/example.dtd
@@ -1,5 +1,6 @@
 
 <!ELEMENT title ( #PCDATA ) >
+<!ATTLIST title xml:base CDATA #FIXED "relative/" >
 
 <!ELEMENT root ( title )>
 <!ATTLIST root dtd-version CDATA #FIXED "1.0" >

--- a/test/uri-utils.xspec
+++ b/test/uri-utils.xspec
@@ -30,19 +30,15 @@
 			<x:like label="Expect" />
 		</x:scenario>
 
-		<x:scenario catch="yes" label="Document created by xsl:document">
+		<x:scenario label="Document created by xsl:document">
 			<x:call>
 				<x:param as="document-node()" select="/">
 					<foo />
 				</x:param>
 			</x:call>
-			<x:expect label="XPTY0004"
-				select="QName('http://www.w3.org/2005/xqt-errors', 'err:XPTY0004')" test="?err?code" />
-			<x:expect label="Empty sequence from fn:document-node()"
-				select="'An empty sequence is not allowed as the first argument of x:resolve-xml-uri-with-catalog()'"
-				test="?err?description" />
-			<x:expect label="In the stylesheet being tested" select="$x:stylesheet-uri"
-				test="?err?module" />
+			<!-- TODO: Test to see if URI is resolved with catalog -->
+			<x:expect label="Compiled stylesheet"
+				test="ends-with($x:result, '/uri-utils-compiled.xsl')" />
 		</x:scenario>
 	</x:scenario>
 

--- a/test/uri-utils.xspec
+++ b/test/uri-utils.xspec
@@ -19,12 +19,31 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function document-actual-uri">
-		<x:call function="x:document-actual-uri">
-			<x:param as="document-node()"
-				select="doc('catalog-01:/example.xml')[document-uri() => starts-with('catalog-01:')]"
-			 />
-		</x:call>
-		<x:like label="Expect" />
+		<x:call function="x:document-actual-uri" />
+
+		<x:scenario label="Document loaded by doc()">
+			<x:call>
+				<x:param as="document-node()"
+					select="doc('catalog-01:/example.xml')[document-uri() => starts-with('catalog-01:')]"
+				 />
+			</x:call>
+			<x:like label="Expect" />
+		</x:scenario>
+
+		<x:scenario catch="yes" label="Document created by xsl:document">
+			<x:call>
+				<x:param as="document-node()" select="/">
+					<foo />
+				</x:param>
+			</x:call>
+			<x:expect label="XPTY0004"
+				select="QName('http://www.w3.org/2005/xqt-errors', 'err:XPTY0004')" test="?err?code" />
+			<x:expect label="Empty sequence from fn:document-node()"
+				select="'An empty sequence is not allowed as the first argument of x:resolve-xml-uri-with-catalog()'"
+				test="?err?description" />
+			<x:expect label="In the stylesheet being tested" select="$x:stylesheet-uri"
+				test="?err?module" />
+		</x:scenario>
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function base-uri">

--- a/test/uri-utils.xspec
+++ b/test/uri-utils.xspec
@@ -2,53 +2,124 @@
 <?xspec-test additional-classpath=${env.APACHE_XMLRESOLVER_JAR}?>
 <?xspec-test saxon-custom-options=-catalog:"${xspec.project.dir}/test/catalog/01/catalog-public.xml;${xspec.project.dir}/test/catalog/01/catalog-rewriteURI.xml"?>
 <x:description stylesheet="../src/common/uri-utils.xsl"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	xmlns:myv="http://example.org/ns/my/variable" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<x:scenario label="Expect" shared="yes">
-		<x:expect as="xs:anyURI"
-			label="Resolved with catalog, working around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
-			select="resolve-uri('catalog/01/example.xml', $x:xspec-uri)[starts-with(., 'file:/')]"
-		 />
-	</x:scenario>
+	<!--
+		TODO: Add tests with a document loaded by Saxon '-s' command line option or Saxon '+'
+		command line parameter.
+	-->
+
+	<!-- URI whose private scheme needs to be resolved with catalog -->
+	<x:variable name="myv:uri-with-private-scheme" select="'catalog-01:/example.xml'" />
+
+	<!-- Document node loaded by doc() and catalog -->
+	<x:variable as="document-node(element(root))"
+		name="myv:document-node-loaded-by-fn-doc-and-catalog"
+		select="doc($myv:uri-with-private-scheme)[document-uri() => starts-with('catalog-01:')]" />
+
+	<!-- URI resolved with catalog, working around https://issues.apache.org/jira/browse/XMLCOMMONS-24 -->
+	<x:variable as="xs:anyURI" name="myv:uri-resolved-with-catalog-working-around-xmlcommons-24"
+		select="resolve-uri('catalog/01/example.xml', $x:xspec-uri)[starts-with(., 'file:/')]" />
+
+	<!-- Document node created by xsl:document and catalog -->
+	<!-- TODO: Involve catalog -->
+	<x:variable as="document-node(element(foo))"
+		name="myv:document-node-created-by-xsl-document-and-catalog" select="/">
+		<foo />
+	</x:variable>
 
 	<x:scenario label="Scenario for testing function resolve-xml-uri-with-catalog">
 		<x:call function="x:resolve-xml-uri-with-catalog">
-			<x:param select="'catalog-01:/example.xml'" />
+			<x:param select="$myv:uri-with-private-scheme" />
 		</x:call>
-		<x:like label="Expect" />
+		<x:expect
+			label="Resolved with catalog, working around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
+			select="$myv:uri-resolved-with-catalog-working-around-xmlcommons-24" />
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function document-actual-uri">
 		<x:call function="x:document-actual-uri" />
 
-		<x:scenario label="Document loaded by doc()">
+		<x:scenario label="Document node loaded by doc() and catalog">
 			<x:call>
-				<x:param as="document-node()"
-					select="doc('catalog-01:/example.xml')[document-uri() => starts-with('catalog-01:')]"
-				 />
+				<x:param select="$myv:document-node-loaded-by-fn-doc-and-catalog" />
 			</x:call>
-			<x:like label="Expect" />
+			<x:expect
+				label="Resolved with catalog, working around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
+				select="$myv:uri-resolved-with-catalog-working-around-xmlcommons-24" />
 		</x:scenario>
 
-		<x:scenario label="Document created by xsl:document">
+		<x:scenario label="Document node created by xsl:document and catalog">
+			<!-- TODO: Test with catalog -->
 			<x:call>
-				<x:param as="document-node()" select="/">
-					<foo />
-				</x:param>
+				<x:param select="$myv:document-node-created-by-xsl-document-and-catalog" />
 			</x:call>
-			<!-- TODO: Test to see if URI is resolved with catalog -->
-			<x:expect label="Compiled stylesheet"
+			<x:expect label="Compiled stylesheet URI"
 				test="ends-with($x:result, '/uri-utils-compiled.xsl')" />
+			<x:expect
+				label="Resolved with catalog, working around https://issues.apache.org/jira/browse/XMLCOMMONS-24"
+				test="starts-with($x:result, 'file:/')" />
 		</x:scenario>
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing function base-uri">
-		<x:call function="x:base-uri">
-			<x:param as="element()"
-				select="doc('catalog-01:/example.xml')/element()[document-uri(/) => starts-with('catalog-01:')]"
-			 />
-		</x:call>
-		<x:like label="Expect" />
+		<x:call function="x:base-uri" />
+
+		<x:scenario label="Document node loaded by doc() and catalog">
+			<x:call>
+				<x:param select="$myv:document-node-loaded-by-fn-doc-and-catalog" />
+			</x:call>
+			<x:expect
+				label="URI either before or after catalog resolution. If after, URI should work around https://issues.apache.org/jira/browse/XMLCOMMONS-24."
+				test="
+				$x:result = (
+					$myv:uri-with-private-scheme,
+					$myv:uri-resolved-with-catalog-working-around-xmlcommons-24
+				)" />
+		</x:scenario>
+
+		<x:scenario label="Document node created by xsl:document and catalog">
+			<!-- TODO: Test with catalog -->
+			<x:call>
+				<x:param select="$myv:document-node-created-by-xsl-document-and-catalog" />
+			</x:call>
+			<x:expect label="Compiled stylesheet URI"
+				test="ends-with($x:result, '/uri-utils-compiled.xsl')" />
+			<x:expect
+				label="URI either before or after catalog resolution. If after, URI should work around https://issues.apache.org/jira/browse/XMLCOMMONS-24."
+				test="starts-with($x:result, 'file:/')" />
+		</x:scenario>
+
+		<x:scenario label="Element loaded by doc() and catalog, without effective xml:base">
+			<x:call>
+				<x:param as="element(root)"
+					select="$myv:document-node-loaded-by-fn-doc-and-catalog/root[ancestor-or-self::element()/@xml:base => empty()]"
+				 />
+			</x:call>
+			<x:expect
+				label="Document URI either before or after catalog resolution. If after, URI should work around https://issues.apache.org/jira/browse/XMLCOMMONS-24."
+				test="
+					$x:result = (
+						$myv:uri-with-private-scheme,
+						$myv:uri-resolved-with-catalog-working-around-xmlcommons-24
+					)" />
+		</x:scenario>
+
+		<x:scenario label="Element loaded by doc() and catalog, with effective relative xml:base">
+			<x:call>
+				<x:param as="element(title)"
+					select="$myv:document-node-loaded-by-fn-doc-and-catalog/root/title[@xml:base]"
+				 />
+			</x:call>
+			<x:expect
+				label="@xml:base resolved on document URI either before or after catalog resolution. If after, URI should work around https://issues.apache.org/jira/browse/XMLCOMMONS-24."
+				test="
+					$x:result = (
+						resolve-uri('relative/', $myv:uri-with-private-scheme)[starts-with(., 'catalog-01:')],
+						resolve-uri('relative/', $myv:uri-resolved-with-catalog-working-around-xmlcommons-24)[starts-with(., 'file:/')]
+					)" />
+		</x:scenario>
 	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
This pull request removes unnecessary `@use-when` from `x:document-actual-uri()`.

The tests in `test/uri-utils.xspec` are revised so that they describe the expected behaviors more clearly.