### PR TITLE
ci: revert last direct commit on schxslt branch, except bats test cases

### DIFF
--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -356,18 +356,37 @@
       Local templates
    -->
 
-   <xsl:template name="local:set-up-context" as="element(xsl:variable)+">
-      <xsl:context-item use="absent" />
+   <xsl:template name="local:set-up-context" as="element()+">
+      <!-- Template output is sequence of xsl:variable+, xsl:if, xsl:variable -->
+      <!-- Context item is x:context or x:scenario -->
+      <xsl:context-item as="element()" use="required"/>
 
       <xsl:param name="context" as="element(x:context)" required="yes" tunnel="yes"/>
 
       <!-- Set up the variable of x:context -->
       <xsl:apply-templates select="$context" mode="x:declare-variable"/>
 
+      <!-- If x:context exists but evaluates to empty at runtime, the
+         test does not execute any code from the SUT. Assume it was
+         a user mistake and issue an error message. -->
+      <if test="empty(${x:variable-UQName($context)})">
+         <message terminate="yes">
+            <xsl:call-template name="x:prefix-diag-message">
+               <xsl:with-param name="message"
+                  select="'Context is an empty sequence.'"/>
+            </xsl:call-template>
+         </message>
+      </if>
+
       <!-- Set up its alias variable ($x:context) for publishing it along with $x:result -->
       <xsl:element name="xsl:variable" namespace="{$x:xsl-namespace}">
          <xsl:attribute name="name" select="x:known-UQName('x:context')"/>
+
+         <!-- Actually, @as is 'item()+'.
+            But it is loosened to 'item()*', otherwise the static type checking can ruin the runtime
+            empty sequence checking written above. -->
          <xsl:attribute name="as" select="'item()*'" />
+
          <xsl:attribute name="select" select="'$' || x:variable-UQName($context)"/>
       </xsl:element>
    </xsl:template>

--- a/test/as_stylesheet.xspec
+++ b/test/as_stylesheet.xspec
@@ -55,19 +55,25 @@
 
 	<x:param as="local-xs:double" name="global-param" select="xs:integer(0)" xmlns:local-xs="http://www.w3.org/2001/XMLSchema" />
 	<x:scenario label="In global-param (i.e. /x:description/x:param), when @as uses a prefix defined in x:param,">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@as takes effect" test="$global-param instance of xs:double" />
 	</x:scenario>
 
 	<x:variable as="local-xs:double" name="myv:global-var" select="xs:integer(0)" xmlns:local-xs="http://www.w3.org/2001/XMLSchema" />
 	<x:scenario label="In global variable (i.e. /x:description/x:variable), when @as uses a prefix defined in x:variable,">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@as takes effect" test="$myv:global-var instance of xs:double" />
 	</x:scenario>
 
 	<x:scenario label="In scenario-level variable (i.e. //x:scenario/x:variable), when @as uses a prefix defined in x:variable,">
 		<x:variable as="local-xs:double" name="myv:local-var" select="xs:integer(0)" xmlns:local-xs="http://www.w3.org/2001/XMLSchema" />
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@as takes effect" test="$myv:local-var instance of xs:double" />
 	</x:scenario>
 

--- a/test/bad-context/apply-templates/child-constant-select.xspec
+++ b/test/bad-context/apply-templates/child-constant-select.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/* exists, but hard-coded @select finds nothing">
+		<x:context select="/nonexistent">
+			<foo/>
+		</x:context>
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/child-variable-select.xspec
+++ b/test/bad-context/apply-templates/child-variable-select.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/* exists, but @select computation finds nothing">
+		<x:variable name="qualifier" select="'nonexistent'" as="xs:string" />
+		<x:context select="/*[@id=$qualifier]">
+			<foo/>
+		</x:context>
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/external_child-constant-select.xspec
+++ b/test/bad-context/apply-templates/external_child-constant-select.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external"
+	stylesheet="../../mirror.xsl"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:import href="child-constant-select.xspec" />
+</x:description>

--- a/test/bad-context/apply-templates/href-broken.xspec
+++ b/test/bad-context/apply-templates/href-broken.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file does not exist">
+		<x:context href="nonexistent.xml" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/href-constant-select-inherited-augmented.xspec
+++ b/test/bad-context/apply-templates/href-constant-select-inherited-augmented.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing">
+		<x:context href="node-selection.xml" />
+		<x:scenario label="at child level">
+			<x:context select="/nonexistent" />
+			<x:expect label="should be error" test="true()" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/href-constant-select-inherited.xspec
+++ b/test/bad-context/apply-templates/href-constant-select-inherited.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing,">
+		<x:context href="node-selection.xml" select="/nonexistent" />
+		<x:scenario label="inherited without more context,">
+			<x:expect label="should be error" test="true()" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/href-constant-select.xspec
+++ b/test/bad-context/apply-templates/href-constant-select.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing">
+		<x:context href="node-selection.xml" select="/nonexistent" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/href-variable-select.xspec
+++ b/test/bad-context/apply-templates/href-variable-select.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but @select computation finds nothing">
+		<x:variable name="qualifier" select="'nonexistent'" as="xs:string" />
+		<x:context href="node-selection.xml" select="/*[@id=$qualifier]" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/no-attr.xspec
+++ b/test/bad-context/apply-templates/no-attr.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context has no attributes and no children">
+		<x:context />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/apply-templates/select-only.xspec
+++ b/test/bad-context/apply-templates/select-only.xspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context has no information other than @select">
+		<x:context select="/missing-context" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/child-constant-select.xspec
+++ b/test/bad-context/call-template/child-constant-select.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/* exists, but hard-coded @select finds nothing">
+		<x:context select="/nonexistent">
+			<foo/>
+		</x:context>
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/child-variable-select.xspec
+++ b/test/bad-context/call-template/child-variable-select.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/* exists, but @select computation finds nothing">
+		<x:variable name="qualifier" select="'nonexistent'" as="xs:string" />
+		<x:context select="/*[@id=$qualifier]">
+			<foo/>
+		</x:context>
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/external_child-constant-select.xspec
+++ b/test/bad-context/call-template/external_child-constant-select.xspec
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" 
+	stylesheet="../../mirror.xsl"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:import href="child-constant-select.xspec" />
+
+</x:description>

--- a/test/bad-context/call-template/href-broken.xspec
+++ b/test/bad-context/call-template/href-broken.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file does not exist">
+		<x:context href="nonexistent.xml" />
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/href-constant-select-inherited-augmented.xspec
+++ b/test/bad-context/call-template/href-constant-select-inherited-augmented.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing">
+		<x:context href="node-selection.xml" />
+		<x:call template="mirror:context-mirror" />
+		<x:scenario label="at child level">
+			<x:context select="/nonexistent" />
+			<x:expect label="should be error" test="true()" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/href-constant-select-inherited.xspec
+++ b/test/bad-context/call-template/href-constant-select-inherited.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing,">
+		<x:context href="node-selection.xml" select="/nonexistent" />
+		<x:scenario label="inherited without more context,">
+			<x:call template="mirror:context-mirror" />
+			<x:expect label="should be error" test="true()" />
+		</x:scenario>
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/href-constant-select.xspec
+++ b/test/bad-context/call-template/href-constant-select.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but hard-coded @select finds nothing">
+		<x:context href="node-selection.xml" select="/nonexistent" />
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/href-variable-select.xspec
+++ b/test/bad-context/call-template/href-variable-select.xspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context/@href file exists, but @select computation finds nothing">
+		<x:variable name="qualifier" select="'nonexistent'" as="xs:string" />
+		<x:context href="node-selection.xml" select="/*[@id=$qualifier]" />
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/no-attr.xspec
+++ b/test/bad-context/call-template/no-attr.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context has no attributes and no children">
+		<x:context />
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/bad-context/call-template/select-only.xspec
+++ b/test/bad-context/call-template/select-only.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	xml:base="../../"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:scenario label="x:context has no information other than @select">
+		<x:context select="/missing-context" />
+		<x:call template="mirror:context-mirror" />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+
+</x:description>

--- a/test/compiler-eqname-utils.xspec
+++ b/test/compiler-eqname-utils.xspec
@@ -206,7 +206,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing variable capture-NCName">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="Captured" select="'bar'" test="
 				replace(
 					'foo:bar[baz]',

--- a/test/end-to-end/cases/coverage_no-hit.xspec
+++ b/test/end-to-end/cases/coverage_no-hit.xspec
@@ -2,7 +2,9 @@
 <?xspec-test enable-coverage?>
 <x:description stylesheet="coverage_no-hit.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="Testing a stylesheet without any matching context">
-		<x:context />
+		<x:context>
+		   <unmatched />
+		</x:context>
 		<x:expect label="should be reported as 'not used' in the coverage report" />
 	</x:scenario>
 </x:description>

--- a/test/end-to-end/cases/expected/stylesheet/coverage_no-hit-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/coverage_no-hit-result.xml
@@ -6,7 +6,9 @@
    <scenario id="scenario1" xspec="../../coverage_no-hit.xspec">
       <label>Testing a stylesheet without any matching context</label>
       <input-wrap xmlns="">
-         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <unmatched/>
+         </x:context>
       </input-wrap>
       <result select="()"/>
       <test id="scenario1-expect1" successful="true">

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.xml
@@ -6,7 +6,9 @@
    <scenario id="scenario1" xspec="../../external_issue-450-451_stylesheet.xspec">
       <label>scenario-level global-param containing curly brackets</label>
       <input-wrap xmlns="">
-         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+         <x:context xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <foo/>
+         </x:context>
       </input-wrap>
       <result select="()"/>
       <test id="scenario1-expect1" successful="true">
@@ -106,7 +108,9 @@
       <input-wrap xmlns="">
          <x:context xmlns:mirror="x-urn:test:mirror"
                     xmlns:myv="http://example.org/ns/my/variable"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+                    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <foo/>
+         </x:context>
       </input-wrap>
       <result select="()"/>
       <test id="scenario5-expect1" successful="true">

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.xml
@@ -85,7 +85,9 @@
       <input-wrap xmlns="">
          <x:context xmlns:mirror="x-urn:test:mirror"
                     xmlns:myv="http://example.org/ns/my/variable"
-                    xmlns:x="http://www.jenitennison.com/xslt/xspec"/>
+                    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+            <foo/>
+         </x:context>
       </input-wrap>
       <result select="()"/>
       <test id="scenario4-expect1" successful="true">

--- a/test/end-to-end/cases/external_issue-450-451_stylesheet.xspec
+++ b/test/end-to-end/cases/external_issue-450-451_stylesheet.xspec
@@ -6,7 +6,9 @@
 
 	<x:scenario label="scenario-level global-param containing curly brackets">
 		<x:param name="scenario-param">}{<elem attr="}}{{">}{</elem></x:param>
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect as="node()+" href="issue-450-451.xml" label="should work" select="wrap/node()"
 			test="$scenario-param" />
 	</x:scenario>

--- a/test/end-to-end/cases/issue-450-451_stylesheet.xspec
+++ b/test/end-to-end/cases/issue-450-451_stylesheet.xspec
@@ -27,7 +27,9 @@
 
 	<x:param name="global-param">}{<elem attr="}}{{">}{</elem></x:param>
 	<x:scenario label="global-param containing curly brackets">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect href="issue-450-451.xml" label="should work" select="wrap/node()" as="node()+"
 			test="$global-param" />
 	</x:scenario>

--- a/test/error-compiling-scenario/function-with-context.xspec
+++ b/test/error-compiling-scenario/function-with-context.xspec
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="x:call[@function] with x:context">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:call function="my-function" />
 		<x:expect label="should be error" test="true()" />
 	</x:scenario>

--- a/test/error-compiling-scenario/xquery_context.xspec
+++ b/test/error-compiling-scenario/xquery_context.xspec
@@ -2,7 +2,9 @@
 <x:description query="x-urn:test:do-nothing" query-at="../do-nothing.xqm"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="x:context">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="should be error" test="true()" />
 	</x:scenario>
 </x:description>

--- a/test/external_as_stylesheet.xspec
+++ b/test/external_as_stylesheet.xspec
@@ -8,7 +8,9 @@
 		label="In scenario-level global-param (i.e. //x:scenario/x:param), when @as uses a prefix defined in x:param,">
 		<x:param as="local-xs:double" name="scenario-param" select="xs:integer(0)"
 			xmlns:local-xs="http://www.w3.org/2001/XMLSchema" />
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@as takes effect" test="$scenario-param instance of xs:double" />
 	</x:scenario>
 

--- a/test/external_global-override.xsl
+++ b/test/external_global-override.xsl
@@ -22,6 +22,9 @@
 		<xsl:sequence select="$scenario-x-param_vs_xsl-variable" />
 	</xsl:template>
 
+	<!-- No XSLT parameter or variable -->
+	<xsl:template as="empty-sequence()" match=".[. eq 'scenario-x-param_vs_none']" />
+
 	<!--
 		Scenario-level x:param (empty) versus
 	-->

--- a/test/external_global-override.xspec
+++ b/test/external_global-override.xspec
@@ -31,7 +31,7 @@
 		<x:scenario label="no corresponding xsl:param,">
 			<x:param name="scenario-x-param_vs_none"
 				select="'scenario-level x:param without corresponding xsl:param'" />
-			<x:context />
+			<x:context select="'scenario-x-param_vs_none'" />
 			<x:expect label="the declared param takes effect only in XSpec"
 				select="'scenario-level x:param without corresponding xsl:param'"
 				test="$scenario-x-param_vs_none" />

--- a/test/external_node-selection_stylesheet.xspec
+++ b/test/external_node-selection_stylesheet.xspec
@@ -12,7 +12,9 @@
 			<scenario-param-child-not-allowed />
 		</x:param>
 
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 
 		<x:expect label="In //x:scenario/x:param[node()][not(@href)], child node is used."
 			test="$scenario-param-no-href instance of element(scenario-param-child)" />

--- a/test/external_prefix-conflict_stylesheet.xspec
+++ b/test/external_prefix-conflict_stylesheet.xspec
@@ -10,7 +10,9 @@
 			select="element(x:scenario-param-child)">
 			<x:scenario-param-child />
 		</t:param>
-		<t:context />
+		<t:context>
+			<foo />
+		</t:context>
 		<t:expect label="should work" select="'x:scenario-param-child'"
 			test="name($x:scenario-param)" />
 	</t:scenario>

--- a/test/external_undeclare-ns_stylesheet.xspec
+++ b/test/external_undeclare-ns_stylesheet.xspec
@@ -12,7 +12,9 @@
 				</scenario-param-grandchild>
 			</scenario-param-child>
 		</param>
-		<context />
+		<context>
+			<foo xmlns="" />
+		</context>
 		<expect label="scenario-param-child"
 			select="
 				doc($Q{http://www.jenitennison.com/xslt/xspec}xspec-uri)

--- a/test/external_ws-only-text_stylesheet.xspec
+++ b/test/external_ws-only-text_stylesheet.xspec
@@ -23,7 +23,9 @@
 			<x:text>&#x09;&#x0A;&#x0D;&#x20;</x:text>
 		</x:param>
 
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 
 		<x:scenario>
 			<x:label>So, in

--- a/test/external_xml-base_stylesheet.xspec
+++ b/test/external_xml-base_stylesheet.xspec
@@ -6,7 +6,9 @@
 
 	<x:scenario label="In scenario-level global-param (i.e. //x:scenario/x:param),">
 		<x:param href="test.xml" name="scenario-param" xml:base="node-selection/" />
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@href is resolved with @xml:base"
 			test="$scenario-param instance of document-node(element(testing-xml-base))" />
 	</x:scenario>

--- a/test/global-override.xsl
+++ b/test/global-override.xsl
@@ -24,6 +24,9 @@
 		<xsl:sequence select="$global-x-param_vs_xsl-variable" />
 	</xsl:template>
 
+	<!-- No XSLT parameter or variable -->
+	<xsl:template as="empty-sequence()" match=".[. eq 'global-x-param_vs_none']" />
+
 	<!--
 		Global x:param (empty) versus
 	-->

--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -30,7 +30,7 @@
 		</x:scenario>
 
 		<x:scenario label="no corresponding xsl:param,">
-			<x:context />
+			<x:context select="'global-x-param_vs_none'" />
 			<x:expect label="the declared param takes effect only in XSpec"
 				select="'global x:param without corresponding xsl:param'"
 				test="$global-x-param_vs_none" />

--- a/test/import/file-not-found.xspec
+++ b/test/import/file-not-found.xspec
@@ -4,7 +4,9 @@
 	<x:import href="this.file.never.exists" />
 
 	<x:scenario label="Dummy scenario">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="always successful" test="true()" />
 	</x:scenario>
 

--- a/test/import/no-href.xspec
+++ b/test/import/no-href.xspec
@@ -4,7 +4,9 @@
 	<x:import />
 
 	<x:scenario label="Dummy scenario">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="always successful" test="true()" />
 	</x:scenario>
 

--- a/test/issue-987_child.xspec
+++ b/test/issue-987_child.xspec
@@ -6,7 +6,9 @@
 	<x:import href="issue-987_parent.xspec" />
 
 	<x:scenario label="Scenario in child">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="Expect in child" test="true()" />
 	</x:scenario>
 

--- a/test/issue-987_parent.xspec
+++ b/test/issue-987_parent.xspec
@@ -6,7 +6,9 @@
 	<x:import href="issue-987_child.xspec" />
 
 	<x:scenario label="Scenario in parent">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="Expect in parent" test="true()" />
 	</x:scenario>
 

--- a/test/namespace-vars.xspec
+++ b/test/namespace-vars.xspec
@@ -8,7 +8,9 @@
 	-->
 
 	<x:scenario label="Scenario for testing variable deq-namespace">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="xs:anyURI of 'deq' namespace URI" select="
 				namespace-uri-for-prefix(
 					'deq',
@@ -17,7 +19,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing variable rep-namespace">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="xs:anyURI of 'rep' namespace URI" select="
 				namespace-uri-for-prefix(
 					'rep',
@@ -26,7 +30,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing variable saxon-namespace">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="xs:anyURI of 'saxon' namespace URI" select="
 				namespace-uri-for-prefix(
 					'saxon',
@@ -35,7 +41,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing variable xs-namespace">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="xs:anyURI of 'xs' namespace URI" select="
 				namespace-uri-for-prefix(
 					'xs',
@@ -44,7 +52,9 @@
 	</x:scenario>
 
 	<x:scenario label="Scenario for testing variable xsl-namespace">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="xs:anyURI of 'xsl' namespace URI"
 			select="doc('')/element() => namespace-uri()" test="$x:xsl-namespace treat as xs:anyURI"
 		 />

--- a/test/node-selection_stylesheet.xspec
+++ b/test/node-selection_stylesheet.xspec
@@ -105,7 +105,9 @@
 		<global-param-child-not-allowed />
 	</x:param>
 	<x:scenario label="In global-param, @href precedes child node. So...">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="In /x:description/x:param[node()][not(@href)], child node is used."
 			test="$global-param-no-href instance of element(global-param-child)" />
 		<x:expect label="In /x:description/x:param[node()][@href], @href is used."

--- a/test/prefix-conflict_stylesheet.xspec
+++ b/test/prefix-conflict_stylesheet.xspec
@@ -51,7 +51,9 @@
 		<x:global-param-child />
 	</t:param>
 	<t:scenario label="Using x: prefix in global-param @name, @select, @as, and child node">
-		<t:context />
+		<t:context>
+			<foo />
+		</t:context>
 		<t:expect label="should work" select="'x:global-param-child'" test="name($x:global-param)"
 		 />
 	</t:scenario>

--- a/test/undeclare-ns_stylesheet.xspec
+++ b/test/undeclare-ns_stylesheet.xspec
@@ -173,7 +173,9 @@
 		</global-param-child>
 	</param>
 	<scenario label="global-param">
-		<context />
+		<context>
+			<foo xmlns="" />
+		</context>
 		<expect label="global-param-child"
 			select="
 				doc($Q{http://www.jenitennison.com/xslt/xspec}xspec-uri)

--- a/test/version-utils.xspec
+++ b/test/version-utils.xspec
@@ -5,7 +5,9 @@
 
 	<x:scenario label="Scenario for testing variable saxon-version">
 		<x:scenario label="Assume we test this on Saxon versions from 9.9 to 12.x">
-			<x:context />
+			<x:context>
+				<foo />
+			</x:context>
 			<x:expect label="Greater than or equal to 9.9.0.0"
 				test="$x:saxon-version ge x:pack-version((9, 9))" />
 			<x:expect label="Less than 13.0" test="$x:saxon-version lt x:pack-version(13)" />

--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -350,7 +350,7 @@ rem
     if %CASE_NUM% GTR %NUM_CASES% goto :EOF
 
     rem Failsafe
-    if %CASE_NUM% GEQ 200 (
+    if %CASE_NUM% GEQ 250 (
         call :failed "Too many test cases"
         goto :EOF
     )

--- a/test/ws-only-text_stylesheet.xspec
+++ b/test/ws-only-text_stylesheet.xspec
@@ -256,7 +256,9 @@
 	</x:param>
 	<x:scenario
 		label="In global-param, whitespace-only text nodes in user-content are removed by default.">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 
 		<x:scenario>
 			<x:label>So, in

--- a/test/xml-base_stylesheet.xspec
+++ b/test/xml-base_stylesheet.xspec
@@ -28,7 +28,9 @@
 
 	<x:param href="test.xml" name="global-param" xml:base="node-selection/" />
 	<x:scenario label="In global-param (i.e. /x:description/x:param),">
-		<x:context />
+		<x:context>
+			<foo />
+		</x:context>
 		<x:expect label="@href is resolved with @xml:base"
 			test="$global-param instance of document-node(element(testing-xml-base))" />
 	</x:scenario>


### PR DESCRIPTION
This PR is my next attempt to clean up the mess I inadvertently made on the `schxslt` branch when trying to fix merge conflicts there. Reverting my first bad commit avoided the problem of duplicate content in the bats test case files, but created a new problem where necessary files and changes for #1780 were missing.

This PR restores the files and changes that ca0ba38d61927a16d115e7e178b3a9a2cb54bbc7 deleted -- without changing `collection.xml` or `xspec.bats`, which now have the correct content (i.e., the `bad-context/` test cases exactly once, not zero times and not twice).

### Testing Done
Locally, I ran the test suites on Windows and everything passed. I also made a copy of the branch and squashed the 3 commits to check that the result is empty. It is.

Tests passed in my fork.
https://github.com/galtm/xspec/actions/runs/7604133229

This branch in my fork has the correct content in `collection.xml`, `xspec.bats`, and the `test/bad-context` folder.
