### PR TITLE
ci: remove Saxon 9.9 from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [8, 17]
-        env: [saxon-12, saxon-11, saxon-10, saxon-9-9, oxygen]
+        env: [saxon-12, saxon-11, saxon-10, oxygen]
         exclude:
           - os: macos-latest
             env: saxon-10
-          - os: macos-latest
-            env: saxon-9-9
           - java: 8
             env: oxygen
 

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -31,9 +31,6 @@ jobs:
         Saxon-10:
           XSPEC_TEST_ENV: saxon-10
 
-        Saxon-9-9:
-          XSPEC_TEST_ENV: saxon-9-9
-
         ${{ if eq(parameters.testOxygen, true) }}:
           Oxygen:
             XSPEC_TEST_ENV: oxygen

--- a/test/ci/env/saxon-9-9.env
+++ b/test/ci/env/saxon-9-9.env
@@ -1,6 +1,0 @@
-#
-# Latest Saxon 9.9
-#
-SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-Archive/main/Saxon-HE/9/9.9
-SAXON_VERSION=9.9.1-8
-XMLCALABASH_VERSION=1.3.2-99


### PR DESCRIPTION
Following #1833, this pr removes Saxon 9.9 from GitHub Actions and Azure Pipelines, which means XSpec no longer supports Saxon 9.9.

After merging this, we can start deleting code specifically designed for Saxon 9.9.