### PR TITLE
build(oxygen): add-on v3.0.2

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -22,7 +22,9 @@
 					<li>feat(xslt): code coverage for Saxon 12.4+ (<a href="https://github.com/xspec/xspec/pull/1833"
 							>#1833</a>)</li>
 					<li>Removes Saxon 9.9 support</li>
+					<li>Saxon versions earlier than 12.4 are no longer recommended</li>
 					<li>Tested with Saxon 10.9, 11.6, and 12.4</li>
+					<li>Tested with Oxygen 26.1</li>
 				</ul>
 			</div>
 			<div>

--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,16 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.0.2</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>feat(xslt): code coverage for Saxon 12.4+ (<a href="https://github.com/xspec/xspec/pull/1833"
+							>#1833</a>)</li>
+					<li>Removes Saxon 9.9 support</li>
+					<li>Tested with Saxon 10.9, 11.6, and 12.4</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.0.1</h3>
 				<ul>
 					<li>feat(schematron): SchXslt 1.9.5 replaces skeleton implementation</li>
@@ -78,13 +88,6 @@
 				<ul>
 					<li>Release Candidate of the stable release</li>
 					<li>Tested with BaseX 9.6.1</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.2.2</h3>
-				<ul>
-					<li>fix(schematron): handle location attribute not pointing to one node (<a
-							href="https://github.com/xspec/xspec/pull/1506">#1506</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/437e1e80e79262acf844ddf4a6f6c9dd25dcbbf6.zip" />
+			href="https://github.com/xspec/xspec/archive/0ee659425111f7e0ad1fde54913074260c641c39.zip" />
 
-		<xt:version>3.0.1</xt:version>
+		<xt:version>3.0.2</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-437e1e80e79262acf844ddf4a6f6c9dd25dcbbf6/xspec.framework/XSpec</String>
+                                    <String>4/xspec-0ee659425111f7e0ad1fde54913074260c641c39/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This v3.0.2 add-on has all the changes we expect to be in XSpec v3.0, including the XSLT Code Coverage upgrade.

I tested this change in Oxygen 26.1 build 2024031806 using https://github.com/galtm/xspec/raw/oxygen-3.0.2/oxygen-addon.xml. All the transformation scenarios work. Note that Oxygen 26.1 uses Saxon 12.3. Under 12.3, the XSLT Code Coverage scenario produces a report with some content (not merely "not used") but the console says Saxon 12.3 is not recommended.

---

\* Unless you're using a special add-on that accesses Saxon 12.4 (https://www.oxygenxml.com/doc/versions/26.1/ug-editor/topics/saxon-transformer-addon.html)