### PR TITLE
ci: make AppVeyor testing include bats only

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,10 @@ install:
 build: off
 
 test_script:
+  # XSpec unit tests and end-to-end tests omitted due to time limit. They run on GitHub Actions and Azure Pipelines.
   - cmd: |
       test\ci\print-env.cmd
-      test\ci\run-core-tests.cmd
+      test\run-bats.cmd
       rem test\ci\maven-package.cmd -q
       test\ci\compile-java.cmd -silent
       test\ci\last-git-status.cmd


### PR DESCRIPTION
AppVeyor has been fairly consistently timing out upon reaching 60-minute time limit. This PR implements idea "A" in #1900.

@xspec/xspec : I'm still open to alternate suggestions, but I'd like to get this repo fairly soon to a state where AppVeyor completes successfully most of the time.

Closes #1900 .