### PR TITLE
feat(ant): xspec.force.focus=#none

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -16,7 +16,8 @@
         "xproc",
         "schema",
         "maven",
-        "cli"
+        "cli",
+        "ant"
       ]
     ]
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ You are also encouraged to use a scope to highlight which functionality is affec
 | `schema`     | Schema for .xspec files  |
 | `maven`      | Maven                    |
 | `cli`        | `bin/xspec.*`            |
+| `ant`        | Ant                      |
 
 Note that type is mandatory and scope is optional and both values should be written in lower case.
 

--- a/test/end-to-end/cases/expected/query/force-focus_none-junit.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_none-junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_none.xspec">
+   <testsuite name="Test @focus" tests="4" failures="2">
+      <testcase name="an unfocused Success scenario must be Pending it would return Success if it were not Pending"
+                status="passed"/>
+      <testcase name="an unfocused Failure scenario must be Pending it would return Failure if it were not Pending"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+      <testcase name="a focused Success scenario must execute the test and return Success"
+                status="passed"/>
+      <testcase name="a focused Failure scenario must execute the test and return Failure"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.html
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Query: x-urn:test:do-nothing</p>
+      <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
+      <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 2</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 2</th>
+               <th class="totals">total: 4</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Test @focus</a></th>
+               <th class="totals">2</th>
+               <th class="totals">0</th>
+               <th class="totals">2</th>
+               <th class="totals">4</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">Test @focus<span class="scenario-totals">passed: 2 / pending: 0 / failed: 2 / total: 4</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Test @focus</th>
+                  <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
+               </tr>
+               <tr class="successful">
+                  <th>an unfocused Success scenario must be Pending</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it would return Success if it were not Pending</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario2">an unfocused Failure scenario must be Pending</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario2-expect1">it would return Failure if it were not Pending</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <th>a focused Success scenario</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>must execute the test and return Success</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario4">a focused Failure scenario</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario4-expect1">must execute the test and return Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1-scenario2">
+            <h3>Test @focus an unfocused Failure scenario must be Pending</h3>
+            <div id="scenario1-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">it would return Failure if it were not Pending</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario1-scenario4">
+            <h3>Test @focus a focused Failure scenario</h3>
+            <div id="scenario1-scenario4-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_none.xspec"
+        query="x-urn:test:do-nothing"
+        query-at="../../../../do-nothing.xqm"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
+      <label>Test @focus</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="exactly-one">
+            <t:param select="9"/>
+         </t:call>
+      </input-wrap>
+      <scenario id="scenario1-scenario1" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Success scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario1-expect1" successful="true">
+            <label>it would return Success if it were not Pending</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario2" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Failure scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario2-expect1" successful="false">
+            <label>it would return Failure if it were not Pending</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario3" xspec="../../focus-without-pending.xspec">
+         <label>a focused Success scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario3-expect1" successful="true">
+            <label>must execute the test and return Success</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario4" xspec="../../focus-without-pending.xspec">
+         <label>a focused Failure scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario4-expect1" successful="false">
+            <label>must execute the test and return Failure</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-junit.xml
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_none.xspec">
+   <testsuite name="Test @focus" tests="4" failures="2">
+      <testcase name="an unfocused Success scenario must be Pending it would return Success if it were not Pending"
+                status="passed"/>
+      <testcase name="an unfocused Failure scenario must be Pending it would return Failure if it were not Pending"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+      <testcase name="a focused Success scenario must execute the test and return Success"
+                status="passed"/>
+      <testcase name="a focused Failure scenario must execute the test and return Failure"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.sch (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
+      <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 2</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 2</th>
+               <th class="totals">total: 4</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Test @focus</a></th>
+               <th class="totals">2</th>
+               <th class="totals">0</th>
+               <th class="totals">2</th>
+               <th class="totals">4</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">Test @focus<span class="scenario-totals">passed: 2 / pending: 0 / failed: 2 / total: 4</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Test @focus</th>
+                  <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
+               </tr>
+               <tr class="successful">
+                  <th>an unfocused Success scenario must be Pending</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it would return Success if it were not Pending</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario2">an unfocused Failure scenario must be Pending</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario2-expect1">it would return Failure if it were not Pending</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <th>a focused Success scenario</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>must execute the test and return Success</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario4">a focused Failure scenario</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario4-expect1">must execute the test and return Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1-scenario2">
+            <h3>Test @focus an unfocused Failure scenario must be Pending</h3>
+            <div id="scenario1-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">it would return Failure if it were not Pending</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario1-scenario4">
+            <h3>Test @focus a focused Failure scenario</h3>
+            <div id="scenario1-scenario4-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_none.xspec"
+        stylesheet="force-focus_none-sch-preprocessed.xsl"
+        schematron="../../../../do-nothing.sch"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
+      <label>Test @focus</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="exactly-one">
+            <t:param select="9"/>
+         </t:call>
+      </input-wrap>
+      <scenario id="scenario1-scenario1" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Success scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario1-expect1" successful="true">
+            <label>it would return Success if it were not Pending</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario2" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Failure scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario2-expect1" successful="false">
+            <label>it would return Failure if it were not Pending</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario3" xspec="../../focus-without-pending.xspec">
+         <label>a focused Success scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario3-expect1" successful="true">
+            <label>must execute the test and return Success</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario4" xspec="../../focus-without-pending.xspec">
+         <label>a focused Failure scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario4-expect1" successful="false">
+            <label>must execute the test and return Failure</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="force-focus_none.xspec">
+   <testsuite name="Test @focus" tests="4" failures="2">
+      <testcase name="an unfocused Success scenario must be Pending it would return Success if it were not Pending"
+                status="passed"/>
+      <testcase name="an unfocused Failure scenario must be Pending it would return Failure if it were not Pending"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+      <testcase name="a focused Success scenario must execute the test and return Success"
+                status="passed"/>
+      <testcase name="a focused Failure scenario must execute the test and return Failure"
+                status="failed">
+         <failure message="expect assertion failed">Expecting: $t:result instance of xs:string</failure>
+      </testcase>
+   </testsuite>
+</testsuites>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Report</h1>
+      <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
+      <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
+      <p>Tested: 1 January 2000 at 00:00</p>
+      <h2>Contents</h2>
+      <table class="xspec">
+         <colgroup>
+            <col style="width:75%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+            <col style="width:6.25%" />
+         </colgroup>
+         <thead>
+            <tr>
+               <th></th>
+               <th class="totals">passed: 2</th>
+               <th class="totals">pending: 0</th>
+               <th class="totals">failed: 2</th>
+               <th class="totals">total: 4</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr class="failed">
+               <th><a href="#top_scenario1">Test @focus</a></th>
+               <th class="totals">2</th>
+               <th class="totals">0</th>
+               <th class="totals">2</th>
+               <th class="totals">4</th>
+            </tr>
+         </tbody>
+      </table>
+      <div id="top_scenario1">
+         <h2 class="successful">Test @focus<span class="scenario-totals">passed: 2 / pending: 0 / failed: 2 / total: 4</span></h2>
+         <table class="xspec" id="table_scenario1">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Test @focus</th>
+                  <th>passed: 2 / pending: 0 / failed: 2 / total: 4</th>
+               </tr>
+               <tr class="successful">
+                  <th>an unfocused Success scenario must be Pending</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>it would return Success if it were not Pending</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario2">an unfocused Failure scenario must be Pending</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario2-expect1">it would return Failure if it were not Pending</a></td>
+                  <td>Failure</td>
+               </tr>
+               <tr class="successful">
+                  <th>a focused Success scenario</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>must execute the test and return Success</td>
+                  <td>Success</td>
+               </tr>
+               <tr class="failed">
+                  <th><a href="#scenario1-scenario4">a focused Failure scenario</a></th>
+                  <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
+               </tr>
+               <tr class="failed">
+                  <td><a href="#scenario1-scenario4-expect1">must execute the test and return Failure</a></td>
+                  <td>Failure</td>
+               </tr>
+            </tbody>
+         </table>
+         <div id="scenario1-scenario2">
+            <h3>Test @focus an unfocused Failure scenario must be Pending</h3>
+            <div id="scenario1-scenario2-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">it would return Failure if it were not Pending</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+         <div id="scenario1-scenario4">
+            <h3>Test @focus a focused Failure scenario</h3>
+            <div id="scenario1-scenario4-expect1" class="xTestReport">
+               <h4 class="xTestReportTitle">must execute the test and return Failure</h4>
+               <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
+               <table class="xspecResult">
+                  <thead>
+                     <tr>
+                        <th>Result</th>
+                        <th>Expecting</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>
+                           <pre>9</pre>
+                        </td>
+                        <td>
+                           <pre>$t:result instance of xs:string</pre>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </body>
+</html>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.jenitennison.com/xslt/xspec"
+        xspec="../../force-focus_none.xspec"
+        stylesheet="../../../../do-nothing.xsl"
+        date="2000-01-01T00:00:00Z">
+   <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
+      <label>Test @focus</label>
+      <input-wrap xmlns="">
+         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 function="exactly-one">
+            <t:param select="9"/>
+         </t:call>
+      </input-wrap>
+      <scenario id="scenario1-scenario1" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Success scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario1-expect1" successful="true">
+            <label>it would return Success if it were not Pending</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario2" xspec="../../focus-without-pending.xspec">
+         <label>an unfocused Failure scenario must be Pending</label>
+         <result select="9"/>
+         <test id="scenario1-scenario2-expect1" successful="false">
+            <label>it would return Failure if it were not Pending</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario3" xspec="../../focus-without-pending.xspec">
+         <label>a focused Success scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario3-expect1" successful="true">
+            <label>must execute the test and return Success</label>
+            <expect select="9"/>
+         </test>
+      </scenario>
+      <scenario id="scenario1-scenario4" xspec="../../focus-without-pending.xspec">
+         <label>a focused Failure scenario</label>
+         <result select="9"/>
+         <test id="scenario1-scenario4-expect1" successful="false">
+            <label>must execute the test and return Failure</label>
+            <expect-test-wrap xmlns="">
+               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         test="$t:result instance of xs:string"/>
+            </expect-test-wrap>
+            <expect select="()"/>
+         </test>
+      </scenario>
+   </scenario>
+</report>

--- a/test/end-to-end/cases/focus-without-pending.xspec
+++ b/test/end-to-end/cases/focus-without-pending.xspec
@@ -38,7 +38,7 @@
 
       <!--
          Focused scenarios
-         - force-focus_focus-without-pending.xspec removes focus from these scenarios
+         - force-focus_focus-without-pending.xspec and force-focus_none.xspec remove focus from these scenarios
       -->
       <t:scenario label="a focused Success scenario"
                   focus="testing @focus of a Success scenario">

--- a/test/end-to-end/cases/force-focus_none.xspec
+++ b/test/end-to-end/cases/force-focus_none.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Remove focus from all the scenarios -->
+<?xspec-test force-focus=#none?>
+
+<x:description query="x-urn:test:do-nothing" query-at="../../do-nothing.xqm"
+	schematron="../../do-nothing.sch" stylesheet="../../do-nothing.xsl"
+	xmlns:t="http://www.jenitennison.com/xslt/xspec"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="focus-without-pending.xspec" />
+</x:description>


### PR DESCRIPTION
Closes #1811

This PR adds another test for Ant property `xspec.force.focus`.
`#none` (case sensitive) should always invalidate `//x:scenario/@focus`.

### Follow-Up Tasks

- [ ] Update [Wiki](https://github.com/xspec/xspec/wiki/Running-with-Ant#ant-properties).
      (Given that the intricate feature of `xspec.force.focus` is only necessary for [Oxygen XSpec Helper View](https://github.com/xspec/oXygen-XML-editor-xspec-support), Wiki should mention only `#none`.)