### PR TITLE
test(schematron): fix typo 'Schematrion' in scenario label

### DIFF
--- a/test/schematron-019.xspec
+++ b/test/schematron-019.xspec
@@ -3,7 +3,7 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     schematron="schematron/schematron-019.sch">
     
-    <x:scenario label="XSLT Function in Schematrion">
+    <x:scenario label="XSLT Function in Schematron">
         <x:scenario label="XSLT function test">
             <x:call function="e:add" xmlns:e="example">
                 <x:param name="a" select="5" as="xs:integer"/>


### PR DESCRIPTION
This pull request merely fixes a typo in a scenario label. This is the only instance of this particular typo that I found.