### PR TITLE
docs: namespace demo files for XSLT and XQuery

### DIFF
--- a/test/tutorial_namespaces_query.xspec
+++ b/test/tutorial_namespaces_query.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+	query="x-urn:tutorial:namespaces:namespace-demo"
+	query-at="namespace-demo.xqm"
+	xml:base="../tutorial/namespaces/"
+	xmlns:db="http://docbook.org/ns/docbook"
+	xmlns:h="http://www.w3.org/1999/xhtml"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xlink="http://www.w3.org/1999/xlink">
+	<x:import href="namespace-demo_query.xspec" />
+</x:description>

--- a/test/tutorial_namespaces_stylesheet.xspec
+++ b/test/tutorial_namespaces_stylesheet.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+	stylesheet="namespace-demo.xsl"
+	xml:base="../tutorial/namespaces/"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="namespace-demo_stylesheet.xspec" />
+</x:description>

--- a/tutorial/namespaces/namespace-demo.xqm
+++ b/tutorial/namespaces/namespace-demo.xqm
@@ -1,0 +1,17 @@
+module namespace ns-demo = "x-urn:tutorial:namespaces:namespace-demo";
+declare namespace db = "http://docbook.org/ns/docbook";
+declare default element namespace "http://www.w3.org/1999/xhtml";
+declare namespace h = "http://www.w3.org/1999/xhtml";
+declare namespace xlink = "http://www.w3.org/1999/xlink";
+
+(:
+    Default element namespace is for XHTML.
+    DocBook and XLink namespaces are also in use.
+:)
+declare function ns-demo:link($arg as element(db:link))
+as element(a) {
+    (: Produces XHTML 'a' :)
+    <a href="{$arg/@xlink:href}">
+        { string($arg) }
+    </a>
+};

--- a/tutorial/namespaces/namespace-demo.xqm
+++ b/tutorial/namespaces/namespace-demo.xqm
@@ -1,7 +1,6 @@
 module namespace ns-demo = "x-urn:tutorial:namespaces:namespace-demo";
 declare namespace db = "http://docbook.org/ns/docbook";
 declare default element namespace "http://www.w3.org/1999/xhtml";
-declare namespace h = "http://www.w3.org/1999/xhtml";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 
 (:

--- a/tutorial/namespaces/namespace-demo.xsl
+++ b/tutorial/namespaces/namespace-demo.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xpath-default-namespace="http://docbook.org/ns/docbook"
+    version="3.0">
+
+    <!--
+        Default element namespace is for XHTML.
+        Default XPath namespace is for DocBook.
+        XLink namespace is also in use.
+    -->
+
+    <xsl:template match="link">  <!-- Matches DocBook 'link' -->
+        <a href="{@xlink:href}"> <!-- Produces XHTML 'a' -->
+            <xsl:apply-templates/>
+        </a>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/tutorial/namespaces/namespace-demo_query.xspec
+++ b/tutorial/namespaces/namespace-demo_query.xspec
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    query="x-urn:tutorial:namespaces:namespace-demo"
+    query-at="namespace-demo.xqm"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ns-demo="x-urn:tutorial:namespaces:namespace-demo"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <!--
+        Default element namespace is for DocBook, except where
+        overridden by xmlns="http://www.w3.org/1999/xhtml".
+
+        File declares prefixes for XSpec, DocBook, XHTML, and
+        XLink namespaces on <x:description>. Prefix 'xml' is
+        special and needs no declaration.
+    -->
+
+    <x:scenario label="Context in DocBook namespace, result in XHTML namespace">
+        <x:scenario label="Element content in DocBook and XHTML uses default namespace">
+            <x:call function="ns-demo:link">
+               <x:param select="/db:section/db:para/db:link[@xlink:href]">
+                   <section xml:id="s1">
+                       <para>Working link: <link xlink:href="https://github.com/xspec">XSpec</link></para>
+                       <para>Degenerate link: <link>Null</link></para>
+                   </section>
+               </x:param>
+            </x:call>
+            <x:expect label="XHTML link uses override of default element namespace"
+                xmlns="http://www.w3.org/1999/xhtml">
+                <a href="https://github.com/xspec">XSpec</a>
+            </x:expect>
+            <x:expect label="Boolean @test uses namespace prefix"
+                test="$x:result/self::h:a/@href ne ''" />
+            <x:expect label="Boolean @test uses Q notation"
+                test="$x:result/self::Q{http://www.w3.org/1999/xhtml}a/@href ne ''" />
+        </x:scenario>
+        <x:scenario label="Content and XPath use namespace prefixes or Q notation">
+            <x:call function="ns-demo:link">
+                <x:param select="/db:section/db:para/db:link[@xlink:href]">
+                    <db:section xml:id="s1">
+                        <db:para>Working link: <db:link xlink:href="https://github.com/xspec">XSpec</db:link></db:para>
+                        <db:para>Degenerate link: <db:link>Null</db:link></db:para>
+                    </db:section>
+                </x:param>
+            </x:call>
+            <x:expect label="XHTML link uses namespace prefix">
+                <h:a href="https://github.com/xspec">XSpec</h:a>
+            </x:expect>
+            <x:expect label="Boolean @test uses namespace prefix"
+                test="$x:result/self::h:a/@href ne ''" />
+            <x:expect label="Boolean @test uses Q notation"
+                test="$x:result/self::Q{http://www.w3.org/1999/xhtml}a/@href ne ''" />
+        </x:scenario>
+    </x:scenario>
+</x:description>

--- a/tutorial/namespaces/namespace-demo_query.xspec
+++ b/tutorial/namespaces/namespace-demo_query.xspec
@@ -21,12 +21,12 @@
     <x:scenario label="Context in DocBook namespace, result in XHTML namespace">
         <x:scenario label="Element content in DocBook and XHTML uses default namespace">
             <x:call function="ns-demo:link">
-               <x:param select="/db:section/db:para/db:link[@xlink:href]">
-                   <section xml:id="s1">
-                       <para>Working link: <link xlink:href="https://github.com/xspec">XSpec</link></para>
-                       <para>Degenerate link: <link>Null</link></para>
-                   </section>
-               </x:param>
+                <x:param select="/db:section/db:para/db:link[@xlink:href]">
+                    <section xml:id="s1">
+                        <para>Working link: <link xlink:href="https://github.com/xspec">XSpec</link></para>
+                        <para>Degenerate link: <link>Null</link></para>
+                    </section>
+                </x:param>
             </x:call>
             <x:expect label="XHTML link uses override of default element namespace"
                 xmlns="http://www.w3.org/1999/xhtml">

--- a/tutorial/namespaces/namespace-demo_stylesheet.xspec
+++ b/tutorial/namespaces/namespace-demo_stylesheet.xspec
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    stylesheet="namespace-demo.xsl"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <!--
+        Default element namespace is for DocBook, except where
+        overridden by xmlns="http://www.w3.org/1999/xhtml".
+
+        File declares prefixes for XSpec, DocBook, XHTML, and
+        XLink namespaces. Prefix 'xml' is special and needs no
+        declaration.
+    -->
+
+    <x:scenario label="Context in DocBook namespace, result in XHTML namespace">
+        <x:scenario label="Element content in DocBook and XHTML uses default namespace">
+            <x:context select="/db:section/db:para/db:link[@xlink:href]">
+                <section xml:id="s1">
+                    <para>Working link: <link xlink:href="https://github.com/xspec">XSpec</link></para>
+                    <para>Degenerate link: <link>Null</link></para>
+                </section>
+            </x:context>
+            <x:expect label="XHTML link uses override of default element namespace"
+                xmlns="http://www.w3.org/1999/xhtml">
+                <a href="https://github.com/xspec">XSpec</a>
+            </x:expect>
+            <x:expect label="Boolean @test uses namespace prefix"
+                test="$x:result/self::h:a/@href ne ''" />
+            <x:expect label="Boolean @test uses Q notation"
+                test="$x:result/self::Q{http://www.w3.org/1999/xhtml}a/@href ne ''" />
+        </x:scenario>
+        <x:scenario label="Content and XPath use namespace prefixes or Q notation">
+            <x:context select="/db:section/db:para/db:link[@xlink:href]">
+                <db:section xml:id="s1">
+                    <db:para>Working link: <db:link xlink:href="https://github.com/xspec">XSpec</db:link></db:para>
+                    <db:para>Degenerate link: <db:link>Null</db:link></db:para>
+                </db:section>
+            </x:context>
+            <x:expect label="XHTML link uses namespace prefix">
+                <h:a href="https://github.com/xspec">XSpec</h:a>
+            </x:expect>
+            <x:expect label="Boolean @test uses namespace prefix"
+                test="$x:result/self::h:a/@href ne ''" />
+            <x:expect label="Boolean @test uses Q notation"
+                test="$x:result/self::Q{http://www.w3.org/1999/xhtml}a/@href ne ''" />
+        </x:scenario>
+    </x:scenario>
+</x:description>


### PR DESCRIPTION
#229 asks for enhancements in the wiki and tutorials to help XSpec users who are working with elements in namespaces.

There is already a set of tutorial files that illustrate namespace usage in XSpec tests for Schematron:
https://github.com/xspec/xspec/blob/master/tutorial/schematron/demo-04.xspec

This pull request adds tutorial files that show some options for referring to elements in namespaces in XSpec tests for XSLT and XQuery.

Follow-up:
- [ ] Link to the files from the wiki pages that I mentioned updating, in #229.
- [ ] Add comment in #141 that if additional options are introduced, these tutorial files should be updated.