### PR TITLE
refactor(schema): remove expand-text from empty elements

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -64,7 +64,7 @@ helper =
 	## set up by SAXON_CUSTOM_OPTIONS (CLI) or saxon.custom.options (Ant).
 	## XSLT ignores query modules. XQuery ignores stylesheets and packages.
 	element helper {
-		common-attributes,
+		xml-ns-attributes,
 		(
 			(
 				attribute stylesheet { xsd:anyURI }
@@ -88,7 +88,7 @@ import =
 	## XSpec will be run on the stylesheet that this XSpec document describes.
 	## Importing is recursive and may be circular (although only one copy of a given
 	## imported document will actually be imported).
-	element import { common-attributes,
+	element import { xml-ns-attributes,
 	## The document URI (location) of the imported document.
 	attribute href { xsd:anyURI } }
 


### PR DESCRIPTION
This PR removes the `expand-text` attribute from the schema definitions of `<x:import>` and `<x:helper>` because these empty elements can't support text value templates. If any users have XSpec code that uses `expand-text` on these two elements 
(which I expect to be unlikely), the attribute has no effect and should be removed.

### Testing Done
I validated the `.rnc` file. I validated all the `.xspec` files under `test/` and `tutorial/` on this branch and the master branch, and there are no differences between the branches. Then I modified one of the files temporarily by adding
```
<x:import expand-text="blah" href="test.xspec"/>
<x:helper expand-text="blah" stylesheet="blah.xsl"/>
```
and I got validation errors as expected:
```
error: attribute "expand-text" not allowed here; expected attribute "href" or an attribute from another namespace
```

```
error: attribute "expand-text" not allowed here; expected attribute "package-name", "package-version", "query", "query-at" or "stylesheet" or an attribute from another namespace
```