### PR TITLE
docs: point only to GitHub for support requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ XSpec consists of a syntax for describing the behaviour of XSLT, XQuery, or Sche
 
 ## Getting Started
 
-To get started, check out the installation instructions for [MacOS/Linux](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux) and [Windows](https://github.com/xspec/xspec/wiki/Installation-on-Windows) and how to [write your first XSpec test](https://github.com/xspec/xspec/wiki/Getting-Started).
+To get started, check out the installation instructions for [macOS/Linux](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux) and [Windows](https://github.com/xspec/xspec/wiki/Installation-on-Windows) and how to [write your first XSpec test](https://github.com/xspec/xspec/wiki/Getting-Started).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started, check out the installation instructions for [MacOS/Linux](https:
 
 ## Support
 
-Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki) before raising an issue or ask a question. If you have any question which is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues) or post it in the [XSpec discussion list](https://groups.google.com/d/forum/xspec-users).
+Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki) before raising an issue or ask a question. If you have any question that is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues). For historical searches, the unmonitored [XSpec discussion list](https://groups.google.com/d/forum/xspec-users) might also be useful.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started, check out the installation instructions for [MacOS/Linux](https:
 
 ## Support
 
-Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki) before raising an issue or ask a question. If you have any question that is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues). For historical searches, the unmonitored [XSpec discussion list](https://groups.google.com/d/forum/xspec-users) might also be useful.
+Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki) before raising an issue or asking a question. If you have any question that is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues). For historical searches, the unmonitored [XSpec discussion list](https://groups.google.com/d/forum/xspec-users) might also be useful.
 
 ## Contribute
 


### PR DESCRIPTION
The XSpec discussion list has had no user input in more than a year, and I don't think anyone on the XSpec team is monitoring the list. For support requests, I think we should point users only to GitHub.

cc'ing @xspec/xspec in case anyone has a different perspective.
