### PR TITLE
build(oxygen): add-on v2.3.1

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,22 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v2.3.1</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>fix(cli): properly detect <code>XSPEC_HOME</code> (<a
+							href="https://github.com/xspec/xspec/issues/1568">#1568</a>)</li>
+					<li>Saxon 9.9 is no longer recommended, though the <a
+							href="https://github.com/xspec/xspec/wiki/Code-Coverage">Code
+							Coverage</a> feature still <a
+							href="https://github.com/xspec/xspec/issues/852">requires 9.9</a>.</li>
+					<li>Tested with Saxon 10.9, 11.6 and 12.3</li>
+					<li>Tested with SchXslt 1.9.5</li>
+					<li>Tested with Oxygen 25.1</li>
+					<li>Tested with BaseX 10.7</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.3.0</h3>
 				<ul>
 					<li>Initial development version of v2.3</li>
@@ -72,19 +88,6 @@
 				<h3>v2.1.4</h3>
 				<ul>
 					<li>Official release of v2.1</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.1.3</h3>
-				<ul>
-					<li>Release Candidate of the stable release</li>
-					<li>feat: <code>x:expect/@pending</code> (<a
-							href="https://github.com/xspec/xspec/issues/728">#728</a>)</li>
-					<li>feat: measure time (<a href="https://github.com/xspec/xspec/pull/1397"
-							>#1397</a>)</li>
-					<li>fix(report): recognize doctypes in stylesheets (<a
-							href="https://github.com/xspec/xspec/pull/1413">#1413</a>)</li>
-					<li>Fully tested with SchXslt 1.7.1</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/6cae146c6e2fcbcba21bc45db822bd2443f207e8.zip" />
+			href="https://github.com/xspec/xspec/archive/707d9a8cddce6d6b92eed15a976b12119542d388.zip" />
 
-		<xt:version>2.3.0</xt:version>
+		<xt:version>2.3.1</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -24,7 +24,7 @@
 			* oXygen add-on and framework require manual testing.
 			* oXygen framework cannot always be backward compatible. See
 			  https://github.com/TEIC/oxygen-tei/issues/30. -->
-		<xt:oxy_version>22.0+</xt:oxy_version>
+		<xt:oxy_version>24.1+</xt:oxy_version>
 
 		<xt:type>framework</xt:type>
 

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-6cae146c6e2fcbcba21bc45db822bd2443f207e8/xspec.framework/XSpec</String>
+                                    <String>4/xspec-707d9a8cddce6d6b92eed15a976b12119542d388/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.
The [changelog](https://htmlpreview.github.io/?https://github.com/AirQuick/xspec/blob/a0163a9c8184d742fdf92d1b50fbf1f5bffe45b0/editors/oxygen/add-on/description/latest.xhtml) denotes this version as "Release Candidate of the stable release".

I tested this change on Oxygen 25.1 build 2023070306 and 24.1 build 2022110312 using `https://github.com/AirQuick/xspec/raw/oxy-addon_2-3-1/oxygen-addon.xml`:

- All the 4 transformation scenarios work including **Run XSpec Test** with XSLT, XQuery and Schematron. (**XSLT Code Coverage** transformation scenario generates uselses reports (#852).)
- Loading `xspec.xpr` disables the add-on and enables its own framework.

XSpec's Ant transformation scenarios will not work on Oxygen 24.0 or older versions, because of their library jar differences (Apache Log4j). 47a9d6f8257365973269609b489e5987785b4e59 reflects it.
