### PR TITLE
feat(oxygen): add library jar files for Oxygen 26.0

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -796,6 +796,7 @@
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
 										<String>${oxygenHome}/lib/xmlresolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*12*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*11*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
@@ -1192,6 +1193,7 @@
 										<String>${oxygenHome}/lib/xml-apis.jar</String>
 										<String>${oxygenHome}/lib/*resolver*.jar</String>
 										<String>${oxygenHome}/lib/xmlresolver*.jar</String>
+										<String>${oxygenHome}/lib/*saxon*12*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*11*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*10*.jar</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>


### PR DESCRIPTION
This pull request adds Saxon 12 jar to `xspec.framework` so that the Ant transformation scenarios for XSpec work on Oxygen 26.0.
This change is based on `OXYGEN26.0/frameworks/xspec/xspec.framework`.

With this change, I verified that the **Run XSpec Test** transformation scenario (XSLT, XQuery and Schematron) worked on Oxygen 26.0 build 2023100905. 

Note that the **XSLT Code Coverate** transformation scenario does not work correctly on Oxygen 26.0, as the code coverage feature doesn't support Saxon 10+ (#852).

The XProc transformation scenarios for XSpec require no change.