### PR TITLE
feat: support calling XPath function defined in variable

### DIFF
--- a/src/compiler/base/combine/mode/check-combined-doc.xsl
+++ b/src/compiler/base/combine/mode/check-combined-doc.xsl
@@ -12,6 +12,11 @@
    -->
    <xsl:mode name="x:check-combined-doc" on-multiple-match="fail" on-no-match="shallow-skip" />
 
+   <xsl:template match="x:call" as="empty-sequence()" mode="x:check-combined-doc">
+      <xsl:call-template name="local:detect-call-as-variable-run-as-external" />
+      <xsl:apply-templates mode="#current"/>
+   </xsl:template>
+
    <xsl:template match="x:param" as="empty-sequence()" mode="x:check-combined-doc">
       <xsl:call-template name="local:detect-reserved-vardecl-name" />
 
@@ -79,6 +84,21 @@
                </xsl:otherwise>
             </xsl:choose>
          </xsl:if>
+      </xsl:if>
+   </xsl:template>
+
+   <!-- Reject x:call[@call-as='variable'] if @run-as=external. -->
+   <xsl:template name="local:detect-call-as-variable-run-as-external" as="empty-sequence()">
+      <xsl:context-item as="element(x:call)" use="required" />
+      
+      <xsl:if test="$is-external and @call-as eq 'variable'">
+         <xsl:message terminate="yes">
+            <xsl:call-template name="x:prefix-diag-message">
+               <xsl:with-param name="message">
+                  <xsl:text expand-text="yes">Calling a variable stored in a function is not supported when /{$initial-document/x:description => name()} has @run-as='external'.</xsl:text>
+               </xsl:with-param>
+            </xsl:call-template>
+         </xsl:message>
       </xsl:if>
    </xsl:template>
 

--- a/src/compiler/base/combine/mode/check-combined-doc.xsl
+++ b/src/compiler/base/combine/mode/check-combined-doc.xsl
@@ -90,7 +90,7 @@
    <!-- Reject x:call[@call-as='variable'] if @run-as=external. -->
    <xsl:template name="local:detect-call-as-variable-run-as-external" as="empty-sequence()">
       <xsl:context-item as="element(x:call)" use="required" />
-      
+
       <xsl:if test="$is-external and @call-as eq 'variable'">
          <xsl:message terminate="yes">
             <xsl:call-template name="x:prefix-diag-message">
@@ -158,7 +158,7 @@
       <!-- Variable declarations that the current one is allowed to override -->
       <xsl:variable name="overridable-vardecls" as="element()*" select="
             $visible-vardecls[node-name() eq node-name(current())]
-            
+
             (: Description-level variable declaration are not allowed to override another
                description-level one :)
             except $visible-description-vardecls[current()[parent::x:description]]" />

--- a/src/compiler/base/compile/compile-scenario.xsl
+++ b/src/compiler/base/compile/compile-scenario.xsl
@@ -50,6 +50,9 @@
          </xsl:variable>
 
          <xsl:value-of>
+            <xsl:if test="@call-as='variable'">
+               <xsl:text>$</xsl:text>
+            </xsl:if>
             <xsl:text expand-text="yes">{$function-uqname}(</xsl:text>
             <xsl:for-each select="x:param">
                <xsl:sort select="xs:integer(@position)" />

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -245,6 +245,10 @@ function-call =
 		common-attributes,
 		## The qualified name of the function which should get called.
 		attribute function { eqname.datatype }?,
+		## "module-function" (default) refers to an XSLT stylesheet function or XQuery module function.
+		## "variable" refers to an XPath function stored in a variable.
+		[ a:defaultValue = "module-function" ]
+		attribute call-as { "module-function" | "variable" }?,
 		function-params
 	}
 

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -146,7 +146,7 @@
 					</xsl:when>
 
 					<xsl:when test="
-							($test-type eq 't')
+							($test-type = ('s', 't'))
 							and ($pis = 'require-xslt-to-support-hof')
 							and not($XSLT-SUPPORTS-HOF)">
 						<xsl:text>Requires XSLT processor to support higher-order functions</xsl:text>

--- a/test/call-disallowed/external_function-in-variable.xspec
+++ b/test/call-disallowed/external_function-in-variable.xspec
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" stylesheet="function-in-variable.xsl"
+	xml:base="../"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:import href="function-in-variable.xspec" />
+</x:description>

--- a/test/function-in-variable.sch
+++ b/test/function-in-variable.sch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema queryBinding="xslt2"
+	xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--
+		SchXslt discards xsl:variable as of v1.9.5.
+		It allows xsl:include before patterns (schxslt/schxslt#154).
+		Declare xsl:variable indirectly via xsl:include.
+	-->
+	<xsl:include href="function-in-variable.xsl" />
+
+	<sch:pattern id="dummy-pattern">
+		<sch:rule context="element()" id="dummy-rule" />
+	</sch:pattern>
+
+</sch:schema>

--- a/test/function-in-variable.xqm
+++ b/test/function-in-variable.xqm
@@ -1,0 +1,15 @@
+module namespace fv = "x-urn:test:function-in-variable";
+
+(:
+	Returns the first and last items in a sequence.
+	If sequence has fewer than 2 items, returns sequence intact.
+:)
+declare variable $fv:first-last as function(*) :=
+    function($param-items as item()*) as item()* {
+		(head($param-items), $param-items[last()][count($param-items) gt 1])
+	};
+
+declare variable $fv:function-item as function(*) :=
+    function() as function(*) {
+        function-lookup(QName('http://www.w3.org/2005/xpath-functions','head'),1)
+    };

--- a/test/function-in-variable.xsl
+++ b/test/function-in-variable.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:fv="x-urn:test:function-in-variable"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--
+		Returns the first and last items in a sequence.
+		If sequence has fewer than 2 items, returns sequence intact.
+	-->
+	<xsl:variable name="fv:first-last" as="function(*)"
+		select="function($param-items as item()*) as item()* {
+			(head($param-items), $param-items[last()][count($param-items) gt 1])
+		}" />
+
+	<xsl:variable name="fv:function-item" as="function(*)"
+		select="function() as function(*) {
+			function-lookup(QName('http://www.w3.org/2005/xpath-functions','head'),1)
+		}" />
+</xsl:stylesheet>

--- a/test/function-in-variable.xspec
+++ b/test/function-in-variable.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test require-xquery-to-support-hof?>
+<?xspec-test require-xslt-to-support-hof?>
+<x:description
+	xmlns:fv="x-urn:test:function-in-variable"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	query="x-urn:test:function-in-variable"
+	query-at="function-in-variable.xqm"
+	schematron="function-in-variable.sch"
+	stylesheet="function-in-variable.xsl">
+
+	<x:scenario label="Calling 1-parameter function stored in a variable">
+		<x:call call-as="variable" function="fv:first-last">
+			<x:param select="(10, 20, 30)"/>
+		</x:call>
+		<x:expect label="works; in this case, returns first and last items"
+			select="(10, 30)" />
+	</x:scenario>
+
+	<x:scenario label="Calling 0-parameter function stored in a variable">
+		<x:call call-as="variable" function="fv:function-item" />
+		<x:expect label="works; in this case, returns a function item that can be applied"
+			test="$x:result( (10, 20, 30) )"
+			select="10" />
+	</x:scenario>
+</x:description>

--- a/test/function-in-variable.xspec
+++ b/test/function-in-variable.xspec
@@ -23,4 +23,48 @@
 			test="$x:result( (10, 20, 30) )"
 			select="10" />
 	</x:scenario>
+
+	<x:scenario label="Test inheritance and override of @call-as">
+		<x:scenario label="Inheriting call-as='variable'">
+			<x:call call-as="variable" />
+			<x:scenario label="should work">
+				<x:call function="fv:first-last">
+					<x:param select="1" />
+				</x:call>
+				<x:like label="check function call result" />
+			</x:scenario>
+		</x:scenario>
+		<x:scenario label="Overriding call-as='module-function' with 'variable'">
+			<x:call function="fv:first-last" call-as="module-function">
+				<x:param select="1" />
+			</x:call>
+			<x:scenario label="should work">
+				<x:call call-as="variable" />
+				<x:like label="check function call result" />
+			</x:scenario>
+		</x:scenario>
+		<x:scenario label="Inheriting call-as='module-function'">
+			<x:call call-as="module-function" />
+			<x:scenario label="should work">
+				<x:call function="exactly-one">
+					<x:param select="1" />
+				</x:call>
+				<x:like label="check function call result" />
+			</x:scenario>
+		</x:scenario>
+		<x:scenario label="Overriding call-as='variable' with 'module-function'">
+			<x:call function="exactly-one" call-as="variable">
+				<x:param select="1" />
+			</x:call>
+			<x:scenario label="should work">
+				<x:call call-as="module-function" />
+				<x:like label="check function call result" />
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
+
+	<x:scenario shared="yes" label="check function call result">
+		<x:expect label="function returns 1" select="1" />
+	</x:scenario>
+
 </x:description>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2454,6 +2454,17 @@
 	</case>
 
 	<!--
+		Calling function stored in variable not allowed
+	-->
+
+	<case name="Calling function stored in variable not allowed (XSLT with @run-as=external)">
+    call :run ..\bin\xspec.bat -t call-disallowed\external_function-in-variable.xspec
+    call :verify_retval 2
+    call :verify_line  5 x "ERROR in x:call (under 'Calling 1-parameter function stored in a variable'): Calling a variable stored in a function is not supported when /x:description has @run-as='external'."
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+
+	<!--
 		Static param not allowed
 	-->
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2616,6 +2616,17 @@ load bats-helper
 }
 
 #
+# Calling function stored in variable not allowed
+#
+
+@test "Calling function stored in variable not allowed (XSLT with @run-as=external)" {
+    myrun ../bin/xspec.sh -t call-disallowed/external_function-in-variable.xspec
+    [ "$status" -eq 1 ]
+    [ "${lines[4]}" = "ERROR in x:call (under 'Calling 1-parameter function stored in a variable'): Calling a variable stored in a function is not supported when /x:description has @run-as='external'." ]
+    [ "${lines[${#lines[@]} - 1]}" = "*** Error compiling the test suite" ]
+}
+
+#
 # Static param not allowed
 #
 


### PR DESCRIPTION
This PR adds support for `<x:call function="..." call-as="variable">` so that a scenario can test a function that is stored in an XSLT variable or XQuery variable. This design is like [AirQuick's suggestion](https://github.com/xspec/xspec/issues/1748#issuecomment-1849008579) except that the new attribute is named `call-as` instead of `type`. Thanks for the suggestion, @AirQuick !

If the `call-as` attribute is missing, the default value of `"module-function"` provides the usual `x:call[@function]` behavior.

### Limitations

- Not supported when the test has `x:description/@run-as="external"`. External transformations use the `transform` XPath function, and I believe that function's `'initial-function'` option must point to a module function rather than a variable.
- Requires Saxon 10 or later, or Saxon 9.9 EE or PE. (XSpec is on the verge of dropping support for Saxon 9.9 anyway, though.)

---

Closes #1748 