### PR TITLE
test: fix typo in label (export -> external)

### DIFF
--- a/test/global-override.xspec
+++ b/test/global-override.xspec
@@ -74,7 +74,7 @@
 					else
 						'global x:variable overriding xsl:param'">
 				<x:label>run-as=import allows x:variable to override xsl:param, although not an
-					official recommended usage of x:variable. run-as=export should never allow
+					official recommended usage of x:variable. run-as=external should never allow
 					it.</x:label>
 			</x:expect>
 		</x:scenario>
@@ -87,7 +87,7 @@
 					else
 						'global x:variable overriding xsl:variable'">
 				<x:label>run-as=import allows x:variable to override xsl:variable, although not an
-					official recommended usage of x:variable. run-as=export should never allow
+					official recommended usage of x:variable. run-as=external should never allow
 					it.</x:label>
 			</x:expect>
 		</x:scenario>


### PR DESCRIPTION
This pull request merely fixes two labels that use the wrong word. The `run-as` attribute value other than `import` is `external`, not `export`.