### PR TITLE
build(oxygen): add-on v3.0.0

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,13 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.0.0</h3>
+				<ul>
+					<li>Initial development version of v3.0</li>
+					<li>Tested with Oxygen 26.0</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v2.3.2</h3>
 				<ul>
 					<li>Official release of v2.3</li>
@@ -78,16 +85,6 @@
 					<li>feat: <code>/x:description/@result-file-threshold</code> (<a
 							href="https://github.com/xspec/xspec/pull/1500">#1500</a>)</li>
 					<li>Fully tested with SchXslt 1.7.4</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.2.0</h3>
-				<ul>
-					<li>Initial development version of v2.2</li>
-					<li>feat(schematron): pending attribute on Schematron x:expect-* elements (<a
-							href="https://github.com/xspec/xspec/pull/1446">#1446</a>)</li>
-					<li>fix: pending variable declarations (<a
-							href="https://github.com/xspec/xspec/pull/1452">#1452</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/80cbe529d92578a2189f686c0bada8a82ba9d539.zip" />
+			href="https://github.com/xspec/xspec/archive/31cde537d99719a0049994a1da187ccd5a4b9763.zip" />
 
-		<xt:version>2.3.2</xt:version>
+		<xt:version>3.0.0</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-80cbe529d92578a2189f686c0bada8a82ba9d539/xspec.framework/XSpec</String>
+                                    <String>4/xspec-31cde537d99719a0049994a1da187ccd5a4b9763/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.

I tested this change on Oxygen 26.0 build 2023100905 using `https://github.com/AirQuick/xspec/raw/oxy-addon_3-0-0/oxygen-addon.xml`:

- All the 4 transformation scenarios work including **Run XSpec Test** with XSLT, XQuery and Schematron. (**XSLT Code Coverage** transformation scenario generates useless reports (#852).)
- **Schematron Unit Test** and **XQuery Unit Test** templates are available in **File** - **New** dialog.
- Loading `xspec.xpr` disables the add-on and enables its own framework.
