### PR TITLE
build(maven): use 3.0.3 in pom.xml, not 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>3.0</version>
+  <version>3.0.3</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
The Maven repository uses a three-part version number, so use 3.0.3 instead of 3.0.

This pull request fixes a mistake I made in #1904.