### PR TITLE
feat(report): use Oxygen styling and add alert about failures

### DIFF
--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -265,11 +265,9 @@
       </xsl:where-populated>
       <xsl:variable name="summary-stats"
          select="x:descendant-tests(.) => x:test-stats()" />
-      <xsl:where-populated>
-         <xsl:call-template name="x:failure-alert">
-            <xsl:with-param name="failure-count" select="$summary-stats[@label='failed']/@count" />
-         </xsl:call-template>
-      </xsl:where-populated>
+      <xsl:call-template name="x:failure-alert">
+         <xsl:with-param name="failure-count" select="$summary-stats[@label='failed']/@count" />
+      </xsl:call-template>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -263,6 +263,13 @@
             <xsl:call-template name="x:report-elapsed" />
          </p>
       </xsl:where-populated>
+      <xsl:variable name="summary-stats"
+         select="x:descendant-tests(.) => x:test-stats()" />
+      <xsl:where-populated>
+         <xsl:call-template name="x:failure-alert">
+            <xsl:with-param name="failure-count" select="$summary-stats[@label='failed']/@count" />
+         </xsl:call-template>
+      </xsl:where-populated>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>
@@ -275,7 +282,7 @@
          <thead>
             <tr>
                <th/>
-               <xsl:for-each select="x:descendant-tests(.) => x:test-stats()">
+               <xsl:for-each select="$summary-stats">
                   <th class="totals">
                      <xsl:text expand-text="yes">{@label}:&#xA0;{@count}</xsl:text>
                   </th>
@@ -533,6 +540,20 @@
                <xsl:text>) </xsl:text>
             </xsl:if>
          </span>
+      </xsl:if>
+   </xsl:template>
+
+   <xsl:template name="x:failure-alert" as="element(xhtml:p)?">
+      <xsl:param name="failure-count" as="xs:integer?" />
+      <xsl:if test="$failure-count gt 0">
+         <p class="alert">
+            <strong>Alert: </strong>
+            <xsl:value-of select="concat(
+               $failure-count,
+               if ($failure-count eq 1) then ' test ' else ' tests ',
+               'failed'
+               )"/>
+         </p>         
       </xsl:if>
    </xsl:template>
 

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -182,7 +182,7 @@ h4 {
 }
 
 p.alert {
-	font-size:120%;
+	font-size: 120%;
 }
 
 dt {
@@ -280,16 +280,16 @@ a:active img,
 
 a,
 a:visited {
-	color:rgb(0, 0, 150);
-	background-color:inherit;
+	color: rgb(0, 0, 150);
+	background-color: inherit;
 	font-weight: bold;
 }
 a:link,
 a:visited {
-	text-decoration:none; 
+	text-decoration: none;
 }
 a:hover {
-	text-decoration:underline;
+	text-decoration: underline;
 }
 
 a.img:hover,
@@ -504,32 +504,32 @@ span.scenario-totals {
 
 h2.failed,
 p.alert {
-	background-color: #FCC;
+	background-color: #fcc;
 }
 
 h1,
 h2 {
 	margin-left: 3%;
-	font-size:1.4em;
-	font-weight:bold;
-	text-align:left;
-	margin-top:1.4em;
-	margin-bottom:0.7em;
-	color:#333333;
-	background-color:inherit;
+	font-size: 1.4em;
+	font-weight: bold;
+	text-align: left;
+	margin-top: 1.4em;
+	margin-bottom: 0.7em;
+	color: #333333;
+	background-color: inherit;
 }
 
 h1 {
-	font-size:1.7em;
+	font-size: 1.7em;
 }
 
 div > h3 {
-	font-weight:bold;
+	font-weight: bold;
 	margin-left: 3%;
 }
 
 div > h4 {
-	font-weight:normal;
+	font-weight: normal;
 	margin-left: 4%;
 }
 

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -14,7 +14,8 @@ body {
 	margin-left: 5%;
 }
 
-h1 {
+h1,
+p.alert {
 	padding: 0.3em 0.5em 0.3em 0.5em;
 	position: relative;
 }
@@ -178,6 +179,10 @@ h3 {
 h4 {
 	font-size: 100%;
 	font-weight: bold;
+}
+
+p.alert {
+	font-size:120%;
 }
 
 dt {
@@ -458,6 +463,7 @@ body > table:first-of-type tr.successful th:first-child:before {
 	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAABcUlEQVR42m1SPUsDQRB9661BIoEQDBqJnRhE1BD8CP4AgwhWEbQIKIhi6Q/QwspCtBBs/CBG1Fb9AWK0iBosLCQgYmGQEFARRUguezfuLeZygsWbmZ037zEMyxZ2W0IgHBIoIjPoF6q2QQYIWVlPcxmS3mYt4vFpjmEpd4pNaJ9vRvS9ILa57Aw2ejUYBtVcTdsZPnc7Qk0juNQ3QC/o55JkhnAO19wDnjAmIkkcZBMwBVmci1uEoR5Od4K73o94eAuZpx3kX+9U35TgVjAqVWdmZUWOhldQrnwhnduEELD7dVYhdMJY9zom+/ZAgqOnNY7OQAynt0sol3TFSyiRWklUCKXyN8Jt40gM7SPo68VDIY1c/ly5KlBtJaU+vlmEpyGArmBMkiZOrpdV3yFQ4PJBkmBkCqTO5jE3fITixyOei/dy0L5aVSjY7Jo/w10sqnFmn9VU+e+ZhW7BvGAzq/4O2UiBMCBJRv9/DyHDFQFTPwI/IlPYPLYnAAAAAElFTkSuQmCC");
 }
 
+p.alert:before,
 .failed td:first-child:before,
 body > table:first-of-type tr.failed th:first-child:before {
 	margin-right: 5px;
@@ -496,7 +502,8 @@ span.scenario-totals {
 	text-align: right;
 }
 
-h2.failed {
+h2.failed,
+p.alert {
 	background-color: #FCC;
 }
 

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -160,15 +160,6 @@ table {
 	font-size: 12px;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	font-family: sans-serif;
-}
-
 h1 {
 	font-size: 1.7em;
 	font-weight: bold;
@@ -262,14 +253,8 @@ h2 {
 	width: auto;
 }
 
-h1 {
-	background: #606;
-	color: #6f6;
-}
-
 h2 {
 	color: #606;
-	background: #cfc;
 }
 
 hr {
@@ -288,28 +273,18 @@ a:active img,
 	background: transparent;
 }
 
-a:link {
-	color: #636;
-	background: transparent;
-	border: 0px none white;
-}
-
+a,
 a:visited {
-	color: #606;
-	background: transparent;
-	border: 0px none white;
+	color:rgb(0, 0, 150);
+	background-color:inherit;
+	font-weight: bold;
 }
-
-a:active {
-	color: #6f6;
-	background: #606;
-	border: 0px none white;
+a:link,
+a:visited {
+	text-decoration:none; 
 }
-
 a:hover {
-	color: #636;
-	background: #9f9;
-	border: 0px none white;
+	text-decoration:underline;
 }
 
 a.img:hover,
@@ -475,17 +450,6 @@ div > table > tbody > tr > th:first-child {
 	font-weight: initial;
 }
 
-.successful {
-	background-color: #cfc;
-}
-.pending {
-	background-color: #eee;
-	color: #666;
-}
-.failed {
-	background-color: #fcc;
-}
-
 .successful td:first-child:before,
 body > table:first-of-type tr.successful th:first-child:before {
 	margin-right: 5px;
@@ -530,6 +494,36 @@ body > table:first-of-type tr.pending th:first-child:before {
 span.scenario-totals {
 	float: right;
 	text-align: right;
+}
+
+h2.failed {
+	background-color: #FCC;
+}
+
+h1,
+h2 {
+	margin-left: 3%;
+	font-size:1.4em;
+	font-weight:bold;
+	text-align:left;
+	margin-top:1.4em;
+	margin-bottom:0.7em;
+	color:#333333;
+	background-color:inherit;
+}
+
+h1 {
+	font-size:1.7em;
+}
+
+div > h3 {
+	font-weight:bold;
+	margin-left: 3%;
+}
+
+div > h4 {
+	font-weight:normal;
+	margin-left: 4%;
 }
 
 /* highlight the link target */

--- a/test/end-to-end/cases/expected/query/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/query/expect-empty-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../expect-empty.xspec">expect-empty.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-without-pending-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../focus-without-pending.xspec">focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../force-focus_focus-without-pending.xspec">force-focus_focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/function-result.html
+++ b/test/end-to-end/cases/expected/query/function-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../function.xspec">function.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/import-result.html
+++ b/test/end-to-end/cases/expected/query/import-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../import.xspec">import.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/imported-result.html
+++ b/test/end-to-end/cases/expected/query/imported-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../imported.xspec">imported.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../issue-1340.xspec">issue-1340.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-153-result.html
+++ b/test/end-to-end/cases/expected/query/issue-153-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../issue-153.xspec">issue-153.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-177-result.html
+++ b/test/end-to-end/cases/expected/query/issue-177-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../issue-177.xspec">issue-177.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-346-result.html
+++ b/test/end-to-end/cases/expected/query/issue-346-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-346.xspec">issue-346.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-355.xspec">issue-355.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-452-result.html
+++ b/test/end-to-end/cases/expected/query/issue-452-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-452.xspec">issue-452.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-467-result.html
+++ b/test/end-to-end/cases/expected/query/issue-467-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-467.xspec">issue-467.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-50-result.html
+++ b/test/end-to-end/cases/expected/query/issue-50-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../issue-50.xspec">issue-50.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-528-result.html
+++ b/test/end-to-end/cases/expected/query/issue-528-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-528.xspec">issue-528.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-55-result.html
+++ b/test/end-to-end/cases/expected/query/issue-55-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../issue-55.xspec">issue-55.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/issue-67-result.html
+++ b/test/end-to-end/cases/expected/query/issue-67-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../items.xqm">items.xqm</a></p>
       <p>XSpec: <a href="../../issue-67.xspec">issue-67.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/pending-result.html
+++ b/test/end-to-end/cases/expected/query/pending-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../do-nothing.xqm">do-nothing.xqm</a></p>
       <p>XSpec: <a href="../../pending.xspec">pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/report-result.html
+++ b/test/end-to-end/cases/expected/query/report-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../report.xspec">report.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>34 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
+++ b/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../result-file-threshold_query.xspec">result-file-threshold_query.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/serialize-result.html
+++ b/test/end-to-end/cases/expected/query/serialize-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../serialize.xspec">serialize.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>28 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/three-dots-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../three-dots.xqm">three-dots.xqm</a></p>
       <p>XSpec: <a href="../../three-dots.xspec">three-dots.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>30 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.html
@@ -10,6 +10,7 @@
       <p>Query-at: <a href="../../../../mirror.xqm">mirror.xqm</a></p>
       <p>XSpec: <a href="../../xml-1-1.xspec">xml-1-1.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../focus-vs-pending_schematron.xspec">focus-vs-pending_schematron.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>12 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../focus-without-pending.xspec">focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../force-focus_focus-without-pending.xspec">force-focus_focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../issue-693.sch">issue-693.sch</a></p>
       <p>XSpec: <a href="../../issue-693.xspec">issue-693.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../pending.xspec">pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../do-nothing.sch">do-nothing.sch</a></p>
       <p>XSpec: <a href="../../pending_schematron.xspec">pending_schematron.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>6 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_default.xspec">result-file-threshold_default.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_inf-importing-min.xspec">result-file-threshold_inf-importing-min.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_inf.xspec">result-file-threshold_inf.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_issue-361.xspec">result-file-threshold_issue-361.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_large.xspec">result-file-threshold_large.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../result-file-threshold.sch">result-file-threshold.sch</a></p>
       <p>XSpec: <a href="../../result-file-threshold_min.xspec">result-file-threshold_min.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../../../schematron/schematron-023.sch">schematron-023.sch</a></p>
       <p>XSpec: <a href="../../schematron-023.xspec">schematron-023.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -9,6 +9,7 @@
       <p>Schematron: <a href="../../xml-1-1.sch">xml-1-1.sch</a></p>
       <p>XSpec: <a href="../../xml-1-1_schematron.xspec">xml-1-1_schematron.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/coverage_by-child-nodes-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/coverage_by-child-nodes-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../coverage_by-child-nodes.xsl">coverage_by-child-nodes.xsl</a></p>
       <p>XSpec: <a href="../../coverage_by-child-nodes.xspec">coverage_by-child-nodes.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../expect-empty.xspec">expect-empty.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/external_function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_function-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../external_mirror.xsl">external_mirror.xsl</a></p>
       <p>XSpec: <a href="../../external_function.xspec">external_function.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/external_import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_import-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../external_mirror.xsl">external_mirror.xsl</a></p>
       <p>XSpec: <a href="../../external_import.xspec">external_import.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../focus-without-pending.xspec">focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../force-focus_focus-without-pending.xspec">force-focus_focus-without-pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../force-focus_none.xspec">force-focus_none.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -36,6 +36,7 @@ function toggle(scenarioID) {
       <p>Stylesheet: <a href="../../../../square.xsl">square.xsl</a></p>
       <p>XSpec: <a href="../../format-xspec-report-folding.xspec">format-xspec-report-folding.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../function.xspec">function.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../import.xspec">import.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../imported.xspec">imported.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../issue-1340.xspec">issue-1340.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../issue-153.xspec">issue-153.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../issue-177.xspec">issue-177.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-346.xspec">issue-346.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-355.xspec">issue-355.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>2 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-452.xspec">issue-452.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>4 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-467.xspec">issue-467.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../issue-50.xspec">issue-50.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-528.xspec">issue-528.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../issue-55.xspec">issue-55.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../items.xsl">items.xsl</a></p>
       <p>XSpec: <a href="../../issue-67.xspec">issue-67.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../issue-778_ws.xsl">issue-778_ws.xsl</a></p>
       <p>XSpec: <a href="../../issue-778_ws.xspec">issue-778_ws.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../issue-793-cr.xsl">issue-793-cr.xsl</a></p>
       <p>XSpec: <a href="../../issue-793-cr.xspec">issue-793-cr.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../issue-793-crlf.xsl">issue-793-crlf.xsl</a></p>
       <p>XSpec: <a href="../../issue-793-crlf.xspec">issue-793-crlf.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../issue-793-lf.xsl">issue-793-lf.xsl</a></p>
       <p>XSpec: <a href="../../issue-793-lf.xspec">issue-793-lf.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../label-element.xspec">label-element.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../mode-all.xsl">mode-all.xsl</a></p>
       <p>XSpec: <a href="../../mode-all.xspec">mode-all.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../do-nothing.xsl">do-nothing.xsl</a></p>
       <p>XSpec: <a href="../../pending.xspec">pending.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../report.xspec">report.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>34 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_default.xspec">result-file-threshold_default.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_inf-importing-min.xspec">result-file-threshold_inf-importing-min.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_inf.xspec">result-file-threshold_inf.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_issue-361.xspec">result-file-threshold_issue-361.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>3 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_large.xspec">result-file-threshold_large.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../result-file-threshold_min.xspec">result-file-threshold_min.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>5 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../serialize.xspec">serialize.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>28 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../three-dots.xsl">three-dots.xsl</a></p>
       <p>XSpec: <a href="../../three-dots.xspec">three-dots.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>30 tests failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../mirror.xsl">mirror.xsl</a></p>
       <p>XSpec: <a href="../../xml-1-1.xspec">xml-1-1.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
@@ -9,6 +9,7 @@
       <p>Stylesheet: <a href="../../../../xslt1.xsl">xslt1.xsl</a></p>
       <p>XSpec: <a href="../../xslt2.xspec">xslt2.xspec</a></p>
       <p>Tested: 1 January 2000 at 00:00</p>
+      <p class="alert"><strong>Alert: </strong>1 test failed</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>


### PR DESCRIPTION
This pull request merges CSS styles coming from Oxygen 19 with the existing CSS styles from this repo's master branch. Thanks to @AlexJitianu and the rest of the Oxygen team for creating those styles and letting us use them in this repo!

As I mentioned in my comments in #92, I feel that the reduced shading is a step backward in the ease of distinguishing at a glance between some failures and no failures. To compensate, this pull request adds an "alert" line near the top of the report when there is at least one failure. I'm open to feedback about other ways to compensate.

Resolves #92
Resolves #919