### PR TITLE
test(schematron): test prefix usage in location attribute

### DIFF
--- a/test/xmlns.sch
+++ b/test/xmlns.sch
@@ -2,10 +2,10 @@
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <sch:ns uri="http://example.org/ns/default" prefix="d"/>
    <sch:ns uri="http://example.org/ns/default/description" prefix="dd"/>
-   <sch:ns uri="http://example.org/ns/my" prefix="my"/>
+   <sch:ns uri="http://example.org/ns/my" prefix="my-sch"/>
    <sch:pattern>
       <sch:rule context="*:root">
-         <sch:report id="prefixed" test="my:element">element in my namespace</sch:report>
+         <sch:report id="prefixed" test="my-sch:element">element in my namespace</sch:report>
          <sch:report id="default-description" test="dd:element">element in what XSpec x:description will declare as default element namespace</sch:report>
          <sch:report id="default" test="d:element">element in what XSpec x:description descendant will declare as default element namespace</sch:report>
       </sch:rule>

--- a/test/xmlns_schematron.xspec
+++ b/test/xmlns_schematron.xspec
@@ -11,6 +11,8 @@
 				</root>
 			</x:context>
 			<x:expect-report label="should work." id="prefixed"/>
+			<x:expect-report label="Location can use prefix."
+				location="//t1:element/parent::*"/>
 		</x:scenario>
 		<x:scenario label="on x:scenario" xmlns:my="http://example.org/ns/my">
 			<x:context>
@@ -19,6 +21,8 @@
 				</root>
 			</x:context>
 			<x:expect-report label="should work." id="prefixed"/>
+			<x:expect-report label="Location can use prefix."
+				location="//my:element/parent::*"/>
 		</x:scenario>
 		<x:scenario label="on x:context">
 			<x:context xmlns:my="http://example.org/ns/my">
@@ -27,6 +31,9 @@
 				</root>
 			</x:context>
 			<x:expect-report label="should work." id="prefixed"/>
+			<x:expect-report label="Location can use prefix."
+				location="//my:element/parent::*"
+				xmlns:my="http://example.org/ns/my"/>
 		</x:scenario>
 		<x:scenario label="in user content">
 			<x:context>
@@ -35,6 +42,9 @@
 				</root>
 			</x:context>
 			<x:expect-report label="should work." id="prefixed"/>
+			<x:expect-report label="Location can use prefix."
+				location="//my:element/parent::*"
+				xmlns:my="http://example.org/ns/my"/>
 		</x:scenario>
 	</x:scenario>
 	<x:scenario label="Context user content relying on default element namespace">


### PR DESCRIPTION
The `location` attribute of Schematron `x:expect-*` elements holds an XPath expression. The expression can use element names with namespace prefixes that have been declared in the XSpec file. Also, when the Schematron schema declares prefixes for the same element names, those prefixes are allowed to differ from the prefixes used in XSpec.

This pull request enhances an existing test to demonstrate use of namespace prefixes in `@location` and different prefixes between Schematron and XSpec. I skimmed through the comments in #640, which introduced this test, and I didn't see anything that suggested these aspects were omitted deliberately.