### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver from 5.2.1 to 5.2.2

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -24,4 +24,4 @@ XMLCALABASH_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.1
+XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.2


### PR DESCRIPTION
Looks like this version is merely a submodule update (the standard DTDs and schemas that ship with the resolver).