### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver from 5.2.2 to 5.2.3

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -24,4 +24,4 @@ XMLCALABASH_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.2
+XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.3


### PR DESCRIPTION
From the release notes:

>This release fixes bug https://github.com/xmlresolver/xmlresolver/issues/156 where the resolver would throw an NPE if no class loader is available.