### PR TITLE
fix(schema): remove expand-text from x:like content model

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -190,7 +190,7 @@ like =
 	## this one, and any tests in the shared scenario are run in addition to the
 	## ones in this scenario. This allows for modular, reusable sets of tests which
 	## can be applied in multiple contexts.
-	element like { common-attributes, label }
+	element like { xml-ns-attributes, label }
 
 ## A matching scenario is one based on the application of templates to a
 ## particular item. The <context> element defines <xsl:apply-templates> used to
@@ -310,7 +310,8 @@ assertion =
 
 test = attribute test { xpath }
 
-common-attributes = attribute xml:* { text }*,
+xml-ns-attributes = attribute xml:* { text }*
+common-attributes = xml-ns-attributes,
 	## Works like XSLT @expand-text
 	attribute expand-text { boolean.datatype }?
 


### PR DESCRIPTION
`x:like` does not support text value templates, so it should not permit the `expand-text` attribute. This pull request removes the `expand-text` attribute from the `x:like` content model, leaving the rest of the content model unchanged.

Fixes #1836 using approach 3 under "Possible fixes".

### Testing Done

I validated the `.rnc` file. I validated all the `.xspec` files under `test/` on this branch and the master branch, and there are no differences between the branches.   Then I modified one of the files by adding
```
<x:like expand-text="yes"><x:label>{blah}</x:label></x:like>
<x:like expand-text="yes" label="blah"/>
```
and I got the expected validation error for both lines:
```
error: attribute "expand-text" not allowed here; expected attribute "label" or an attribute from another namespace
```