### PR TITLE
build(maven): use BC signer, with maven-gpg-plugin 3.2.0

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -24,10 +24,10 @@ jobs:
           server-id: xspec-io.ossrh
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
-          gpg-private-key: ${{ secrets.gpg_private_key }}
 
-      - run: mvn clean deploy --batch-mode --activate-profiles release
+      - run: mvn clean deploy --batch-mode --activate-profiles release -Dgpg.signer=bc
         env:
           NEXUS_USERNAME: ${{ secrets.nexus_username }}
           NEXUS_PASSWORD: ${{ secrets.nexus_password }}
-          GPG_PASSPHRASE: ${{ secrets.gpg_passphrase }}
+          MAVEN_GPG_KEY: ${{ secrets.gpg_private_key }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.gpg_passphrase }}


### PR DESCRIPTION
Maven deployment broke when xspec repo bumped maven-gpg-plugin from 3.1.0 to 3.2.0 (#1874).
```
[INFO] Signer 'gpg' is signing 6 files
gpg: signing failed: No pinentry
gpg: signing failed: No pinentry
```
Runs that showed the same failure:
* https://github.com/xspec/xspec/actions/runs/8256289815
* https://github.com/xspec/xspec/actions/runs/8258185796

This change imitates the fix in another repo that had the "gpg: signing failed: No pinentry" error with that version of the plugin.

References:
* https://maven.apache.org/plugins-archives/maven-gpg-plugin-LATEST/examples/deploy-signed-artifacts.html#sign-using-bc-signer
* https://issues.apache.org/jira/projects/MGPG/issues/MGPG-90?filter=allopenissues (see comments in 3/2024)
* Example, https://github.com/xerial/sqlite-jdbc/pull/1082