### PR TITLE
fix: typo in code comment (XLST)

### DIFF
--- a/src/compiler/base/invoke-compiled/threads.xsl
+++ b/src/compiler/base/invoke-compiled/threads.xsl
@@ -17,7 +17,7 @@
    -->
 
    <!-- Returns true if the given x:description or x:scenario wants to enable multi-threading.
-      Whether multi-threading is actually enabled or not depends on language (XLST or XQuery) and
+      Whether multi-threading is actually enabled or not depends on language (XSLT or XQuery) and
       its runtime processor. -->
    <xsl:function name="x:wants-to-enable-threads" as="xs:boolean">
       <!-- x:description or x:scenario -->


### PR DESCRIPTION
This pull request fixes an instance of the typo "XLST" in a code comment.

There are a few [other instances](https://github.com/search?q=repo%3Axspec%2Fxspec+xlst&type=code) of the same typo in this repo, but they are under `lib/` where I think the policy is not to change those files. If you do want me to fix the typos there, let me know.

I considered whether the codespell project should have XLST in its list of typos, which would help us detect new instances of XLST in this repo. However, that acronym apparently is not a typo when it has the following meaning: https://whatext.com/xlst