### PR TITLE
test: generate e2e expected results using Saxon 12.3

### DIFF
--- a/test/end-to-end/ant/generate-expected/worker/generate.xsl
+++ b/test/end-to-end/ant/generate-expected/worker/generate.xsl
@@ -19,16 +19,14 @@
 		Require specific Saxon versions
 	-->
 	<xsl:template as="document-node(element(project))" match="document-node(element(project))">
-		<xsl:variable as="xs:integer+" name="require-ge" select="9, 9, 0, 2" />
-		<xsl:variable as="xs:integer+" name="require-lt" select="10" />
+		<!-- https://saxonica.plan.io/issues/6063 -->
+		<xsl:variable as="xs:integer+" name="require-ge" select="12, 3" />
 		<xsl:if test="
 				not(
-				($x:saxon-version ge x:pack-version($require-ge))
-				and
-				($x:saxon-version lt x:pack-version($require-lt))
+				$x:saxon-version ge x:pack-version($require-ge)
 				)">
 			<xsl:message terminate="yes">
-				<xsl:text expand-text="yes">ERROR: Saxon version is {system-property('xsl:product-version')}. To generate the expected files, Saxon version must be ge {string-join($require-ge, '.')} and lt {string-join($require-lt, '.')}. Other versions will produce unrelated changes.</xsl:text>
+				<xsl:text expand-text="yes">ERROR: Saxon version is {system-property('xsl:product-version')}. To generate the expected files, Saxon version must be ge {string-join($require-ge, '.')}. Other versions will produce unrelated changes.</xsl:text>
 			</xsl:message>
 		</xsl:if>
 

--- a/test/end-to-end/cases/expected/query/focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/query/focus-without-pending-result.xml
@@ -9,8 +9,8 @@
              pending="testing @focus of a Success scenario">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -47,8 +47,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.xml
@@ -9,8 +9,8 @@
              pending="force focus">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -29,8 +29,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -27,8 +27,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -48,8 +48,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/function-result.xml
+++ b/test/end-to-end/cases/expected/query/function-result.xml
@@ -8,8 +8,8 @@
       <label>when a function returns 0</label>
       <input-wrap xmlns="">
          <t:call xmlns:mirror="x-urn:test:mirror"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="mirror:param-mirror">
             <t:param select="0"/>
          </t:call>
@@ -23,8 +23,8 @@
          <label>expecting xs:integer in @test must be Success</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:integer"/>
          </expect-test-wrap>
          <expect select="()"/>
@@ -37,8 +37,8 @@
          <label>expecting xs:string in @test must be Failure</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:string"/>
          </expect-test-wrap>
          <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/import-result.xml
+++ b/test/end-to-end/cases/expected/query/import-result.xml
@@ -10,8 +10,8 @@
          <label>where a function returns 0</label>
          <input-wrap xmlns="">
             <t:call xmlns:mirror="x-urn:test:mirror"
-                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="mirror:param-mirror">
                <t:param select="0"/>
             </t:call>
@@ -25,8 +25,8 @@
             <label>expecting x:integer in @test must be Success</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:integer"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -39,8 +39,8 @@
             <label>expecting xs:string in @test must be Failure</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -55,8 +55,8 @@
             <label>where a function returns 0</label>
             <input-wrap xmlns="">
                <t:call xmlns:mirror="x-urn:test:mirror"
-                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        function="mirror:param-mirror">
                   <t:param select="0"/>
                </t:call>
@@ -70,8 +70,8 @@
                <label>expecting x:integer in @test must be Success</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:integer"/>
                </expect-test-wrap>
                <expect select="()"/>
@@ -84,8 +84,8 @@
                <label>expecting xs:string in @test must be Failure</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:string"/>
                </expect-test-wrap>
                <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/imported-result.xml
+++ b/test/end-to-end/cases/expected/query/imported-result.xml
@@ -12,8 +12,8 @@
             <label>where a function returns 0</label>
             <input-wrap xmlns="">
                <t:call xmlns:mirror="x-urn:test:mirror"
-                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        function="mirror:param-mirror">
                   <t:param select="0"/>
                </t:call>
@@ -27,8 +27,8 @@
                <label>expecting x:integer in @test must be Success</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:integer"/>
                </expect-test-wrap>
                <expect select="()"/>
@@ -41,8 +41,8 @@
                <label>expecting xs:string in @test must be Failure</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:string"/>
                </expect-test-wrap>
                <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-153-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../issue-153.xspec">
       <label>When a function returns a local date time string</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="string">
             <x:param select="xs:dateTime('2000-01-01T12:00:00+12:00')"/>
          </x:call>
@@ -17,8 +17,8 @@
       <test id="scenario1-expect1" successful="true">
          <label>Comparing the function result with the same date time in UTC will report Success</label>
          <expect-test-wrap xmlns="">
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="xs:dateTime($x:result)"/>
          </expect-test-wrap>
          <result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
@@ -27,8 +27,8 @@
       <test id="scenario1-expect2" successful="false">
          <label>Comparing the function result with a different date time will report Failure</label>
          <expect-test-wrap xmlns="">
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="xs:dateTime($x:result)"/>
          </expect-test-wrap>
          <result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>

--- a/test/end-to-end/cases/expected/query/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-355-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../issue-355.xspec">
       <label>xs:integer()</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
          </x:call>
@@ -26,8 +26,8 @@
    <scenario id="scenario2" xspec="../../issue-355.xspec">
       <label>Anonymous</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="function(*)" select="function($x){$x+1}"/>
          </x:call>

--- a/test/end-to-end/cases/expected/query/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-467-result.xml
@@ -12,7 +12,7 @@
                  function="mirror:param-mirror">
             <x:param>
                <e1 xmlns="ns1">
-                  <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
+                  <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
                      <ns3:e3>
                         <e4/>
                      </ns3:e3>
@@ -23,10 +23,10 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <e1 xmlns:mirror="x-urn:test:mirror"
-                xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                xmlns="ns1">
-               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
+            <e1 xmlns="ns1"
+                xmlns:mirror="x-urn:test:mirror"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
                   <ns3:e3>
                      <e4/>
                   </ns3:e3>
@@ -38,10 +38,10 @@
          <label>Expecting the same structure but in different namespaces</label>
          <expect select="/element()">
             <content-wrap xmlns="">
-               <e1 xmlns:mirror="x-urn:test:mirror"
-                   xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                   xmlns="ns1">
-                  <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2!">
+               <e1 xmlns="ns1"
+                   xmlns:mirror="x-urn:test:mirror"
+                   xmlns:x="http://www.jenitennison.com/xslt/xspec">
+                  <e2 xmlns="ns2!" xmlns:ns3="ns3" xmlns:ns4="ns4">
                      <ns3:e3 xmlns:ns3="ns3!">
                         <e4 xmlns=""/>
                      </ns3:e3>

--- a/test/end-to-end/cases/expected/query/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-50-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../issue-50.xspec">
       <label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="xs:untypedAtomic">
             <x:param select="'0123'"/>
          </x:call>

--- a/test/end-to-end/cases/expected/query/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-55-result.xml
@@ -8,8 +8,8 @@
       <label>In a failure report HTML</label>
       <input-wrap xmlns="">
          <x:call xmlns:mirror="x-urn:test:mirror"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="mirror:true"/>
       </input-wrap>
       <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>

--- a/test/end-to-end/cases/expected/query/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-67-result.xml
@@ -13,16 +13,16 @@
       </input-wrap>
       <result select="/*/namespace::*">
          <content-wrap xmlns="">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                   xmlns:namespace-name="namespace-text"/>
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="true">
          <label>must be Success</label>
          <expect select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                      xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                      xmlns:namespace-name="namespace-text"/>
             </content-wrap>
          </expect>
       </test>
@@ -59,16 +59,16 @@
       </input-wrap>
       <result select="/*/namespace::*">
          <content-wrap xmlns="">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                   xmlns:namespace-name="namespace-text"/>
          </content-wrap>
       </result>
       <test id="scenario3-expect1" successful="false">
          <label>must be Failure</label>
          <expect select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
-                                      xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                      xmlns:another-namespace-name="another-namespace-text"/>
             </content-wrap>
          </expect>
       </test>

--- a/test/end-to-end/cases/expected/query/pending-result.xml
+++ b/test/end-to-end/cases/expected/query/pending-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../pending.xspec">
       <label>Test pending features (x:pending and @pending)</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -27,8 +27,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/query/report-result.xml
+++ b/test/end-to-end/cases/expected/query/report-result.xml
@@ -57,7 +57,7 @@
       <result select="/*/(@* | node())">
          <content-wrap xmlns="">
             <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
-               <elem1 xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="">text</elem1>
+               <elem1 xmlns="" xmlns:x="http://www.jenitennison.com/xslt/xspec">text</elem1>
             </pseudo-element>
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="attr-val"/>
          </content-wrap>
@@ -105,7 +105,7 @@
          <content-wrap xmlns="">
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr1="attr1-val"/>
             <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
-               <elem2 xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="">text</elem2>
+               <elem2 xmlns="" xmlns:x="http://www.jenitennison.com/xslt/xspec">text</elem2>
             </pseudo-element>
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr3="attr3-val"/>
          </content-wrap>
@@ -199,8 +199,8 @@
    <scenario id="scenario8" xspec="../../report.xspec">
       <label>Derived types</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror"/>
       </input-wrap>
       <scenario id="scenario8-scenario1" xspec="../../report.xspec">
@@ -208,8 +208,8 @@
          <scenario id="scenario8-scenario1-scenario1" xspec="../../report.xspec">
             <label>xs:dateTimeStamp</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:dateTimeStamp('1234-01-02T03:04:05Z')"/>
                </x:call>
             </input-wrap>
@@ -229,8 +229,8 @@
          <scenario id="scenario8-scenario2-scenario1" xspec="../../report.xspec">
             <label>xs:integer</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:integer(1)"/>
                </x:call>
             </input-wrap>
@@ -243,8 +243,8 @@
          <scenario id="scenario8-scenario2-scenario2" xspec="../../report.xspec">
             <label>xs:long</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:long(1)"/>
                </x:call>
             </input-wrap>
@@ -257,8 +257,8 @@
          <scenario id="scenario8-scenario2-scenario3" xspec="../../report.xspec">
             <label>xs:int</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:int(1)"/>
                </x:call>
             </input-wrap>
@@ -271,8 +271,8 @@
          <scenario id="scenario8-scenario2-scenario4" xspec="../../report.xspec">
             <label>xs:short</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:short(1)"/>
                </x:call>
             </input-wrap>
@@ -286,8 +286,8 @@
          <scenario id="scenario8-scenario2-scenario5" xspec="../../report.xspec">
             <label>xs:byte</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:byte(1)"/>
                </x:call>
             </input-wrap>
@@ -300,8 +300,8 @@
          <scenario id="scenario8-scenario2-scenario6" xspec="../../report.xspec">
             <label>xs:nonNegativeInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:nonNegativeInteger(0)"/>
                </x:call>
             </input-wrap>
@@ -315,8 +315,8 @@
          <scenario id="scenario8-scenario2-scenario7" xspec="../../report.xspec">
             <label>xs:positiveInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:positiveInteger(1)"/>
                </x:call>
             </input-wrap>
@@ -330,8 +330,8 @@
          <scenario id="scenario8-scenario2-scenario8" xspec="../../report.xspec">
             <label>xs:unsignedLong</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedLong(1)"/>
                </x:call>
             </input-wrap>
@@ -345,8 +345,8 @@
          <scenario id="scenario8-scenario2-scenario9" xspec="../../report.xspec">
             <label>xs:unsignedInt</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedInt(1)"/>
                </x:call>
             </input-wrap>
@@ -360,8 +360,8 @@
          <scenario id="scenario8-scenario2-scenario10" xspec="../../report.xspec">
             <label>xs:unsignedShort</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedShort(1)"/>
                </x:call>
             </input-wrap>
@@ -375,8 +375,8 @@
          <scenario id="scenario8-scenario2-scenario11" xspec="../../report.xspec">
             <label>xs:unsignedByte</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedByte(1)"/>
                </x:call>
             </input-wrap>
@@ -390,8 +390,8 @@
          <scenario id="scenario8-scenario2-scenario12" xspec="../../report.xspec">
             <label>xs:nonPositiveInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:nonPositiveInteger(0)"/>
                </x:call>
             </input-wrap>
@@ -405,8 +405,8 @@
          <scenario id="scenario8-scenario2-scenario13" xspec="../../report.xspec">
             <label>xs:negativeInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:negativeInteger(-1)"/>
                </x:call>
             </input-wrap>
@@ -423,8 +423,8 @@
          <scenario id="scenario8-scenario3-scenario1" xspec="../../report.xspec">
             <label>xs:dayTimeDuration</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:dayTimeDuration('P1DT2H3M4S')"/>
                </x:call>
             </input-wrap>
@@ -438,8 +438,8 @@
          <scenario id="scenario8-scenario3-scenario2" xspec="../../report.xspec">
             <label>xs:yearMonthDuration</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:yearMonthDuration('P1Y2M')"/>
                </x:call>
             </input-wrap>
@@ -456,8 +456,8 @@
          <scenario id="scenario8-scenario4-scenario1" xspec="../../report.xspec">
             <label>xs:normalizedString</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:normalizedString('foo')"/>
                </x:call>
             </input-wrap>
@@ -471,8 +471,8 @@
          <scenario id="scenario8-scenario4-scenario2" xspec="../../report.xspec">
             <label>xs:token</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:token('foo')"/>
                </x:call>
             </input-wrap>
@@ -486,8 +486,8 @@
          <scenario id="scenario8-scenario4-scenario3" xspec="../../report.xspec">
             <label>xs:language</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:language('en')"/>
                </x:call>
             </input-wrap>
@@ -501,8 +501,8 @@
          <scenario id="scenario8-scenario4-scenario4" xspec="../../report.xspec">
             <label>xs:Name</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:Name('foo')"/>
                </x:call>
             </input-wrap>
@@ -516,8 +516,8 @@
          <scenario id="scenario8-scenario4-scenario5" xspec="../../report.xspec">
             <label>xs:NCName</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:NCName('foo')"/>
                </x:call>
             </input-wrap>
@@ -531,8 +531,8 @@
          <scenario id="scenario8-scenario4-scenario6" xspec="../../report.xspec">
             <label>xs:ENTITY</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:ENTITY('foo')"/>
                </x:call>
             </input-wrap>
@@ -546,8 +546,8 @@
          <scenario id="scenario8-scenario4-scenario7" xspec="../../report.xspec">
             <label>xs:ID</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:ID('foo')"/>
                </x:call>
             </input-wrap>
@@ -561,8 +561,8 @@
          <scenario id="scenario8-scenario4-scenario8" xspec="../../report.xspec">
             <label>xs:IDREF</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:IDREF('foo')"/>
                </x:call>
             </input-wrap>
@@ -576,8 +576,8 @@
          <scenario id="scenario8-scenario4-scenario9" xspec="../../report.xspec">
             <label>xs:NMTOKEN</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:NMTOKEN('foo')"/>
                </x:call>
             </input-wrap>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -365,7 +365,7 @@
             <result select="/element()">
                <content-wrap xmlns="">
                   <looooooooooooooooooooooooooooooooooong xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                     <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
+                     <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
                         <a/>
                      </test>
                   </looooooooooooooooooooooooooooooooooong>
@@ -398,7 +398,7 @@
                <expect select="/element()">
                   <content-wrap xmlns="">
                      <looooooooooooooooooooooooooooooooooong xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                        <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
+                        <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
                            <a/>
                         </test>
                      </looooooooooooooooooooooooooooooooooong>
@@ -714,7 +714,7 @@
             <label>both in [Result] and [Expected Result] with diff,</label>
             <result select="/element()">
                <content-wrap xmlns="">
-                  <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                  <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                      <bar xmlns=""/>
                   </foo>
                </content-wrap>
@@ -723,7 +723,7 @@
                <label>the 2nd-level element should have xmlns="".</label>
                <expect select="/element()">
                   <content-wrap xmlns="">
-                     <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                     <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                         <baz xmlns=""/>
                      </foo>
                   </content-wrap>
@@ -734,7 +734,7 @@
             <label>in [Result] without diff,</label>
             <result select="/element()">
                <content-wrap xmlns="">
-                  <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                  <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                      <bar xmlns=""/>
                   </foo>
                </content-wrap>

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -11,8 +11,8 @@
 					&lt;elem&gt;text&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem>text</elem>
@@ -48,8 +48,8 @@
 					&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem/>
@@ -91,8 +91,8 @@
 					&lt;elem&gt;...&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem>...</elem>
@@ -142,8 +142,8 @@
 					&lt;elem attrib="val" /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem attrib="val"/>
@@ -195,8 +195,8 @@
 					&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(outer)">
                   <outer>text<inner1/>
@@ -247,8 +247,8 @@
 					&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(outer)">
                   <outer>
@@ -297,8 +297,8 @@
 						 @attrib="val"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib="val"/>
@@ -332,8 +332,8 @@
 						 @attrib=""
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib=""/>
@@ -361,8 +361,8 @@
 						 @attrib="..."
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib="..."/>
@@ -407,8 +407,8 @@
       <scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <label>When result is usual text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">text</x:param>
             </x:call>
@@ -430,8 +430,8 @@
       <scenario id="scenario5-scenario2" xspec="../../three-dots.xspec">
          <label>When result is whitespace-only text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">	
 &#xD; </x:param>
@@ -459,8 +459,8 @@
       <scenario id="scenario5-scenario3" xspec="../../three-dots.xspec">
          <label>When result is zero-length text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_zero-length"/>
             </x:call>
@@ -486,8 +486,8 @@
       <scenario id="scenario5-scenario4" xspec="../../three-dots.xspec">
          <label>When result is three-dot text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">...</x:param>
             </x:call>
@@ -520,8 +520,8 @@
 					&lt;!--comment--&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!--comment--></x:param>
             </x:call>
@@ -549,8 +549,8 @@
 					&lt;!----&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!----></x:param>
             </x:call>
@@ -572,8 +572,8 @@
 					&lt;!--...--&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!--...--></x:param>
             </x:call>
@@ -612,8 +612,8 @@
 					&lt;?pi data?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi data?></x:param>
             </x:call>
@@ -641,8 +641,8 @@
 					&lt;?pi?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi?></x:param>
             </x:call>
@@ -664,8 +664,8 @@
 					&lt;?pi ...?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi ...?></x:param>
             </x:call>
@@ -704,8 +704,8 @@
 														 &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()" select="/"><?pi?><!--comment-->
                   <elem/>
@@ -734,8 +734,8 @@
       <scenario id="scenario8-scenario2" xspec="../../three-dots.xspec">
          <label>When result is document node containing nothing</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()"
                         select="$Q{x-urn:test:three-dots}document-node_empty"/>
@@ -760,8 +760,8 @@
       <scenario id="scenario8-scenario3" xspec="../../three-dots.xspec">
          <label>When result is document node containing ...</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()" select="/">...</x:param>
             </x:call>
@@ -796,8 +796,8 @@
 				xmlns:prefix="namespace-uri"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="'prefix'"/>
                <x:param select="'namespace-uri'"/>
@@ -805,7 +805,7 @@
          </input-wrap>
          <result select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
             </content-wrap>
          </result>
          <test id="scenario9-scenario1-expect1" successful="true">
@@ -814,7 +814,7 @@
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
                </content-wrap>
             </expect>
          </test>
@@ -830,8 +830,8 @@
 				xmlns="namespace-uri"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="''"/>
                <x:param select="'namespace-uri'"/>
@@ -864,8 +864,8 @@
 				xmlns:prefix="..."
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="'prefix'"/>
                <x:param select="'...'"/>
@@ -873,7 +873,7 @@
          </input-wrap>
          <result select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
             </content-wrap>
          </result>
          <test id="scenario9-scenario3-expect1" successful="true">
@@ -882,7 +882,7 @@
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
                </content-wrap>
             </expect>
          </test>
@@ -898,7 +898,7 @@
 					should be Failure</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
                </content-wrap>
             </expect>
          </test>
@@ -911,8 +911,8 @@
 					&lt;elem1 /&gt;&lt;elem2 /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="one-or-more">
                <x:param as="element()+">
                   <elem1/>
@@ -967,8 +967,8 @@
    <scenario id="scenario11" xspec="../../three-dots.xspec">
       <label>When result is empty sequence</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="zero-or-one">
             <x:param as="empty-sequence()"/>
          </x:call>
@@ -986,8 +986,8 @@
       <scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <label>When result is 'string'</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="xs:string" select="'string'"/>
             </x:call>
@@ -1011,8 +1011,8 @@
       <scenario id="scenario12-scenario2" xspec="../../three-dots.xspec">
          <label>When result is '...'</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="xs:string" select="'...'"/>
             </x:call>
@@ -1037,8 +1037,8 @@
    <scenario id="scenario13" xspec="../../three-dots.xspec">
       <label>For any resultant item</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <x:param as="text()">item</x:param>
          </x:call>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.xml
@@ -48,13 +48,13 @@
          <label>Schematron-specific x:expect-* elements in a focused scenario alongside another focused scenario must execute the test</label>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -149,13 +149,13 @@
          <label>Schematron-specific x:expect-* elements with both @pending and ancestor::x:scenario/@focus must execute the test (not recommended as ambiguous)</label>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/schematron/focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/schematron/focus-without-pending-result.xml
@@ -9,8 +9,8 @@
              pending="testing @focus of a Success scenario">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -47,8 +47,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.xml
@@ -9,8 +9,8 @@
              pending="force focus">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -29,8 +29,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -27,8 +27,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -48,8 +48,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.xml
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.xml
@@ -17,13 +17,13 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/schematron/pending-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending-result.xml
@@ -7,8 +7,8 @@
    <scenario id="scenario1" xspec="../../pending.xspec">
       <label>Test pending features (x:pending and @pending)</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -27,8 +27,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.xml
@@ -16,13 +16,13 @@
          <label>non-pending Schematron-specific x:expect-* elements alongside pending ones must execute the test</label>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -87,13 +87,13 @@
          <label>Schematron-specific x:expect-* elements with @pending must be Pending</label>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -134,13 +134,13 @@
          <label>Schematron-specific x:expect-* elements with zero-length @pending must be Pending</label>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.xml
@@ -19,13 +19,13 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""><!--   
 		   
@@ -77,13 +77,13 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""><!--   
 		   
@@ -130,13 +130,13 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -13,14 +13,14 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:local="local"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                    xmlns:local="local"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""
                                     phase="PhaseB"><!--   
@@ -96,14 +96,14 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:local="local"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                    xmlns:local="local"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""
                                     phase="PhaseB"><!--   
@@ -167,8 +167,8 @@
       <label>XSpec function scenario imported</label>
       <input-wrap xmlns="">
          <x:call xmlns:local="local"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="local:add">
             <x:param name="a" select="5" as="xs:integer"/>
             <x:param name="b" select="2" as="xs:integer"/>
@@ -189,14 +189,14 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:local="local"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                                    xmlns:local="local"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""
                                     phase="PhaseB"><!--   

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.xml
@@ -16,13 +16,13 @@
          </input-wrap>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -52,13 +52,13 @@
          </input-wrap>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -88,13 +88,13 @@
          </input-wrap>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -127,13 +127,13 @@
          </input-wrap>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   
@@ -163,13 +163,13 @@
          </input-wrap>
          <result select="/element()">
             <content-wrap xmlns="">
-               <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                        xmlns:saxon="http://saxon.sf.net/"
                                        xmlns:schold="http://www.ascc.net/xml/schematron"
-                                       xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                       xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                        title=""
                                        schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.xml
@@ -14,13 +14,13 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            <svrl:schematron-output xmlns:iso="http://purl.oclc.org/dsdl/schematron"
                                     xmlns:saxon="http://saxon.sf.net/"
                                     xmlns:schold="http://www.ascc.net/xml/schematron"
-                                    xmlns:iso="http://purl.oclc.org/dsdl/schematron"
+                                    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                                     xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                                     title=""
                                     schemaVersion=""><!--   
 		   

--- a/test/end-to-end/cases/expected/stylesheet/external_function-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/external_function-result.xml
@@ -7,8 +7,8 @@
       <label>when a function returns 0</label>
       <input-wrap xmlns="">
          <t:call xmlns:mirror="x-urn:test:mirror"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="mirror:param-mirror">
             <t:param select="0"/>
          </t:call>
@@ -22,8 +22,8 @@
          <label>expecting xs:integer in @test must be Success</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:integer"/>
          </expect-test-wrap>
          <expect select="()"/>
@@ -36,8 +36,8 @@
          <label>expecting xs:string in @test must be Failure</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:string"/>
          </expect-test-wrap>
          <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/external_import-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/external_import-result.xml
@@ -9,8 +9,8 @@
          <label>where a function returns 0</label>
          <input-wrap xmlns="">
             <t:call xmlns:mirror="x-urn:test:mirror"
-                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="mirror:param-mirror">
                <t:param select="0"/>
             </t:call>
@@ -24,8 +24,8 @@
             <label>expecting x:integer in @test must be Success</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:integer"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -38,8 +38,8 @@
             <label>expecting xs:string in @test must be Failure</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -54,8 +54,8 @@
             <label>where a function returns 0</label>
             <input-wrap xmlns="">
                <t:call xmlns:mirror="x-urn:test:mirror"
-                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        function="mirror:param-mirror">
                   <t:param select="0"/>
                </t:call>
@@ -69,8 +69,8 @@
                <label>expecting x:integer in @test must be Success</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:integer"/>
                </expect-test-wrap>
                <expect select="()"/>
@@ -83,8 +83,8 @@
                <label>expecting xs:string in @test must be Failure</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:string"/>
                </expect-test-wrap>
                <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.xml
@@ -8,8 +8,8 @@
              pending="testing @focus of a Success scenario">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -46,8 +46,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.xml
@@ -8,8 +8,8 @@
              pending="force focus">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -28,8 +28,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../focus-without-pending.xspec">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -26,8 +26,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>it would return Failure if it were not Pending</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -47,8 +47,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.xml
@@ -8,8 +8,8 @@
              pending="testing @focus of a Success scenario">
       <label>Test @focus</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -46,8 +46,8 @@
          <test id="scenario1-scenario4-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/function-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.xml
@@ -7,8 +7,8 @@
       <label>when a function returns 0</label>
       <input-wrap xmlns="">
          <t:call xmlns:mirror="x-urn:test:mirror"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="mirror:param-mirror">
             <t:param select="0"/>
          </t:call>
@@ -22,8 +22,8 @@
          <label>expecting xs:integer in @test must be Success</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:integer"/>
          </expect-test-wrap>
          <expect select="()"/>
@@ -36,8 +36,8 @@
          <label>expecting xs:string in @test must be Failure</label>
          <expect-test-wrap xmlns="">
             <t:expect xmlns:mirror="x-urn:test:mirror"
-                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="$t:result instance of xs:string"/>
          </expect-test-wrap>
          <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.xml
@@ -9,8 +9,8 @@
          <label>where a function returns 0</label>
          <input-wrap xmlns="">
             <t:call xmlns:mirror="x-urn:test:mirror"
-                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="mirror:param-mirror">
                <t:param select="0"/>
             </t:call>
@@ -24,8 +24,8 @@
             <label>expecting x:integer in @test must be Success</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:integer"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -38,8 +38,8 @@
             <label>expecting xs:string in @test must be Failure</label>
             <expect-test-wrap xmlns="">
                <t:expect xmlns:mirror="x-urn:test:mirror"
-                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -54,8 +54,8 @@
             <label>where a function returns 0</label>
             <input-wrap xmlns="">
                <t:call xmlns:mirror="x-urn:test:mirror"
-                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        function="mirror:param-mirror">
                   <t:param select="0"/>
                </t:call>
@@ -69,8 +69,8 @@
                <label>expecting x:integer in @test must be Success</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:integer"/>
                </expect-test-wrap>
                <expect select="()"/>
@@ -83,8 +83,8 @@
                <label>expecting xs:string in @test must be Failure</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:string"/>
                </expect-test-wrap>
                <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.xml
@@ -11,8 +11,8 @@
             <label>where a function returns 0</label>
             <input-wrap xmlns="">
                <t:call xmlns:mirror="x-urn:test:mirror"
-                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema"
                        function="mirror:param-mirror">
                   <t:param select="0"/>
                </t:call>
@@ -26,8 +26,8 @@
                <label>expecting x:integer in @test must be Success</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:integer"/>
                </expect-test-wrap>
                <expect select="()"/>
@@ -40,8 +40,8 @@
                <label>expecting xs:string in @test must be Failure</label>
                <expect-test-wrap xmlns="">
                   <t:expect xmlns:mirror="x-urn:test:mirror"
-                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
                             test="$t:result instance of xs:string"/>
                </expect-test-wrap>
                <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../issue-153.xspec">
       <label>When a function returns a local date time string</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="string">
             <x:param select="xs:dateTime('2000-01-01T12:00:00+12:00')"/>
          </x:call>
@@ -16,8 +16,8 @@
       <test id="scenario1-expect1" successful="true">
          <label>Comparing the function result with the same date time in UTC will report Success</label>
          <expect-test-wrap xmlns="">
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="xs:dateTime($x:result)"/>
          </expect-test-wrap>
          <result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>
@@ -26,8 +26,8 @@
       <test id="scenario1-expect2" successful="false">
          <label>Comparing the function result with a different date time will report Failure</label>
          <expect-test-wrap xmlns="">
-            <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                      xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="xs:dateTime($x:result)"/>
          </expect-test-wrap>
          <result select="Q{http://www.w3.org/2001/XMLSchema}dateTime('2000-01-01T12:00:00+12:00')"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../issue-355.xspec">
       <label>xs:integer()</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="function(*)" select="function-lookup(xs:QName('xs:integer'), 1)"/>
          </x:call>
@@ -25,8 +25,8 @@
    <scenario id="scenario2" xspec="../../issue-355.xspec">
       <label>Anonymous</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="function(*)" select="function($x){$x+1}"/>
          </x:call>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.xml
@@ -11,7 +11,7 @@
                  function="mirror:param-mirror">
             <x:param>
                <e1 xmlns="ns1">
-                  <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
+                  <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
                      <ns3:e3>
                         <e4/>
                      </ns3:e3>
@@ -22,10 +22,10 @@
       </input-wrap>
       <result select="/element()">
          <content-wrap xmlns="">
-            <e1 xmlns:mirror="x-urn:test:mirror"
-                xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                xmlns="ns1">
-               <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2">
+            <e1 xmlns="ns1"
+                xmlns:mirror="x-urn:test:mirror"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <e2 xmlns="ns2" xmlns:ns3="ns3" xmlns:ns4="ns4">
                   <ns3:e3>
                      <e4/>
                   </ns3:e3>
@@ -37,10 +37,10 @@
          <label>Expecting the same structure but in different namespaces</label>
          <expect select="/element()">
             <content-wrap xmlns="">
-               <e1 xmlns:mirror="x-urn:test:mirror"
-                   xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                   xmlns="ns1">
-                  <e2 xmlns:ns3="ns3" xmlns:ns4="ns4" xmlns="ns2!">
+               <e1 xmlns="ns1"
+                   xmlns:mirror="x-urn:test:mirror"
+                   xmlns:x="http://www.jenitennison.com/xslt/xspec">
+                  <e2 xmlns="ns2!" xmlns:ns3="ns3" xmlns:ns4="ns4">
                      <ns3:e3 xmlns:ns3="ns3!">
                         <e4 xmlns=""/>
                      </ns3:e3>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../issue-50.xspec">
       <label>Expecting xs:hexBinary('0123') when $x:result is xs:untypedAtomic('0123')</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="xs:untypedAtomic">
             <x:param select="'0123'"/>
          </x:call>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.xml
@@ -7,8 +7,8 @@
       <label>In a failure report HTML</label>
       <input-wrap xmlns="">
          <x:call xmlns:mirror="x-urn:test:mirror"
-                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="mirror:true"/>
       </input-wrap>
       <result select="Q{http://www.w3.org/2001/XMLSchema}boolean('true')"/>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.xml
@@ -12,16 +12,16 @@
       </input-wrap>
       <result select="/*/namespace::*">
          <content-wrap xmlns="">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                   xmlns:namespace-name="namespace-text"/>
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="true">
          <label>must be Success</label>
          <expect select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                      xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                      xmlns:namespace-name="namespace-text"/>
             </content-wrap>
          </expect>
       </test>
@@ -58,16 +58,16 @@
       </input-wrap>
       <result select="/*/namespace::*">
          <content-wrap xmlns="">
-            <pseudo-namespace-node xmlns:namespace-name="namespace-text"
-                                   xmlns="http://www.jenitennison.com/xslt/xspec"/>
+            <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                   xmlns:namespace-name="namespace-text"/>
          </content-wrap>
       </result>
       <test id="scenario3-expect1" successful="false">
          <label>must be Failure</label>
          <expect select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:another-namespace-name="another-namespace-text"
-                                      xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec"
+                                      xmlns:another-namespace-name="another-namespace-text"/>
             </content-wrap>
          </expect>
       </test>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../pending.xspec">
       <label>Test pending features (x:pending and @pending)</label>
       <input-wrap xmlns="">
-         <t:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:t="http://www.jenitennison.com/xslt/xspec"
+         <t:call xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <t:param select="9"/>
          </t:call>
@@ -26,8 +26,8 @@
          <test id="scenario1-scenario2-expect1" successful="false">
             <label>must execute the test and return Failure</label>
             <expect-test-wrap xmlns="">
-               <t:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:t="http://www.jenitennison.com/xslt/xspec"
+               <t:expect xmlns:t="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$t:result instance of xs:string"/>
             </expect-test-wrap>
             <expect select="()"/>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.xml
@@ -56,7 +56,7 @@
       <result select="/*/(@* | node())">
          <content-wrap xmlns="">
             <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
-               <elem1 xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="">text</elem1>
+               <elem1 xmlns="" xmlns:x="http://www.jenitennison.com/xslt/xspec">text</elem1>
             </pseudo-element>
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr="attr-val"/>
          </content-wrap>
@@ -104,7 +104,7 @@
          <content-wrap xmlns="">
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr1="attr1-val"/>
             <pseudo-element xmlns="http://www.jenitennison.com/xslt/xspec">
-               <elem2 xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="">text</elem2>
+               <elem2 xmlns="" xmlns:x="http://www.jenitennison.com/xslt/xspec">text</elem2>
             </pseudo-element>
             <pseudo-attribute xmlns="http://www.jenitennison.com/xslt/xspec" attr3="attr3-val"/>
          </content-wrap>
@@ -198,8 +198,8 @@
    <scenario id="scenario8" xspec="../../report.xspec">
       <label>Derived types</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="Q{x-urn:test:mirror}param-mirror"/>
       </input-wrap>
       <scenario id="scenario8-scenario1" xspec="../../report.xspec">
@@ -207,8 +207,8 @@
          <scenario id="scenario8-scenario1-scenario1" xspec="../../report.xspec">
             <label>xs:dateTimeStamp</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:dateTimeStamp('1234-01-02T03:04:05Z')"/>
                </x:call>
             </input-wrap>
@@ -228,8 +228,8 @@
          <scenario id="scenario8-scenario2-scenario1" xspec="../../report.xspec">
             <label>xs:integer</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:integer(1)"/>
                </x:call>
             </input-wrap>
@@ -242,8 +242,8 @@
          <scenario id="scenario8-scenario2-scenario2" xspec="../../report.xspec">
             <label>xs:long</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:long(1)"/>
                </x:call>
             </input-wrap>
@@ -256,8 +256,8 @@
          <scenario id="scenario8-scenario2-scenario3" xspec="../../report.xspec">
             <label>xs:int</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:int(1)"/>
                </x:call>
             </input-wrap>
@@ -270,8 +270,8 @@
          <scenario id="scenario8-scenario2-scenario4" xspec="../../report.xspec">
             <label>xs:short</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:short(1)"/>
                </x:call>
             </input-wrap>
@@ -285,8 +285,8 @@
          <scenario id="scenario8-scenario2-scenario5" xspec="../../report.xspec">
             <label>xs:byte</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:byte(1)"/>
                </x:call>
             </input-wrap>
@@ -299,8 +299,8 @@
          <scenario id="scenario8-scenario2-scenario6" xspec="../../report.xspec">
             <label>xs:nonNegativeInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:nonNegativeInteger(0)"/>
                </x:call>
             </input-wrap>
@@ -314,8 +314,8 @@
          <scenario id="scenario8-scenario2-scenario7" xspec="../../report.xspec">
             <label>xs:positiveInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:positiveInteger(1)"/>
                </x:call>
             </input-wrap>
@@ -329,8 +329,8 @@
          <scenario id="scenario8-scenario2-scenario8" xspec="../../report.xspec">
             <label>xs:unsignedLong</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedLong(1)"/>
                </x:call>
             </input-wrap>
@@ -344,8 +344,8 @@
          <scenario id="scenario8-scenario2-scenario9" xspec="../../report.xspec">
             <label>xs:unsignedInt</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedInt(1)"/>
                </x:call>
             </input-wrap>
@@ -359,8 +359,8 @@
          <scenario id="scenario8-scenario2-scenario10" xspec="../../report.xspec">
             <label>xs:unsignedShort</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedShort(1)"/>
                </x:call>
             </input-wrap>
@@ -374,8 +374,8 @@
          <scenario id="scenario8-scenario2-scenario11" xspec="../../report.xspec">
             <label>xs:unsignedByte</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:unsignedByte(1)"/>
                </x:call>
             </input-wrap>
@@ -389,8 +389,8 @@
          <scenario id="scenario8-scenario2-scenario12" xspec="../../report.xspec">
             <label>xs:nonPositiveInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:nonPositiveInteger(0)"/>
                </x:call>
             </input-wrap>
@@ -404,8 +404,8 @@
          <scenario id="scenario8-scenario2-scenario13" xspec="../../report.xspec">
             <label>xs:negativeInteger</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:negativeInteger(-1)"/>
                </x:call>
             </input-wrap>
@@ -422,8 +422,8 @@
          <scenario id="scenario8-scenario3-scenario1" xspec="../../report.xspec">
             <label>xs:dayTimeDuration</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:dayTimeDuration('P1DT2H3M4S')"/>
                </x:call>
             </input-wrap>
@@ -437,8 +437,8 @@
          <scenario id="scenario8-scenario3-scenario2" xspec="../../report.xspec">
             <label>xs:yearMonthDuration</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:yearMonthDuration('P1Y2M')"/>
                </x:call>
             </input-wrap>
@@ -455,8 +455,8 @@
          <scenario id="scenario8-scenario4-scenario1" xspec="../../report.xspec">
             <label>xs:normalizedString</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:normalizedString('foo')"/>
                </x:call>
             </input-wrap>
@@ -470,8 +470,8 @@
          <scenario id="scenario8-scenario4-scenario2" xspec="../../report.xspec">
             <label>xs:token</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:token('foo')"/>
                </x:call>
             </input-wrap>
@@ -485,8 +485,8 @@
          <scenario id="scenario8-scenario4-scenario3" xspec="../../report.xspec">
             <label>xs:language</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:language('en')"/>
                </x:call>
             </input-wrap>
@@ -500,8 +500,8 @@
          <scenario id="scenario8-scenario4-scenario4" xspec="../../report.xspec">
             <label>xs:Name</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:Name('foo')"/>
                </x:call>
             </input-wrap>
@@ -515,8 +515,8 @@
          <scenario id="scenario8-scenario4-scenario5" xspec="../../report.xspec">
             <label>xs:NCName</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:NCName('foo')"/>
                </x:call>
             </input-wrap>
@@ -530,8 +530,8 @@
          <scenario id="scenario8-scenario4-scenario6" xspec="../../report.xspec">
             <label>xs:ENTITY</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:ENTITY('foo')"/>
                </x:call>
             </input-wrap>
@@ -545,8 +545,8 @@
          <scenario id="scenario8-scenario4-scenario7" xspec="../../report.xspec">
             <label>xs:ID</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:ID('foo')"/>
                </x:call>
             </input-wrap>
@@ -560,8 +560,8 @@
          <scenario id="scenario8-scenario4-scenario8" xspec="../../report.xspec">
             <label>xs:IDREF</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:IDREF('foo')"/>
                </x:call>
             </input-wrap>
@@ -575,8 +575,8 @@
          <scenario id="scenario8-scenario4-scenario9" xspec="../../report.xspec">
             <label>xs:NMTOKEN</label>
             <input-wrap xmlns="">
-               <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">
+               <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   <x:param select="xs:NMTOKEN('foo')"/>
                </x:call>
             </input-wrap>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -364,7 +364,7 @@
             <result select="/element()">
                <content-wrap xmlns="">
                   <looooooooooooooooooooooooooooooooooong xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                     <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
+                     <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
                         <a/>
                      </test>
                   </looooooooooooooooooooooooooooooooooong>
@@ -397,7 +397,7 @@
                <expect select="/element()">
                   <content-wrap xmlns="">
                      <looooooooooooooooooooooooooooooooooong xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                        <test xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3" xmlns="ns">
+                        <test xmlns="ns" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:ns3="ns3">
                            <a/>
                         </test>
                      </looooooooooooooooooooooooooooooooooong>
@@ -713,7 +713,7 @@
             <label>both in [Result] and [Expected Result] with diff,</label>
             <result select="/element()">
                <content-wrap xmlns="">
-                  <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                  <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                      <bar xmlns=""/>
                   </foo>
                </content-wrap>
@@ -722,7 +722,7 @@
                <label>the 2nd-level element should have xmlns="".</label>
                <expect select="/element()">
                   <content-wrap xmlns="">
-                     <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                     <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                         <baz xmlns=""/>
                      </foo>
                   </content-wrap>
@@ -733,7 +733,7 @@
             <label>in [Result] without diff,</label>
             <result select="/element()">
                <content-wrap xmlns="">
-                  <foo xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="default-ns">
+                  <foo xmlns="default-ns" xmlns:x="http://www.jenitennison.com/xslt/xspec">
                      <bar xmlns=""/>
                   </foo>
                </content-wrap>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.xml
@@ -10,8 +10,8 @@
 					&lt;elem&gt;text&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem>text</elem>
@@ -47,8 +47,8 @@
 					&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem/>
@@ -90,8 +90,8 @@
 					&lt;elem&gt;...&lt;/elem&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem>...</elem>
@@ -141,8 +141,8 @@
 					&lt;elem attrib="val" /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(elem)">
                   <elem attrib="val"/>
@@ -194,8 +194,8 @@
 					&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(outer)">
                   <outer>text<inner1/>
@@ -246,8 +246,8 @@
 					&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="element(outer)">
                   <outer>
@@ -296,8 +296,8 @@
 						 @attrib="val"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib="val"/>
@@ -331,8 +331,8 @@
 						 @attrib=""
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib=""/>
@@ -360,8 +360,8 @@
 						 @attrib="..."
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="attribute(attrib)" select="elem/@*">
                   <elem attrib="..."/>
@@ -406,8 +406,8 @@
       <scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <label>When result is usual text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">text</x:param>
             </x:call>
@@ -429,8 +429,8 @@
       <scenario id="scenario5-scenario2" xspec="../../three-dots.xspec">
          <label>When result is whitespace-only text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">	
 &#xD; </x:param>
@@ -458,8 +458,8 @@
       <scenario id="scenario5-scenario3" xspec="../../three-dots.xspec">
          <label>When result is zero-length text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()" select="$Q{x-urn:test:three-dots}text-node_zero-length"/>
             </x:call>
@@ -485,8 +485,8 @@
       <scenario id="scenario5-scenario4" xspec="../../three-dots.xspec">
          <label>When result is three-dot text node</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="text()">...</x:param>
             </x:call>
@@ -519,8 +519,8 @@
 					&lt;!--comment--&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!--comment--></x:param>
             </x:call>
@@ -548,8 +548,8 @@
 					&lt;!----&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!----></x:param>
             </x:call>
@@ -571,8 +571,8 @@
 					&lt;!--...--&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="comment()"><!--...--></x:param>
             </x:call>
@@ -611,8 +611,8 @@
 					&lt;?pi data?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi data?></x:param>
             </x:call>
@@ -640,8 +640,8 @@
 					&lt;?pi?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi?></x:param>
             </x:call>
@@ -663,8 +663,8 @@
 					&lt;?pi ...?&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="processing-instruction(pi)"><?pi ...?></x:param>
             </x:call>
@@ -703,8 +703,8 @@
 														 &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()" select="/"><?pi?><!--comment-->
                   <elem/>
@@ -733,8 +733,8 @@
       <scenario id="scenario8-scenario2" xspec="../../three-dots.xspec">
          <label>When result is document node containing nothing</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()"
                         select="$Q{x-urn:test:three-dots}document-node_empty"/>
@@ -759,8 +759,8 @@
       <scenario id="scenario8-scenario3" xspec="../../three-dots.xspec">
          <label>When result is document node containing ...</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="document-node()" select="/">...</x:param>
             </x:call>
@@ -795,8 +795,8 @@
 				xmlns:prefix="namespace-uri"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="'prefix'"/>
                <x:param select="'namespace-uri'"/>
@@ -804,7 +804,7 @@
          </input-wrap>
          <result select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
             </content-wrap>
          </result>
          <test id="scenario9-scenario1-expect1" successful="true">
@@ -813,7 +813,7 @@
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
                </content-wrap>
             </expect>
          </test>
@@ -829,8 +829,8 @@
 				xmlns="namespace-uri"
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="''"/>
                <x:param select="'namespace-uri'"/>
@@ -863,8 +863,8 @@
 				xmlns:prefix="..."
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="Q{x-urn:test:three-dots}namespace-node">
                <x:param select="'prefix'"/>
                <x:param select="'...'"/>
@@ -872,7 +872,7 @@
          </input-wrap>
          <result select="/*/namespace::*">
             <content-wrap xmlns="">
-               <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+               <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
             </content-wrap>
          </result>
          <test id="scenario9-scenario3-expect1" successful="true">
@@ -881,7 +881,7 @@
 					should be Success</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="..." xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="..."/>
                </content-wrap>
             </expect>
          </test>
@@ -897,7 +897,7 @@
 					should be Failure</label>
             <expect select="/*/namespace::*">
                <content-wrap xmlns="">
-                  <pseudo-namespace-node xmlns:prefix="namespace-uri" xmlns="http://www.jenitennison.com/xslt/xspec"/>
+                  <pseudo-namespace-node xmlns="http://www.jenitennison.com/xslt/xspec" xmlns:prefix="namespace-uri"/>
                </content-wrap>
             </expect>
          </test>
@@ -910,8 +910,8 @@
 					&lt;elem1 /&gt;&lt;elem2 /&gt;
 				</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="one-or-more">
                <x:param as="element()+">
                   <elem1/>
@@ -966,8 +966,8 @@
    <scenario id="scenario11" xspec="../../three-dots.xspec">
       <label>When result is empty sequence</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="zero-or-one">
             <x:param as="empty-sequence()"/>
          </x:call>
@@ -985,8 +985,8 @@
       <scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <label>When result is 'string'</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="xs:string" select="'string'"/>
             </x:call>
@@ -1010,8 +1010,8 @@
       <scenario id="scenario12-scenario2" xspec="../../three-dots.xspec">
          <label>When result is '...'</label>
          <input-wrap xmlns="">
-            <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+            <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     function="exactly-one">
                <x:param as="xs:string" select="'...'"/>
             </x:call>
@@ -1036,8 +1036,8 @@
    <scenario id="scenario13" xspec="../../three-dots.xspec">
       <label>For any resultant item</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  function="exactly-one">
             <x:param as="text()">item</x:param>
          </x:call>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.xml
@@ -6,8 +6,8 @@
    <scenario id="scenario1" xspec="../../../../xslt1.xspec">
       <label>With 2 text nodes</label>
       <input-wrap xmlns="">
-         <x:call xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
+         <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                  template="text-nodes"/>
       </input-wrap>
       <scenario id="scenario1-scenario1" xspec="../../../../xslt1.xspec">
@@ -18,8 +18,8 @@
          <test id="scenario1-scenario1-expect1" successful="true">
             <label>Result should be text nodes</label>
             <expect-test-wrap xmlns="">
-               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="$x:result instance of text()+"/>
             </expect-test-wrap>
             <expect select="()"/>
@@ -27,8 +27,8 @@
          <test id="scenario1-scenario1-expect2" successful="true">
             <label>Result count should be 2</label>
             <expect-test-wrap xmlns="">
-               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                         xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          test="count($x:result)"/>
             </expect-test-wrap>
             <result select="2"/>
@@ -70,9 +70,9 @@
          <test id="scenario1-scenario3-expect1" successful="false">
             <label>Expecting the compiled stylesheet to have version=1.0</label>
             <expect-test-wrap xmlns="">
-               <x:expect xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               <x:expect xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                         xmlns:xs="http://www.w3.org/2001/XMLSchema"
                          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                         xmlns:x="http://www.jenitennison.com/xslt/xspec"
                          test="document('')/xsl:stylesheet/@version/string()"/>
             </expect-test-wrap>
             <result select="'2.0'"/>


### PR DESCRIPTION
This pull request just updates the expected result files for the e2e tests using Saxon 12.3[^1], with the aim of streamlining the upcoming pull request for #852.

Upon inspecting the generated expected results, I observed that only the order of `xmlns` declarations has been modified.

This pull request intentionally leaves certain expected result files for Code Coverage unchanged, as they still depend on Saxon 9.9.

[^1]: Saxon versions from 10 to 12.2 can't be used for generating expected results due to https://saxonica.plan.io/issues/6063.
While 11.6 might be usable, attemping it is of no use, as Code Coverage won't work there (https://saxonica.plan.io/issues/6223).