### PR TITLE
test: test $x:context variable more, mainly in x:expect

### DIFF
--- a/test/external_global-context_stylesheet.xspec
+++ b/test/external_global-context_stylesheet.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description run-as="external" stylesheet="external_global-context.xsl"
+	xmlns:myv="http://example.org/ns/my/variable"
 	xmlns:test="x-urn:test:external_global-context" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
 	<x:helper stylesheet="test-utils.xsl" />
@@ -15,6 +16,12 @@
 			test="$x:result?err?module => x:filename-and-extension()" />
 	</x:scenario>
 
+	<x:scenario label="Global context can be stored in a variable" shared="yes">
+		<x:variable name="myv:context-variable" select="$x:context" />
+		<x:expect label="User variable accesses $x:context correctly"
+			test="$myv:context-variable" select="$x:context" />
+	</x:scenario>
+
 	<x:scenario label="apply-templates invocation and call-template invocation">
 
 		<x:scenario label="x:context is a node">
@@ -23,6 +30,7 @@
 					<context-grandchild />
 				</context-child>
 			</x:context>
+			<x:like label="Global context can be stored in a variable" />
 
 			<x:scenario label="apply-templates invocation">
 				<x:context mode="test:get-global-context" />
@@ -33,8 +41,10 @@
 
 			<x:scenario label="call-template invocation">
 				<x:call template="test:get-global-context" />
-				<x:expect label="Global context item should be identical with x:context node"
+				<x:expect label="Global context item should be identical with $x:context node"
 					test="$x:result is $x:context" />
+				<x:expect label="which is the expected node from x:context"
+					test="$x:context instance of element(context-grandchild)" />
 			</x:scenario>
 		</x:scenario>
 
@@ -43,13 +53,18 @@
 
 			<x:scenario catch="yes" label="apply-templates invocation">
 				<x:context mode="test:get-global-context" />
+				<x:like label="Global context can be stored in a variable" />
 				<x:like label="Global context item should be absent" />
 			</x:scenario>
 
 			<x:scenario label="call-template invocation">
 				<x:call template="test:get-global-context" />
-				<x:expect label="Global context item should be the same as x:context value"
+				<x:like label="Global context can be stored in a variable" />
+				<x:expect label="Global context item should be the same as $x:context value"
 					select="$x:context" />
+				<x:expect label="which is the expected atomic value from x:context"
+					test="$x:context"
+					select="'context-string'" />
 			</x:scenario>
 		</x:scenario>
 
@@ -73,14 +88,21 @@
 					<context-grandchild />
 				</context-child>
 			</x:context>
-			<x:expect label="Global context item should be identical with x:context node"
+			<x:like label="Global context can be stored in a variable" />
+			<x:expect label="Global context item should be identical with $x:context node"
 				test="$x:result is $x:context" />
+			<x:expect label="which is the expected node from x:context"
+				test="$x:context instance of element(context-grandchild)" />
 		</x:scenario>
 
 		<x:scenario label="x:context is an atomic value">
 			<x:context select="'context-string'" />
-			<x:expect label="Global context item should be the same as x:context value"
+			<x:like label="Global context can be stored in a variable" />
+			<x:expect label="Global context item should be the same as $x:context value"
 				select="$x:context" />
+			<x:expect label="which is the expected atomic value from x:context"
+				test="$x:context"
+				select="'context-string'" />
 		</x:scenario>
 
 		<x:scenario catch="yes" label="No x:context">

--- a/test/external_x-context.xspec
+++ b/test/external_x-context.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" stylesheet="x-context.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:import href="x-context.xspec" />
+
+</x:description>

--- a/test/external_x-context_schematron.xspec
+++ b/test/external_x-context_schematron.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external"
+	schematron="do-nothing.sch"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:import href="x-context_schematron.xspec" />
+</x:description>

--- a/test/x-context.xsl
+++ b/test/x-context.xsl
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:include href="items.xsl" />
+
+	<xsl:mode on-no-match="shallow-skip" />
+	<xsl:mode name="template-mode" on-no-match="shallow-skip" />
 
 	<xsl:template as="empty-sequence()" name="null">
 		<xsl:context-item use="absent" />
+	</xsl:template>
+
+	<xsl:template as="item()*" name="template-with-param">
+		<xsl:context-item use="absent" />
+		<xsl:param name="param" as="item()*"/>
+		<xsl:sequence select="$param" />
 	</xsl:template>
 </xsl:stylesheet>

--- a/test/x-context.xspec
+++ b/test/x-context.xspec
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="x-context.xsl" xmlns:items="x-urn:test:xspec-items"
+	xmlns:myv="http://example.org/ns/my/variable"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:helper stylesheet="items.xsl" />
 
 	<!--
 		Common shared
@@ -10,6 +13,35 @@
 			select="$x:context" test="$x:context" />
 	</x:scenario>
 
+	<x:scenario label="Use $x:context in x:variable" shared="yes">
+		<x:variable name="myv:context" select="$x:context" />
+		<x:variable name="myv:context-in-tvt" expand-text="yes">{$x:context}</x:variable>
+		<x:variable name="myv:context-in-avt">
+			<child-element attr="{$x:context}" />
+		</x:variable>
+		<x:expect label="$x:context should be available in x:variable"
+			select="$x:context" test="$myv:context" />
+		<x:expect label="$x:context should be available in TVT within x:variable"
+			expand-text="yes" test="$myv:context-in-tvt">{$x:context ! string(.)}</x:expect>
+		<x:expect label="$x:context should be available in AVT within x:variable"
+			test="$myv:context-in-avt/@attr => tokenize(' ')"
+			select="$x:context ! string()" />
+	</x:scenario>
+
+	<x:scenario label="Use $x:context in user content" shared="yes">
+		<x:expect label="$x:context should be available in TVT within user content"
+			expand-text="yes"
+			test="$x:context ! string()"
+			select="/child-element => tokenize(' ')">
+			<child-element>{$x:context}</child-element>
+		</x:expect>
+		<x:expect label="$x:context should be available in AVT within user content"
+			test="$x:context ! string()"
+			select="/child-element/@attr => tokenize(' ')">
+			<child-element attr="{$x:context}" />
+		</x:expect>
+	</x:scenario>
+
 	<!--
 		Node
 	-->
@@ -17,10 +49,14 @@
 	<!-- Shared x:expect -->
 	<x:scenario label="Expect the identical single node" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
+		<x:like label="Use $x:context in x:variable" />
+		<x:like label="Use $x:context in user content" />
 		<x:expect label="Identical node" test="$x:context is $items:element" />
 	</x:scenario>
 	<x:scenario label="Expect the identical multiple nodes" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
+		<x:like label="Use $x:context in x:variable" />
+		<x:like label="Use $x:context in user content" />
 		<x:expect label="Identical nodes" select="$items:all-nodes ! generate-id()"
 			test="$x:context ! generate-id()" />
 	</x:scenario>
@@ -31,7 +67,7 @@
 			<x:context select="$items:element" />
 			<x:like label="Expect the identical single node" />
 
-			<x:scenario label="With template call">
+			<x:scenario label="With template call inheriting the context">
 				<x:call template="null" />
 				<x:like label="Expect the identical single node" />
 			</x:scenario>
@@ -41,7 +77,7 @@
 			<x:context select="$items:all-nodes" />
 			<x:like label="Expect the identical multiple nodes" />
 
-			<x:scenario label="With template call">
+			<x:scenario label="With template call inheriting the context">
 				<x:call template="null" />
 				<x:like label="Expect the identical multiple nodes" />
 			</x:scenario>
@@ -55,10 +91,14 @@
 	<!-- Shared x:expect -->
 	<x:scenario label="Expect the same single atomic value" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
+		<x:like label="Use $x:context in x:variable" />
+		<x:like label="Use $x:context in user content" />
 		<x:expect label="Same value" select="$items:integer" test="$x:context" />
 	</x:scenario>
 	<x:scenario label="Expect the same multiple atomic values" shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
+		<x:like label="Use $x:context in x:variable" />
+		<x:like label="Use $x:context in user content" />
 		<x:expect label="Same values" select="$items:integer, $items:integer" test="$x:context" />
 	</x:scenario>
 
@@ -68,7 +108,7 @@
 			<x:context select="$items:integer" />
 			<x:like label="Expect the same single atomic value" />
 
-			<x:scenario label="With template call">
+			<x:scenario label="With template call inheriting the context">
 				<x:call template="null" />
 				<x:like label="Expect the same single atomic value" />
 			</x:scenario>
@@ -78,7 +118,7 @@
 			<x:context select="$items:integer, $items:integer" />
 			<x:like label="Expect the same multiple atomic values" />
 
-			<x:scenario label="With template call">
+			<x:scenario label="With template call inheriting the context">
 				<x:call template="null" />
 				<x:like label="Expect the same multiple atomic values" />
 			</x:scenario>
@@ -93,21 +133,133 @@
 	<x:scenario label="Expect the same sequence of the identical nodes and the same atomic values"
 		shared="yes">
 		<x:like label="Use $x:context both in @select and @test" />
+		<x:like label="Use $x:context in x:variable" />
+		<x:like label="Use $x:context in user content" />
 		<x:expect label="Same items" select="$items:all-nodes, $items:integer" test="$x:context" />
 		<x:expect label="Identical nodes" select="$items:all-nodes ! generate-id()"
 			test="$x:context[. instance of node()] ! generate-id()" />
 	</x:scenario>
 
-	<!-- Test -->
-	<x:scenario label="Mixture of nodes and atomic values">
-		<x:context select="$items:all-nodes, $items:integer" />
+	<!-- Shared scenario contents -->
+	<x:scenario label="Test mixture of nodes and atomic values" shared="yes">
 		<x:like label="Expect the same sequence of the identical nodes and the same atomic values" />
 
-		<x:scenario label="With template call">
+		<x:scenario label="With template call inheriting the context">
 			<x:call template="null" />
 			<x:like
 				label="Expect the same sequence of the identical nodes and the same atomic values"
-			 />
+			/>
+		</x:scenario>
+	</x:scenario>
+
+	<!-- Test -->
+	<x:scenario label="Mixture of nodes and atomic values">
+		<x:context select="$items:all-nodes, $items:integer" />
+		<x:like label="Test mixture of nodes and atomic values" />
+	</x:scenario>
+
+	<!--
+		x:context in parent and child scenarios
+	-->
+
+	<!-- Shared x:expect -->
+	<x:scenario label="Expect $x:context and user variable to have correct values"
+		shared="yes">
+		<x:expect label="Test that $x:context is correct"
+			test="$x:context" select="0" />
+		<x:expect label="Test that user variable is correct"
+			test="$myv:parent-context" select="0" />
+	</x:scenario>
+
+	<!-- Test -->
+	<x:scenario label="Inheritance">
+		<x:scenario label="Parent has mode">
+			<x:context mode="template-mode" />
+			<x:scenario label="and child has content">
+				<x:context select="$items:all-nodes, $items:integer" />
+				<x:like label="Test mixture of nodes and atomic values" />
+			</x:scenario>
+		</x:scenario>
+	
+		<x:scenario label="Parent has content">
+			<x:context select="$items:all-nodes, $items:integer" />
+			<x:scenario label="and child has mode">
+				<x:context mode="template-mode" />
+				<x:like label="Test mixture of nodes and atomic values" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Parent has content">
+			<x:context select="0" />
+			<x:scenario label="and child overrides the content">
+				<x:context select="$items:all-nodes, $items:integer" />
+				<x:like label="Test mixture of nodes and atomic values" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Parent stores context in user variable" pending="Errors out">
+			<x:context select="0" />
+			<x:variable name="myv:parent-context" select="$x:context" />
+			<x:scenario label="and x:expect is in child scenario">
+				<x:like label="Expect $x:context and user variable to have correct values" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Parent stores context in user variable" pending="Errors out">
+			<x:context select="0" />
+			<x:variable name="myv:parent-context" select="$x:context" />
+			<x:scenario label="referenced by child scenario's x:context">
+				<x:context select="1 + $myv:parent-context" />
+				<x:expect label="Test that overridden $x:context is correct"
+					test="$x:context" select="1" />
+				<x:expect label="Test that user variable is correct"
+					test="$myv:parent-context" select="0" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="Parent has x:context," pending="Errors out">
+			<x:context select="0" />
+			<x:scenario label="child scenario has x:variable that references $x:context,">
+				<x:variable name="myv:some-variable" select="0" />
+				<x:variable name="myv:parent-context" select="$x:context" />
+				<x:scenario label="and x:expect is in grandchild scenario">
+					<x:like label="Expect $x:context and user variable to have correct values" />
+				</x:scenario>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
+	<!--
+		$x:context in template parameters
+	-->
+
+	<!-- Shared scenario contents -->
+	<x:scenario label="Expect template parameter to access $x:context correctly" shared="yes">
+		<x:call template="template-with-param">
+			<x:param name="param" select="$x:context"/>
+		</x:call>
+		<!-- for loops are because a multiple-item context calls the
+			named template for each item in the context -->
+		<x:expect label="Same items passed through parameter to result"
+			select="for $i in (1 to count($x:context))
+			return ($items:all-nodes, $items:integer)" />
+		<x:expect label="Identical nodes passed through parameter to result"
+			test="$x:result[. instance of node()] ! generate-id()"
+			select="for $i in (1 to count($x:context))
+			return $items:all-nodes ! generate-id()" />
+	</x:scenario>
+	
+	<!-- Test -->
+	<x:scenario label="Template parameter">
+		<x:scenario label="Parameter using $x:context in same scenario">
+			<x:context select="$items:all-nodes, $items:integer" />
+			<x:like label="Expect template parameter to access $x:context correctly" />
+		</x:scenario>
+		<x:scenario label="Parent defines context">
+			<x:context select="$items:all-nodes, $items:integer" />
+			<x:scenario label="and child scenario defines parameter using $x:context">
+				<x:like label="Expect template parameter to access $x:context correctly" />
+			</x:scenario>
 		</x:scenario>
 	</x:scenario>
 

--- a/test/x-context_schematron.xspec
+++ b/test/x-context_schematron.xspec
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="do-nothing.sch"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:scenario label="Check $x:context value" shared="yes">
+		<x:expect label="$x:context is a document whose outermost element is foo"
+			test="$x:context instance of document-node(element(foo))" />
+	</x:scenario>
+
+	<x:scenario label="$x:context while validating, non-inherited context">
+		<x:scenario label="x:context without @select">
+			<x:context>
+				<foo />
+			</x:context>
+			<x:like label="Check $x:context value" />
+		</x:scenario>
+
+		<x:scenario label="x:context with @select pointing at outermost element">
+			<x:context select="/foo">
+				<foo />
+			</x:context>
+			<x:like label="Check $x:context value" />
+		</x:scenario>
+
+		<x:scenario label="x:context with @select pointing at inner element">
+			<x:context select="//foo">
+				<bar>
+					<foo />
+				</bar>
+			</x:context>
+			<x:like label="Check $x:context value" />
+		</x:scenario>
+
+	</x:scenario>
+
+	<x:scenario label="$x:context while validating, inherited context">
+		<x:scenario label="x:context without @select">
+			<x:context>
+				<foo />
+			</x:context>
+			<x:scenario label="and $x:context in child scenario">
+				<x:like label="Check $x:context value" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="x:context with @select pointing at outermost element">
+			<x:context select="/foo">
+				<foo />
+			</x:context>
+			<x:scenario label="and $x:context in child scenario">
+				<x:like label="Check $x:context value" />
+			</x:scenario>
+		</x:scenario>
+
+		<x:scenario label="x:context with @select pointing at inner element">
+			<x:context select="//foo">
+				<bar>
+					<foo />
+				</bar>
+			</x:context>
+			<x:scenario label="and $x:context in child scenario">
+				<x:like label="Check $x:context value" />
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
This pull request adds more tests for `$x:context` to prepare for documenting this predefined variable as part of #1771.

The original design of `$x:context` in #1089 makes the variable available in `x:expect/(@select|@test)`. In fact, `$x:context` is usable in other situations, too, but not all. The pending test scenarios here are outside the scope of #1089. I'd like to make `$x:context` available even in scenarios that don't contain `x:expect` as a child. I will do that in a separate pull request.