### PR TITLE
ci: on macOS with Java 8, use liberica instead of temurin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: temurin
+          distribution: ${{ runner.os == 'macOS' && matrix.java == '8' && 'liberica' || 'temurin' }}
 
       - name: Run tests for *nix
         if: runner.os != 'Windows'


### PR DESCRIPTION
Temurin distribution is not available for Java 8 with macos-14 on M1.

This pull request changes as little as possible in the test environments, so macOS with Java 8 uses Liberica and everything else (including macOS with Java 17) uses Temurin.

Fixes #1919.

---

When the GitHub Actions ran in my own fork, I checked the **Run actions/setup-java@v4** > **Installed distributions** section of the [test logs](https://github.com/galtm/xspec/actions/runs/8884405147) for all the Saxon 12 runs. They all say `Distribution: temurin` except that the `macos-latest, 8, saxon-12` run says `Distribution: liberica`.

The full macOS/Java8/Saxon12 installation log says:
```
Trying to resolve the latest version from remote
  Resolved latest version as 8.0.412+9
  Trying to download...
  Downloading Java 8.0.412+9 (Liberica) from https://github.com/bell-sw/Liberica/releases/download/8u412+9/bellsoft-jdk8u412+9-macos-aarch64.tar.gz ...
  Extracting Java archive...
  /usr/bin/tar xz -C /Users/runner/work/_temp/c2a96913-a84c-4bbe-adec-4868dfe447[20](https://github.com/galtm/xspec/actions/runs/8884405147/job/24393410244#step:3:21) -f /Users/runner/work/_temp/529cf9d6-362e-4951-b3f5-e5ec50cd1108
  Java 8.0.412+9 was downloaded
  Setting Java 8.0.412+9 as the default
  Creating toolchains.xml for JDK version 8 from liberica
  Writing to /Users/runner/.m2/toolchains.xml
  
  Java configuration:
    Distribution: liberica
    Version: 8.0.412+9
    Path: /Users/runner/hostedtoolcache/Java_Liberica_jdk/8.0.412-9/arm64
```