### PR TITLE
ci: check .properties style

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -9,10 +9,17 @@
       }
     },
     {
+      "files": ["*.properties"],
+      "options": {
+        "keySeparator": "="
+      }
+    },
+    {
       "files": ["*.yml"],
       "options": {
         "singleQuote": true
       }
     }
-  ]
+  ],
+  "plugins": ["prettier-plugin-properties"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-angular": "^18.4.3",
         "bats": "^1.10.0",
-        "prettier": "^3.1.0"
+        "prettier": "^3.1.0",
+        "prettier-plugin-properties": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -744,6 +745,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dot-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dot-properties/-/dot-properties-1.0.1.tgz",
+      "integrity": "sha512-cjIHHKlf2dPINJ5Io3lPocWvWmthXn3ztqyHVzUfufRiCiPECb0oiEqEGbEGaunFZtcMvwgUcxP9CTpLG4KCsA==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1518,6 +1525,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-properties": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-properties/-/prettier-plugin-properties-0.3.0.tgz",
+      "integrity": "sha512-j2h4NbG6hIaRx0W7CDPUH+yDbzXHmI2urPC1EC8pYrsS5R5AYgAmcSDN0oea+C5mBiN6BK0AkiSKPj0RC17NDQ==",
+      "dev": true,
+      "dependencies": {
+        "dot-properties": "^1.0.0"
+      },
+      "peerDependencies": {
+        "prettier": ">= 2.3.0"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-angular": "^18.4.3",
     "bats": "^1.10.0",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.0",
+    "prettier-plugin-properties": "^0.3.0"
   },
   "scripts": {
     "prettier:check": "prettier --check .",


### PR DESCRIPTION
This PR just adds [`prettier-plugin-properties` plugin](https://github.com/eemeli/prettier-plugin-properties) to Prettier, so that `*.properties` file style can be checked by GitHub Actions [`Lint` workflow](https://github.com/xspec/xspec/blob/ecad57a4f445dab36e3eba51b7036061f7a3f5c5/.github/workflows/lint.yml#L33-L41).