### PR TITLE
docs(schema): inheritance of id from Schematron pattern

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -405,12 +405,12 @@ common-schematron-assert-report-expect-attributes =
     attribute label { text }?,
 
     ## Identify a specific <assert> or <report> using its id attribute or 
-    ## the id attribute of the parent <rule>.
+    ## the id attribute of the ancestor <rule> or <pattern>.
     attribute id { xsd:NCName }?,
 
     ## Match a specific role attribute value of an <assert> or <report> or 
-    ## the parent <rule>. Role attribute values are often used to specify 
-    ## 'error', 'fatal', 'warn', 'warning', 'info', 'information'.
+    ## the ancestor <rule> or <pattern>. Role attribute values are often
+    ## used to specify 'error', 'fatal', 'warn', 'warning', 'info', 'information'.
     attribute role { text }?,
 
     ## XPath of a location in the context XML that the <assert> or <report> 

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -406,13 +406,13 @@ common-schematron-assert-report-expect-attributes =
 
     ## Identify a specific <assert> or <report> using its id attribute or 
     ## the id attribute of the ancestor <rule> or <pattern>. The test
-    ## uses the nearest of these id attribute.
+    ## uses the nearest of these id attributes.
     attribute id { xsd:NCName }?,
 
     ## Match a specific role attribute value of an <assert> or <report> or 
-    ## the ancestor <rule> or <pattern>. The test uses the nearest of
-    ## these role attributes. Role attribute values are often used to
-    ## specify 'error', 'fatal', 'warn', 'warning', 'info', 'information'.
+    ## the parent <rule>. The test uses the nearest of these role attributes.
+    ## Role attribute values are often used to specify 'error', 'fatal',
+    ## 'warn', 'warning', 'info', 'information'.
     attribute role { text }?,
 
     ## XPath of a location in the context XML that the <assert> or <report> 

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -405,12 +405,14 @@ common-schematron-assert-report-expect-attributes =
     attribute label { text }?,
 
     ## Identify a specific <assert> or <report> using its id attribute or 
-    ## the id attribute of the ancestor <rule> or <pattern>.
+    ## the id attribute of the ancestor <rule> or <pattern>. The test
+    ## uses the nearest of these id attribute.
     attribute id { xsd:NCName }?,
 
     ## Match a specific role attribute value of an <assert> or <report> or 
-    ## the ancestor <rule> or <pattern>. Role attribute values are often
-    ## used to specify 'error', 'fatal', 'warn', 'warning', 'info', 'information'.
+    ## the ancestor <rule> or <pattern>. The test uses the nearest of
+    ## these role attributes. Role attribute values are often used to
+    ## specify 'error', 'fatal', 'warn', 'warning', 'info', 'information'.
     attribute role { text }?,
 
     ## XPath of a location in the context XML that the <assert> or <report> 


### PR DESCRIPTION
In `x:expect-*` elements that refer to the `common-schematron-assert-report-expect-attributes` RelaxNG pattern, the `id` <s>or `role`</s> attribute can match one in the grandparent pattern if neither the original element nor its parent rule has such an attribute. Add mention of the pattern to the schema annotation.

I noticed a discrepancy between the schema doc (and wiki, which I can update after this PR is merged) and the software behavior. The behavior seems intentional, based on #149, which included "Extended the `@id` attribute matching to include the `@id` attribute on the Schematron pattern element." and made the following change affecting both `@id` and `@role`:
https://github.com/xspec/xspec/pull/149/files#diff-86c7b8ace6363b8f27bc79fdc83ee00461da0216a2c68c840a5f5913d225a54bL131-L135

### Follow-Up Tasks

- [x] Update wiki page, https://github.com/xspec/xspec/wiki/Writing-Scenarios-for-Schematron#xexpect-