### PR TITLE
refactor: drop support for Saxon 9.9

### DIFF
--- a/src/common/report-sequence.xqm
+++ b/src/common/report-sequence.xqm
@@ -140,7 +140,7 @@ declare %private function rep:report-pseudo-item(
         { QName($report-namespace, ($local-name-prefix || rep:node-type($item))) }
         { rep:report-node($item) }
 
-    else if (rep:instance-of-function($item)) then
+    else if ($item instance of function(*)) then
       element
         { QName($report-namespace, ($local-name-prefix || rep:function-type($item))) }
         { rep:serialize-adaptive($item) }
@@ -367,38 +367,12 @@ declare function rep:node-type(
 };
 
 (:
-  Returns true if item is function (including map and array).
-
-  Alternative to "instance of function(*)" which is not widely available.
-
-  This function should be %private. But ../../test/report-sequence.xspec requires this to be exposed.
-:)
-declare function rep:instance-of-function(
-  $item as item()
-) as xs:boolean
-{
-  if (($item instance of array(*)) or ($item instance of map(*))) then
-    true()
-  else
-    (: TODO: Enable this 'if' when function(*) is made available on all the supported XQuery processors :)
-    (:
-    if ($item instance of function(*)) then
-      true()
-    else
-    :)
-    false()
-};
-
-(:
   Returns type of function (including map and array).
-
-  $function must be an instance of function(*).
 
   This function should be %private. But ../../test/report-sequence.xspec requires this to be exposed.
 :)
 declare function rep:function-type(
-  (: TODO: "as function(*)" :)
-  $function as item()
+  $function as function(*)
 ) as xs:string
 {
   typeswitch ($function)

--- a/src/common/report-sequence.xsl
+++ b/src/common/report-sequence.xsl
@@ -194,7 +194,7 @@
             </xsl:element>
          </xsl:when>
 
-         <xsl:when test="rep:instance-of-function($item)">
+         <xsl:when test="$item instance of function(*)">
             <xsl:element name="{$local-name-prefix}{rep:function-type($item)}"
                namespace="{$report-namespace}">
                <xsl:value-of select="local:serialize-adaptive($item)" />
@@ -470,44 +470,14 @@
    </xsl:function>
 
    <!--
-      Returns true if item is function (including map and array).
-
-      Alternative to "instance of function(*)" which is not widely available.
-
-      This function should be local:. But ../../test/report-sequence.xspec requires this to be
-      exposed.
-   -->
-   <xsl:function as="xs:boolean" name="rep:instance-of-function">
-      <xsl:param as="item()" name="item" />
-
-      <xsl:choose>
-         <xsl:when test="($item instance of array(*)) or ($item instance of map(*))">
-            <xsl:sequence select="true()" />
-         </xsl:when>
-
-         <xsl:when test="$item instance of function(*)"
-            use-when="function-available('function-lookup')">
-            <xsl:sequence select="true()" />
-         </xsl:when>
-
-         <xsl:otherwise>
-            <xsl:sequence select="false()" />
-         </xsl:otherwise>
-      </xsl:choose>
-   </xsl:function>
-
-   <!--
       Returns type of function (including map and array).
-
-      $function must be an instance of function(*).
 
       This function should be local:. But ../../test/report-sequence.xspec requires this to be
       exposed.
    -->
    <xsl:function as="xs:string" name="rep:function-type">
 
-      <!-- TODO: @as="function(*)" -->
-      <xsl:param as="item()" name="function" />
+      <xsl:param as="function(*)" name="function" />
 
       <xsl:choose>
          <xsl:when test="$function instance of array(*)">array</xsl:when>

--- a/src/compiler/xslt/main.xsl
+++ b/src/compiler/xslt/main.xsl
@@ -138,28 +138,9 @@
             <!-- Use xsl:result-document/@format to avoid clashes with <xsl:output> in the stylesheet
                being tested which would otherwise govern the output of the report XML. -->
             <xsl:element name="xsl:result-document" namespace="{$x:xsl-namespace}">
-               <xsl:choose>
-                  <xsl:when test="$x:saxon-version lt x:pack-version((9, 9, 1, 1))">
-                     <!-- Workaround for a Saxon bug: https://saxonica.plan.io/issues/4093 -->
-
-                     <!-- Create a temp XSpec namespace node, because non-zero-length XSpec prefix
-                        is not always available here. Any non-zero-length non-xsl prefix will do,
-                        because the temp namespace node is only for the xsl:result-document element -->
-                     <xsl:variable name="temp-prefix" as="xs:string"
-                        select="'workaround-for-saxon-bug-4093'" />
-                     <xsl:namespace name="{$temp-prefix}" select="$x:xspec-namespace" />
-
-                     <xsl:attribute name="format"
-                        select="$temp-prefix || ':xml-report-serialization-parameters'" />
-                  </xsl:when>
-
-                  <xsl:otherwise>
-                     <!-- Escape curly braces because @format is AVT -->
-                     <xsl:attribute name="format"
-                        select="'Q{{' || $x:xspec-namespace || '}}xml-report-serialization-parameters'" />
-                  </xsl:otherwise>
-               </xsl:choose>
-
+               <!-- Escape curly braces because @format is AVT -->
+               <xsl:attribute name="format"
+                  select="'Q{{' || $x:xspec-namespace || '}}xml-report-serialization-parameters'" />
                <xsl:element name="xsl:element" namespace="{$x:xsl-namespace}">
                   <xsl:attribute name="name" select="'report'" />
                   <xsl:attribute name="namespace" select="$x:xspec-namespace" />

--- a/test/ant/build.xml
+++ b/test/ant/build.xml
@@ -29,17 +29,6 @@
 		</condition>
 		<echo message="xslt.supports.schema=${xslt.supports.schema}" />
 
-		<!-- Checks to see if XSLT processor supports higher-order functions -->
-		<java classname="net.sf.saxon.Transform" classpath="${java.class.path}" fork="true"
-			resultproperty="xslt.hof.compile.result">
-			<arg value="-nogo" />
-			<arg value="-xsl:${run-xspec-tests.basedir}/../caps/hof.xsl" />
-		</java>
-		<condition else="false" property="xslt.supports.hof">
-			<equals arg1="${xslt.hof.compile.result}" arg2="0" />
-		</condition>
-		<echo message="xslt.supports.hof=${xslt.supports.hof}" />
-
 		<!-- Checks to see if XSLT processor supports Java type -->
 		<java classname="net.sf.saxon.Transform" classpath="${java.class.path}" fork="true"
 			resultproperty="xslt.jref.compile.result">
@@ -73,16 +62,6 @@
 		</condition>
 		<echo message="xquery.supports.schema=${xquery.supports.schema}" />
 
-		<!-- Checks to see if XQuery processor supports higher-order functions -->
-		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
-			resultproperty="xquery.hof.run.result">
-			<arg value="-q:${run-xspec-tests.basedir}/../caps/hof.xq" />
-		</java>
-		<condition else="false" property="xquery.supports.hof">
-			<equals arg1="${xquery.hof.run.result}" arg2="0" />
-		</condition>
-		<echo message="xquery.supports.hof=${xquery.supports.hof}" />
-
 		<!-- Checks to see if XQuery processor supports Java type -->
 		<java classname="net.sf.saxon.Query" classpath="${java.class.path}" fork="true"
 			resultproperty="xquery.jref.run.result">
@@ -111,13 +90,11 @@
 			<param expression="${xspecfiles.dir.url}" name="XSPECFILES-DIR-URI" />
 			<param expression="${xspecfiles.dir.url.query}" name="XSPECFILES-DIR-URI-QUERY" />
 			<param expression="${xslt.supports.schema}" name="XSLT-SUPPORTS-SCHEMA" type="BOOLEAN" />
-			<param expression="${xslt.supports.hof}" name="XSLT-SUPPORTS-HOF" type="BOOLEAN" />
 			<param expression="${xslt.supports.jref}" name="XSLT-SUPPORTS-JREF" type="BOOLEAN" />
 			<param expression="${xslt.supports.timestamp}" name="XSLT-SUPPORTS-TIMESTAMP"
 				type="BOOLEAN" />
 			<param expression="${xquery.supports.schema}" name="XQUERY-SUPPORTS-SCHEMA"
 				type="BOOLEAN" />
-			<param expression="${xquery.supports.hof}" name="XQUERY-SUPPORTS-HOF" type="BOOLEAN" />
 			<param expression="${xquery.supports.jref}" name="XQUERY-SUPPORTS-JREF" type="BOOLEAN" />
 			<param expression="${xquery.supports.timestamp}" name="XQUERY-SUPPORTS-TIMESTAMP"
 				type="BOOLEAN" />

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -225,25 +225,6 @@
 					</xsl:when>
 
 					<xsl:when test="
-							($pis = 'require-saxon-bug-4315-fixed')
-							and ($x:saxon-version ge x:pack-version((9, 9)))
-							and ($x:saxon-version le x:pack-version((9, 9, 1, 6)))">
-						<xsl:text>Requires Saxon bug #4315 to have been fixed</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
-							($pis = 'require-saxon-bug-4376-fixed')
-							and ($x:saxon-version le x:pack-version((9, 9, 1, 5)))">
-						<xsl:text>Requires Saxon bug #4376 to have been fixed</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
-							($pis = 'require-saxon-bug-4471-fixed')
-							and ($x:saxon-version lt x:pack-version((9, 9, 1, 7)))">
-						<xsl:text>Requires Saxon bug #4471 to have been fixed</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
 							($pis = 'require-saxon-bug-4483-fixed')
 							and ($x:saxon-version eq x:pack-version((10, 0)))">
 						<xsl:text>Requires Saxon bug #4483 to have been fixed</xsl:text>
@@ -253,13 +234,9 @@
 							($pis = 'require-saxon-bug-4621-fixed')
 							and
 							(
-							(
 							($x:saxon-version ge x:pack-version(10))
 							and
 							($x:saxon-version le x:pack-version((10, 1)))
-							)
-							or
-							($x:saxon-version le x:pack-version((9, 9, 1, 7)))
 							)">
 						<xsl:text>Requires Saxon bug #4621 to have been fixed</xsl:text>
 					</xsl:when>

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -23,13 +23,11 @@
 
 	<!-- XSLT processor capabilities -->
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-SCHEMA" required="yes" />
-	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-HOF" required="yes" />
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-JREF" required="yes" />
 	<xsl:param as="xs:boolean" name="XSLT-SUPPORTS-TIMESTAMP" required="yes" />
 
 	<!-- XQuery processor capabilities -->
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-SCHEMA" required="yes" />
-	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-HOF" required="yes" />
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-JREF" required="yes" />
 	<xsl:param as="xs:boolean" name="XQUERY-SUPPORTS-TIMESTAMP" required="yes" />
 
@@ -147,13 +145,6 @@
 					</xsl:when>
 
 					<xsl:when test="
-							($test-type = ('s', 't'))
-							and ($pis = 'require-xslt-to-support-hof')
-							and not($XSLT-SUPPORTS-HOF)">
-						<xsl:text>Requires XSLT processor to support higher-order functions</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
 							($test-type eq 't')
 							and ($pis = 'require-xslt-to-support-jref')
 							and not($XSLT-SUPPORTS-JREF)">
@@ -190,13 +181,6 @@
 							and ($pis = 'require-xquery-to-support-schema')
 							and not($XQUERY-SUPPORTS-SCHEMA)">
 						<xsl:text>Requires schema-aware XQuery processor</xsl:text>
-					</xsl:when>
-
-					<xsl:when test="
-							($test-type eq 'q')
-							and ($pis = 'require-xquery-to-support-hof')
-							and not($XQUERY-SUPPORTS-HOF)">
-						<xsl:text>Requires XQuery processor to support higher-order functions</xsl:text>
 					</xsl:when>
 
 					<xsl:when test="

--- a/test/catalog/01/imported-xspec-uri.xspec
+++ b/test/catalog/01/imported-xspec-uri.xspec
@@ -15,10 +15,11 @@
 	<t:scenario label="$x:xspec-uri defined and checked in imported file">
 		<t:call function="true" />
 		<!-- Verification fails when this test file runs but
-			passes when the importing file, xspec-uri.xspec, runs.	-->
+			passes when the importing file, xspec-uri.xspec, runs. -->
 		<t:expect label="should be top-level .xspec file that is running"
-			test="ends-with($im:xspec-uri-in-global-var, '/catalog-01_xspec-uri.xspec')
-			or ends-with($im:xspec-uri-in-global-var, '/xspec-uri.xspec')" />
+			test="('/catalog-01_xspec-uri.xspec','/xspec-uri.xspec')
+			=> filter(ends-with($im:xspec-uri-in-global-var,?))
+			=> exists()" />
 	</t:scenario>
 
 	<t:scenario label="Store $x:xspec-uri in variable in imported file" shared="yes">

--- a/test/ci/build_install-deps.xml
+++ b/test/ci/build_install-deps.xml
@@ -59,23 +59,16 @@
 			<!-- Saxon 9 and 10 have no target files -->
 			<matches pattern="^(9|10)\." string="${env.SAXON_VERSION}" />
 		</condition>
-		<condition property="saxon.has.lib">
-			<!-- Saxon 9 has no lib/ subdirectory -->
-			<not>
-				<matches pattern="^9\." string="${env.SAXON_VERSION}" />
-			</not>
-		</condition>
 		<condition property="saxon.xmlresolverorg-xmlresolver.jar.count.ok">
 			<resourcecount count="${saxon.xmlresolverorg-xmlresolver.jar.count.expected}">
-				<fileset dir="${saxon.jar.dir}/lib/" erroronmissingdir="${saxon.has.lib}"
+				<fileset dir="${saxon.jar.dir}/lib/"
 					id="saxon.xmlresolverorg-xmlresolver.jar" includes="xmlresolver-*.jar" />
 			</resourcecount>
 		</condition>
 		<fail message="Failed to identify XMLResolver.org XML Resolver jar in Saxon lib dir"
 			unless="saxon.xmlresolverorg-xmlresolver.jar.count.ok" />
 		<delete verbose="true">
-			<fileset erroronmissingdir="${saxon.has.lib}"
-				refid="saxon.xmlresolverorg-xmlresolver.jar" />
+			<fileset refid="saxon.xmlresolverorg-xmlresolver.jar" />
 		</delete>
 	</target>
 

--- a/test/ci/set-env.cmd
+++ b/test/ci/set-env.cmd
@@ -49,11 +49,8 @@ rem
 set "SAXON_JAR=%XSPEC_TEST_DEPS%\saxon-%SAXON_VERSION%"
 
 rem Keep the original (not Maven) file name convention so that we can test SAXON_HOME properly
-if "%SAXON_VERSION:~0,2%"=="9." (
-    set "SAXON_JAR=%SAXON_JAR%\saxon9he.jar"
-) else (
-    set "SAXON_JAR=%SAXON_JAR%\saxon-he-%SAXON_VERSION%.jar"
-)
+set "SAXON_JAR=%SAXON_JAR%\saxon-he-%SAXON_VERSION%.jar"
+
 
 rem
 rem Apache XML Resolver jar

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -70,11 +70,8 @@ export PATH="${ant_bin}:${PATH}"
 SAXON_JAR="${XSPEC_TEST_DEPS}/saxon-${SAXON_VERSION}"
 
 # Keep the original (not Maven) file name convention so that we can test SAXON_HOME properly
-if [ "${SAXON_VERSION:0:2}" = "9." ]; then
-    export SAXON_JAR="${SAXON_JAR}/saxon9he.jar"
-else
-    export SAXON_JAR="${SAXON_JAR}/saxon-he-${SAXON_VERSION}.jar"
-fi
+export SAXON_JAR="${SAXON_JAR}/saxon-he-${SAXON_VERSION}.jar"
+
 
 #
 # Apache XML Resolver jar

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -72,7 +72,6 @@ SAXON_JAR="${XSPEC_TEST_DEPS}/saxon-${SAXON_VERSION}"
 # Keep the original (not Maven) file name convention so that we can test SAXON_HOME properly
 export SAXON_JAR="${SAXON_JAR}/saxon-he-${SAXON_VERSION}.jar"
 
-
 #
 # Apache XML Resolver jar
 #

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -79,7 +79,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">xs:integer#1</span>&lt;/pseudo-other&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-function</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">xs:integer#1</span>&lt;/pseudo-function&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>
@@ -124,7 +124,7 @@
                      <tr>
                         <td>
                            <p>XPath <code class="diff">/*</code> from:</p>
-                           <pre>&lt;<span class="diff">pseudo-other</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">(anonymous-function)#1</span>&lt;/pseudo-other&gt;</pre>
+                           <pre>&lt;<span class="diff">pseudo-function</span> <span class="xmlns trivial">xmlns="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">(anonymous-function)#1</span>&lt;/pseudo-function&gt;</pre>
                         </td>
                         <td>
                            <pre>()</pre>

--- a/test/end-to-end/cases/expected/query/issue-355-result.xml
+++ b/test/end-to-end/cases/expected/query/issue-355-result.xml
@@ -15,7 +15,7 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec">xs:integer#1</pseudo-other>
+            <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">xs:integer#1</pseudo-function>
          </content-wrap>
       </result>
       <test id="scenario1-expect1" successful="false">
@@ -34,7 +34,7 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-other xmlns="http://www.jenitennison.com/xslt/xspec">(anonymous-function)#1</pseudo-other>
+            <pseudo-function xmlns="http://www.jenitennison.com/xslt/xspec">(anonymous-function)#1</pseudo-function>
          </content-wrap>
       </result>
       <test id="scenario2-expect1" successful="false">

--- a/test/end-to-end/cases/expected/query/three-dots-result.xml
+++ b/test/end-to-end/cases/expected/query/three-dots-result.xml
@@ -4,11 +4,9 @@
         query="x-urn:test:three-dots"
         query-at="../../three-dots.xqm"
         date="2000-01-01T00:00:00Z">
-   <scenario id="scenario1"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario1" xspec="../../three-dots.xspec">
       <label>For resultant element (simple)</label>
-      <scenario id="scenario1-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario1-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;elem&gt;text&lt;/elem&gt;
 				</label>
@@ -45,8 +43,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario1-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario1-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;elem /&gt;
 				</label>
@@ -89,8 +86,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario1-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario1-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;elem&gt;...&lt;/elem&gt;
 				</label>
@@ -139,11 +135,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario2"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario2" xspec="../../three-dots.xspec">
       <label>For resultant element (with attribute)</label>
-      <scenario id="scenario2-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario2-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;elem attrib="val" /&gt;
 				</label>
@@ -219,11 +213,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario3"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario3" xspec="../../three-dots.xspec">
       <label>For resultant element (with mixed content)</label>
-      <scenario id="scenario3-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario3-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;outer&gt;text&lt;inner1 /&gt;&lt;inner2 /&gt;&lt;/outer&gt;
 				</label>
@@ -275,8 +267,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario3-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario3-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;outer&gt;&lt;inner /&gt;&lt;/outer&gt;
 				</label>
@@ -324,11 +315,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario4"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario4" xspec="../../three-dots.xspec">
       <label>For resultant attribute</label>
-      <scenario id="scenario4-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario4-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 						 @attrib="val"
 				</label>
@@ -388,8 +377,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario4-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario4-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 						 @attrib=""
 				</label>
@@ -430,8 +418,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario4-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario4-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
 						 @attrib="..."
 				</label>
@@ -489,11 +476,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario5"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario5" xspec="../../three-dots.xspec">
       <label>For resultant text node</label>
-      <scenario id="scenario5-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario5-scenario1" xspec="../../three-dots.xspec">
          <label>When result is usual text node</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -516,8 +501,7 @@
             <expect select="'...'"/>
          </test>
       </scenario>
-      <scenario id="scenario5-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario5-scenario2" xspec="../../three-dots.xspec">
          <label>When result is whitespace-only text node</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -546,8 +530,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario5-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario5-scenario3" xspec="../../three-dots.xspec">
          <label>When result is zero-length text node</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -574,8 +557,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario5-scenario4"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario5-scenario4" xspec="../../three-dots.xspec">
          <label>When result is three-dot text node</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -605,11 +587,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario6"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario6" xspec="../../three-dots.xspec">
       <label>For resultant comment</label>
-      <scenario id="scenario6-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario6-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;!--comment--&gt;
 				</label>
@@ -638,8 +618,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario6-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario6-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;!----&gt;
 				</label>
@@ -662,8 +641,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario6-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario6-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;!--...--&gt;
 				</label>
@@ -701,11 +679,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario7"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario7" xspec="../../three-dots.xspec">
       <label>For resultant processing instruction</label>
-      <scenario id="scenario7-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario7-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;?pi data?&gt;
 				</label>
@@ -734,8 +710,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario7-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario7-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;?pi?&gt;
 				</label>
@@ -758,8 +733,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario7-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario7-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
 					&lt;?pi ...?&gt;
 				</label>
@@ -797,11 +771,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario8"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario8" xspec="../../three-dots.xspec">
       <label>For resultant document node</label>
-      <scenario id="scenario8-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario8-scenario1" xspec="../../three-dots.xspec">
          <label>When result is document node containing
 														 &lt;?pi?&gt;&lt;!--comment--&gt;&lt;elem /&gt;
 				</label>
@@ -833,8 +805,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario8-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario8-scenario2" xspec="../../three-dots.xspec">
          <label>When result is document node containing nothing</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -860,8 +831,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario8-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario8-scenario3" xspec="../../three-dots.xspec">
          <label>When result is document node containing ...</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -893,11 +863,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario9"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario9" xspec="../../three-dots.xspec">
       <label>For resultant namespace node</label>
-      <scenario id="scenario9-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario9-scenario1" xspec="../../three-dots.xspec">
          <label>When result is
 				xmlns:prefix="namespace-uri"
 				</label>
@@ -931,8 +899,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario9-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario9-scenario2" xspec="../../three-dots.xspec">
          <label>When result is
 				xmlns="namespace-uri"
 				</label>
@@ -966,8 +933,7 @@
             </expect>
          </test>
       </scenario>
-      <scenario id="scenario9-scenario3"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario9-scenario3" xspec="../../three-dots.xspec">
          <label>When result is
 				xmlns:prefix="..."
 				</label>
@@ -1012,11 +978,9 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario10"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario10" xspec="../../three-dots.xspec">
       <label>For resultant sequence of multiple nodes</label>
-      <scenario id="scenario10-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario10-scenario1" xspec="../../three-dots.xspec">
          <label>When result is sequence of
 					&lt;elem1 /&gt;&lt;elem2 /&gt;
 				</label>
@@ -1074,8 +1038,7 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario11"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario11" xspec="../../three-dots.xspec">
       <label>When result is empty sequence</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -1092,11 +1055,9 @@
          </expect>
       </test>
    </scenario>
-   <scenario id="scenario12"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario12" xspec="../../three-dots.xspec">
       <label>For resultant atomic value</label>
-      <scenario id="scenario12-scenario1"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario12-scenario1" xspec="../../three-dots.xspec">
          <label>When result is 'string'</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -1121,8 +1082,7 @@
             <expect select="'...'"/>
          </test>
       </scenario>
-      <scenario id="scenario12-scenario2"
-                xspec="../../three-dots.xspec">
+      <scenario id="scenario12-scenario2" xspec="../../three-dots.xspec">
          <label>When result is '...'</label>
          <input-wrap xmlns="">
             <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -1148,8 +1108,7 @@
          </test>
       </scenario>
    </scenario>
-   <scenario id="scenario13"
-             xspec="../../three-dots.xspec">
+   <scenario id="scenario13" xspec="../../three-dots.xspec">
       <label>For any resultant item</label>
       <input-wrap xmlns="">
          <x:call xmlns:x="http://www.jenitennison.com/xslt/xspec"

--- a/test/end-to-end/cases/issue-355.xspec
+++ b/test/end-to-end/cases/issue-355.xspec
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test require-xquery-to-support-hof?>
-<?xspec-test require-xslt-to-support-hof?>
 <x:description query="x-urn:test:mirror" query-at="../../mirror.xqm"
 	stylesheet="../../mirror.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/test/end-to-end/cases/issue-778_ws.xspec
+++ b/test/end-to-end/cases/issue-778_ws.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test require-saxon-bug-4315-fixed?>
 <x:description stylesheet="issue-778_ws.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
     <!-- https://github.com/xspec/xspec/issues/778#issuecomment-595101817 -->
 

--- a/test/external_xslt-package_arith_use-1.xspec
+++ b/test/external_xslt-package_arith_use-1.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xspec-test require-saxon-bug-4471-fixed?>
 <x:description run-as="external" stylesheet="xslt-package/arith/use-1.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">

--- a/test/external_xslt-package_arith_use-2.xspec
+++ b/test/external_xslt-package_arith_use-2.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xspec-test require-saxon-bug-4471-fixed?>
 <x:description run-as="external" stylesheet="xslt-package/arith/use-2.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 

--- a/test/external_xslt-package_filter_use.xspec
+++ b/test/external_xslt-package_filter_use.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xspec-test require-saxon-bug-4471-fixed?>
 <x:description run-as="external" stylesheet="xslt-package/filter/use.xsl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 

--- a/test/function-in-variable.xspec
+++ b/test/function-in-variable.xspec
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test require-xquery-to-support-hof?>
-<?xspec-test require-xslt-to-support-hof?>
 <x:description
 	xmlns:fv="x-urn:test:function-in-variable"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec"

--- a/test/issue-638.xspec
+++ b/test/issue-638.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test require-saxon-bug-4315-fixed?>
 <x:description stylesheet="issue-638.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
 	<x:scenario label="Regardless of xsl:output in the stylesheet being tested">
 		<x:context>

--- a/test/issue-700.xspec
+++ b/test/issue-700.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xspec-test require-saxon-bug-4376-fixed?>
 <x:description
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns="http://www.w3.org/1999/xhtml"

--- a/test/report-sequence.xspec
+++ b/test/report-sequence.xspec
@@ -1140,44 +1140,6 @@
       </x:scenario>
    </x:scenario>
 
-   <x:scenario label="Scenario for testing function instance-of-function">
-      <x:call function="rep:instance-of-function" />
-
-      <x:scenario label="Node">
-         <x:call>
-            <x:param>
-               <e />
-            </x:param>
-         </x:call>
-         <x:expect label="False" select="false()" />
-      </x:scenario>
-
-      <x:scenario label="Atomic value">
-         <x:call>
-            <x:param select="1" />
-         </x:call>
-         <x:expect label="False" select="false()" />
-      </x:scenario>
-
-      <x:scenario label="function(*)">
-         <x:scenario label="Array">
-            <x:call>
-               <x:param select="[ 0, 1 ]" />
-            </x:call>
-            <x:expect label="True" select="true()" />
-         </x:scenario>
-
-         <x:scenario label="Map">
-            <x:call>
-               <x:param select="map { 0: 1 }" />
-            </x:call>
-            <x:expect label="True" select="true()" />
-         </x:scenario>
-
-         <!-- Function (excluding map and array) is tested in report-sequence_stylesheet_hof.xspec -->
-      </x:scenario>
-   </x:scenario>
-
    <x:scenario label="Scenario for testing function function-type">
       <x:call function="rep:function-type" />
 

--- a/test/report-sequence_stylesheet_hof.xspec
+++ b/test/report-sequence_stylesheet_hof.xspec
@@ -7,17 +7,6 @@
 		compiler. You don't need to specify it in /x:description/@stylesheet.
 	-->
 
-	<x:scenario label="Scenario for testing function instance-of-function">
-		<!-- array(*) and map(*) are tested in report-sequence.xspec -->
-
-		<x:scenario label="Function (excluding map and array)">
-			<x:call function="rep:instance-of-function">
-				<x:param select="xs:QName('xs:integer') => function-lookup(1)" />
-			</x:call>
-			<x:expect label="True" select="true()" />
-		</x:scenario>
-	</x:scenario>
-
 	<x:scenario label="Scenario for testing function function-type">
 		<!-- array(*) and map(*) are tested in report-sequence.xspec -->
 

--- a/test/report-sequence_stylesheet_hof.xspec
+++ b/test/report-sequence_stylesheet_hof.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xspec-test require-xslt-to-support-hof?>
 <x:description stylesheet="do-nothing.xsl" xmlns:rep="urn:x-xspec:common:report-sequence"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 

--- a/test/version-utils.xspec
+++ b/test/version-utils.xspec
@@ -4,12 +4,12 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<x:scenario label="Scenario for testing variable saxon-version">
-		<x:scenario label="Assume we test this on Saxon versions from 9.9 to 12.x">
+		<x:scenario label="Assume we test this on Saxon versions from 10.9 to 12.x">
 			<x:context>
 				<foo />
 			</x:context>
-			<x:expect label="Greater than or equal to 9.9.0.0"
-				test="$x:saxon-version ge x:pack-version((9, 9))" />
+			<x:expect label="Greater than or equal to 10.9"
+				test="$x:saxon-version ge x:pack-version((10, 9))" />
 			<x:expect label="Less than 13.0" test="$x:saxon-version lt x:pack-version(13)" />
 			<x:expect
 				label="Lower uint32 should be zero on Saxon 10+ (two-part version numbers rather than four-part)"

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -809,7 +809,7 @@
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
     call :verify_line_count 2
-    call :verify_line 2 r "..*:passed: 132 / pending: 0 / failed: 0 / total: 132"
+    call :verify_line 2 r "..*:passed: 128 / pending: 0 / failed: 0 / total: 128"
 
     rem HTML report file should be created and its charset should be UTF-8 #72
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1374,7 +1374,7 @@
     call :copy "%SAXON_JAR%" "%SAXON_HOME%"
 
     rem Apache XML Resolver
-    if not "%SAXON_VERSION:~0,2%"=="9." if not "%SAXON_VERSION:~0,3%"=="10." set APACHE_XMLRESOLVER_JAR=
+    if not "%SAXON_VERSION:~0,3%"=="10." set APACHE_XMLRESOLVER_JAR=
     if defined APACHE_XMLRESOLVER_JAR (
         call :copy "%APACHE_XMLRESOLVER_JAR%" "%SAXON_HOME%\xml-resolver-1.2.jar"
     )
@@ -2060,11 +2060,11 @@
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
 
-    if not "%SAXON_VERSION:~0,3%"=="12." if not "%SAXON_VERSION:~0,2%"=="9." (
+    if not "%SAXON_VERSION:~0,3%"=="12." (
         call :verify_line 4 x "WARNING: Saxon version 12.3 or earlier is not recommended. Consider migrating to Saxon 12.4 or later."
     ) else if "%SAXON_VERSION:~0,4%"=="12.3" (
         call :verify_line 4 x "WARNING: Saxon version 12.3 or earlier is not recommended. Consider migrating to Saxon 12.4 or later."
-    ) else if not "%SAXON_VERSION:~0,2%"=="9." (
+    ) else (
         call :verify_line 4 x "Checking for deprecated Saxon versions: Passed"
     )
 

--- a/test/xspec-uri.xspec
+++ b/test/xspec-uri.xspec
@@ -9,8 +9,10 @@
 	xmlns:t="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<t:variable name="local:end-of-uri" as="xs:string"
-		select="'/test/xspec-uri.xspec'" />
+	<t:variable name="local:check-end-of-uri" as="function(*)"
+		select="function($u as xs:anyURI) as xs:boolean {
+		ends-with($u, '/test/xspec-uri.xspec')
+		}" />
 
 	<t:scenario label="$x:xspec-uri in x:call/x:param">
 		<t:call function="exactly-one">
@@ -18,22 +20,22 @@
 		</t:call>
 		<t:expect label="should be xs:anyURI" test="$t:result instance of xs:anyURI" />
 		<t:expect label="should be this .xspec file"
-			test="$t:result => ends-with($local:end-of-uri)" />
+			test="$t:result => $local:check-end-of-uri()" />
 		<t:expect label="should be the same as the one in x:expect" select="$t:xspec-uri" />
 	</t:scenario>
 
 	<t:scenario label="$x:xspec-uri in x:expect">
 		<t:call function="true" />
 		<t:expect label="in @select, should be this .xspec file"
-			select="$t:xspec-uri => ends-with($local:end-of-uri)" />
+			select="$t:xspec-uri => $local:check-end-of-uri()" />
 		<t:expect label="in Boolean @test, should be this .xspec file"
-			test="$t:xspec-uri => ends-with($local:end-of-uri)" />
+			test="$t:xspec-uri => $local:check-end-of-uri()" />
 		<t:expect label="in user-content attribute, should be this .xspec file"
-			select="/*/@attr/xs:anyURI(.) => ends-with($local:end-of-uri)">
+			select="/*/@attr/xs:anyURI(.) => $local:check-end-of-uri()">
 			<element attr="{$t:xspec-uri}" />
 		</t:expect>
 		<t:expect label="in user-content text node, should be this .xspec file"
-			select="xs:anyURI(.) => ends-with($local:end-of-uri)">
+			select="xs:anyURI(.) => $local:check-end-of-uri()">
 			<element>{$t:xspec-uri}</element>
 		</t:expect>
 		<t:scenario label="in filter @test">
@@ -54,13 +56,13 @@
 	<t:scenario label="$x:xspec-uri in global x:variable">
 		<t:call function="true" />
 		<t:expect label="in @select, should be this .xspec file"
-			test="$local:xspec-uri-in-global-var => ends-with($local:end-of-uri)" />
+			test="$local:xspec-uri-in-global-var => $local:check-end-of-uri()" />
 		<t:expect label="in user-content attribute, should be this .xspec file"
 			test="$local:xspec-uri-in-global-var-user-content/@attr/string()
-			=> xs:anyURI() => ends-with($local:end-of-uri)" />
+			=> xs:anyURI() => $local:check-end-of-uri()" />
 		<t:expect label="in user-content text node, should be this .xspec file"
 			test="$local:xspec-uri-in-global-var-user-content/string()
-			=> xs:anyURI() => ends-with($local:end-of-uri)" />
+			=> xs:anyURI() => $local:check-end-of-uri()" />
 	</t:scenario>
 
 	<t:scenario label="$x:xspec-uri in scenario-level x:variable">
@@ -71,13 +73,13 @@
 		</t:variable>
 		<t:call function="true" />
 		<t:expect label="in @select, should be this .xspec file"
-			test="$local:xspec-uri-in-scenario-var => ends-with($local:end-of-uri)" />
+			test="$local:xspec-uri-in-scenario-var => $local:check-end-of-uri()" />
 		<t:expect label="in user-content attribute, should be this .xspec file"
 			test="$local:xspec-uri-in-scenario-var-user-content/@attr/string()
-			=> xs:anyURI() => ends-with($local:end-of-uri)" />
+			=> xs:anyURI() => $local:check-end-of-uri()" />
 		<t:expect label="in user-content text node, should be this .xspec file"
 			test="$local:xspec-uri-in-scenario-var-user-content/string()
-			=> xs:anyURI() => ends-with($local:end-of-uri)" />
+			=> xs:anyURI() => $local:check-end-of-uri()" />
 	</t:scenario>
 
 	<!-- Import XSpec file here using relative path in @href.
@@ -88,14 +90,14 @@
 		<t:call function="true" />
 		<t:scenario label="in global variable">
 			<t:expect label="should be the importing .xspec file, not the imported one"
-				select="$im:xspec-uri-in-global-var => ends-with($local:end-of-uri)" />
+				select="$im:xspec-uri-in-global-var => $local:check-end-of-uri()" />
 			<t:expect label="should equal the value defined in importing file"
 				test="$im:xspec-uri-in-global-var eq $t:xspec-uri" />
 		</t:scenario>
 		<t:scenario label="in variable brought into importing file via x:like">
 			<t:like label="Store $x:xspec-uri in variable in imported file" />
 			<t:expect label="should be the importing .xspec file, not the imported one"
-				select="$im:xspec-uri-in-local-var => ends-with($local:end-of-uri)" />
+				select="$im:xspec-uri-in-local-var => $local:check-end-of-uri()" />
 			<t:expect label="should equal the value defined in importing file"
 				test="$im:xspec-uri-in-local-var eq $t:xspec-uri" />
 		</t:scenario>

--- a/test/xspec-uri_stylesheet.xspec
+++ b/test/xspec-uri_stylesheet.xspec
@@ -42,6 +42,6 @@
 	<t:scenario label="$x:xspec-uri in x:description/x:param">
 		<t:context select="'global-x-param_vs_xsl-param'" />
 		<t:expect label="should be this .xspec file"
-			test="$t:result => $local:check-end-of-uri()" />
+			test="xs:anyURI($t:result) => $local:check-end-of-uri()" />
 	</t:scenario>
 </t:description>

--- a/test/xspec-uri_stylesheet.xspec
+++ b/test/xspec-uri_stylesheet.xspec
@@ -6,8 +6,10 @@
 	xmlns:t="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<t:variable name="local:end-of-uri" as="xs:string"
-		select="'/test/xspec-uri_stylesheet.xspec'" />
+	<t:variable name="local:check-end-of-uri" as="function(*)"
+		select="function($u as xs:anyURI) as xs:boolean {
+		ends-with($u, '/test/xspec-uri_stylesheet.xspec')
+		}" />
 
 	<t:scenario label="$x:xspec-uri in x:context/x:param">
 		<t:context mode="mirror:param-mirror">
@@ -15,7 +17,7 @@
 			<element />
 		</t:context>
 		<t:expect label="should be this .xspec file"
-			test="$t:result => ends-with($local:end-of-uri)" />
+			test="$t:result => $local:check-end-of-uri()" />
 	</t:scenario>
 
 	<t:scenario label="$x:xspec-uri in x:context user-content">
@@ -23,16 +25,16 @@
 			<element attr="{$t:xspec-uri}">{$t:xspec-uri}</element>
 		</t:context>
 		<t:expect label="in attribute value, should be this .xspec file"
-			test="$t:result/@attr => ends-with($local:end-of-uri)" />
+			test="$t:result/@attr => $local:check-end-of-uri()" />
 		<t:expect label="in text node, should be this .xspec file"
-			test="$t:result/text() => ends-with($local:end-of-uri)" />
+			test="$t:result/text() => $local:check-end-of-uri()" />
 	</t:scenario>
 
 	<t:scenario label="$x:xspec-uri in x:context/@select">
 		<t:context mode="mirror:context-mirror"
 			select="$t:xspec-uri[. ne ''] => doc()" />
 		<t:expect label="should be this .xspec file"
-			test="$t:result => base-uri() => ends-with($local:end-of-uri)" />
+			test="$t:result => base-uri() => $local:check-end-of-uri()" />
 	</t:scenario>
 
 	<t:helper stylesheet="global-override.xsl" />
@@ -40,6 +42,6 @@
 	<t:scenario label="$x:xspec-uri in x:description/x:param">
 		<t:context select="'global-x-param_vs_xsl-param'" />
 		<t:expect label="should be this .xspec file"
-			test="$t:result => ends-with($local:end-of-uri)" />
+			test="$t:result => $local:check-end-of-uri()" />
 	</t:scenario>
 </t:description>

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1496,7 +1496,7 @@ load bats-helper
     cp "${SAXON_JAR}" "${SAXON_HOME}"
 
     # Apache XML Resolver
-    if [ "${SAXON_VERSION:0:2}" != "9." ] && [ "${SAXON_VERSION:0:3}" != "10." ]; then
+    if [ "${SAXON_VERSION:0:3}" != "10." ]; then
         unset APACHE_XMLRESOLVER_JAR
     fi
     if [ -n "${APACHE_XMLRESOLVER_JAR}" ]; then
@@ -2218,11 +2218,11 @@ load bats-helper
     myrun ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     [ "$status" -eq 0 ]
 
-    if [ "${SAXON_VERSION:0:3}" != "12." ] && [ "${SAXON_VERSION:0:2}" != "9." ]; then
+    if [ "${SAXON_VERSION:0:3}" != "12." ]; then
         [ "${lines[3]}" = "WARNING: Saxon version 12.3 or earlier is not recommended. Consider migrating to Saxon 12.4 or later." ]
     elif [ "${SAXON_VERSION:0:4}" = "12.3" ]; then
         [ "${lines[3]}" = "WARNING: Saxon version 12.3 or earlier is not recommended. Consider migrating to Saxon 12.4 or later." ]
-    elif [ "${SAXON_VERSION:0:2}" != "9." ]; then
+    else
         [ "${lines[3]}" = "Checking for deprecated Saxon versions: Passed" ]
     fi
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -900,7 +900,7 @@ load bats-helper
         ../src/harnesses/basex/basex-server-xquery-harness.xproc
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" = "2" ]
-    assert_regex "${lines[1]}" '.+:passed: 132 / pending: 0 / failed: 0 / total: 132'
+    assert_regex "${lines[1]}" '.+:passed: 128 / pending: 0 / failed: 0 / total: 128'
 
     # HTML report file should be created and its charset should be UTF-8 #72
     myrun java -cp "${SAXON_CP}" net.sf.saxon.Transform \


### PR DESCRIPTION
This pull request removes Saxon 9.9 support from the code base, or at least the vestiges I'm aware of.

Related to #1834 and #1835.

Fixes #1826.