### PR TITLE
fix(schematron): make wrapper define $x:xspec-uri

### DIFF
--- a/src/schematron/generate-step3-wrapper.xsl
+++ b/src/schematron/generate-step3-wrapper.xsl
@@ -64,6 +64,13 @@
 				-->
 				<xsl:element name="{x:xspec-name('description', .)}"
 					namespace="{$x:xspec-namespace}">
+					<!-- Define $x:xspec-uri in case global params or variables references it -->
+					<xsl:element name="{x:xspec-name('variable', .)}" namespace="{$x:xspec-namespace}">
+						<xsl:attribute name="as" select="x:known-UQName('xs:anyURI')" />
+						<xsl:attribute name="name" select="x:known-UQName('x:xspec-uri')" />
+						<xsl:value-of select="x:document-actual-uri(/)" />
+					</xsl:element>
+					
 					<!-- Resolve x:import and gather only the user-provided global params and
 						variables -->
 					<xsl:sequence select="x:resolve-import(.)" />

--- a/test/generate-step3-wrapper_custom.xspec
+++ b/test/generate-step3-wrapper_custom.xspec
@@ -15,6 +15,14 @@
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 				<xsl:import href="{$ACTUAL-PREPROCESSOR-URI}" />
+				<xsl:variable name="..." as="document-node()">
+					<xsl:document>
+						<xsl:text>...</xsl:text>
+					</xsl:document>
+				</xsl:variable>
+				<xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}xspec-uri"
+					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI"
+					select="..." />
 				<xsl:variable as="document-node()" name="...">
 					<xsl:document>
 						<xsl:text>PhaseA</xsl:text>

--- a/test/generate-step3-wrapper_default.xspec
+++ b/test/generate-step3-wrapper_default.xspec
@@ -13,6 +13,14 @@
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 				<xsl:import href="{$x:schematron-preprocessor?stylesheets?3 treat as xs:anyURI}" />
+				<xsl:variable name="..." as="document-node()">
+					<xsl:document>
+						<xsl:text>...</xsl:text>
+					</xsl:document>
+				</xsl:variable>
+				<xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}xspec-uri"
+					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI"
+					select="..." />
 				<xsl:variable as="document-node()" name="...">
 					<xsl:document>
 						<xsl:text>PhaseA</xsl:text>

--- a/test/schematron-global-xspec-uri.xspec
+++ b/test/schematron-global-xspec-uri.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="do-nothing.sch">
+
+    <!-- $x:xspec-uri should be accessible to a global XSpec variable. -->
+    <x:variable name="this-test-uri" select="$x:xspec-uri" />
+
+</x:description>


### PR DESCRIPTION
While working on tests for #1771, I got an error when a test for Schematron referenced `$x:xspec-uri` in a global XSpec variable (`/x:description/x:variable`).
```
[xslt] Loading stylesheet C:\...\src\schematron\schut-to-xslt.xsl
[xslt] C:\...\src\compiler\xslt\declare-variable\declare-variable.xsl: Fatal Error! Variable $x:xspec-uri has not been declared (or its declaration is not in scope)
[xslt] Fatal error during transformation using C:\...\src\schematron\schut-to-xslt.xsl: Variable $x:xspec-uri has not been declared (or its declaration is not in scope); SystemID: file:/C:/.../src/compiler/xslt/declare-variable/declare-variable.xsl; Line#: -1; Column#: -1
```

The file `test/schematron-global-xspec-uri.xspec` reproduces the problem.

This fix provides the definition of `$x:xspec-uri` in case it is needed.

I will soon have more test additions that use `$x:xspec-uri`, in a separate pull request that builds on this one.