### PR TITLE
build(oxygen): add-on v3.0.1

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,18 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.0.1</h3>
+				<ul>
+					<li>feat(schematron): SchXslt 1.9.5 replaces skeleton implementation</li>
+					<li>feat(schematron): verification of messages (<a href="https://github.com/xspec/xspec/pull/1822"
+							>#1822</a>)</li>
+					<li>feat: syntax to ignore some or all attributes (<a href="https://github.com/xspec/xspec/pull/1838"
+							>#1838</a>)</li>
+					<li>feat: experimental support for XSLT/XQuery/XPath 4.0 (<a href="https://github.com/xspec/xspec/pull/1883"
+							>#1883</a>)</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.0.0</h3>
 				<ul>
 					<li>Initial development version of v3.0</li>
@@ -73,18 +85,6 @@
 				<ul>
 					<li>fix(schematron): handle location attribute not pointing to one node (<a
 							href="https://github.com/xspec/xspec/pull/1506">#1506</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.2.1</h3>
-				<ul>
-					<li>feat: multi-threading (<a href="https://github.com/xspec/xspec/pull/1497"
-							>#1497</a>)</li>
-					<li>feat(xslt): context for function-call (<a
-							href="https://github.com/xspec/xspec/pull/1503">#1503</a>)</li>
-					<li>feat: <code>/x:description/@result-file-threshold</code> (<a
-							href="https://github.com/xspec/xspec/pull/1500">#1500</a>)</li>
-					<li>Fully tested with SchXslt 1.7.4</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/31cde537d99719a0049994a1da187ccd5a4b9763.zip" />
+			href="https://github.com/xspec/xspec/archive/437e1e80e79262acf844ddf4a6f6c9dd25dcbbf6.zip" />
 
-		<xt:version>3.0.0</xt:version>
+		<xt:version>3.0.1</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-31cde537d99719a0049994a1da187ccd5a4b9763/xspec.framework/XSpec</String>
+                                    <String>4/xspec-437e1e80e79262acf844ddf4a6f6c9dd25dcbbf6/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This v3.0.1 add-on has most of the changes we expect to be in XSpec v3.0, but it excludes the XSLT Code Coverage upgrade.

The next add-on version will include the XSLT Code Coverage upgrade. Creating separate add-on versions might make it easier for users to compare the old and new functionality.

I tested this change in Oxygen 26.0 build 2023100905 using `https://github.com/galtm/xspec/raw/oxygen-3.0.1/oxygen-addon.xml`. The transformation scenarios work, except that the XSLT Code Coverage scenario produces a mostly blank report that says "not used". This result is expected for this add-on because it doesn't include the changes from #1833.