### PR TITLE
ci(deps): bump Saxon from 11.5 to 11.6

### DIFF
--- a/test/ci/env/saxon-11.env
+++ b/test/ci/env/saxon-11.env
@@ -2,5 +2,5 @@
 # Latest Saxon 11
 #
 SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
-SAXON_VERSION=11.5
+SAXON_VERSION=11.6
 XMLCALABASH_VERSION=1.5.6-110


### PR DESCRIPTION
This pull request just updates the Saxon 11 version used for testing.