### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver version from 5.2.0 to 5.2.1

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -24,4 +24,4 @@ XMLCALABASH_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.0
+XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.1


### PR DESCRIPTION
In the following list of changes in v5.2.1, nothing jumped out at me as looking unsafe.

https://github.com/xmlresolver/xmlresolver/compare/5.2.0...5.2.1
- https://github.com/xmlresolver/xmlresolver/pull/151
- https://github.com/xmlresolver/xmlresolver/pull/152
 