### PR TITLE
test(report): per-element tests of coverage data and coverage reports

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for external_xsl-global-context-item-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../external_xsl-global-context-item-01.xsl">external_xsl-global-context-item-01.xsl</a></p>
+      <h2>module: external_xsl-global-context-item-01.xsl; 17 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:global-context-item Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:global-context-item use="required" as="item()" /&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Put the context item in a global variable --&gt;</span>
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="globalVariable" select="." /&gt;</span>
+09: 
+10: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-global-context-item"&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;node type="global-context-item"&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalVariable" /&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+17: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../external_xsl-global-context-item-01.xspec">
+   <compiled uri="external_xsl-global-context-item-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../external_xsl-global-context-item-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="10" columnNumber="49" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="11" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="40" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="12" columnNumber="40" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="13" columnNumber="50" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="8" columnNumber="52" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for external_xsl-result-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../external_xsl-result-document-01.xsl">external_xsl-result-document-01.xsl</a></p>
+      <h2>module: external_xsl-result-document-01.xsl; 18 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:result-document Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-result-document"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="result-document"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;xsl:result-document href="result-document.xml"&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="result-document"&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">    </span><span class="hit">&lt;/xsl:result-document&gt;</span>
+17: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+18: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../external_xsl-result-document-01.xspec">
+   <compiled uri="external_xsl-result-document-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../external_xsl-result-document-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="45" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="36" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="36" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="9" columnNumber="19" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}result-document"/>
+   <hit lineNumber="12" columnNumber="53" moduleId="0" traceableId="4"/>
+   <hit lineNumber="13" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="14" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-accumulator-01.xsl">xsl-accumulator-01.xsl</a></p>
-      <h2>module: xsl-accumulator-01.xsl; 34 lines</h2>
+      <h2>module: xsl-accumulator-01.xsl; 38 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -25,22 +25,26 @@
 15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
 16: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for accumulator --&gt;</span>
 17: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span>
-18: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
-19: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
-20: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-21: <span class="ignored">      </span><span class="ignored">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
-22: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
-23: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-24: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-25: <span class="ignored">  </span><span class="ignored">&lt;!-- used in xsl:accumulator test --&gt;</span>
-26: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
-27: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
-28: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
-29: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-30: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
-31: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
-32: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-33: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+18: <span class="ignored">  </span><span class="ignored">&lt;!-- Make accumulator applicable in default mode, too, so that</span>
+19: <span class="ignored">    xsl-accumulator-01.xspec can run with run-as="external" or</span>
+20: <span class="ignored">    when imported by a test with that setting. --&gt;</span>
+21: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" /&gt;</span>
+22: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+23: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
+24: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
+27: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+28: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+29: <span class="ignored">  </span><span class="ignored">&lt;!-- used in xsl:accumulator test --&gt;</span>
+30: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
+31: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
+33: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+34: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
+36: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+37: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+38: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-accumulator-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-accumulator-01.xsl">xsl-accumulator-01.xsl</a></p>
+      <h2>module: xsl-accumulator-01.xsl; 34 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">       xsl:accumulator Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span>
+08: <span class="ignored">    </span><span class="missed">&lt;xsl:accumulator-rule match="node"&gt;</span>
+09: <span class="ignored">      </span><span class="missed">&lt;xsl:value-of select="$value + 1" /&gt;</span>
+10: <span class="ignored">    </span><span class="missed">&lt;/xsl:accumulator-rule&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
+12: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator not used --&gt;</span>
+13: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span>
+14: <span class="ignored">    </span><span class="missed">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
+16: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for accumulator --&gt;</span>
+17: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span>
+18: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+19: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
+22: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
+23: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+24: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+25: <span class="ignored">  </span><span class="ignored">&lt;!-- used in xsl:accumulator test --&gt;</span>
+26: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
+27: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
+29: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
+32: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+33: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
@@ -4,37 +4,37 @@
    <module moduleId="0" uri="../../xsl-accumulator-01.xsl"/>
    <traceable traceableId="0"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="19" columnNumber="41" moduleId="0" traceableId="0"/>
+   <hit lineNumber="23" columnNumber="41" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="20" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="24" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
-   <hit lineNumber="22" columnNumber="60" moduleId="0" traceableId="2"/>
-   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="26" columnNumber="60" moduleId="0" traceableId="2"/>
+   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
    <traceable traceableId="3"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
-   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
-   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-accumulator-01.xspec">
+   <compiled uri="xsl-accumulator-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-accumulator-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="19" columnNumber="41" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="20" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="22" columnNumber="60" moduleId="0" traceableId="2"/>
+   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="26" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="28" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="30" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-analyze-string-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-analyze-string-01.xsl">xsl-analyze-string-01.xsl</a></p>
+      <h2>module: xsl-analyze-string-01.xsl; 36 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:analyze-string Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-analyze-string"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- regex matches string so non-matching-substring not executed --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:analyze-string select="'abc 123'" regex="abc 123"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:matching-substring&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;node type="matching-substring"&gt;</span>
+12: <span class="ignored">            </span><span class="hit">&lt;xsl:value-of select="regex-group(0)" /&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;/xsl:matching-substring&gt;</span>
+15: <span class="ignored">        </span><span class="missed">&lt;xsl:non-matching-substring&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+16: <span class="ignored">          </span><span class="missed">&lt;node type="non-matching-substring"&gt;</span><span class="ignored">                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+17: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">No match</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+18: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+19: <span class="ignored">        </span><span class="missed">&lt;/xsl:non-matching-substring&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;!-- regex doesn't match string so matching-substring not executed --&gt;</span>
+22: <span class="ignored">      </span><span class="hit">&lt;xsl:analyze-string select="'def 456 def 456'" regex="abc 123"&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;xsl:matching-substring&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">          </span><span class="missed">&lt;node type="matching-substring"&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="regex-group(0)" /&gt;</span><span class="ignored">                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+26: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+27: <span class="ignored">        </span><span class="missed">&lt;/xsl:matching-substring&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:non-matching-substring&gt;</span>
+29: <span class="ignored">          </span><span class="hit">&lt;node type="non-matching-substring"&gt;</span>
+30: <span class="ignored">            </span><span class="missed">&lt;xsl:sequence select="string('No match')"/&gt;</span>
+31: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;/xsl:non-matching-substring&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
+34: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+35: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+36: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-analyze-string-01.xspec">
+   <compiled uri="xsl-analyze-string-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-analyze-string-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="44" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}analyze-string"/>
+   <hit lineNumber="9" columnNumber="62" moduleId="0" traceableId="2"/>
+   <hit lineNumber="11" columnNumber="43" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="11" columnNumber="43" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="12" columnNumber="53" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="70" moduleId="0" traceableId="2"/>
+   <hit lineNumber="29" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="47" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-apply-imports-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-apply-imports-01.xsl">xsl-apply-imports-01.xsl</a></p>
+      <h2>module: xsl-apply-imports-01.xsl; 24 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:apply-imports Coverage Test Case (see xsl-apply-imports-01A.xsl as well)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Import stylesheet --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-apply-imports-01A.xsl" /&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for this test --&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="applyImportsMode" /&gt;</span>
+10: <span class="ignored">  </span><span class="ignored">&lt;!-- Main Stylesheet--&gt;</span>
+11: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-apply-imports"&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="applyImportsMode" /&gt;</span>
+14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
+17: <span class="ignored">  </span><span class="ignored">&lt;!-- Current Stylesheet Template --&gt;</span>
+18: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="applyImportsMode"&gt;</span>
+19: <span class="ignored">    </span><span class="hit">&lt;node type="apply-imports - top stylesheet"&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+21: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+22: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports/&gt;</span>
+23: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+24: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-apply-imports-01A.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: 
+04: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:apply-imports Template --&gt;</span>
+05: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="applyImportsMode"&gt;</span>
+06: <span class="ignored">    </span><span class="hit">&lt;node type="apply-imports - import stylesheet"&gt;</span>
+07: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+09: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+10: <span class="ignored"> </span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-apply-imports-01.xspec">
+   <compiled uri="xsl-apply-imports-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-apply-imports-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="11" columnNumber="43" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="12" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="13" columnNumber="65" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="54" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-imports"/>
+   <hit lineNumber="22" columnNumber="25" moduleId="0" traceableId="5"/>
+   <module moduleId="1" uri="../../xsl-apply-imports-01A.xsl"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="6" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="7" columnNumber="34" moduleId="1" traceableId="4"/>
+   <hit lineNumber="18" columnNumber="54" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="25" moduleId="0" traceableId="5"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="6" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="7" columnNumber="34" moduleId="1" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-apply-templates-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-apply-templates-01.xsl">xsl-apply-templates-01.xsl</a></p>
+      <h2>module: xsl-apply-templates-01.xsl; 17 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:apply-templates Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-apply-templates"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates /&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+11: 
+12: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="applyTemplateNode"&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;node type="apply-templates"&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+17: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-apply-templates-01.xsl">xsl-apply-templates-01.xsl</a></p>
-      <h2>module: xsl-apply-templates-01.xsl; 17 lines</h2>
+      <h2>module: xsl-apply-templates-01.xsl; 31 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -16,14 +16,28 @@
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-apply-templates"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates /&gt;</span>
-09: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-11: 
-12: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="applyTemplateNode"&gt;</span>
-13: <span class="ignored">    </span><span class="hit">&lt;node type="apply-templates"&gt;</span>
-14: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
-15: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="#unnamed" /&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="#current" /&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="#default" /&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="mode-with-matching-template" /&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="mode-without-explicit-template-with-xsl-mode" /&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="mode-without-explicit-template-without-xsl-mode" /&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-17: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+17: 
+18: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="applyTemplateNode"&gt;</span>
+19: <span class="ignored">    </span><span class="hit">&lt;node type="apply-templates"&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+21: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+22: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+23: 
+24: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" /&gt;</span>
+25: 
+26: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="applyTemplateNode" mode="mode-with-matching-template"&gt;</span>
+27: <span class="ignored">    </span><span class="hit">&lt;node type="apply-templates-mode-with-matching-template"&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+29: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+31: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-apply-templates-01.xspec">
+   <compiled uri="xsl-apply-templates-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-apply-templates-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="45" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="8" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="14" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="34" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.xml
@@ -10,18 +10,56 @@
    <traceable traceableId="2"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
    <hit lineNumber="8" columnNumber="30" moduleId="0" traceableId="2"/>
-   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="0"/>
-   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
    <traceable traceableId="3"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="14" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="0"/>
-   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="1"/>
-   <hit lineNumber="13" columnNumber="34" moduleId="0" traceableId="3"/>
-   <hit lineNumber="14" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="9" columnNumber="46" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="46" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="11" columnNumber="46" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="34" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="65" moduleId="0" traceableId="2"/>
+   <hit lineNumber="26" columnNumber="78" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="3"/>
+   <hit lineNumber="28" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="26" columnNumber="78" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="3"/>
+   <hit lineNumber="28" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="13" columnNumber="82" moduleId="0" traceableId="2"/>
+   <hit lineNumber="14" columnNumber="85" moduleId="0" traceableId="2"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-assert-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-assert-01.xsl">xsl-assert-01.xsl</a></p>
+      <h2>module: xsl-assert-01.xsl; 34 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:assert Coverage Test Case (needs AssertEnabled option -ea). xsl:assert is always executed.</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert false --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
+11: <span class="ignored">          </span><span class="ignored">&lt;!-- Added instruction between xsl:try and xsl:assert to check trace output --&gt;</span>
+12: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="name()" /&gt;</span>
+13: <span class="ignored">          </span><span class="missed">&lt;xsl:assert test="100 lt 0"&gt;</span>
+14: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 lt 0</span><span class="missed">&lt;/xsl:text&gt;</span>
+15: <span class="ignored">          </span><span class="missed">&lt;/xsl:assert&gt;</span>
+16: <span class="ignored">          </span><span class="missed">&lt;xsl:catch&gt;</span>
+17: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert was triggered as expected</span><span class="missed">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span>
+19: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
+22: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
+23: <span class="ignored">      </span><span class="missed">&lt;xsl:try&gt;</span>
+24: <span class="ignored">        </span><span class="hit">&lt;xsl:assert test="100 gt 0"&gt;</span>
+25: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+26: <span class="ignored">        </span><span class="hit">&lt;/xsl:assert&gt;</span>
+27: <span class="ignored">        </span><span class="missed">&lt;xsl:catch&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+28: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert was triggered unexpectedly</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+29: <span class="ignored">        </span><span class="missed">&lt;/xsl:catch&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+30: <span class="ignored">      </span><span class="missed">&lt;/xsl:try&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+32: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+33: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -7,40 +7,33 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-assert-01.xsl">xsl-assert-01.xsl</a></p>
-      <h2>module: xsl-assert-01.xsl; 34 lines</h2>
+      <h2>module: xsl-assert-01.xsl; 27 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 04: <span class="ignored">      xsl:assert Coverage Test Case (needs AssertEnabled option -ea). xsl:assert is always executed.</span>
 05: <span class="ignored">  --&gt;</span>
-06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert"&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-false"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert false --&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
-10: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
-11: <span class="ignored">          </span><span class="ignored">&lt;!-- Added instruction between xsl:try and xsl:assert to check trace output --&gt;</span>
-12: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="name()" /&gt;</span>
-13: <span class="ignored">          </span><span class="missed">&lt;xsl:assert test="100 lt 0"&gt;</span>
-14: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 lt 0</span><span class="missed">&lt;/xsl:text&gt;</span>
-15: <span class="ignored">          </span><span class="missed">&lt;/xsl:assert&gt;</span>
-16: <span class="ignored">          </span><span class="missed">&lt;xsl:catch&gt;</span>
-17: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert was triggered as expected</span><span class="missed">&lt;/xsl:text&gt;</span>
-18: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span>
-19: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
-20: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-21: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
-22: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
-23: <span class="ignored">      </span><span class="missed">&lt;xsl:try&gt;</span>
-24: <span class="ignored">        </span><span class="hit">&lt;xsl:assert test="100 gt 0"&gt;</span>
-25: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-26: <span class="ignored">        </span><span class="hit">&lt;/xsl:assert&gt;</span>
-27: <span class="ignored">        </span><span class="missed">&lt;xsl:catch&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-28: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert was triggered unexpectedly</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-29: <span class="ignored">        </span><span class="missed">&lt;/xsl:catch&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-30: <span class="ignored">      </span><span class="missed">&lt;/xsl:try&gt;</span>
-31: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-32: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-33: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 lt 0"&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 lt 0</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
+17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-true"&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+19: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
+21: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 gt 0"&gt;</span>
+22: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+25: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+26: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+27: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-assert-01.xspec">
+   <compiled uri="xsl-assert-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-assert-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="36" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="27" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="27" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.TryCatch"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="27" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="27" moduleId="0" traceableId="2"/>
+   <hit lineNumber="24" columnNumber="37" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
@@ -4,22 +4,23 @@
    <module moduleId="0" uri="../../xsl-assert-01.xsl"/>
    <traceable traceableId="0"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="6" columnNumber="36" moduleId="0" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="60" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
    <hit lineNumber="9" columnNumber="27" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
    <hit lineNumber="9" columnNumber="27" moduleId="0" traceableId="2"/>
-   <traceable traceableId="3" class="net.sf.saxon.expr.TryCatch"/>
-   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="3"/>
-   <traceable traceableId="4"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="4"/>
-   <hit lineNumber="22" columnNumber="27" moduleId="0" traceableId="1"/>
-   <hit lineNumber="22" columnNumber="27" moduleId="0" traceableId="2"/>
-   <hit lineNumber="24" columnNumber="37" moduleId="0" traceableId="3"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}assert"/>
+   <hit lineNumber="11" columnNumber="21" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="21" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
-   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/wrap.xsl"/>
+   <util utilId="3" uri="../../../../../src/common/deep-equal.xsl"/>
+   <hit lineNumber="17" columnNumber="59" moduleId="0" traceableId="0"/>
+   <hit lineNumber="18" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="27" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="27" moduleId="0" traceableId="2"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-attribute-01.xsl">xsl-attribute-01.xsl</a></p>
-      <h2>module: xsl-attribute-01.xsl; 56 lines</h2>
+      <h2>module: xsl-attribute-01.xsl; 61 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -51,18 +51,23 @@
 41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 42: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
 43: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
-44: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span>
-45: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:text&gt;</span>
-46: <span class="ignored">        </span><span class="hit">&lt;/xsl:attribute&gt;</span>
-47: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:text&gt;</span>
-48: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-49: <span class="ignored">      </span><span class="ignored">&lt;!-- As a child of xsl:copy. Context node is the template match node xsl-attribute --&gt;</span>
-50: <span class="ignored">      </span><span class="hit">&lt;xsl:copy&gt;</span>
-51: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+44: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+45: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:text&gt;</span>
+46: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+47: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+48: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
+49: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span>
+50: <span class="ignored">          </span><span class="hit">&lt;text-container&gt;</span><span class="hit">attribute</span><span class="hit">&lt;/text-container&gt;</span>
+51: <span class="ignored">        </span><span class="hit">&lt;/xsl:attribute&gt;</span>
 52: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">600</span><span class="hit">&lt;/xsl:text&gt;</span>
-53: <span class="ignored">      </span><span class="hit">&lt;/xsl:copy&gt;</span>
-54: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-55: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-56: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+53: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+54: <span class="ignored">      </span><span class="ignored">&lt;!-- As a child of xsl:copy. Context node is the template match node xsl-attribute --&gt;</span>
+55: <span class="ignored">      </span><span class="hit">&lt;xsl:copy&gt;</span>
+56: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+57: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:text&gt;</span>
+58: <span class="ignored">      </span><span class="hit">&lt;/xsl:copy&gt;</span>
+59: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+60: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+61: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-attribute-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-attribute-01.xsl">xsl-attribute-01.xsl</a></p>
+      <h2>module: xsl-attribute-01.xsl; 56 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:attribute Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Single xsl:attribute in xsl:attribute-set --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="type"&gt;</span>
+08: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+10: 
+11: <span class="ignored">  </span><span class="ignored">&lt;!-- Two xsl:attribute in xsl:attribute-set --&gt;</span>
+12: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="types"&gt;</span>
+13: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type1"&gt;</span>
+14: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">attribute1</span><span class="missed">&lt;/xsl:text&gt;</span>
+15: <span class="ignored">    </span><span class="missed">&lt;/xsl:attribute&gt;</span>
+16: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type2"&gt;</span>
+17: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">attribute2</span><span class="missed">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">    </span><span class="missed">&lt;/xsl:attribute&gt;</span>
+19: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+20: 
+21: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-attribute"&gt;</span>
+22: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+23: <span class="ignored">      </span><span class="ignored">&lt;!-- use-attribute-sets in xsl:element --&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="node" use-attribute-sets="type"&gt;</span>
+25: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+27: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
+29: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type" select="'attribute'" /&gt;</span>
+30: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+32: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
+34: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type" select="string('attribute')" /&gt;</span>
+35: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+36: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+37: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+38: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
+39: <span class="ignored">       </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+40: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">400</span><span class="hit">&lt;/xsl:text&gt;</span>
+41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+42: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+43: <span class="ignored">      </span><span class="hit">&lt;node&gt;</span>
+44: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span>
+45: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:text&gt;</span>
+46: <span class="ignored">        </span><span class="hit">&lt;/xsl:attribute&gt;</span>
+47: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:text&gt;</span>
+48: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+49: <span class="ignored">      </span><span class="ignored">&lt;!-- As a child of xsl:copy. Context node is the template match node xsl-attribute --&gt;</span>
+50: <span class="ignored">      </span><span class="hit">&lt;xsl:copy&gt;</span>
+51: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+52: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">600</span><span class="hit">&lt;/xsl:text&gt;</span>
+53: <span class="ignored">      </span><span class="hit">&lt;/xsl:copy&gt;</span>
+54: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+55: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+56: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-attribute-01.xspec">
+   <compiled uri="xsl-attribute-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-attribute-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="21" columnNumber="39" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="22" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="24" columnNumber="58" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="25" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="28" columnNumber="13" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="29" columnNumber="59" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="33" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="67" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="38" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="39" columnNumber="35" moduleId="0" traceableId="3"/>
+   <hit lineNumber="40" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="43" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="44" columnNumber="36" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="45" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="47" columnNumber="19" moduleId="0" traceableId="2"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
+   <hit lineNumber="50" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="51" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="52" columnNumber="19" moduleId="0" traceableId="2"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.xml
@@ -23,13 +23,17 @@
    <hit lineNumber="40" columnNumber="19" moduleId="0" traceableId="2"/>
    <hit lineNumber="43" columnNumber="13" moduleId="0" traceableId="1"/>
    <hit lineNumber="44" columnNumber="36" moduleId="0" traceableId="3"/>
-   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="45" columnNumber="21" moduleId="0" traceableId="4"/>
-   <hit lineNumber="47" columnNumber="19" moduleId="0" traceableId="2"/>
-   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
-   <hit lineNumber="50" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="51" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="45" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="48" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="49" columnNumber="36" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" class="net.sf.saxon.expr.instruct.TraceExpression"/>
+   <hit lineNumber="50" columnNumber="27" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="27" moduleId="0" traceableId="2"/>
    <hit lineNumber="52" columnNumber="19" moduleId="0" traceableId="2"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
+   <hit lineNumber="55" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="56" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="57" columnNumber="19" moduleId="0" traceableId="2"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-attribute-set-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-attribute-set-01.xsl">xsl-attribute-set-01.xsl</a></p>
+      <h2>module: xsl-attribute-set-01.xsl; 40 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:attribute-set Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Single attribute --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet01"&gt;</span>
+08: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr01"&gt;</span><span class="missed">attr01</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+10: <span class="ignored">  </span><span class="ignored">&lt;!-- Multiple attributes--&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet02"&gt;</span>
+12: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr02A"&gt;</span><span class="missed">attr02A</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+13: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr02B"&gt;</span><span class="missed">attr02B</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+14: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;!-- Including another attribute set --&gt;</span>
+16: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B"&gt;</span>
+17: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr03A"&gt;</span><span class="missed">attr03A</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+18: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+19: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03B"&gt;</span>
+20: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr03B"&gt;</span><span class="missed">attr03B</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+21: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+22: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+23: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-attribute-set"&gt;</span>
+24: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- use-attribute-sets in xsl:element --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="node" use-attribute-sets="attrSet01"&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute-set</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+30: <span class="ignored">      </span><span class="ignored">&lt;!-- use-attribute-sets in literal result element --&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;node xsl:use-attribute-sets="attrSet02" type="attribute-set"&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- use-attribute-sets in literal result element --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;node xsl:use-attribute-sets="attrSet03A" type="attribute-set"&gt;</span>
+36: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+37: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+38: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+39: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+40: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-attribute-set-01.xspec">
+   <compiled uri="xsl-attribute-set-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-attribute-set-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="23" columnNumber="43" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="24" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="26" columnNumber="63" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="27" columnNumber="36" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="28" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="1"/>
+   <hit lineNumber="31" columnNumber="69" moduleId="0" traceableId="2"/>
+   <hit lineNumber="32" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="70" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="70" moduleId="0" traceableId="2"/>
+   <hit lineNumber="36" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-call-template-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-call-template-01.xsl">xsl-call-template-01.xsl</a></p>
+      <h2>module: xsl-call-template-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:call-template Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-call-template"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="calledTemplate" /&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;!-- Called template--&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="calledTemplate"&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;node type="call-template"&gt;</span><span class="missed">100</span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-call-template-01.xspec">
+   <compiled uri="xsl-call-template-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-call-template-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="43" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="8" columnNumber="50" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="12" columnNumber="39" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="32" moduleId="0" traceableId="1"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="13" columnNumber="32" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="13" columnNumber="32" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-character-map-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-character-map-01.xsl">xsl-character-map-01.xsl</a></p>
+      <h2>module: xsl-character-map-01.xsl; 26 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:character-map Coverage Test Case (includes xsl:output-character)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- character map does not do any mapping changes (confident that it is used in Saxon).</span>
+07: <span class="ignored">       But xspec doesn't do character-map without some additional effort (which isn't done here)--&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:character-map name="charMap01" use-character-maps="charMap01A"&gt;</span>
+09: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="0" string="0" /&gt;</span>
+10: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="&amp;#xE003;" string="3" /&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
+12: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:character-map included in one above --&gt;</span>
+13: <span class="ignored">  </span><span class="ignored">&lt;xsl:character-map name="charMap01A"&gt;</span>
+14: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="1" string="1" /&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
+16: 
+17: <span class="ignored">  </span><span class="ignored">&lt;xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" /&gt;</span>
+18: 
+19: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-character-map"&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;node type="character-map"&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">&lt;!-- Maps to 100 --&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+24: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+25: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+26: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-character-map-01.xspec">
+   <compiled uri="xsl-character-map-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-character-map-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="19" columnNumber="43" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="20" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="34" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="21" columnNumber="34" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-choose-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-choose-01.xsl">xsl-choose-01.xsl</a></p>
+      <h2>module: xsl-choose-01.xsl; 59 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:choose Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-choose"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:when matches so otherwise not executed --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="1 eq 1"&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;node type="choose when"&gt;</span>
+12: <span class="ignored">            </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+15: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise version="3.0"&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+16: <span class="ignored">          </span><span class="missed">&lt;node type="choose otherwise" version="3.0"&gt;</span><span class="ignored">                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+17: <span class="ignored">            </span><span class="missed">&lt;xsl:text version="3.0"&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+18: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+19: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:when doesn't match so when not executed --&gt;</span>
+22: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="1 eq 2" version="3.0"&gt;</span><span class="ignored">                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">          </span><span class="missed">&lt;node type="choose when" version="3.0"&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">            </span><span class="missed">&lt;xsl:text version="3.0"&gt;</span><span class="missed">100</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+26: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+27: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:otherwise&gt;</span>
+29: <span class="ignored">          </span><span class="hit">&lt;node type="choose otherwise"&gt;</span>
+30: <span class="ignored">            </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+31: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;/xsl:otherwise&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:when with no content matches so first when and otherwise not executed --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="1 eq 2" version="3.0"&gt;</span><span class="ignored">                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+37: <span class="ignored">          </span><span class="missed">&lt;node type="choose when" version="3.0"&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+38: <span class="ignored">            </span><span class="missed">&lt;xsl:text version="3.0"&gt;</span><span class="missed">100</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+39: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+40: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+41: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="2 eq 2"&gt;</span><span class="missed">&lt;/xsl:when&gt;</span>
+42: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise version="3.0"&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+43: <span class="ignored">          </span><span class="missed">&lt;node type="choose otherwise" version="3.0"&gt;</span><span class="ignored">                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+44: <span class="ignored">            </span><span class="missed">&lt;xsl:text version="3.0"&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+45: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+46: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+47: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+48: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:when doesn't match so when not executed. otherwise has no content. --&gt;</span>
+49: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+50: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="1 eq 2" version="3.0"&gt;</span><span class="ignored">                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+51: <span class="ignored">          </span><span class="missed">&lt;node type="choose when" version="3.0"&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+52: <span class="ignored">            </span><span class="missed">&lt;xsl:text version="3.0"&gt;</span><span class="missed">100</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+53: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+54: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+55: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="missed">&lt;/xsl:otherwise&gt;</span>
+56: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+57: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+58: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+59: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-choose-01.xspec">
+   <compiled uri="xsl-choose-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-choose-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="36" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
+   <hit lineNumber="9" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="11" columnNumber="36" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="11" columnNumber="36" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="12" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="29" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="35" columnNumber="19" moduleId="0" traceableId="2"/>
+   <hit lineNumber="49" columnNumber="19" moduleId="0" traceableId="2"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-comment-01.xsl">xsl-comment-01.xsl</a></p>
-      <h2>module: xsl-comment-01.xsl; 13 lines</h2>
+      <h2>module: xsl-comment-01.xsl; 23 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -18,8 +18,18 @@
 08: <span class="ignored">      </span><span class="hit">&lt;node type="comment"&gt;</span>
 09: <span class="ignored">        </span><span class="hit">&lt;xsl:comment&gt;</span><span class="missed"> 100 </span><span class="hit">&lt;/xsl:comment&gt;</span>
 10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+11: <span class="ignored">      </span><span class="hit">&lt;node type="comment"&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;xsl:comment&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed"> 100 </span><span class="hit">&lt;/xsl:text&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;/xsl:comment&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">      </span><span class="hit">&lt;node type="comment"&gt;</span>
+17: <span class="ignored">        </span><span class="hit">&lt;xsl:comment&gt;</span>
+18: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="concat('Data is ', @data)"/&gt;</span>
+19: <span class="ignored">        </span><span class="hit">&lt;/xsl:comment&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+21: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+22: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+23: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-comment-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-comment-01.xsl">xsl-comment-01.xsl</a></p>
+      <h2>module: xsl-comment-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:comment Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-comment"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="comment"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:comment&gt;</span><span class="missed"> 100 </span><span class="hit">&lt;/xsl:comment&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.xml
@@ -13,6 +13,15 @@
    <hit lineNumber="8" columnNumber="28" moduleId="0" traceableId="2"/>
    <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}comment"/>
    <hit lineNumber="9" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="22" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="13" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="16" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="17" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="61" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-comment-01.xspec">
+   <compiled uri="xsl-comment-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-comment-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="28" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="28" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}comment"/>
+   <hit lineNumber="9" columnNumber="22" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-context-item-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-context-item-01.xsl">xsl-context-item-01.xsl</a></p>
+      <h2>module: xsl-context-item-01.xsl; 14 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:context-item Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-context-item"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;xsl:context-item use="required" as="item()" /&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;node type="context-item"&gt;</span>
+10: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+13: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-context-item-01.xspec">
+   <compiled uri="xsl-context-item-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-context-item-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="42" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="35" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="21" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-copy-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-copy-01.xsl">xsl-copy-01.xsl</a></p>
+      <h2>module: xsl-copy-01.xsl; 20 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:copy Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-copy"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="copy"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:copy select="node[2]/text()" /&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="copy"&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:copy&gt;</span>
+15: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="node[3]/text()" /&gt;</span><span class="ignored">&lt;!-- Copies the context node which is xsl-copy --&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;/xsl:copy&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+19: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+20: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-copy-01.xspec">
+   <compiled uri="xsl-copy-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-copy-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="34" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="25" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="25" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy-of"/>
+   <hit lineNumber="10" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="2"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
+   <hit lineNumber="14" columnNumber="19" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="15" columnNumber="51" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-copy-of-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-copy-of-01.xsl">xsl-copy-of-01.xsl</a></p>
+      <h2>module: xsl-copy-of-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:copy-of Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-copy-of"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="copy-of"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:copy-of select="*" /&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-copy-of-01.xspec">
+   <compiled uri="xsl-copy-of-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-copy-of-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="28" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="28" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy-of"/>
+   <hit lineNumber="9" columnNumber="35" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-decimal-format-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-decimal-format-01.xsl">xsl-decimal-format-01.xsl</a></p>
+      <h2>module: xsl-decimal-format-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:decimal-format Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:decimal-format name="decFormat01" digit="?" /&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-decimal-format"&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="decimal-format"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="format-number(100.00, '???0', 'decFormat01')" /&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-decimal-format-01.xspec">
+   <compiled uri="xsl-decimal-format-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-decimal-format-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="8" columnNumber="44" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="9" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="11" columnNumber="79" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-document-01.xsl">xsl-document-01.xsl</a></p>
+      <h2>module: xsl-document-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:document Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-document"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:document&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;node type="document"&gt;</span>
+10: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/xsl:document&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-document-01.xspec">
+   <compiled uri="xsl-document-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-document-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="8" columnNumber="21" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="31" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="31" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="21" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-element-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-element-01.xsl">xsl-element-01.xsl</a></p>
+      <h2>module: xsl-element-01.xsl; 14 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:element Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-element"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="node"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">element</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+13: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-element-01.xspec">
+   <compiled uri="xsl-element-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-element-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="32" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-evaluate-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-evaluate-01.xsl">xsl-evaluate-01.xsl</a></p>
+      <h2>module: xsl-evaluate-01.xsl; 35 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:evaluate Coverage Test Case - need a test case using with-param</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Data for the test --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="data"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;data value="400"&gt;</span><span class="hit">400</span><span class="hit">&lt;/data&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;data value="100"&gt;</span><span class="hit">100</span><span class="hit">&lt;/data&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;data value="300"&gt;</span><span class="hit">300</span><span class="hit">&lt;/data&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;data value="200"&gt;</span><span class="hit">300</span><span class="hit">&lt;/data&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+13: <span class="ignored">  </span><span class="ignored">&lt;!-- Sort key --&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="sortKey"&gt;</span><span class="hit">@value</span><span class="hit">&lt;/xsl:variable&gt;</span>
+15: 
+16: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="xsl-evaluate"&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;xsl:for-each select="$data/data"&gt;</span>
+19: <span class="ignored">          </span><span class="missed">&lt;xsl:sort&gt;</span>
+20: <span class="ignored">            </span><span class="missed">&lt;xsl:evaluate xpath="$sortKey" context-item="."  /&gt;</span>
+21: <span class="ignored">          </span><span class="missed">&lt;/xsl:sort&gt;</span>
+22: <span class="ignored">          </span><span class="hit">&lt;node type="evaluate"&gt;</span>
+23: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="@value" /&gt;</span>
+24: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+25: <span class="ignored">        </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+26: <span class="ignored">        </span><span class="ignored">&lt;!--xsl:variable name="evaluateExpression"&gt;</span>
+27: <span class="ignored">            &lt;xsl:evaluate xpath="substring('hello', 1, 4)" /&gt;</span>
+28: <span class="ignored">        &lt;/xsl:variable&gt;</span>
+29: <span class="ignored">          &lt;node type="evaluate"&gt;</span>
+30: <span class="ignored">            &lt;xsl:value-of select="$evaluateExpression" /&gt;</span>
+31: <span class="ignored">          &lt;/node--&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+33: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+35: </pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -11,7 +11,7 @@
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-04: <span class="ignored">      xsl:evaluate Coverage Test Case - need a test case using with-param</span>
+04: <span class="ignored">      xsl:evaluate Coverage Test Case</span>
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- Data for the test --&gt;</span>
 07: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="data"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-evaluate-01.xsl">xsl-evaluate-01.xsl</a></p>
-      <h2>module: xsl-evaluate-01.xsl; 35 lines</h2>
+      <h2>module: xsl-evaluate-01.xsl; 49 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -18,7 +18,7 @@
 08: <span class="ignored">    </span><span class="hit">&lt;data value="400"&gt;</span><span class="hit">400</span><span class="hit">&lt;/data&gt;</span>
 09: <span class="ignored">    </span><span class="hit">&lt;data value="100"&gt;</span><span class="hit">100</span><span class="hit">&lt;/data&gt;</span>
 10: <span class="ignored">    </span><span class="hit">&lt;data value="300"&gt;</span><span class="hit">300</span><span class="hit">&lt;/data&gt;</span>
-11: <span class="ignored">    </span><span class="hit">&lt;data value="200"&gt;</span><span class="hit">300</span><span class="hit">&lt;/data&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;data value="200"&gt;</span><span class="hit">200</span><span class="hit">&lt;/data&gt;</span>
 12: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
 13: <span class="ignored">  </span><span class="ignored">&lt;!-- Sort key --&gt;</span>
 14: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="sortKey"&gt;</span><span class="hit">@value</span><span class="hit">&lt;/xsl:variable&gt;</span>
@@ -33,15 +33,29 @@
 23: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="@value" /&gt;</span>
 24: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
 25: <span class="ignored">        </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-26: <span class="ignored">        </span><span class="ignored">&lt;!--xsl:variable name="evaluateExpression"&gt;</span>
-27: <span class="ignored">            &lt;xsl:evaluate xpath="substring('hello', 1, 4)" /&gt;</span>
-28: <span class="ignored">        &lt;/xsl:variable&gt;</span>
-29: <span class="ignored">          &lt;node type="evaluate"&gt;</span>
-30: <span class="ignored">            &lt;xsl:value-of select="$evaluateExpression" /&gt;</span>
-31: <span class="ignored">          &lt;/node--&gt;</span>
-32: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
-33: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
-34: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
-35: </pre>
+26: 
+27: <span class="ignored">        </span><span class="ignored">&lt;!-- Circuitous ways to get $data/data[2] content --&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
+29: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
+30: <span class="ignored">          </span><span class="hit">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"&gt;</span>
+31: <span class="ignored">            </span><span class="hit">&lt;xsl:with-param name="index" select="$index" /&gt;</span>
+32: <span class="ignored">            </span><span class="hit">&lt;xsl:with-param name="sortKey"&gt;</span><span class="hit">parameter not used in evaluation</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+33: <span class="ignored">          </span><span class="hit">&lt;/xsl:evaluate&gt;</span>
+34: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
+35: <span class="ignored">        </span><span class="hit">&lt;node type="evaluate/with-param"&gt;</span>
+36: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span>
+37: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+38: 
+39: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamAttr"&gt;</span>
+40: <span class="ignored">          </span><span class="hit">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"</span>
+41: <span class="hit">            with-params="map{QName('','index'): $index }" /&gt;</span>
+42: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
+43: <span class="ignored">        </span><span class="hit">&lt;node type="evaluate/with-param"&gt;</span>
+44: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="$evaluatedExpressionParamAttr" /&gt;</span>
+45: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+46: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+47: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+48: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
+49: </pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.xml
@@ -49,6 +49,21 @@
    <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="1"/>
    <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="5"/>
    <hit lineNumber="23" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="29" columnNumber="60" moduleId="0" traceableId="4"/>
+   <traceable traceableId="7" class="net.sf.saxon.expr.LetExpression"/>
+   <hit lineNumber="29" columnNumber="60" moduleId="0" traceableId="7"/>
+   <hit lineNumber="30" columnNumber="0" moduleId="0" traceableId="4"/>
+   <traceable traceableId="8" class="net.sf.saxon.expr.instruct.EvaluateInstr"/>
+   <hit lineNumber="30" columnNumber="0" moduleId="0" traceableId="8"/>
+   <hit lineNumber="35" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="42" moduleId="0" traceableId="5"/>
+   <hit lineNumber="36" columnNumber="67" moduleId="0" traceableId="6"/>
+   <hit lineNumber="39" columnNumber="59" moduleId="0" traceableId="7"/>
+   <hit lineNumber="41" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="41" columnNumber="0" moduleId="0" traceableId="8"/>
+   <hit lineNumber="43" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="42" moduleId="0" traceableId="5"/>
+   <hit lineNumber="44" columnNumber="66" moduleId="0" traceableId="6"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-evaluate-01.xspec">
+   <compiled uri="xsl-evaluate-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-evaluate-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="16" columnNumber="39" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="17" columnNumber="13" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="18" columnNumber="43" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="7" columnNumber="29" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="8" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="8" columnNumber="23" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="23" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="8" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="9" columnNumber="23" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="23" moduleId="0" traceableId="5"/>
+   <hit lineNumber="9" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="10" columnNumber="23" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="23" moduleId="0" traceableId="5"/>
+   <hit lineNumber="10" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="11" columnNumber="23" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="23" moduleId="0" traceableId="5"/>
+   <hit lineNumber="11" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="20" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="32" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="20" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="20" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="20" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="45" moduleId="0" traceableId="6"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-fallback-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-fallback-01.xsl">xsl-fallback-01.xsl</a></p>
+      <h2>module: xsl-fallback-01.xsl; 19 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+03: <span class="ignored">                version="99.0"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:fallback Coverage Test Case</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="xsl-fallback"&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">        </span><span class="ignored">&lt;!-- Sets the xsl version number higher than current version and has unknown instruction (adapted from XSLT Spec) --&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:non-existant-instruction&gt;</span><span class="ignored">                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+11: <span class="ignored">          </span><span class="missed">&lt;xsl:fallback&gt;</span>
+12: <span class="ignored">            </span><span class="hit">&lt;node type="fallback"&gt;</span>
+13: <span class="ignored">              </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+14: <span class="ignored">            </span><span class="hit">&lt;/node&gt;</span>
+15: <span class="ignored">          </span><span class="missed">&lt;/xsl:fallback&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;/xsl:non-existant-instruction&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+18: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+19: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -17,13 +17,13 @@
 07: <span class="ignored">   </span><span class="hit">&lt;xsl:template match="xsl-fallback"&gt;</span>
 08: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
 09: <span class="ignored">        </span><span class="ignored">&lt;!-- Sets the xsl version number higher than current version and has unknown instruction (adapted from XSLT Spec) --&gt;</span>
-10: <span class="ignored">        </span><span class="missed">&lt;xsl:non-existant-instruction&gt;</span><span class="ignored">                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:non-existent-instruction&gt;</span><span class="ignored">                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 11: <span class="ignored">          </span><span class="missed">&lt;xsl:fallback&gt;</span>
 12: <span class="ignored">            </span><span class="hit">&lt;node type="fallback"&gt;</span>
 13: <span class="ignored">              </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
 14: <span class="ignored">            </span><span class="hit">&lt;/node&gt;</span>
 15: <span class="ignored">          </span><span class="missed">&lt;/xsl:fallback&gt;</span>
-16: <span class="ignored">        </span><span class="missed">&lt;/xsl:non-existant-instruction&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;/xsl:non-existent-instruction&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 17: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
 18: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
 19: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-fallback-01.xspec">
+   <compiled uri="xsl-fallback-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-fallback-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="39" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="12" columnNumber="35" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-for-each-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-for-each-01.xsl">xsl-for-each-01.xsl</a></p>
+      <h2>module: xsl-for-each-01.xsl; 16 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:for-each Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-for-each"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple for-each --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="1 to 5"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;node type="for-each"&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select=". * 100" /&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+16: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-for-each-01.xspec">
+   <compiled uri="xsl-for-each-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-for-each-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="9" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="11" columnNumber="44" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="44" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="44" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="44" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="31" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="44" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
@@ -11,7 +11,7 @@
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-04: <span class="ignored">      xsl:for-each-group - just a singe example using group-by.</span>
+04: <span class="ignored">      xsl:for-each-group - just a single example using group-by.</span>
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-for-each-group"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-for-each-group-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-for-each-group-01.xsl">xsl-for-each-group-01.xsl</a></p>
+      <h2>module: xsl-for-each-group-01.xsl; 16 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:for-each-group - just a singe example using group-by.</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-for-each-group"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Returns remainder after division by 3. Groups contain 0, 1 and 2 --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each-group select="9 to 20" group-by="(. mod 3)"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;node type="for-each-group"&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="current-grouping-key()" /&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
+14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+16: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-for-each-group-01.xspec">
+   <compiled uri="xsl-for-each-group-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-for-each-group-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="44" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each-group"/>
+   <hit lineNumber="9" columnNumber="65" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="11" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="59" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-function-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-function-01.xsl">xsl-function-01.xsl</a></p>
+      <h2>module: xsl-function-01.xsl; 23 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:myns="myNamespace"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:function Coverage Test Case</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-function"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Very simple just to check function called --&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="function"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnHundred()" /&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;!-- Function called --&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:returnHundred"&gt;</span>
+17: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+19: <span class="ignored">  </span><span class="ignored">&lt;!-- Function NOT called --&gt;</span>
+20: <span class="ignored">  </span><span class="missed">&lt;xsl:function name="myns:returnThousand"&gt;</span><span class="ignored">                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+21: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+22: <span class="ignored">  </span><span class="missed">&lt;/xsl:function&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-function-01.xspec">
+   <compiled uri="xsl-function-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-function-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="11" columnNumber="55" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
+   <hit lineNumber="16" columnNumber="43" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
@@ -16,11 +16,11 @@
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-if"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Test succeeds --&gt;</span>
-09: <span class="ignored">      </span><span class="hit">&lt;xsl:if test=" 1 eq 1"&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="1 eq 1"&gt;</span>
 10: <span class="ignored">        </span><span class="hit">&lt;node type="if"&gt;</span><span class="missed">100</span><span class="hit">&lt;/node&gt;</span>
 11: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
 12: <span class="ignored">      </span><span class="ignored">&lt;!-- Test fails but xsl:if still executed and is a hit--&gt;</span>
-13: <span class="ignored">      </span><span class="hit">&lt;xsl:if test=" 1 eq 2"&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="1 eq 2"&gt;</span>
 14: <span class="ignored">        </span><span class="missed">&lt;node type="if"&gt;</span><span class="missed">200</span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 15: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
 16: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-if-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-if-01.xsl">xsl-if-01.xsl</a></p>
+      <h2>module: xsl-if-01.xsl; 18 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:if - xsl:if is always executed</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-if"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Test succeeds --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:if test=" 1 eq 1"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;node type="if"&gt;</span><span class="missed">100</span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Test fails but xsl:if still executed and is a hit--&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;xsl:if test=" 1 eq 2"&gt;</span>
+14: <span class="ignored">        </span><span class="missed">&lt;node type="if"&gt;</span><span class="missed">200</span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+16: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+17: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+18: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.xml
@@ -8,14 +8,14 @@
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
-   <hit lineNumber="9" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="2"/>
    <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="1"/>
    <traceable traceableId="3"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
    <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="3"/>
    <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
    <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="4"/>
-   <hit lineNumber="13" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="2"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-if-01.xspec">
+   <compiled uri="xsl-if-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-if-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="32" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="9" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="25" moduleId="0" traceableId="4"/>
+   <hit lineNumber="13" columnNumber="30" moduleId="0" traceableId="2"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-import-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-import-01.xsl">xsl-import-01.xsl</a></p>
+      <h2>module: xsl-import-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:import Coverage Test Case (See imported stylesheet)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-import-01A.xsl" /&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-import"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Call template in imported stylesheet --&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="importTemplate01" /&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-import-01A.xsl; 10 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+03: 
+04: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:import Template --&gt;</span>
+05: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="importTemplate01"&gt;</span>
+06: <span class="ignored">    </span><span class="hit">&lt;node type="import"&gt;</span>
+07: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+09: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+10: <span class="ignored"> </span><span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-import-01.xspec">
+   <compiled uri="xsl-import-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-import-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="36" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="10" columnNumber="52" moduleId="0" traceableId="2"/>
+   <module moduleId="1" uri="../../xsl-import-01A.xsl"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="5" columnNumber="41" moduleId="1" traceableId="3"/>
+   <hit lineNumber="6" columnNumber="25" moduleId="1" traceableId="1"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="6" columnNumber="25" moduleId="1" traceableId="4"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="7" columnNumber="17" moduleId="1" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-include-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-include-01.xsl">xsl-include-01.xsl</a></p>
+      <h2>module: xsl-include-01.xsl; 14 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:include Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:include --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01A.xsl" /&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+09: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-include"&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="includeTemplate01" /&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+13: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-include-01A.xsl; 9 lines</h2>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+2: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+3: <span class="ignored">  </span><span class="ignored">&lt;!-- Caled Template in this include stylesheet --&gt;</span>
+4: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="includeTemplate01"&gt;</span>
+5: <span class="ignored">    </span><span class="hit">&lt;node type="include"&gt;</span>
+6: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+7: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+8: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+9: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -25,7 +25,7 @@
       <h2>module: xsl-include-01A.xsl; 9 lines</h2>
       <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 2: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
-3: <span class="ignored">  </span><span class="ignored">&lt;!-- Caled Template in this include stylesheet --&gt;</span>
+3: <span class="ignored">  </span><span class="ignored">&lt;!-- Called Template in this include stylesheet --&gt;</span>
 4: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="includeTemplate01"&gt;</span>
 5: <span class="ignored">    </span><span class="hit">&lt;node type="include"&gt;</span>
 6: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-include-01.xspec">
+   <compiled uri="xsl-include-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-include-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="9" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="10" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="11" columnNumber="53" moduleId="0" traceableId="2"/>
+   <module moduleId="1" uri="../../xsl-include-01A.xsl"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="4" columnNumber="42" moduleId="1" traceableId="3"/>
+   <hit lineNumber="5" columnNumber="26" moduleId="1" traceableId="1"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="5" columnNumber="26" moduleId="1" traceableId="4"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="6" columnNumber="17" moduleId="1" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -77,7 +77,7 @@
 067: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="param01" select="$newValue" /&gt;</span>
 068: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
 069: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-070: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion and xsl:break executed (xsl:on-completion not executed) --&gt;</span>
+070: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:break executed and xsl:on-completion not executed --&gt;</span>
 071: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
 072: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 073: <span class="ignored">          </span><span class="missed">&lt;node type="iterate/on-completion/break"&gt;</span><span class="ignored">                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
@@ -91,7 +91,7 @@
 081: <span class="ignored">          </span><span class="hit">&lt;xsl:break /&gt;</span>
 082: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
 083: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-084: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion and xsl:break not executed --&gt;</span>
+084: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion executed and xsl:break not executed --&gt;</span>
 085: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
 086: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span>
 087: <span class="ignored">          </span><span class="hit">&lt;node type="iterate/on-completion/break"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-iterate-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-iterate-01.xsl">xsl-iterate-01.xsl</a></p>
+      <h2>module: xsl-iterate-01.xsl; 135 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+003: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+004: <span class="ignored">      xsl:iterate Coverage Test Case (includes xsl:next-iteration xsl:on-completion xsl:break)</span>
+005: <span class="ignored">  --&gt;</span>
+006: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-iterate"&gt;</span>
+007: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+008: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple xsl:iterate with no xsl:next-iteration, xsl:on-competion or xsl:break --&gt;</span>
+009: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+010: <span class="ignored">        </span><span class="hit">&lt;node type="iterate"&gt;</span>
+011: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+012: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+013: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+014: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple xsl:iterate with just xsl:on-completion --&gt;</span>
+015: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+016: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span>
+017: <span class="ignored">          </span><span class="hit">&lt;node type="iterate/on-completion"&gt;</span>
+018: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Complete</span><span class="missed">&lt;/xsl:text&gt;</span>
+019: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+020: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-completion&gt;</span>
+021: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/on-completion"&gt;</span>
+022: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+023: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+024: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+025: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple xsl:iterate with just xsl:next-iteration --&gt;</span>
+026: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+027: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="param01" select="1" /&gt;</span>
+028: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="newValue" select="$param01 * 2" /&gt;</span>
+029: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/next-iteration"&gt;</span>
+030: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select=". * $newValue" /&gt;</span>
+031: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+032: <span class="ignored">        </span><span class="hit">&lt;xsl:next-iteration&gt;</span>
+033: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="param01" select="$newValue" /&gt;</span>
+034: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
+035: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+036: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple xsl:iterate with xsl:break executed --&gt;</span>
+037: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+038: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+039: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+040: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+041: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
+042: <span class="ignored">          </span><span class="hit">&lt;xsl:break /&gt;</span>
+043: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+044: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+045: <span class="ignored">      </span><span class="ignored">&lt;!-- Simple xsl:iterate with xsl:break not executed --&gt;</span>
+046: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+047: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+048: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+049: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+050: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 2500"&gt;</span>
+051: <span class="ignored">          </span><span class="missed">&lt;xsl:break /&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+052: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+054: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:next-iteration and xsl:on-completion --&gt;</span>
+055: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+056: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="param01" select="1" /&gt;</span>
+057: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span>
+058: <span class="ignored">          </span><span class="hit">&lt;node type="iterate/next-iteration/on-completion"&gt;</span>
+059: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Complete</span><span class="missed">&lt;/xsl:text&gt;</span>
+060: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+061: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-completion&gt;</span>
+062: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="newValue" select="$param01 * 2" /&gt;</span>
+063: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/next-iteration/on-completion"&gt;</span>
+064: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select=". * $newValue" /&gt;</span>
+065: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+066: <span class="ignored">        </span><span class="hit">&lt;xsl:next-iteration&gt;</span>
+067: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="param01" select="$newValue" /&gt;</span>
+068: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
+069: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+070: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion and xsl:break executed (xsl:on-completion not executed) --&gt;</span>
+071: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+072: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+073: <span class="ignored">          </span><span class="missed">&lt;node type="iterate/on-completion/break"&gt;</span><span class="ignored">                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+074: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Complete</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+075: <span class="ignored">          </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+076: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+077: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/on-completion/break"&gt;</span>
+078: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+079: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+080: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
+081: <span class="ignored">          </span><span class="hit">&lt;xsl:break /&gt;</span>
+082: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+083: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+084: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion and xsl:break not executed --&gt;</span>
+085: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+086: <span class="ignored">        </span><span class="missed">&lt;xsl:on-completion&gt;</span>
+087: <span class="ignored">          </span><span class="hit">&lt;node type="iterate/on-completion/break"&gt;</span>
+088: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Complete</span><span class="missed">&lt;/xsl:text&gt;</span>
+089: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+090: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-completion&gt;</span>
+091: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/on-completion/break"&gt;</span>
+092: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+093: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+094: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 2500"&gt;</span>
+095: <span class="ignored">          </span><span class="missed">&lt;xsl:break /&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+096: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+097: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+098: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:break executed (xsl:break has select attribute) --&gt;</span>
+099: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+100: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+101: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+102: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+103: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
+104: <span class="ignored">          </span><span class="hit">&lt;xsl:break select="'break executed'" /&gt;</span>
+105: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+106: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+107: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:break executed (xsl:break has sequence constructor) --&gt;</span>
+108: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+109: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+110: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+111: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+112: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
+113: <span class="ignored">          </span><span class="hit">&lt;xsl:break&gt;</span>
+114: <span class="ignored">            </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+115: <span class="ignored">              </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+116: <span class="ignored">            </span><span class="hit">&lt;/node&gt;</span>
+117: <span class="ignored">          </span><span class="hit">&lt;/xsl:break&gt;</span>
+118: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+119: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+120: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:break not executed (xsl:break has sequence constructor) --&gt;</span>
+121: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+122: <span class="ignored">        </span><span class="hit">&lt;node type="iterate/break"&gt;</span>
+123: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+124: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+125: <span class="ignored">        </span><span class="hit">&lt;xsl:if test=". &amp;gt; 2400"&gt;</span>
+126: <span class="ignored">          </span><span class="missed">&lt;xsl:break&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+127: <span class="ignored">            </span><span class="missed">&lt;node type="iterate/break"&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+128: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+129: <span class="ignored">            </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+130: <span class="ignored">          </span><span class="missed">&lt;/xsl:break&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+131: <span class="ignored">        </span><span class="hit">&lt;/xsl:if&gt;</span>
+132: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+133: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+134: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+135: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-iterate-01.xspec">
+   <compiled uri="xsl-iterate-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-iterate-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
+   <hit lineNumber="9" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="11" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="30" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="15" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="46" moduleId="0" traceableId="1"/>
+   <hit lineNumber="17" columnNumber="46" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="26" columnNumber="34" moduleId="0" traceableId="2"/>
+   <traceable traceableId="5" class="net.sf.saxon.expr.LetExpression"/>
+   <hit lineNumber="28" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="50" moduleId="0" traceableId="4"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}next-iteration"/>
+   <hit lineNumber="32" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="28" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="32" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="28" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="32" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="37" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="38" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="38" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="39" columnNumber="38" moduleId="0" traceableId="4"/>
+   <traceable traceableId="7" uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="38" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="38" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="39" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="7"/>
+   <traceable traceableId="8" uqname="Q{http://www.w3.org/1999/XSL/Transform}break"/>
+   <hit lineNumber="42" columnNumber="24" moduleId="0" traceableId="8"/>
+   <hit lineNumber="46" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="48" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="48" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="47" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="48" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="55" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="62" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="1"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="3"/>
+   <hit lineNumber="64" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="62" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="1"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="3"/>
+   <hit lineNumber="64" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="62" columnNumber="63" moduleId="0" traceableId="5"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="1"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="3"/>
+   <hit lineNumber="64" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="58" columnNumber="61" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="61" moduleId="0" traceableId="3"/>
+   <hit lineNumber="59" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="71" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="77" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="77" columnNumber="50" moduleId="0" traceableId="3"/>
+   <hit lineNumber="78" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="80" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="77" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="77" columnNumber="50" moduleId="0" traceableId="3"/>
+   <hit lineNumber="78" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="80" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="81" columnNumber="24" moduleId="0" traceableId="8"/>
+   <hit lineNumber="85" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="3"/>
+   <hit lineNumber="92" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="94" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="3"/>
+   <hit lineNumber="92" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="94" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="91" columnNumber="50" moduleId="0" traceableId="3"/>
+   <hit lineNumber="92" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="94" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="87" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="99" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="100" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="100" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="101" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="100" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="100" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="101" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="104" columnNumber="50" moduleId="0" traceableId="8"/>
+   <hit lineNumber="108" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="109" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="109" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="110" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="112" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="109" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="109" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="110" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="112" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="114" columnNumber="40" moduleId="0" traceableId="1"/>
+   <hit lineNumber="114" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="115" columnNumber="42" moduleId="0" traceableId="4"/>
+   <hit lineNumber="113" columnNumber="22" moduleId="0" traceableId="8"/>
+   <hit lineNumber="121" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="123" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="125" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="123" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="125" columnNumber="36" moduleId="0" traceableId="7"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="122" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="123" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="125" columnNumber="36" moduleId="0" traceableId="7"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-key-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-key-01.xsl">xsl-key-01.xsl</a></p>
+      <h2>module: xsl-key-01.xsl; 19 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:key Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:key declaration --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:key name="key01" match="node" use="@type" /&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+09: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-key"&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;node type="key"&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="key('key01', 'B')" /&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;node type="key"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="key('key01', 'D')" /&gt;</span>
+16: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+17: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+18: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+19: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-key-01.xspec">
+   <compiled uri="xsl-key-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-key-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="9" columnNumber="33" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="10" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="24" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="11" columnNumber="24" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="12" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="24" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="24" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="52" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -7,39 +7,81 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-map-01.xsl">xsl-map-01.xsl</a></p>
-      <h2>module: xsl-map-01.xsl; 33 lines</h2>
+      <h2>module: xsl-map-01.xsl; 75 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
-03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"&gt;</span>
-04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-05: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map)</span>
-06: <span class="ignored">  --&gt;</span>
-07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
-08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-09: <span class="ignored">      </span><span class="ignored">&lt;!-- Map construction, including xsl:map --&gt;</span>
-10: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="hundreds" as="map(xs:string, xs:integer)"&gt;</span>
-11: <span class="ignored">        </span><span class="hit">&lt;xsl:map&gt;</span>
-12: <span class="ignored">          </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
-13: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
-14: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
-15: <span class="ignored">          </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
-16: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
-17: <span class="ignored">            </span><span class="hit">&lt;xsl:sequence select="300" /&gt;</span>
-18: <span class="ignored">          </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
-19: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Four'"&gt;</span>
-20: <span class="ignored">            </span><span class="hit">&lt;xsl:sequence select="400" /&gt;</span>
-21: <span class="ignored">          </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
-22: <span class="ignored">        </span><span class="hit">&lt;/xsl:map&gt;</span>
-23: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
-24: <span class="ignored">      </span><span class="ignored">&lt;!-- Use xsl:map values --&gt;</span>
-25: <span class="ignored">      </span><span class="hit">&lt;node type="map"&gt;</span>
-26: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds('One')" /&gt;</span>
-27: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-28: <span class="ignored">      </span><span class="hit">&lt;node type="map"&gt;</span>
-29: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds('Three')" /&gt;</span>
-30: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-31: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-32: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-33: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
+04: <span class="ignored">                xmlns:myns="myNamespace"&gt;</span>
+05: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+06: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map)</span>
+07: <span class="ignored">  --&gt;</span>
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
+09: <span class="ignored">    </span><span class="ignored">&lt;!-- Map construction, including xsl:map --&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="hundreds-param" as="map(xs:string, xs:integer)"&gt;</span>
+11: <span class="ignored">      </span><span class="missed">&lt;xsl:map&gt;</span>
+12: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+13: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+14: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+15: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
+17: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="300" /&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+19: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
+20: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+21: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+22: <span class="ignored">      </span><span class="missed">&lt;/xsl:map&gt;</span>
+23: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+24: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="hundreds-variable" as="map(xs:string, xs:integer)"&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;xsl:map&gt;</span>
+26: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+29: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+30: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
+31: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence select="300" /&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+33: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Four'"&gt;</span>
+34: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence select="400" /&gt;</span>
+35: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+36: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
+37: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+38: <span class="ignored">    </span><span class="ignored">&lt;!-- Use xsl:map values --&gt;</span>
+39: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+40: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
+41: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('One')" /&gt;</span>
+42: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+43: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
+44: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('Three')" /&gt;</span>
+45: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+46: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+47: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('One')" /&gt;</span>
+48: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+49: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+50: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('Three')" /&gt;</span>
+51: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+52: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
+53: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('One')" /&gt;</span>
+54: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+55: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
+56: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('Three')" /&gt;</span>
+57: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+58: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+59: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+60: 
+61: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:returnMap" as="map(xs:string, xs:integer)"&gt;</span>
+62: <span class="ignored">    </span><span class="missed">&lt;xsl:map&gt;</span>
+63: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+64: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+65: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+66: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+67: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
+68: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="300" /&gt;</span>
+69: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+70: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
+71: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+72: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+73: <span class="ignored">    </span><span class="missed">&lt;/xsl:map&gt;</span>
+74: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+75: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -13,7 +13,7 @@
 03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
 04: <span class="ignored">                xmlns:myns="myNamespace"&gt;</span>
 05: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-06: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map)</span>
+06: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map-entry)</span>
 07: <span class="ignored">  --&gt;</span>
 08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
 09: <span class="ignored">    </span><span class="ignored">&lt;!-- Map construction, including xsl:map --&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-map-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-map-01.xsl">xsl-map-01.xsl</a></p>
+      <h2>module: xsl-map-01.xsl; 33 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map)</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Map construction, including xsl:map --&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="hundreds" as="map(xs:string, xs:integer)"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:map&gt;</span>
+12: <span class="ignored">          </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+14: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+15: <span class="ignored">          </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+16: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
+17: <span class="ignored">            </span><span class="hit">&lt;xsl:sequence select="300" /&gt;</span>
+18: <span class="ignored">          </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+19: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="'Four'"&gt;</span>
+20: <span class="ignored">            </span><span class="hit">&lt;xsl:sequence select="400" /&gt;</span>
+21: <span class="ignored">          </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;/xsl:map&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+24: <span class="ignored">      </span><span class="ignored">&lt;!-- Use xsl:map values --&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;node type="map"&gt;</span>
+26: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds('One')" /&gt;</span>
+27: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;node type="map"&gt;</span>
+29: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds('Three')" /&gt;</span>
+30: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+31: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+32: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+33: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-map-01.xspec">
+   <compiled uri="xsl-map-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-map-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="33" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.LetExpression"/>
+   <hit lineNumber="10" columnNumber="69" moduleId="0" traceableId="2"/>
+   <hit lineNumber="25" columnNumber="24" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="25" columnNumber="24" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="26" columnNumber="51" moduleId="0" traceableId="4"/>
+   <hit lineNumber="28" columnNumber="24" moduleId="0" traceableId="1"/>
+   <hit lineNumber="28" columnNumber="24" moduleId="0" traceableId="3"/>
+   <hit lineNumber="29" columnNumber="53" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
@@ -4,21 +4,39 @@
    <module moduleId="0" uri="../../xsl-map-01.xsl"/>
    <traceable traceableId="0"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="7" columnNumber="33" moduleId="0" traceableId="0"/>
-   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="33" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="13" columnNumber="0" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" class="net.sf.saxon.expr.LetExpression"/>
-   <hit lineNumber="10" columnNumber="69" moduleId="0" traceableId="2"/>
-   <hit lineNumber="25" columnNumber="24" moduleId="0" traceableId="1"/>
-   <traceable traceableId="3"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="25" columnNumber="24" moduleId="0" traceableId="3"/>
+   <hit lineNumber="24" columnNumber="76" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="39" columnNumber="11" moduleId="0" traceableId="3"/>
+   <hit lineNumber="40" columnNumber="30" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="40" columnNumber="30" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="26" columnNumber="51" moduleId="0" traceableId="4"/>
-   <hit lineNumber="28" columnNumber="24" moduleId="0" traceableId="1"/>
-   <hit lineNumber="28" columnNumber="24" moduleId="0" traceableId="3"/>
-   <hit lineNumber="29" columnNumber="53" moduleId="0" traceableId="4"/>
+   <hit lineNumber="41" columnNumber="57" moduleId="0" traceableId="5"/>
+   <hit lineNumber="43" columnNumber="30" moduleId="0" traceableId="3"/>
+   <hit lineNumber="43" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="44" columnNumber="59" moduleId="0" traceableId="5"/>
+   <hit lineNumber="46" columnNumber="33" moduleId="0" traceableId="3"/>
+   <hit lineNumber="46" columnNumber="33" moduleId="0" traceableId="4"/>
+   <hit lineNumber="47" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="49" columnNumber="33" moduleId="0" traceableId="3"/>
+   <hit lineNumber="49" columnNumber="33" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="52" columnNumber="33" moduleId="0" traceableId="3"/>
+   <hit lineNumber="52" columnNumber="33" moduleId="0" traceableId="4"/>
+   <hit lineNumber="53" columnNumber="58" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
+   <hit lineNumber="61" columnNumber="71" moduleId="0" traceableId="6"/>
+   <hit lineNumber="55" columnNumber="33" moduleId="0" traceableId="3"/>
+   <hit lineNumber="55" columnNumber="33" moduleId="0" traceableId="4"/>
+   <hit lineNumber="56" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="61" columnNumber="71" moduleId="0" traceableId="6"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-merge-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-merge-01.xsl">xsl-merge-01.xsl</a></p>
+      <h2>module: xsl-merge-01.xsl; 37 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:merge Coverage Test Case (also includes xsl:merge-source, xsl:merge-key and xsl:merge-action)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-merge"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">        </span><span class="ignored">&lt;!-- 2 data sets to be merged --&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="mergeSourceA"&gt;</span>
+10: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">100</span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">300</span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">500</span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="mergeSourceB"&gt;</span>
+15: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">200</span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">400</span><span class="hit">&lt;/node&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">600</span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
+19: <span class="ignored">        </span><span class="ignored">&lt;!-- 1st merge-key uses select attribute, 2nd uses sequence constructor --&gt;</span>
+20: <span class="ignored">        </span><span class="hit">&lt;xsl:merge&gt;</span>
+21: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span>
+22: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key select="." /&gt;</span>
+23: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
+24: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
+25: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key&gt;</span>
+26: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
+27: <span class="ignored">            </span><span class="missed">&lt;/xsl:merge-key&gt;</span>
+28: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
+29: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-action&gt;</span>
+30: <span class="ignored">            </span><span class="missed">&lt;node type="merge"&gt;</span>
+31: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="current-merge-group()" /&gt;</span>
+32: <span class="ignored">            </span><span class="missed">&lt;/node&gt;</span>
+33: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-action&gt;</span>
+34: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge&gt;</span>
+35: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+36: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+37: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-merge-01.xspec">
+   <compiled uri="xsl-merge-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-merge-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="35" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.LetExpression"/>
+   <hit lineNumber="9" columnNumber="43" moduleId="0" traceableId="2"/>
+   <hit lineNumber="14" columnNumber="43" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}merge"/>
+   <hit lineNumber="20" columnNumber="20" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="11" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="12" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="16" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-message-01.xsl">xsl-message-01.xsl</a></p>
-      <h2>module: xsl-message-01.xsl; 22 lines</h2>
+      <h2>module: xsl-message-01.xsl; 35 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -27,8 +27,21 @@
 17: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
 18: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
 19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- Terminate upon request --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'select'"&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;xsl:message select="string('Terminating Message: 100')" terminate="yes"/&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;xsl:message select="string('After terminating message')"/&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'sequence constructor'"&gt;</span>
+26: <span class="ignored">        </span><span class="hit">&lt;xsl:message terminate="yes"&gt;</span>
+27: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">Terminating Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
+29: <span class="ignored">        </span><span class="missed">&lt;xsl:message&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+30: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">After terminating message</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+31: <span class="ignored">        </span><span class="missed">&lt;/xsl:message&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+33: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+34: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+35: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-message-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-message-01.xsl">xsl-message-01.xsl</a></p>
+      <h2>module: xsl-message-01.xsl; 22 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:message Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-message"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="message"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:message select="string('Message: 100')" /&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="ignored">&lt;!-- Add content --&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;node type="message"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;xsl:message&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-message-01.xspec">
+   <compiled uri="xsl-message-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-message-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}message"/>
+   <hit lineNumber="11" columnNumber="56" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
@@ -20,7 +20,39 @@
    <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
    <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
    <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="25" columnNumber="59" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="56" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="22" columnNumber="83" moduleId="0" traceableId="4"/>
+   <util utilId="3" uri="../../../../../src/common/wrap.xsl"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="56" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="25" columnNumber="59" moduleId="0" traceableId="5"/>
+   <hit lineNumber="26" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="27" columnNumber="21" moduleId="0" traceableId="3"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-mode-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-mode-01.xsl">xsl-mode-01.xsl</a></p>
+      <h2>module: xsl-mode-01.xsl; 22 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:mode Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="modeUsed" /&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Mode not used --&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="modeNotUsed" /&gt;</span>
+09: 
+10: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-mode"&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+12: <span class="ignored">        </span><span class="ignored">&lt;!-- Apply template using mode - xspec context has a node element --&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;xsl:apply-templates mode="modeUsed" /&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+16: 
+17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="modeUsed"&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;node type="mode"&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -7,28 +7,29 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-mode-01.xsl">xsl-mode-01.xsl</a></p>
-      <h2>module: xsl-mode-01.xsl; 22 lines</h2>
+      <h2>module: xsl-mode-01.xsl; 23 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 04: <span class="ignored">      xsl:mode Coverage Test Case</span>
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="modeUsed" /&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;!-- Mode not used --&gt;</span>
-08: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="modeNotUsed" /&gt;</span>
-09: 
-10: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-mode"&gt;</span>
-11: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
-12: <span class="ignored">        </span><span class="ignored">&lt;!-- Apply template using mode - xspec context has a node element --&gt;</span>
-13: <span class="ignored">        </span><span class="hit">&lt;xsl:apply-templates mode="modeUsed" /&gt;</span>
-14: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
-15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-16: 
-17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="modeUsed"&gt;</span>
-18: <span class="ignored">    </span><span class="hit">&lt;node type="mode"&gt;</span>
-19: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
-20: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode on-multiple-match="fail" /&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;!-- Mode not used --&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="modeNotUsed" /&gt;</span>
+10: 
+11: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-mode"&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+13: <span class="ignored">        </span><span class="ignored">&lt;!-- Apply template using mode - xspec context has a node element --&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:apply-templates mode="modeUsed" /&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+17: 
+18: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="modeUsed"&gt;</span>
+19: <span class="ignored">    </span><span class="hit">&lt;node type="mode"&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+21: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+22: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+23: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.xml
@@ -4,19 +4,19 @@
    <module moduleId="0" uri="../../xsl-mode-01.xsl"/>
    <traceable traceableId="0"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="10" columnNumber="34" moduleId="0" traceableId="0"/>
+   <hit lineNumber="11" columnNumber="34" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="11" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="13" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
-   <hit lineNumber="13" columnNumber="48" moduleId="0" traceableId="2"/>
-   <hit lineNumber="17" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="48" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="19" columnNumber="23" moduleId="0" traceableId="1"/>
    <traceable traceableId="3"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="3"/>
+   <hit lineNumber="19" columnNumber="23" moduleId="0" traceableId="3"/>
    <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="19" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="20" columnNumber="17" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-mode-01.xspec">
+   <compiled uri="xsl-mode-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-mode-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="10" columnNumber="34" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="11" columnNumber="13" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="13" columnNumber="48" moduleId="0" traceableId="2"/>
+   <hit lineNumber="17" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="19" columnNumber="17" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-namespace-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-namespace-01.xsl">xsl-namespace-01.xsl</a></p>
+      <h2>module: xsl-namespace-01.xsl; 22 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:namespace Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-namespace"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="namespace"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:namespace name="dummy" select="'namespaceURI'" /&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;node type="namespace"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;xsl:namespace name="dummy"&gt;</span>
+16: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">namespaceURI</span><span class="hit">&lt;/xsl:text&gt;</span>
+17: <span class="ignored">        </span><span class="hit">&lt;/xsl:namespace&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-namespace-01.xspec">
+   <compiled uri="xsl-namespace-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-namespace-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="39" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="30" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="30" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}namespace"/>
+   <hit lineNumber="10" columnNumber="63" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="19" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="37" moduleId="0" traceableId="3"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="16" columnNumber="21" moduleId="0" traceableId="5"/>
+   <hit lineNumber="18" columnNumber="19" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-namespace-alias-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-namespace-alias-01.xsl">xsl-namespace-alias-01.xsl</a></p>
+      <h2>module: xsl-namespace-alias-01.xsl; 17 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:myxslt="file://namespace.alias"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:namespace-alias Coverage Test Case</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" /&gt;</span>
+08: 
+09: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-namespace-alias"&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+11: <span class="ignored">      </span><span class="ignored">&lt;!-- See myxslt namespace defined above. Also xsl namespace defined in xspec. --&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;myxslt:node type="namespace-alias"&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/myxslt:node&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+17: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-namespace-alias-01.xspec">
+   <compiled uri="xsl-namespace-alias-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-namespace-alias-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="9" columnNumber="45" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="10" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="12" columnNumber="43" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="13" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-next-match-01.xsl">xsl-next-match-01.xsl</a></p>
-      <h2>module: xsl-next-match-01.xsl; 28 lines</h2>
+      <h2>module: xsl-next-match-01.xsl; 31 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -19,7 +19,7 @@
 09: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="nextMatch" /&gt;</span>
 10: <span class="ignored">  </span><span class="ignored">&lt;!-- Variable with the node to be processed --&gt;</span>
 11: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="nextMatchNodes"&gt;</span>
-12: <span class="ignored">    </span><span class="hit">&lt;node /&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;node&gt;</span><span class="hit">content for built-in template</span><span class="hit">&lt;/node&gt;</span>
 13: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
 14: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
 15: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-next-match"&gt;</span>
@@ -34,17 +34,23 @@
 24: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
 25: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
 26: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match /&gt;</span>
-27: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
-28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
-      <h2>module: xsl-next-match-01A.xsl; 9 lines</h2>
-      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
-2: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
-3: <span class="ignored">  </span><span class="ignored">&lt;!-- Secondary template invoked for node --&gt;</span>
-4: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="nextMatch" priority="2"&gt;</span>
-5: <span class="ignored">    </span><span class="hit">&lt;node type="next-match"&gt;</span>
-6: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
-7: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-8: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-9: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+27: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
+28: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="param"&gt;</span><span class="missed">300</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+29: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
+30: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+31: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-next-match-01A.xsl; 12 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!-- Secondary template invoked for node --&gt;</span>
+04: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="nextMatch" priority="2"&gt;</span>
+05: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="param" select="200" /&gt;</span>
+06: <span class="ignored">    </span><span class="hit">&lt;node type="next-match"&gt;</span>
+07: <span class="ignored">      </span><span class="missed">&lt;xsl:value-of select="$param" /&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+09: <span class="ignored">    </span><span class="ignored">&lt;!-- Next match is built-in template --&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match /&gt;</span>
+11: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+12: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-next-match-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-next-match-01.xsl">xsl-next-match-01.xsl</a></p>
+      <h2>module: xsl-next-match-01.xsl; 28 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:next-match Coverage Test Case - See imported template as well</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Import stylesheet with lower priority template --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-next-match-01A.xsl" /&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;!-- Use a mode for matching --&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="nextMatch" /&gt;</span>
+10: <span class="ignored">  </span><span class="ignored">&lt;!-- Variable with the node to be processed --&gt;</span>
+11: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="nextMatchNodes"&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;node /&gt;</span>
+13: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+14: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+15: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-next-match"&gt;</span>
+16: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+17: <span class="ignored">      </span><span class="ignored">&lt;!-- Start processing node --&gt;</span>
+18: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="$nextMatchNodes" mode="nextMatch" /&gt;</span>
+19: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+20: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+21: <span class="ignored">  </span><span class="ignored">&lt;!-- Initial template invoked for node --&gt;</span>
+22: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="nextMatch" priority="1"&gt;</span>
+23: <span class="ignored">    </span><span class="hit">&lt;node type="next-match"&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+25: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+26: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match /&gt;</span>
+27: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-next-match-01A.xsl; 9 lines</h2>
+      <pre>1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+2: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+3: <span class="ignored">  </span><span class="ignored">&lt;!-- Secondary template invoked for node --&gt;</span>
+4: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="nextMatch" priority="2"&gt;</span>
+5: <span class="ignored">    </span><span class="hit">&lt;node type="next-match"&gt;</span>
+6: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+7: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+8: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+9: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.xml
@@ -15,23 +15,35 @@
    <hit lineNumber="11" columnNumber="39" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
-   <hit lineNumber="12" columnNumber="13" moduleId="0" traceableId="4"/>
-   <hit lineNumber="12" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="12" columnNumber="11" moduleId="0" traceableId="5"/>
    <hit lineNumber="22" columnNumber="60" moduleId="0" traceableId="0"/>
    <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="1"/>
-   <traceable traceableId="5"
+   <traceable traceableId="6"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
-   <traceable traceableId="6" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="24" columnNumber="17" moduleId="0" traceableId="6"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="6"/>
+   <hit lineNumber="24" columnNumber="17" moduleId="0" traceableId="5"/>
    <traceable traceableId="7"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}next-match"/>
    <hit lineNumber="26" columnNumber="23" moduleId="0" traceableId="7"/>
    <module moduleId="1" uri="../../xsl-next-match-01A.xsl"/>
    <hit lineNumber="4" columnNumber="60" moduleId="1" traceableId="0"/>
-   <hit lineNumber="5" columnNumber="29" moduleId="1" traceableId="1"/>
-   <hit lineNumber="5" columnNumber="29" moduleId="1" traceableId="5"/>
-   <hit lineNumber="6" columnNumber="17" moduleId="1" traceableId="6"/>
+   <traceable traceableId="8" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="5" columnNumber="0" moduleId="1" traceableId="8"/>
+   <hit lineNumber="6" columnNumber="29" moduleId="1" traceableId="1"/>
+   <hit lineNumber="6" columnNumber="29" moduleId="1" traceableId="6"/>
+   <hit lineNumber="7" columnNumber="39" moduleId="1" traceableId="5"/>
+   <hit lineNumber="10" columnNumber="23" moduleId="1" traceableId="7"/>
+   <hit lineNumber="27" columnNumber="21" moduleId="0" traceableId="7"/>
+   <hit lineNumber="4" columnNumber="60" moduleId="1" traceableId="0"/>
+   <hit lineNumber="5" columnNumber="0" moduleId="1" traceableId="8"/>
+   <hit lineNumber="28" columnNumber="36" moduleId="0" traceableId="4"/>
+   <hit lineNumber="6" columnNumber="29" moduleId="1" traceableId="1"/>
+   <hit lineNumber="6" columnNumber="29" moduleId="1" traceableId="6"/>
+   <hit lineNumber="7" columnNumber="39" moduleId="1" traceableId="5"/>
+   <hit lineNumber="10" columnNumber="23" moduleId="1" traceableId="7"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-next-match-01.xspec">
+   <compiled uri="xsl-next-match-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-next-match-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="15" columnNumber="40" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="16" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="18" columnNumber="72" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="11" columnNumber="39" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="12" columnNumber="13" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="60" moduleId="0" traceableId="0"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="24" columnNumber="17" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}next-match"/>
+   <hit lineNumber="26" columnNumber="23" moduleId="0" traceableId="7"/>
+   <module moduleId="1" uri="../../xsl-next-match-01A.xsl"/>
+   <hit lineNumber="4" columnNumber="60" moduleId="1" traceableId="0"/>
+   <hit lineNumber="5" columnNumber="29" moduleId="1" traceableId="1"/>
+   <hit lineNumber="5" columnNumber="29" moduleId="1" traceableId="5"/>
+   <hit lineNumber="6" columnNumber="17" moduleId="1" traceableId="6"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-number-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-number-01.xsl">xsl-number-01.xsl</a></p>
+      <h2>module: xsl-number-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:number Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-number"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="number"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:number /&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-number-01.xspec">
+   <compiled uri="xsl-number-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-number-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="36" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="27" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="27" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}number"/>
+   <hit lineNumber="9" columnNumber="23" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" class="net.sf.saxon.expr.instruct.TraceExpression"/>
+   <hit lineNumber="9" columnNumber="23" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-on-empty-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-on-empty-01.xsl">xsl-on-empty-01.xsl</a></p>
+      <h2>module: xsl-on-empty-01.xsl; 27 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:on-empty Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-on-empty"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:on-empty select="200 idiv 2" /&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
+14: <span class="ignored">        </span><span class="missed">&lt;xsl:on-empty&gt;</span>
+15: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-empty&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">      </span><span class="ignored">&lt;!-- NOT on-empty--&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
+20: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+21: <span class="ignored">        </span><span class="missed">&lt;xsl:on-empty&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+22: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">300</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-empty&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+25: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+26: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+27: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-on-empty-01.xspec">
+   <compiled uri="xsl-on-empty-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-on-empty-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.Literal"/>
+   <hit lineNumber="10" columnNumber="0" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="15" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="19" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="5" class="net.sf.saxon.expr.instruct.ConditionalBlock"/>
+   <hit lineNumber="20" columnNumber="19" moduleId="0" traceableId="5"/>
+   <hit lineNumber="20" columnNumber="19" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-on-non-empty-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-on-non-empty-01.xsl">xsl-on-non-empty-01.xsl</a></p>
+      <h2>module: xsl-on-non-empty-01.xsl; 28 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:on-non-empty Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-on-non-empty"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">        </span><span class="missed">&lt;xsl:on-non-empty select="'00'" /&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">2</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">00</span><span class="hit">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- NOT on-non-empty --&gt;</span><span class="ignored">&lt;!-- Need to check if comments below affect the outcome - trace does. See https://saxonica.plan.io/issues/6428 --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
+22: <span class="ignored">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+26: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+27: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-on-non-empty-01.xsl">xsl-on-non-empty-01.xsl</a></p>
-      <h2>module: xsl-on-non-empty-01.xsl; 28 lines</h2>
+      <h2>module: xsl-on-non-empty-01.xsl; 35 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -33,8 +33,15 @@
 23: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 24: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-26: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-27: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-28: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+26: <span class="ignored">      </span><span class="ignored">&lt;!-- NOT on-non-empty but static analysis cannot make that judgment --&gt;</span><span class="ignored"> </span>
+27: <span class="ignored">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
+28: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="@nonexistent-attribute" /&gt;</span>
+29: <span class="ignored">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+30: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">400</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+31: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+33: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+34: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+35: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-on-non-empty-01.xspec">
+   <compiled uri="xsl-on-non-empty-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-on-non-empty-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="42" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="33" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="33" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.instruct.ConditionalBlock"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5" class="net.sf.saxon.expr.instruct.OnNonEmptyExpr"/>
+   <hit lineNumber="11" columnNumber="0" moduleId="0" traceableId="5"/>
+   <hit lineNumber="14" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="33" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="33" moduleId="0" traceableId="2"/>
+   <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.xml
@@ -28,6 +28,11 @@
    <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="3"/>
    <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="5"/>
    <hit lineNumber="23" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="27" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="33" moduleId="0" traceableId="2"/>
+   <hit lineNumber="28" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="30" columnNumber="21" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="21" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-output-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-output-01.xsl">xsl-output-01.xsl</a></p>
+      <h2>module: xsl-output-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:output Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:output method="xml" /&gt;</span>
+07: 
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-output"&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="output"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-output-01.xspec">
+   <compiled uri="xsl-output-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-output-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="8" columnNumber="36" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="9" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="27" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="27" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -7,51 +7,56 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-01.xsl">xsl-param-01.xsl</a></p>
-      <h2>module: xsl-param-01.xsl; 45 lines</h2>
+      <h2>module: xsl-param-01.xsl; 50 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
 03: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
 04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 05: <span class="ignored">      xsl:param Coverage Test Case</span>
 06: <span class="ignored">  --&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param --&gt;</span>
-08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01" /&gt;</span>
-09: 
-10: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
-11: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-12: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
-13: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-14: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
-15: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-16: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-17: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
-18: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:with-param&gt;</span>
-19: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-20: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-21: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
-22: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('300')" /&gt;</span>
-23: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-24: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param --&gt;</span>
-25: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-26: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="4" /&gt;</span>
-27: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-28: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-29: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-30: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-31: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-32: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-33: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-34: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
-35: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
-36: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-37: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
-38: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-39: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-40: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-41: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
-42: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
-43: <span class="ignored">    </span><span class="missed">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
-44: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
-45: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec --&gt;</span>
+10: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam02"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span>
+11: 
+12: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+14: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+19: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+22: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('300')" /&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+29: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param --&gt;</span>
+30: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+31: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="4" /&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+33: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+34: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+36: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+37: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+38: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+39: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+40: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+41: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+42: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+43: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+44: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+45: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+46: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
+47: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
+48: <span class="ignored">    </span><span class="missed">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
+49: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+50: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-param-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-param-01.xsl">xsl-param-01.xsl</a></p>
+      <h2>module: xsl-param-01.xsl; 45 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:param Coverage Test Case</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01" /&gt;</span>
+09: 
+10: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('300')" /&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+24: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param --&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+26: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="4" /&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+28: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+29: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+31: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+32: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+33: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+34: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+35: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+36: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+37: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+38: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+39: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+40: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+41: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
+42: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
+43: <span class="ignored">    </span><span class="missed">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
+44: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+45: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-param-01.xspec">
+   <compiled uri="xsl-param-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-param-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="11" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="13" columnNumber="35" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="14" columnNumber="49" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="17" columnNumber="49" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="34" columnNumber="40" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="35" columnNumber="41" moduleId="0" traceableId="6"/>
+   <hit lineNumber="36" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="36" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="37" columnNumber="49" moduleId="0" traceableId="3"/>
+   <traceable traceableId="7"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="18" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="21" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="62" moduleId="0" traceableId="3"/>
+   <traceable traceableId="8"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
+   <hit lineNumber="41" columnNumber="45" moduleId="0" traceableId="8"/>
+   <hit lineNumber="43" columnNumber="47" moduleId="0" traceableId="7"/>
+   <traceable traceableId="9" uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
+   <hit lineNumber="25" columnNumber="34" moduleId="0" traceableId="9"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="28" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="28" columnNumber="58" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
@@ -4,45 +4,53 @@
    <module moduleId="0" uri="../../xsl-param-01.xsl"/>
    <traceable traceableId="0"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="0"/>
+   <hit lineNumber="12" columnNumber="35" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="11" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="13" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="35" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="13" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="35" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="14" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="18" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
-   <hit lineNumber="17" columnNumber="49" moduleId="0" traceableId="4"/>
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="34" columnNumber="40" moduleId="0" traceableId="5"/>
-   <traceable traceableId="6" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="35" columnNumber="41" moduleId="0" traceableId="6"/>
-   <hit lineNumber="36" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="36" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="37" columnNumber="49" moduleId="0" traceableId="3"/>
-   <traceable traceableId="7"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
-   <hit lineNumber="18" columnNumber="48" moduleId="0" traceableId="7"/>
-   <hit lineNumber="21" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="21" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="22" columnNumber="62" moduleId="0" traceableId="3"/>
-   <traceable traceableId="8"
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="22" columnNumber="49" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="39" columnNumber="40" moduleId="0" traceableId="7"/>
+   <traceable traceableId="8" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="40" columnNumber="41" moduleId="0" traceableId="8"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="42" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="26" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="26" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="3"/>
+   <traceable traceableId="9"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
-   <hit lineNumber="41" columnNumber="45" moduleId="0" traceableId="8"/>
-   <hit lineNumber="43" columnNumber="47" moduleId="0" traceableId="7"/>
-   <traceable traceableId="9" uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
-   <hit lineNumber="25" columnNumber="34" moduleId="0" traceableId="9"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="28" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="28" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="46" columnNumber="45" moduleId="0" traceableId="9"/>
+   <hit lineNumber="48" columnNumber="47" moduleId="0" traceableId="5"/>
+   <traceable traceableId="10"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
+   <hit lineNumber="30" columnNumber="34" moduleId="0" traceableId="10"/>
+   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="33" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="33" columnNumber="58" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-perform-sort-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-perform-sort-01.xsl">xsl-perform-sort-01.xsl</a></p>
+      <h2>module: xsl-perform-sort-01.xsl; 32 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:perform-sort Coverage Test Case</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-perform-sort"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="sortedSet1"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:perform-sort select="node"&gt;</span>
+12: <span class="ignored">          </span><span class="hit">&lt;xsl:sort /&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;/xsl:perform-sort&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="$sortedSet1/*"&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;node type="perform-sort"&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor (Didn't use xsl:sequence as it isn't traced so used xsl:copy-of.) --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="sortedSet2" as="xs:string*"&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;xsl:perform-sort&gt;</span>
+23: <span class="ignored">          </span><span class="hit">&lt;xsl:sort select="." /&gt;</span>
+24: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="node" /&gt;</span>
+25: <span class="ignored">        </span><span class="hit">&lt;/xsl:perform-sort&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+27: <span class="ignored">      </span><span class="hit">&lt;node type="perform-sort"&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$sortedSet2" separator=" " /&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+31: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+32: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-perform-sort-01.xspec">
+   <compiled uri="xsl-perform-sort-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-perform-sort-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="42" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.instruct.Block"/>
+   <hit lineNumber="15" columnNumber="44" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="15" columnNumber="44" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="11" columnNumber="4" moduleId="0" traceableId="4"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="17" columnNumber="38" moduleId="0" traceableId="6"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="38" moduleId="0" traceableId="6"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="38" moduleId="0" traceableId="6"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="38" moduleId="0" traceableId="6"/>
+   <hit lineNumber="27" columnNumber="33" moduleId="0" traceableId="4"/>
+   <hit lineNumber="27" columnNumber="33" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="28" columnNumber="60" moduleId="0" traceableId="6"/>
+   <hit lineNumber="24" columnNumber="40" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-preserve-space-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-preserve-space-01.xsl">xsl-preserve-space-01.xsl</a></p>
+      <h2>module: xsl-preserve-space-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:preserve-space Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:preserve-space elements="*" /&gt;</span>
+07: 
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-preserve-space"&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="preserve-space"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-preserve-space-01.xspec">
+   <compiled uri="xsl-preserve-space-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-preserve-space-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="8" columnNumber="44" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="9" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-processing-instruction-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-processing-instruction-01.xsl">xsl-processing-instruction-01.xsl</a></p>
+      <h2>module: xsl-processing-instruction-01.xsl; 17 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:processing-instruction Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-processing-instruction"&gt;</span>
+07: <span class="ignored">    </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;xsl:processing-instruction name="processing-instruction" select="'TestCase1'" /&gt;</span>
+09: <span class="ignored">    </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;xsl:processing-instruction name="processing-instruction"&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">TestCase2="yes"</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;/xsl:processing-instruction&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+14: <span class="ignored">      </span><span class="ignored">&lt;!-- No content --&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+17: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-processing-instruction-01.xspec">
+   <compiled uri="xsl-processing-instruction-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-processing-instruction-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="52" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}processing-instruction"/>
+   <hit lineNumber="8" columnNumber="86" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="63" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="17" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="13" columnNumber="11" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-sequence-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-sequence-01.xsl">xsl-sequence-01.xsl</a></p>
+      <h2>module: xsl-sequence-01.xsl; 20 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:sequence Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-sequence"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="'100'" /&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
+14: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence&gt;</span>
+15: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;/xsl:sequence&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+19: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+20: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-sequence-01.xspec">
+   <compiled uri="xsl-sequence-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-sequence-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="2"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="15" columnNumber="21" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -16,14 +16,14 @@
 06: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="sortMode" /&gt;</span>
 07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-sort"&gt;</span>
 08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-09: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each child, using select attribute --&gt;</span>
 10: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="*"&gt;</span>
 11: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
 12: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each"&gt;</span>
 13: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
 14: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 15: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-16: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each using sequence constructor --&gt;</span>
+16: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each child, using sequence constructor --&gt;</span>
 17: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="*"&gt;</span>
 18: <span class="ignored">        </span><span class="missed">&lt;xsl:sort&gt;</span>
 19: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
@@ -32,14 +32,14 @@
 22: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
 23: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 24: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-25: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group using select attribute --&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group child, using select attribute --&gt;</span>
 26: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each-group select="*" group-by="@type"&gt;</span>
 27: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
 28: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each-group"&gt;</span>
 29: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="sum(current-group()/.)" /&gt;</span>
 30: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 31: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
-32: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group using sequence constructor --&gt;</span>
+32: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group child, using sequence constructor --&gt;</span>
 33: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each-group select="*" group-by="@type"&gt;</span>
 34: <span class="ignored">        </span><span class="missed">&lt;xsl:sort&gt;</span>
 35: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
@@ -48,7 +48,7 @@
 38: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="sum(current-group()/.)" /&gt;</span>
 39: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 40: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
-41: <span class="ignored">      </span><span class="ignored">&lt;!-- apply-templates using select attribute --&gt;</span>
+41: <span class="ignored">      </span><span class="ignored">&lt;!-- apply-templates child, using select attribute --&gt;</span>
 42: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="sortMode"&gt;</span>
 43: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
 44: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
@@ -58,7 +58,7 @@
 48: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
 49: <span class="ignored">        </span><span class="missed">&lt;/xsl:sort&gt;</span>
 50: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
-51: <span class="ignored">      </span><span class="ignored">&lt;!-- perform-sort --&gt;</span>
+51: <span class="ignored">      </span><span class="ignored">&lt;!-- perform-sort child --&gt;</span>
 52: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="sortedSet"&gt;</span>
 53: <span class="ignored">        </span><span class="hit">&lt;xsl:perform-sort select="node"&gt;</span>
 54: <span class="ignored">          </span><span class="hit">&lt;xsl:sort /&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-sort-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-sort-01.xsl">xsl-sort-01.xsl</a></p>
+      <h2>module: xsl-sort-01.xsl; 70 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:sort Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="sortMode" /&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-sort"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each using select attribute --&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="*"&gt;</span>
+11: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each"&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+16: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each using sequence constructor --&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="*"&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;xsl:sort&gt;</span>
+19: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
+20: <span class="ignored">        </span><span class="missed">&lt;/xsl:sort&gt;</span>
+21: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each"&gt;</span>
+22: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+23: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group using select attribute --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each-group select="*" group-by="@type"&gt;</span>
+27: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each-group"&gt;</span>
+29: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="sum(current-group()/.)" /&gt;</span>
+30: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
+32: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:for-each-group using sequence constructor --&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each-group select="*" group-by="@type"&gt;</span>
+34: <span class="ignored">        </span><span class="missed">&lt;xsl:sort&gt;</span>
+35: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;/xsl:sort&gt;</span>
+37: <span class="ignored">        </span><span class="hit">&lt;node type="sort - for-each-group"&gt;</span>
+38: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="sum(current-group()/.)" /&gt;</span>
+39: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+40: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
+41: <span class="ignored">      </span><span class="ignored">&lt;!-- apply-templates using select attribute --&gt;</span>
+42: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="sortMode"&gt;</span>
+43: <span class="ignored">        </span><span class="missed">&lt;xsl:sort select="." /&gt;</span>
+44: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+45: <span class="ignored">      </span><span class="ignored">&lt;!-- apply-templates using sequence constructor --&gt;</span>
+46: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="sortMode"&gt;</span>
+47: <span class="ignored">        </span><span class="missed">&lt;xsl:sort&gt;</span>
+48: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
+49: <span class="ignored">        </span><span class="missed">&lt;/xsl:sort&gt;</span>
+50: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+51: <span class="ignored">      </span><span class="ignored">&lt;!-- perform-sort --&gt;</span>
+52: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="sortedSet"&gt;</span>
+53: <span class="ignored">        </span><span class="hit">&lt;xsl:perform-sort select="node"&gt;</span>
+54: <span class="ignored">          </span><span class="hit">&lt;xsl:sort /&gt;</span>
+55: <span class="ignored">        </span><span class="hit">&lt;/xsl:perform-sort&gt;</span>
+56: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+57: <span class="ignored">      </span><span class="hit">&lt;xsl:for-each select="$sortedSet/*"&gt;</span>
+58: <span class="ignored">        </span><span class="hit">&lt;node type="sort - perform-sort"&gt;</span>
+59: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+60: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+61: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+62: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+63: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+64: 
+65: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="sortMode"&gt;</span>
+66: <span class="ignored">    </span><span class="hit">&lt;node type="sort - apply-templates"&gt;</span>
+67: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+68: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+69: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+70: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-sort-01.xspec">
+   <compiled uri="xsl-sort-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-sort-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="34" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="10" columnNumber="32" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="13" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="32" moduleId="0" traceableId="2"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="22" columnNumber="38" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each-group"/>
+   <hit lineNumber="26" columnNumber="55" moduleId="0" traceableId="5"/>
+   <hit lineNumber="28" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="28" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="29" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="28" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="28" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="29" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="33" columnNumber="55" moduleId="0" traceableId="5"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="38" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="1"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="38" columnNumber="59" moduleId="0" traceableId="4"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="42" columnNumber="44" moduleId="0" traceableId="6"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="46" columnNumber="44" moduleId="0" traceableId="6"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <traceable traceableId="7"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="57" columnNumber="43" moduleId="0" traceableId="7"/>
+   <hit lineNumber="57" columnNumber="43" moduleId="0" traceableId="2"/>
+   <hit lineNumber="53" columnNumber="4" moduleId="0" traceableId="7"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
+   <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
+   <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
+   <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
+   <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-source-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-source-document-01.xsl">xsl-source-document-01.xsl</a></p>
+      <h2>module: xsl-source-document-01.xsl; 18 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:source-document Coverage Test Case (requires xsl-data-01.xml input file)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-source-document"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:source-document href="xsl-data-01.xml"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;node type="source-document"&gt;</span>
+10: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="root/node[1]" /&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;node type="source-document"&gt;</span>
+13: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="root/node[2]" /&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;/xsl:source-document&gt;</span>
+16: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+17: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+18: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-source-document-01.xspec">
+   <compiled uri="xsl-source-document-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-source-document-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="45" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.instruct.SourceDocument"/>
+   <hit lineNumber="8" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="38" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="38" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="10" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="49" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-strip-space-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-strip-space-01.xsl">xsl-strip-space-01.xsl</a></p>
+      <h2>module: xsl-strip-space-01.xsl; 15 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:strip-space Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:strip-space elements="*" /&gt;</span>
+07: 
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-strip-space"&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="strip-space"&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-strip-space-01.xspec">
+   <compiled uri="xsl-strip-space-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-strip-space-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="8" columnNumber="41" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="9" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="32" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="32" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="11" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-stylesheet-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-stylesheet-01.xsl">xsl-stylesheet-01.xsl</a></p>
+      <h2>module: xsl-stylesheet-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:stylesheet Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-stylesheet"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="stylesheet"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-stylesheet-01.xspec">
+   <compiled uri="xsl-stylesheet-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-stylesheet-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="40" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="31" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="31" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="9" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-template-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-template-01.xsl">xsl-template-01.xsl</a></p>
+      <h2>module: xsl-template-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:template Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-template"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="template"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-template-01.xspec">
+   <compiled uri="xsl-template-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-template-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="9" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-text-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-text-01.xsl">xsl-text-01.xsl</a></p>
+      <h2>module: xsl-text-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:text Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-text"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+09: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-text-01.xspec">
+   <compiled uri="xsl-text-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-text-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="34" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="25" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="25" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="9" columnNumber="19" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-transform-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-transform-01.xsl">xsl-transform-01.xsl</a></p>
+      <h2>module: xsl-transform-01.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:transform Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-transform"&gt;</span>
+07: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">        </span><span class="hit">&lt;node type="transform"&gt;</span>
+09: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:transform&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-transform-01.xspec">
+   <compiled uri="xsl-transform-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-transform-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="39" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="8" columnNumber="32" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="8" columnNumber="32" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="9" columnNumber="21" moduleId="0" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-try-01.xsl">xsl-try-01.xsl</a></p>
-      <h2>module: xsl-try-01.xsl; 42 lines</h2>
+      <h2>module: xsl-try-01.xsl; 48 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
 03: <span class="ignored">                xmlns:err="http://www.w3.org/2005/xqt-errors"&gt;</span>
@@ -19,7 +19,7 @@
 09: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try select attribute - xsl:catch not executed--&gt;</span>
 10: <span class="ignored">      </span><span class="hit">&lt;node type="try"&gt;</span>
 11: <span class="ignored">        </span><span class="missed">&lt;xsl:try select="string(100)"&gt;</span>
-12: <span class="ignored">          </span><span class="missed">&lt;xsl:catch /&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+12: <span class="ignored">          </span><span class="missed">&lt;xsl:catch select="'inside xsl:catch'" /&gt;</span><span class="ignored">                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 13: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
 14: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 15: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try sequence constructor - xsl:catch not executed --&gt;</span>
@@ -35,20 +35,26 @@
 25: <span class="ignored">          </span><span class="missed">&lt;xsl:catch select="string(300)" /&gt;</span>
 26: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
 27: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-28: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try sequence constructor - first xsl:catch sequence constructor executed--&gt;</span>
+28: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try select attribute - xsl:catch executed but no-op--&gt;</span>
 29: <span class="ignored">      </span><span class="hit">&lt;node type="try/catch"&gt;</span>
-30: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
-31: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="error()" /&gt;</span>
-32: <span class="ignored">          </span><span class="missed">&lt;xsl:catch errors="err:FOER0000"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- this is code for error() function by default --&gt;</span>
-33: <span class="ignored">            </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">400</span><span class="hit">&lt;/xsl:text&gt;</span>
-34: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span>
-35: <span class="ignored">          </span><span class="missed">&lt;xsl:catch&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-36: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-37: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-38: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
-39: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-40: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-41: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-42: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+30: <span class="ignored">        </span><span class="missed">&lt;xsl:try select="error()"&gt;</span>
+31: <span class="ignored">          </span><span class="missed">&lt;xsl:catch /&gt;</span>
+32: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try sequence constructor - first xsl:catch sequence constructor executed--&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;node type="try/catch"&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
+37: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="error()" /&gt;</span>
+38: <span class="ignored">          </span><span class="missed">&lt;xsl:catch errors="err:FOER0000"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- this is code for error() function by default --&gt;</span>
+39: <span class="ignored">            </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">400</span><span class="hit">&lt;/xsl:text&gt;</span>
+40: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span>
+41: <span class="ignored">          </span><span class="missed">&lt;xsl:catch&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+42: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+43: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+44: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+45: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+46: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+47: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+48: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-try-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-try-01.xsl">xsl-try-01.xsl</a></p>
+      <h2>module: xsl-try-01.xsl; 42 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:err="http://www.w3.org/2005/xqt-errors"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:try Coverage Test Case (includes xsl:catch)</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-try"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try select attribute - xsl:catch not executed--&gt;</span>
+10: <span class="ignored">      </span><span class="hit">&lt;node type="try"&gt;</span>
+11: <span class="ignored">        </span><span class="missed">&lt;xsl:try select="string(100)"&gt;</span>
+12: <span class="ignored">          </span><span class="missed">&lt;xsl:catch /&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+13: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+15: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try sequence constructor - xsl:catch not executed --&gt;</span>
+16: <span class="ignored">      </span><span class="hit">&lt;node type="try"&gt;</span>
+17: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
+18: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+19: <span class="ignored">          </span><span class="missed">&lt;xsl:catch /&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+20: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+22: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try select attribute - xsl:catch select attribute executed--&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;node type="try/catch"&gt;</span>
+24: <span class="ignored">        </span><span class="missed">&lt;xsl:try select="error()"&gt;</span>
+25: <span class="ignored">          </span><span class="missed">&lt;xsl:catch select="string(300)" /&gt;</span>
+26: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+27: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+28: <span class="ignored">      </span><span class="ignored">&lt;!-- Using xsl:try sequence constructor - first xsl:catch sequence constructor executed--&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;node type="try/catch"&gt;</span>
+30: <span class="ignored">        </span><span class="missed">&lt;xsl:try&gt;</span>
+31: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="error()" /&gt;</span>
+32: <span class="ignored">          </span><span class="missed">&lt;xsl:catch errors="err:FOER0000"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- this is code for error() function by default --&gt;</span>
+33: <span class="ignored">            </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">400</span><span class="hit">&lt;/xsl:text&gt;</span>
+34: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span>
+35: <span class="ignored">          </span><span class="missed">&lt;xsl:catch&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+36: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+37: <span class="ignored">          </span><span class="missed">&lt;/xsl:catch&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+38: <span class="ignored">        </span><span class="missed">&lt;/xsl:try&gt;</span>
+39: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+40: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+41: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+42: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-try-01.xspec">
+   <compiled uri="xsl-try-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-try-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="33" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="24" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="10" columnNumber="24" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.TryCatch"/>
+   <hit lineNumber="11" columnNumber="7" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="24" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="24" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="21" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="18" columnNumber="21" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="23" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="24" columnNumber="0" moduleId="0" traceableId="3"/>
+   <hit lineNumber="29" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="31" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="44" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="33" columnNumber="23" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.xml
@@ -23,10 +23,13 @@
    <hit lineNumber="24" columnNumber="0" moduleId="0" traceableId="3"/>
    <hit lineNumber="29" columnNumber="30" moduleId="0" traceableId="1"/>
    <hit lineNumber="29" columnNumber="30" moduleId="0" traceableId="2"/>
-   <hit lineNumber="31" columnNumber="44" moduleId="0" traceableId="3"/>
-   <hit lineNumber="31" columnNumber="44" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="0" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="30" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="30" moduleId="0" traceableId="2"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="3"/>
+   <hit lineNumber="37" columnNumber="44" moduleId="0" traceableId="4"/>
    <traceable traceableId="5" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="33" columnNumber="23" moduleId="0" traceableId="5"/>
+   <hit lineNumber="39" columnNumber="23" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-value-of-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-value-of-01.xsl">xsl-value-of-01.xsl</a></p>
+      <h2>module: xsl-value-of-01.xsl; 20 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:value-of Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-value-of"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="value-of"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:value-of select="string('100')" /&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="value-of"&gt;</span>
+14: <span class="ignored">        </span><span class="missed">&lt;xsl:value-of&gt;</span>
+15: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;/xsl:value-of&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+19: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+20: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-value-of-01.xspec">
+   <compiled uri="xsl-value-of-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-value-of-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="29" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="48" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="29" moduleId="0" traceableId="2"/>
+   <hit lineNumber="14" columnNumber="23" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="15" columnNumber="21" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-variable-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-variable-01.xsl">xsl-variable-01.xsl</a></p>
+      <h2>module: xsl-variable-01.xsl; 44 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:variable Coverage Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!-- Global variable --&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal01" select="string(100)" /&gt;</span>
+08: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal02"&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal03"&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+13: 
+14: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-variable"&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal01" select="string(400)" /&gt;</span>
+16: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal02"&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">500</span><span class="hit">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+19: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal03"&gt;</span><span class="hit">600</span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+21: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+22: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal04"&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">700</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+26: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+27: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobal01" /&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobal02" /&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+36: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocal01" /&gt;</span>
+37: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+38: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+39: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+40: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocal02" /&gt;</span>
+41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+42: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+43: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+44: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-variable-01.xspec">
+   <compiled uri="xsl-variable-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-variable-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="14" columnNumber="38" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.TraceExpression"/>
+   <hit lineNumber="16" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="22" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="25" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="25" columnNumber="11" moduleId="0" traceableId="2"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="28" columnNumber="52" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="7" columnNumber="64" moduleId="0" traceableId="5"/>
+   <hit lineNumber="31" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="31" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="8" columnNumber="41" moduleId="0" traceableId="5"/>
+   <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="35" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="4"/>
+   <hit lineNumber="39" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="39" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="40" columnNumber="51" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="1"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-where-populated-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-where-populated-01.xsl">xsl-where-populated-01.xsl</a></p>
+      <h2>module: xsl-where-populated-01.xsl; 22 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:where-populated Test Case</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-where-populated"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Data doesn't exist so node/copy-of not executed --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated"&gt;</span>
+10: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="nonExistantNode" /&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- node element is empty but this element is executed because it needs to see if there is any output --&gt;</span>
+12: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">      </span><span class="ignored">&lt;!-- Data exists so node/copy-of executed --&gt;</span>
+15: <span class="ignored">      </span><span class="missed">&lt;xsl:where-populated&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;node type="where-populated"&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="node" /&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+19: <span class="ignored">      </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -18,15 +18,15 @@
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Data doesn't exist so node/copy-of not executed --&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated"&gt;</span>
 10: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span>
-11: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="nonExistantNode" /&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- node element is empty but this element is executed because it needs to see if there is any output --&gt;</span>
+11: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="nonExistentNode" /&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- node element is empty but this element is executed because it needs to see if there is any output --&gt;</span>
 12: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
 13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 14: <span class="ignored">      </span><span class="ignored">&lt;!-- Data exists so node/copy-of executed --&gt;</span>
-15: <span class="ignored">      </span><span class="missed">&lt;xsl:where-populated&gt;</span>
-16: <span class="ignored">        </span><span class="hit">&lt;node type="where-populated"&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated"&gt;</span>
+16: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span>
 17: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="node" /&gt;</span>
-18: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-19: <span class="ignored">      </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-where-populated-01.xspec">
+   <compiled uri="xsl-where-populated-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-where-populated-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="6" columnNumber="45" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3" class="net.sf.saxon.expr.instruct.WherePopulated"/>
+   <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy-of"/>
+   <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="4"/>
+   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
@@ -15,9 +15,9 @@
    <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="3"/>
    <traceable traceableId="4" uqname="Q{http://www.w3.org/1999/XSL/Transform}copy-of"/>
    <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="4"/>
-   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="16" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="3"/>
    <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-with-param-01.xsl">xsl-with-param-01.xsl</a></p>
-      <h2>module: xsl-with-param-01.xsl; 79 lines</h2>
+      <h2>module: xsl-with-param-01.xsl; 90 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -22,7 +22,7 @@
 12: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeNM" /&gt;</span>
 13: 
 14: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-with-param"&gt;</span>
-15: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 16: <span class="ignored">      </span><span class="ignored">&lt;!-- Numbers in brackets refer to the value in the node output --&gt;</span>
 17: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate with-param (100, 200, 300, 400) --&gt;</span>
 18: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
@@ -50,43 +50,54 @@
 40: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeNM"&gt;</span>
 41: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01"&gt;</span><span class="missed">1300</span><span class="missed">&lt;/xsl:with-param&gt;</span>
 42: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
-43: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-44: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-45: <span class="ignored">  </span><span class="ignored">&lt;!-- Call Template --&gt;</span>
-46: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="withParamTemplate01"&gt;</span>
-47: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-CT-Param01" /&gt;</span>
-48: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - call-template"&gt;</span>
-49: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-CT-Param01" /&gt;</span>
-50: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-51: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-52: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Templates Template --&gt;</span>
-53: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamMode"&gt;</span>
-54: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AT-Param01" /&gt;</span>
-55: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-templates"&gt;</span>
-56: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AT-Param01 + ." /&gt;</span>
-57: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-58: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-59: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Imports Template --&gt;</span>
-60: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI"&gt;</span>
-61: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
-62: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 1"&gt;</span>
-63: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + ." /&gt;</span>
-64: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-65: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports&gt;</span>
-66: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" /&gt;</span>
-67: <span class="ignored">    </span><span class="hit">&lt;/xsl:apply-imports&gt;</span>
-68: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-69: <span class="ignored">  </span><span class="ignored">&lt;!-- Next Match Template --&gt;</span>
-70: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="1"&gt;</span>
-71: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
-72: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 1"&gt;</span>
-73: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + ." /&gt;</span>
-74: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-75: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
-76: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" /&gt;</span>
-77: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
-78: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
-79: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+43: <span class="ignored">      </span><span class="ignored">&lt;!-- Evaluate with-param (200) --&gt;</span>
+44: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
+45: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
+46: <span class="ignored">        </span><span class="hit">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span>
+47: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="index" select="$index" /&gt;</span>
+48: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="nonexistent"&gt;</span><span class="hit">parameter not used in evaluation</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+49: <span class="ignored">        </span><span class="hit">&lt;/xsl:evaluate&gt;</span>
+50: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+51: <span class="ignored">      </span><span class="hit">&lt;node type="with-param - evaluate"&gt;</span>
+52: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span>
+53: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+54: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+55: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+56: <span class="ignored">  </span><span class="ignored">&lt;!-- Call Template --&gt;</span>
+57: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="withParamTemplate01"&gt;</span>
+58: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-CT-Param01" /&gt;</span>
+59: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - call-template"&gt;</span>
+60: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-CT-Param01" /&gt;</span>
+61: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+62: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+63: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Templates Template --&gt;</span>
+64: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamMode"&gt;</span>
+65: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AT-Param01" /&gt;</span>
+66: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-templates"&gt;</span>
+67: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AT-Param01 + ." /&gt;</span>
+68: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+69: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+70: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Imports Template --&gt;</span>
+71: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI"&gt;</span>
+72: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
+73: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 1"&gt;</span>
+74: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + ." /&gt;</span>
+75: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+76: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports&gt;</span>
+77: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" /&gt;</span>
+78: <span class="ignored">    </span><span class="hit">&lt;/xsl:apply-imports&gt;</span>
+79: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+80: <span class="ignored">  </span><span class="ignored">&lt;!-- Next Match Template --&gt;</span>
+81: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="1"&gt;</span>
+82: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
+83: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 1"&gt;</span>
+84: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + ." /&gt;</span>
+85: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+86: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
+87: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" /&gt;</span>
+88: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
+89: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+90: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       <h2>module: xsl-with-param-01A.xsl; 19 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-with-param-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-with-param-01.xsl">xsl-with-param-01.xsl</a></p>
+      <h2>module: xsl-with-param-01.xsl; 79 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:with-param Coverage Test Case (Quite complex because it covers xsl:iterate, xsl:call-template, xsl:apply-templates, xsl:apply-import, xsl:next-match and xsl:evaluate)</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-with-param-01A.xsl" /&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-templates --&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamMode" /&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-imports --&gt;</span>
+10: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeAI" /&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for next-match --&gt;</span>
+12: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeNM" /&gt;</span>
+13: 
+14: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-with-param"&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;root&gt;</span>
+16: <span class="ignored">      </span><span class="ignored">&lt;!-- Numbers in brackets refer to the value in the node output --&gt;</span>
+17: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate with-param (100, 200, 300, 400) --&gt;</span>
+18: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+19: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="100" /&gt;</span>
+20: <span class="ignored">        </span><span class="hit">&lt;node type="with-param - iterate"&gt;</span>
+21: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01" /&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+23: <span class="ignored">        </span><span class="hit">&lt;xsl:next-iteration&gt;</span>
+24: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="iterateParam01" select="$iterateParam01 + 100" /&gt;</span>
+25: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+27: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template with-param (500) --&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="withParamTemplate01"&gt;</span>
+29: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="withParam-CT-Param01"&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+30: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+31: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Templates with-param (600, 700, 800, 900) --&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="withParamMode"&gt;</span>
+33: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="withParam-AT-Param01"&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+34: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+35: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Imports with-param (1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350) --&gt;</span>
+36: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeAI"&gt;</span>
+37: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01"&gt;</span><span class="missed">900</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+38: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+39: <span class="ignored">      </span><span class="ignored">&lt;!-- Next Match with-param (1400, 1450, 1500, 1550, 1600, 1650, 1700, 1750) --&gt;</span>
+40: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeNM"&gt;</span>
+41: <span class="ignored">        </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01"&gt;</span><span class="missed">1300</span><span class="missed">&lt;/xsl:with-param&gt;</span>
+42: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+43: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+44: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+45: <span class="ignored">  </span><span class="ignored">&lt;!-- Call Template --&gt;</span>
+46: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="withParamTemplate01"&gt;</span>
+47: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-CT-Param01" /&gt;</span>
+48: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - call-template"&gt;</span>
+49: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-CT-Param01" /&gt;</span>
+50: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+51: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+52: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Templates Template --&gt;</span>
+53: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamMode"&gt;</span>
+54: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AT-Param01" /&gt;</span>
+55: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-templates"&gt;</span>
+56: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AT-Param01 + ." /&gt;</span>
+57: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+58: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+59: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Imports Template --&gt;</span>
+60: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI"&gt;</span>
+61: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
+62: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 1"&gt;</span>
+63: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + ." /&gt;</span>
+64: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+65: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports&gt;</span>
+66: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" /&gt;</span>
+67: <span class="ignored">    </span><span class="hit">&lt;/xsl:apply-imports&gt;</span>
+68: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+69: <span class="ignored">  </span><span class="ignored">&lt;!-- Next Match Template --&gt;</span>
+70: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="1"&gt;</span>
+71: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
+72: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 1"&gt;</span>
+73: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + ." /&gt;</span>
+74: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+75: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
+76: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" /&gt;</span>
+77: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
+78: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
+79: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-with-param-01A.xsl; 19 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+03: 
+04: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:apply-imports Template --&gt;</span>
+05: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI" &gt;</span>
+06: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 2"&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + . + 50" /&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+11: 
+12: <span class="ignored">  </span><span class="ignored">&lt;!-- Secondary template invoked for node --&gt;</span>
+13: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="2"&gt;</span>
+14: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
+15: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 2"&gt;</span>
+16: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + . + 50" /&gt;</span>
+17: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+19: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
@@ -6,7 +6,7 @@
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
    <hit lineNumber="14" columnNumber="40" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="15" columnNumber="13" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
    <hit lineNumber="18" columnNumber="34" moduleId="0" traceableId="2"/>
    <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="1"/>
@@ -36,136 +36,145 @@
    <hit lineNumber="28" columnNumber="53" moduleId="0" traceableId="6"/>
    <traceable traceableId="7"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="46" columnNumber="44" moduleId="0" traceableId="7"/>
+   <hit lineNumber="57" columnNumber="44" moduleId="0" traceableId="7"/>
    <traceable traceableId="8" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="47" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="48" columnNumber="45" moduleId="0" traceableId="1"/>
-   <hit lineNumber="48" columnNumber="45" moduleId="0" traceableId="3"/>
-   <hit lineNumber="49" columnNumber="54" moduleId="0" traceableId="4"/>
+   <hit lineNumber="58" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="59" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="59" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="60" columnNumber="54" moduleId="0" traceableId="4"/>
    <traceable traceableId="9"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
    <hit lineNumber="29" columnNumber="53" moduleId="0" traceableId="9"/>
    <traceable traceableId="10"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
    <hit lineNumber="32" columnNumber="49" moduleId="0" traceableId="10"/>
-   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="33" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
    <hit lineNumber="36" columnNumber="62" moduleId="0" traceableId="10"/>
-   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="37" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
    <traceable traceableId="11"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-imports"/>
-   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
    <module moduleId="1" uri="../../xsl-with-param-01A.xsl"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
    <hit lineNumber="40" columnNumber="62" moduleId="0" traceableId="10"/>
-   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="41" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
    <traceable traceableId="12"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}next-match"/>
-   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="45" columnNumber="58" moduleId="0" traceableId="9"/>
+   <traceable traceableId="13" class="net.sf.saxon.expr.LetExpression"/>
+   <hit lineNumber="45" columnNumber="58" moduleId="0" traceableId="13"/>
+   <hit lineNumber="46" columnNumber="0" moduleId="0" traceableId="9"/>
+   <traceable traceableId="14" class="net.sf.saxon.expr.instruct.EvaluateInstr"/>
+   <hit lineNumber="46" columnNumber="0" moduleId="0" traceableId="14"/>
+   <hit lineNumber="51" columnNumber="42" moduleId="0" traceableId="1"/>
+   <hit lineNumber="51" columnNumber="42" moduleId="0" traceableId="3"/>
+   <hit lineNumber="52" columnNumber="65" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-with-param-01.xspec">
+   <compiled uri="xsl-with-param-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-with-param-01.xsl"/>
+   <traceable traceableId="0"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="14" columnNumber="40" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="15" columnNumber="13" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2" uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
+   <hit lineNumber="18" columnNumber="34" moduleId="0" traceableId="2"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="1"/>
+   <traceable traceableId="3"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="21" columnNumber="52" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}next-iteration"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="43" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="29" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="28" columnNumber="53" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="46" columnNumber="44" moduleId="0" traceableId="7"/>
+   <traceable traceableId="8" uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="47" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="48" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="48" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="49" columnNumber="54" moduleId="0" traceableId="4"/>
+   <traceable traceableId="9"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="29" columnNumber="53" moduleId="0" traceableId="9"/>
+   <traceable traceableId="10"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
+   <hit lineNumber="32" columnNumber="49" moduleId="0" traceableId="10"/>
+   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="33" columnNumber="53" moduleId="0" traceableId="9"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="53" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="54" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="55" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="62" moduleId="0" traceableId="10"/>
+   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="37" columnNumber="53" moduleId="0" traceableId="9"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
+   <traceable traceableId="11"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-imports"/>
+   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <module moduleId="1" uri="../../xsl-with-param-01A.xsl"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="60" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="62" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="63" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
+   <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
+   <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
+   <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="40" columnNumber="62" moduleId="0" traceableId="10"/>
+   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="41" columnNumber="53" moduleId="0" traceableId="9"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
+   <traceable traceableId="12"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}next-match"/>
+   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
+   <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
+   <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
+   <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
+   <hit lineNumber="70" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="71" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="75" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
+   <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
@@ -3,9 +3,9 @@
   <!--
       xsl:global-context-item Coverage Test Case
   -->
-  <xsl:global-context-item use="optional" as="item()" />
+  <xsl:global-context-item use="required" as="item()" />
   <!-- Put the context item in a global variable -->
-  <xsl:variable name="globalVariable" select="$globalContextItem" />
+  <xsl:variable name="globalVariable" select="." />
 
   <xsl:template match="xsl-global-context-item">
     <root>

--- a/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:global-context-item Coverage Test Case
+  -->
+  <xsl:global-context-item use="optional" as="item()" />
+  <!-- Put the context item in a global variable -->
+  <xsl:variable name="globalVariable" select="$globalContextItem" />
+
+  <xsl:template match="xsl-global-context-item">
+    <root>
+      <node type="global-context-item">
+        <xsl:value-of select="$globalVariable" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xspec
+++ b/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xspec
@@ -3,12 +3,13 @@
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="external_xsl-global-context-item-01.xsl"
                run-as="external">
-   <x:param name="globalContextItem"><node>100</node></x:param>
 
    <x:scenario label="xsl:global-context-item Coverage Test Case">
       <x:context>
          <root>
-            <xsl-global-context-item/>
+            <xsl-global-context-item>
+               <node>100</node>
+            </xsl-global-context-item>
          </root>
       </x:context>
       <x:expect label="Success">

--- a/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xspec
+++ b/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="external_xsl-global-context-item-01.xsl"
+               run-as="external">
+   <x:param name="globalContextItem"><node>100</node></x:param>
+
+   <x:scenario label="xsl:global-context-item Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-global-context-item/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="global-context-item">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/external_xsl-result-document-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-result-document-01.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:result-document Coverage Test Case
+  -->
+  <xsl:template match="xsl-result-document">
+    <root>
+      <node type="result-document">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+    <xsl:result-document href="result-document.xml">
+      <node type="result-document">
+        <xsl:text>200</xsl:text>
+      </node>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/external_xsl-result-document-01.xspec
+++ b/test/end-to-end/cases-coverage/external_xsl-result-document-01.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="external_xsl-result-document-01.xsl"
+               run-as="external">
+
+   <x:scenario label="xsl:result-document Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-result-document/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="result-document">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/per-element-test-conventions.md
+++ b/test/end-to-end/cases-coverage/per-element-test-conventions.md
@@ -1,22 +1,26 @@
 # Conventions for Per-XSLT-Element Test Cases
 
 ## Filenames
+
 Filename is `xsl-<xslt element name>-01` with `.xsl` or `.xspec` extension, except that tests that use `@run-as="external"` have filenames starting with `"external_"`.
 
 Any import/include stylesheet has A, B, etc. added to the filename.
 
 ## XSpec Code
+
 XSpec scenario label is xsl-<xslt element name> Coverage Test Case.
 
 XSpec scenario context is <root><xsl-<xslt element name>></root>.
 
 Data is defined in `x:context` where it is needed in XSpec file.
 
-Individual XSpec files use the default `run-as` behavior, except those that require `run-as=external`: 
-* `external_xsl-global-context-item-01.xspec`
-* `external_xsl-result-document-01.xspec`
+Individual XSpec files use the default `run-as` behavior, except those that require `run-as=external`:
+
+- `external_xsl-global-context-item-01.xspec`
+- `external_xsl-result-document-01.xspec`
 
 ## XSLT Code
+
 XSLT has comment of xsl:<element name> Coverage Test Case across 3 lines.
 
 XSLT template match is xsl-<element-name>.

--- a/test/end-to-end/cases-coverage/per-element-test-conventions.md
+++ b/test/end-to-end/cases-coverage/per-element-test-conventions.md
@@ -1,0 +1,32 @@
+# Conventions for Per-XSLT-Element Test Cases
+
+## Filenames
+Filename is `xsl-<xslt element name>-01` with `.xsl` or `.xspec` extension, except that tests that use `@run-as="external"` have filenames starting with `"external_"`.
+
+Any import/include stylesheet has A, B, etc. added to the filename.
+
+## XSpec Code
+XSpec scenario label is xsl-<xslt element name> Coverage Test Case.
+
+XSpec scenario context is <root><xsl-<xslt element name>></root>.
+
+Data is defined in `x:context` where it is needed in XSpec file.
+
+Individual XSpec files use the default `run-as` behavior, except those that require `run-as=external`: 
+* `external_xsl-global-context-item-01.xspec`
+* `external_xsl-result-document-01.xspec`
+
+## XSLT Code
+XSLT has comment of xsl:<element name> Coverage Test Case across 3 lines.
+
+XSLT template match is xsl-<element-name>.
+
+Where an element can have a select attribute or a sequence constructor, tests are done for both.
+
+The transformation always outputs something.
+
+The intention is for one element per line, with text enclosed in xsl:text tags.
+
+To facilitate importing multiple tests in a single XSpec file `external_xsl-all-01.xspec`, `xsl:mode is used extensively to avoid interference among individual tests.
+
+Some tests seem trivial because the contents appear in many other tests, e.g., `xsl:template`, `xsl:stylesheet`, and `xsl:text`, but they are included so that there is a specific test that can be viewed.

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
@@ -15,6 +15,10 @@
   </xsl:accumulator>
   <!-- xsl:mode for accumulator -->
   <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />
+  <!-- Make accumulator applicable in default mode, too, so that
+    xsl-accumulator-01.xspec can run with run-as="external" or
+    when imported by a test with that setting. -->
+  <xsl:mode use-accumulators="accumulatorTest" />
   <!-- Main template -->
   <xsl:template match="xsl-accumulator">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+       xsl:accumulator Test Case
+  -->
+  <!-- xsl:accumulator -->
+  <xsl:accumulator name="accumulatorTest" initial-value="0">
+    <xsl:accumulator-rule match="node">
+      <xsl:value-of select="$value + 1" />
+    </xsl:accumulator-rule>
+  </xsl:accumulator>
+  <!-- xsl:accumulator not used -->
+  <xsl:accumulator name="dummy01" initial-value="0">
+    <xsl:accumulator-rule match="node()" select="$value + 1" />
+  </xsl:accumulator>
+  <!-- xsl:mode for accumulator -->
+  <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />
+  <!-- Main template -->
+  <xsl:template match="xsl-accumulator">
+    <root>
+      <!-- Process nodes used in xsl:accumulator -->
+      <xsl:apply-templates select="*" mode="accumulator" />
+    </root>
+  </xsl:template>
+  <!-- used in xsl:accumulator test -->
+  <xsl:template match="node" mode="accumulator">
+    <node type="accumulator before">
+      <xsl:value-of select="accumulator-before('accumulatorTest')" />
+    </node>
+    <node type="accumulator after">
+      <xsl:value-of select="accumulator-after('accumulatorTest')" />
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-accumulator-01.xsl">
+
+  <x:scenario label="xsl:accumulator Coverage Test Case (including xsl:accumulator-rule)">
+    <x:context>
+      <root>
+        <xsl-accumulator>
+          <node>100</node>
+          <node>200</node>
+          <node>300</node>
+        </xsl-accumulator>
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="accumulator before">1</node>
+        <node type="accumulator after">1</node>
+        <node type="accumulator before">2</node>
+        <node type="accumulator after">2</node>
+        <node type="accumulator before">3</node>
+        <node type="accumulator after">3</node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-analyze-string-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-analyze-string-01.xsl
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:analyze-string Test Case
+  -->
+  <xsl:template match="xsl-analyze-string">
+    <root>
+      <!-- regex matches string so non-matching-substring not executed -->
+      <xsl:analyze-string select="'abc 123'" regex="abc 123">
+        <xsl:matching-substring>
+          <node type="matching-substring">
+            <xsl:value-of select="regex-group(0)" />
+          </node>
+        </xsl:matching-substring>
+        <xsl:non-matching-substring>                                           <!-- Expected miss -->
+          <node type="non-matching-substring">                                 <!-- Expected miss -->
+            <xsl:text>No match</xsl:text>                                      <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:non-matching-substring>                                          <!-- Expected miss -->
+      </xsl:analyze-string>
+      <!-- regex doesn't match string so matching-substring not executed -->
+      <xsl:analyze-string select="'def 456 def 456'" regex="abc 123">
+        <xsl:matching-substring>                                               <!-- Expected miss -->
+          <node type="matching-substring">                                     <!-- Expected miss -->
+            <xsl:value-of select="regex-group(0)" />                           <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:matching-substring>                                              <!-- Expected miss -->
+        <xsl:non-matching-substring>
+          <node type="non-matching-substring">
+            <xsl:sequence select="string('No match')"/>
+          </node>
+        </xsl:non-matching-substring>
+      </xsl:analyze-string>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-analyze-string-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-analyze-string-01.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-analyze-string-01.xsl">
+
+  <x:scenario label="xsl:analyze-string Coverage Test Case (including xsl:matching-substring and xsl:non-matching-substring)">
+    <x:context>
+      <root>
+        <xsl-analyze-string />
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="matching-substring">abc 123</node>
+        <node type="non-matching-substring">No match</node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-apply-imports-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-imports-01.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:apply-imports Coverage Test Case (see xsl-apply-imports-01A.xsl as well)
+  -->
+  <!-- Import stylesheet -->
+  <xsl:import href="xsl-apply-imports-01A.xsl" />
+  <!-- xsl:mode for this test -->
+  <xsl:mode name="applyImportsMode" />
+  <!-- Main Stylesheet-->
+  <xsl:template match="xsl-apply-imports">
+    <root>
+      <xsl:apply-templates select="*" mode="applyImportsMode" />
+    </root>
+  </xsl:template>
+
+  <!-- Current Stylesheet Template -->
+  <xsl:template match="node" mode="applyImportsMode">
+    <node type="apply-imports - top stylesheet">
+      <xsl:value-of select="." />
+    </node>
+    <xsl:apply-imports/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-apply-imports-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-apply-imports-01.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-apply-imports-01.xsl">
+   <x:scenario label="xsl:apply-imports Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-apply-imports>
+              <node>100</node>
+              <node>200</node>
+            </xsl-apply-imports>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="apply-imports - top stylesheet">100</node>
+            <node type="apply-imports - import stylesheet">100</node>
+            <node type="apply-imports - top stylesheet">200</node>
+            <node type="apply-imports - import stylesheet">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-apply-imports-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-imports-01A.xsl
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+
+  <!-- xsl:apply-imports Template -->
+  <xsl:template match="node" mode="applyImportsMode">
+    <node type="apply-imports - import stylesheet">
+      <xsl:value-of select="." />
+    </node>
+  </xsl:template>
+ </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
@@ -6,11 +6,25 @@
   <xsl:template match="xsl-apply-templates">
     <root>
       <xsl:apply-templates />
+      <xsl:apply-templates mode="#unnamed" />
+      <xsl:apply-templates mode="#current" />
+      <xsl:apply-templates mode="#default" />
+      <xsl:apply-templates mode="mode-with-matching-template" />
+      <xsl:apply-templates mode="mode-without-explicit-template-with-xsl-mode" />
+      <xsl:apply-templates mode="mode-without-explicit-template-without-xsl-mode" />
     </root>
   </xsl:template>
 
   <xsl:template match="applyTemplateNode">
     <node type="apply-templates">
+      <xsl:value-of select="." />
+    </node>
+  </xsl:template>
+
+  <xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" />
+
+  <xsl:template match="applyTemplateNode" mode="mode-with-matching-template">
+    <node type="apply-templates-mode-with-matching-template">
       <xsl:value-of select="." />
     </node>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:apply-templates Coverage Test Case
+  -->
+  <xsl:template match="xsl-apply-templates">
+    <root>
+      <xsl:apply-templates />
+    </root>
+  </xsl:template>
+
+  <xsl:template match="applyTemplateNode">
+    <node type="apply-templates">
+      <xsl:value-of select="." />
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-apply-templates-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-apply-templates-01.xspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-apply-templates-01.xsl">
+   <x:scenario label="xsl:apply-templates Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-apply-templates>
+              <applyTemplateNode>100</applyTemplateNode>
+              <applyTemplateNode>200</applyTemplateNode>
+            </xsl-apply-templates>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="apply-templates">100</node>
+            <node type="apply-templates">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-apply-templates-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-apply-templates-01.xspec
@@ -15,6 +15,17 @@
          <root>
             <node type="apply-templates">100</node>
             <node type="apply-templates">200</node>
+            <node type="apply-templates">100</node>
+            <node type="apply-templates">200</node>
+            <node type="apply-templates">100</node>
+            <node type="apply-templates">200</node>
+            <node type="apply-templates">100</node>
+            <node type="apply-templates">200</node>
+            <node type="apply-templates-mode-with-matching-template">100</node>
+            <node type="apply-templates-mode-with-matching-template">200</node>
+            <applyTemplateNode>100</applyTemplateNode>
+            <applyTemplateNode>200</applyTemplateNode>
+            <x:text>100200</x:text>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xsl
@@ -3,31 +3,24 @@
   <!--
       xsl:assert Coverage Test Case (needs AssertEnabled option -ea). xsl:assert is always executed.
   -->
-  <xsl:template match="xsl-assert">
+  <xsl:template match="xsl-assert" mode="xsl-assert-false">
     <root>
       <!-- Assert false -->
       <node type="assert">
-        <xsl:try>
-          <!-- Added instruction between xsl:try and xsl:assert to check trace output -->
-          <xsl:value-of select="name()" />
-          <xsl:assert test="100 lt 0">
-            <xsl:text>Assert Message: 100 lt 0</xsl:text>
-          </xsl:assert>
-          <xsl:catch>
-            <xsl:text>Assert was triggered as expected</xsl:text>
-          </xsl:catch>
-        </xsl:try>
+        <xsl:assert test="100 lt 0">
+          <xsl:text>Assert Message: 100 lt 0</xsl:text>
+        </xsl:assert>
       </node>
+    </root>
+  </xsl:template>
+
+  <xsl:template match="xsl-assert" mode="xsl-assert-true">
+    <root>
       <!-- Assert true -->
       <node type="assert">
-      <xsl:try>
         <xsl:assert test="100 gt 0">
           <xsl:text>Assert Message: 100 gt 0</xsl:text>                        <!-- Expected miss -->
         </xsl:assert>
-        <xsl:catch>                                                            <!-- Expected miss -->
-          <xsl:text>Assert was triggered unexpectedly</xsl:text>               <!-- Expected miss -->
-        </xsl:catch>                                                           <!-- Expected miss -->
-      </xsl:try>
       </node>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:assert Coverage Test Case (needs AssertEnabled option -ea). xsl:assert is always executed.
+  -->
+  <xsl:template match="xsl-assert">
+    <root>
+      <!-- Assert false -->
+      <node type="assert">
+        <xsl:try>
+          <!-- Added instruction between xsl:try and xsl:assert to check trace output -->
+          <xsl:value-of select="name()" />
+          <xsl:assert test="100 lt 0">
+            <xsl:text>Assert Message: 100 lt 0</xsl:text>
+          </xsl:assert>
+          <xsl:catch>
+            <xsl:text>Assert was triggered as expected</xsl:text>
+          </xsl:catch>
+        </xsl:try>
+      </node>
+      <!-- Assert true -->
+      <node type="assert">
+      <xsl:try>
+        <xsl:assert test="100 gt 0">
+          <xsl:text>Assert Message: 100 gt 0</xsl:text>                        <!-- Expected miss -->
+        </xsl:assert>
+        <xsl:catch>                                                            <!-- Expected miss -->
+          <xsl:text>Assert was triggered unexpectedly</xsl:text>               <!-- Expected miss -->
+        </xsl:catch>                                                           <!-- Expected miss -->
+      </xsl:try>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-assert-01.xsl">
+   <x:scenario label="xsl:assert Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-assert/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="assert">Assert was triggered as expected</node>
+            <node type="assert"></node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xspec
@@ -1,16 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test enable-coverage?>
+<?xspec-test saxon-custom-options=-ea?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="xsl-assert-01.xsl">
-   <x:scenario label="xsl:assert Coverage Test Case">
-      <x:context>
+   <x:scenario label="xsl:assert Coverage Test Case for false assertion" catch="yes">
+      <x:context mode="xsl-assert-false">
          <root>
-            <xsl-assert/>
+            <xsl-assert />
+         </root>
+      </x:context>
+      <!-- XSpec catches the error and returns a map. -->
+      <x:expect label="Success" test="?err?value => string()"
+         select="'Assert Message: 100 lt 0'"/>
+   </x:scenario>
+
+   <x:scenario label="xsl:assert Coverage Test Case for true assertion">
+      <x:context mode="xsl-assert-true">
+         <root>
+            <xsl-assert />
          </root>
       </x:context>
       <x:expect label="Success">
          <root>
-            <node type="assert">Assert was triggered as expected</node>
             <node type="assert"></node>
          </root>
       </x:expect>

--- a/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
@@ -41,15 +41,20 @@
       </node>
       <!-- Using sequence constructor -->
       <node>
-        <xsl:attribute name="type">
-          <xsl:text>attribute</xsl:text>
-        </xsl:attribute>
+        <xsl:attribute name="type">attribute</xsl:attribute>
         <xsl:text>500</xsl:text>
+      </node>
+      <!-- Using sequence constructor -->
+      <node>
+        <xsl:attribute name="type">
+          <text-container>attribute</text-container>
+        </xsl:attribute>
+        <xsl:text>600</xsl:text>
       </node>
       <!-- As a child of xsl:copy. Context node is the template match node xsl-attribute -->
       <xsl:copy>
         <xsl:attribute name="type">attribute</xsl:attribute>
-        <xsl:text>600</xsl:text>
+        <xsl:text>700</xsl:text>
       </xsl:copy>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:attribute Coverage Test Case
+  -->
+  <!-- Single xsl:attribute in xsl:attribute-set -->
+  <xsl:attribute-set name="type">
+    <xsl:attribute name="type">attribute</xsl:attribute>
+  </xsl:attribute-set>
+
+  <!-- Two xsl:attribute in xsl:attribute-set -->
+  <xsl:attribute-set name="types">
+    <xsl:attribute name="type1">
+      <xsl:text>attribute1</xsl:text>
+    </xsl:attribute>
+    <xsl:attribute name="type2">
+      <xsl:text>attribute2</xsl:text>
+    </xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:template match="xsl-attribute">
+    <root>
+      <!-- use-attribute-sets in xsl:element -->
+      <xsl:element name="node" use-attribute-sets="type">
+        <xsl:text>100</xsl:text>
+      </xsl:element>
+      <!-- Using select attribute -->
+      <node>
+        <xsl:attribute name="type" select="'attribute'" />
+        <xsl:text>200</xsl:text>
+      </node>
+      <!-- Using select attribute -->
+      <node>
+        <xsl:attribute name="type" select="string('attribute')" />
+        <xsl:text>300</xsl:text>
+      </node>
+      <!-- Using sequence constructor -->
+      <node>
+       <xsl:attribute name="type">attribute</xsl:attribute>
+        <xsl:text>400</xsl:text>
+      </node>
+      <!-- Using sequence constructor -->
+      <node>
+        <xsl:attribute name="type">
+          <xsl:text>attribute</xsl:text>
+        </xsl:attribute>
+        <xsl:text>500</xsl:text>
+      </node>
+      <!-- As a child of xsl:copy. Context node is the template match node xsl-attribute -->
+      <xsl:copy>
+        <xsl:attribute name="type">attribute</xsl:attribute>
+        <xsl:text>600</xsl:text>
+      </xsl:copy>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-attribute-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-attribute-01.xspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-attribute-01.xsl">
+
+  <x:scenario label="xsl:attribute Coverage Test Case">
+    <x:context>
+      <root>
+        <xsl-attribute />
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="attribute">100</node>
+        <node type="attribute">200</node>
+        <node type="attribute">300</node>
+        <node type="attribute">400</node>
+        <node type="attribute">500</node>
+        <xsl-attribute type="attribute">600</xsl-attribute>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-attribute-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-attribute-01.xspec
@@ -17,7 +17,8 @@
         <node type="attribute">300</node>
         <node type="attribute">400</node>
         <node type="attribute">500</node>
-        <xsl-attribute type="attribute">600</xsl-attribute>
+        <node type="attribute">600</node>
+        <xsl-attribute type="attribute">700</xsl-attribute>
       </root>
     </x:expect>
   </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-attribute-set-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-attribute-set-01.xsl
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:attribute-set Coverage Test Case
+  -->
+  <!-- Single attribute -->
+  <xsl:attribute-set name="attrSet01">
+    <xsl:attribute name="attr01">attr01</xsl:attribute>
+  </xsl:attribute-set>
+  <!-- Multiple attributes-->
+  <xsl:attribute-set name="attrSet02">
+    <xsl:attribute name="attr02A">attr02A</xsl:attribute>
+    <xsl:attribute name="attr02B">attr02B</xsl:attribute>
+  </xsl:attribute-set>
+  <!-- Including another attribute set -->
+  <xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B">
+    <xsl:attribute name="attr03A">attr03A</xsl:attribute>
+  </xsl:attribute-set>
+  <xsl:attribute-set name="attrSet03B">
+    <xsl:attribute name="attr03B">attr03B</xsl:attribute>
+  </xsl:attribute-set>
+  <!-- Main template -->
+  <xsl:template match="xsl-attribute-set">
+    <root>
+      <!-- use-attribute-sets in xsl:element -->
+      <xsl:element name="node" use-attribute-sets="attrSet01">
+        <xsl:attribute name="type">attribute-set</xsl:attribute>
+        <xsl:text>100</xsl:text>
+      </xsl:element>
+      <!-- use-attribute-sets in literal result element -->
+      <node xsl:use-attribute-sets="attrSet02" type="attribute-set">
+        <xsl:text>100</xsl:text>
+      </node>
+      <!-- use-attribute-sets in literal result element -->
+      <node xsl:use-attribute-sets="attrSet03A" type="attribute-set">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-attribute-set-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-attribute-set-01.xspec
@@ -2,7 +2,6 @@
 <?xspec-test enable-coverage?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-               xmlns:local="http://local/xslt"
                stylesheet="xsl-attribute-set-01.xsl">
 
 

--- a/test/end-to-end/cases-coverage/xsl-attribute-set-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-attribute-set-01.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:local="http://local/xslt"
+               stylesheet="xsl-attribute-set-01.xsl">
+
+
+  <x:scenario label="xsl:attribute-set Coverage Test Case">
+    <x:context>
+      <root>
+        <xsl-attribute-set />
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="attribute-set" attr01="attr01">100</node>
+        <node type="attribute-set" attr02A="attr02A" attr02B="attr02B">100</node>
+        <node type="attribute-set" attr03A="attr03A" attr03B="attr03B">100</node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-call-template-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-call-template-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:call-template Coverage Test Case
+  -->
+  <xsl:template match="xsl-call-template">
+    <root>
+      <xsl:call-template name="calledTemplate" />
+    </root>
+  </xsl:template>
+  <!-- Called template-->
+  <xsl:template name="calledTemplate">
+    <node type="call-template">100</node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-call-template-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-call-template-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-call-template-01.xsl">
+   <x:scenario label="xsl:call-template Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-call-template/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="call-template">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-character-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-character-map-01.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:character-map Coverage Test Case (includes xsl:output-character)
+  -->
+  <!-- character map does not do any mapping changes (confident that it is used in Saxon).
+       But xspec doesn't do character-map without some additional effort (which isn't done here)-->
+  <xsl:character-map name="charMap01" use-character-maps="charMap01A">
+    <xsl:output-character character="0" string="0" />
+    <xsl:output-character character="&#xE003;" string="3" />
+  </xsl:character-map>
+  <!-- xsl:character-map included in one above -->
+  <xsl:character-map name="charMap01A">
+    <xsl:output-character character="1" string="1" />
+  </xsl:character-map>
+
+  <xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" />
+
+  <xsl:template match="xsl-character-map">
+    <root>
+      <node type="character-map">
+        <xsl:text>100</xsl:text><!-- Maps to 100 -->
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-character-map-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-character-map-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-character-map-01.xsl">
+   <x:scenario label="xsl:character-map Coverage Test Case (including xsl:output-character)">
+      <x:context>
+         <root>
+            <xsl-character-map/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="character-map">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-choose-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-choose-01.xsl
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:choose Test Case
+  -->
+  <xsl:template match="xsl-choose">
+    <root>
+      <!-- xsl:when matches so otherwise not executed -->
+      <xsl:choose>
+        <xsl:when test="1 eq 1">
+          <node type="choose when">
+            <xsl:text>100</xsl:text>
+          </node>
+        </xsl:when>
+        <xsl:otherwise version="3.0">                                          <!-- Expected miss -->
+          <node type="choose otherwise" version="3.0">                         <!-- Expected miss -->
+            <xsl:text version="3.0">200</xsl:text>                             <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:otherwise>                                                       <!-- Expected miss -->
+      </xsl:choose>
+      <!-- xsl:when doesn't match so when not executed -->
+      <xsl:choose>
+        <xsl:when test="1 eq 2" version="3.0">                                 <!-- Expected miss -->
+          <node type="choose when" version="3.0">                              <!-- Expected miss -->
+            <xsl:text version="3.0">100</xsl:text>                             <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:when>                                                            <!-- Expected miss -->
+        <xsl:otherwise>
+          <node type="choose otherwise">
+            <xsl:text>200</xsl:text>
+          </node>
+        </xsl:otherwise>
+      </xsl:choose>
+      <!-- xsl:when with no content matches so first when and otherwise not executed -->
+      <xsl:choose>
+        <xsl:when test="1 eq 2" version="3.0">                                 <!-- Expected miss -->
+          <node type="choose when" version="3.0">                              <!-- Expected miss -->
+            <xsl:text version="3.0">100</xsl:text>                             <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:when>                                                            <!-- Expected miss -->
+        <xsl:when test="2 eq 2"></xsl:when>
+        <xsl:otherwise version="3.0">                                          <!-- Expected miss -->
+          <node type="choose otherwise" version="3.0">                         <!-- Expected miss -->
+            <xsl:text version="3.0">200</xsl:text>                             <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:otherwise>                                                       <!-- Expected miss -->
+      </xsl:choose>
+      <!-- xsl:when doesn't match so when not executed. otherwise has no content. -->
+      <xsl:choose>
+        <xsl:when test="1 eq 2" version="3.0">                                 <!-- Expected miss -->
+          <node type="choose when" version="3.0">                              <!-- Expected miss -->
+            <xsl:text version="3.0">100</xsl:text>                             <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:when>                                                            <!-- Expected miss -->
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-choose-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-choose-01.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-choose-01.xsl">
+
+  <x:scenario label="xsl:choose Coverage Test Case (including xsl:when and xsl:otherwise)">
+    <x:context>
+      <root>
+        <xsl-choose />
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="choose when">100</node>
+        <node type="choose otherwise">200</node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-comment-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-comment-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:comment Coverage Test Case
+  -->
+  <xsl:template match="xsl-comment">
+    <root>
+      <node type="comment">
+        <xsl:comment> 100 </xsl:comment>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-comment-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-comment-01.xsl
@@ -8,6 +8,16 @@
       <node type="comment">
         <xsl:comment> 100 </xsl:comment>
       </node>
+      <node type="comment">
+        <xsl:comment>
+          <xsl:text> 100 </xsl:text>
+        </xsl:comment>
+      </node>
+      <node type="comment">
+        <xsl:comment>
+          <xsl:value-of select="concat('Data is ', @data)"/>
+        </xsl:comment>
+      </node>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-comment-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-comment-01.xspec
@@ -5,12 +5,14 @@
    <x:scenario label="xsl:comment Coverage Test Case">
       <x:context>
          <root>
-            <xsl-comment/>
+            <xsl-comment data="100" />
          </root>
       </x:context>
       <x:expect label="Success">
          <root>
             <node type="comment"><!-- 100 --></node>
+            <node type="comment"><!-- 100 --></node>
+            <node type="comment"><!--Data is 100--></node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-comment-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-comment-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-comment-01.xsl">
+   <x:scenario label="xsl:comment Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-comment/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="comment"><!-- 100 --></node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-context-item-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-context-item-01.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:context-item Coverage Test Case
+  -->
+  <xsl:template match="xsl-context-item">
+    <xsl:context-item use="required" as="item()" />
+      <root>
+        <node type="context-item">
+          <xsl:text>100</xsl:text>
+        </node>
+      </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-context-item-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-context-item-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-context-item-01.xsl">
+   <x:scenario label="xsl:context-item Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-context-item/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="context-item">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-copy-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-copy-01.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:copy Coverage Test Case
+  -->
+  <xsl:template match="xsl-copy">
+    <root>
+      <!-- Using select attribute -->
+      <node type="copy">
+        <xsl:copy select="node[2]/text()" />
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="copy">
+        <xsl:copy>
+          <xsl:value-of select="node[3]/text()" /><!-- Copies the context node which is xsl-copy -->
+        </xsl:copy>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-copy-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-copy-01.xspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-copy-01.xsl">
+   <x:scenario label="xsl:copy Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-copy>
+              <node>100</node>
+              <node>200</node>
+              <node>300</node>
+              <node>400</node>
+            </xsl-copy>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="copy">200</node>
+            <node type="copy">
+              <xsl-copy>300</xsl-copy>
+            </node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-copy-of-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-copy-of-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:copy-of Coverage Test Case
+  -->
+  <xsl:template match="xsl-copy-of">
+    <root>
+      <node type="copy-of">
+        <xsl:copy-of select="*" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-copy-of-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-copy-of-01.xspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-copy-of-01.xsl">
+   <x:scenario label="xsl:copy-of Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-copy-of>
+              <node>100</node>
+              <node>200</node>
+              <node>300</node>
+              <node>400</node>
+            </xsl-copy-of>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="copy-of">
+              <node>100</node>
+              <node>200</node>
+              <node>300</node>
+              <node>400</node>
+            </node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-data-01.xml
+++ b/test/end-to-end/cases-coverage/xsl-data-01.xml
@@ -1,0 +1,6 @@
+<root>
+  <node>100</node>
+  <node>200</node>
+  <node>300</node>
+  <node>400</node>
+</root>

--- a/test/end-to-end/cases-coverage/xsl-decimal-format-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-decimal-format-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:decimal-format Coverage Test Case
+  -->
+  <xsl:decimal-format name="decFormat01" digit="?" />
+  <!-- Main template -->
+  <xsl:template match="xsl-decimal-format">
+    <root>
+      <node type="decimal-format">
+        <xsl:value-of select="format-number(100.00, '???0', 'decFormat01')" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-decimal-format-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-decimal-format-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-decimal-format-01.xsl">
+   <x:scenario label="xsl:decimal-format Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-decimal-format/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="decimal-format">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-document-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-document-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:document Coverage Test Case
+  -->
+  <xsl:template match="xsl-document">
+    <root>
+      <xsl:document>
+        <node type="document">
+          <xsl:text>100</xsl:text>
+        </node>
+      </xsl:document>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-document-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-document-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-document-01.xsl">
+   <x:scenario label="xsl:document Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-document/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="document">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-element-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-element-01.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:element Coverage Test Case
+  -->
+  <xsl:template match="xsl-element">
+    <root>
+      <xsl:element name="node">
+        <xsl:attribute name="type">element</xsl:attribute>
+        <xsl:text>100</xsl:text>
+      </xsl:element>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-element-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-element-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-element-01.xsl">
+   <x:scenario label="xsl:element Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-element/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="element">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
@@ -8,7 +8,7 @@
     <data value="400">400</data>
     <data value="100">100</data>
     <data value="300">300</data>
-    <data value="200">300</data>
+    <data value="200">200</data>
   </xsl:variable>
   <!-- Sort key -->
   <xsl:variable name="sortKey">@value</xsl:variable>
@@ -23,12 +23,26 @@
             <xsl:value-of select="@value" />
           </node>
         </xsl:for-each>
-        <!--xsl:variable name="evaluateExpression">
-            <xsl:evaluate xpath="substring('hello', 1, 4)" />
+
+        <!-- Circuitous ways to get $data/data[2] content -->
+        <xsl:variable name="index" select="2" />
+        <xsl:variable name="evaluatedExpressionParamChild">
+          <xsl:evaluate xpath="'string(data[$index])'" context-item="$data">
+            <xsl:with-param name="index" select="$index" />
+            <xsl:with-param name="sortKey">parameter not used in evaluation</xsl:with-param>
+          </xsl:evaluate>
         </xsl:variable>
-          <node type="evaluate">
-            <xsl:value-of select="$evaluateExpression" />
-          </node-->
+        <node type="evaluate/with-param">
+          <xsl:value-of select="$evaluatedExpressionParamChild" />
+        </node>
+
+        <xsl:variable name="evaluatedExpressionParamAttr">
+          <xsl:evaluate xpath="'string(data[$index])'" context-item="$data"
+            with-params="map{QName('','index'): $index }" />
+        </xsl:variable>
+        <node type="evaluate/with-param">
+          <xsl:value-of select="$evaluatedExpressionParamAttr" />
+        </node>
       </root>
    </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <!--
-      xsl:evaluate Coverage Test Case - need a test case using with-param
+      xsl:evaluate Coverage Test Case
   -->
   <!-- Data for the test -->
   <xsl:variable name="data">

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:evaluate Coverage Test Case - need a test case using with-param
+  -->
+  <!-- Data for the test -->
+  <xsl:variable name="data">
+    <data value="400">400</data>
+    <data value="100">100</data>
+    <data value="300">300</data>
+    <data value="200">300</data>
+  </xsl:variable>
+  <!-- Sort key -->
+  <xsl:variable name="sortKey">@value</xsl:variable>
+
+   <xsl:template match="xsl-evaluate">
+      <root>
+        <xsl:for-each select="$data/data">
+          <xsl:sort>
+            <xsl:evaluate xpath="$sortKey" context-item="."  />
+          </xsl:sort>
+          <node type="evaluate">
+            <xsl:value-of select="@value" />
+          </node>
+        </xsl:for-each>
+        <!--xsl:variable name="evaluateExpression">
+            <xsl:evaluate xpath="substring('hello', 1, 4)" />
+        </xsl:variable>
+          <node type="evaluate">
+            <xsl:value-of select="$evaluateExpression" />
+          </node-->
+      </root>
+   </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-evaluate-01.xsl">
+   <x:scenario label="xsl:evaluate Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-evaluate/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="evaluate">100</node>
+            <node type="evaluate">200</node>
+            <node type="evaluate">300</node>
+            <node type="evaluate">400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xspec
@@ -14,6 +14,8 @@
             <node type="evaluate">200</node>
             <node type="evaluate">300</node>
             <node type="evaluate">400</node>
+            <node type="evaluate/with-param">100</node>
+            <node type="evaluate/with-param">100</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-fallback-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-fallback-01.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="99.0">
+  <!--
+      xsl:fallback Coverage Test Case
+  -->
+   <xsl:template match="xsl-fallback">
+      <root>
+        <!-- Sets the xsl version number higher than current version and has unknown instruction (adapted from XSLT Spec) -->
+        <xsl:non-existant-instruction>                                         <!-- Expected miss -->
+          <xsl:fallback>
+            <node type="fallback">
+              <xsl:text>100</xsl:text>
+            </node>
+          </xsl:fallback>
+        </xsl:non-existant-instruction>                                        <!-- Expected miss -->
+      </root>
+   </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-fallback-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-fallback-01.xsl
@@ -7,13 +7,13 @@
    <xsl:template match="xsl-fallback">
       <root>
         <!-- Sets the xsl version number higher than current version and has unknown instruction (adapted from XSLT Spec) -->
-        <xsl:non-existant-instruction>                                         <!-- Expected miss -->
+        <xsl:non-existent-instruction>                                         <!-- Expected miss -->
           <xsl:fallback>
             <node type="fallback">
               <xsl:text>100</xsl:text>
             </node>
           </xsl:fallback>
-        </xsl:non-existant-instruction>                                        <!-- Expected miss -->
+        </xsl:non-existent-instruction>                                        <!-- Expected miss -->
       </root>
    </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-fallback-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-fallback-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-fallback-01.xsl">
+   <x:scenario label="xsl:fallback Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-fallback/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="fallback">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-for-each-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-for-each-01.xsl
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:for-each Coverage Test Case
+  -->
+  <xsl:template match="xsl-for-each">
+    <root>
+      <!-- Simple for-each -->
+      <xsl:for-each select="1 to 5">
+        <node type="for-each">
+          <xsl:value-of select=". * 100" />
+        </node>
+      </xsl:for-each>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-for-each-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-for-each-01.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-for-each-01.xsl">
+
+  <x:scenario label="xsl:for-each Coverage Test Case">
+    <x:context>
+      <root>
+        <xsl-for-each />
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="for-each">100</node>
+        <node type="for-each">200</node>
+        <node type="for-each">300</node>
+        <node type="for-each">400</node>
+        <node type="for-each">500</node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-for-each-group-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-for-each-group-01.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <!--
-      xsl:for-each-group - just a singe example using group-by.
+      xsl:for-each-group - just a single example using group-by.
   -->
   <xsl:template match="xsl-for-each-group">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-for-each-group-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-for-each-group-01.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:for-each-group - just a singe example using group-by.
+  -->
+  <xsl:template match="xsl-for-each-group">
+    <root>
+      <!-- Returns remainder after division by 3. Groups contain 0, 1 and 2 -->
+      <xsl:for-each-group select="9 to 20" group-by="(. mod 3)">
+        <node type="for-each-group">
+          <xsl:value-of select="current-grouping-key()" />
+        </node>
+      </xsl:for-each-group>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-for-each-group-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-for-each-group-01.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-for-each-group-01.xsl">
+   <x:scenario label="xsl:for-each-group Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-for-each-group/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="for-each-group">0</node>
+            <node type="for-each-group">1</node>
+            <node type="for-each-group">2</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-function-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-function-01.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:myns="myNamespace">
+  <!--
+      xsl:function Coverage Test Case
+  -->
+  <xsl:template match="xsl-function">
+    <root>
+      <!-- Very simple just to check function called -->
+      <node type="function">
+        <xsl:value-of select="myns:returnHundred()" />
+      </node>
+    </root>
+  </xsl:template>
+  <!-- Function called -->
+  <xsl:function name="myns:returnHundred">
+    <xsl:text>100</xsl:text>
+  </xsl:function>
+  <!-- Function NOT called -->
+  <xsl:function name="myns:returnThousand">                                    <!-- Expected miss -->
+    <xsl:text>1000</xsl:text>                                                  <!-- Expected miss -->
+  </xsl:function>                                                              <!-- Expected miss -->
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-function-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-function-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-function-01.xsl">
+   <x:scenario label="xsl:function Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-function/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="function">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-if-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-if-01.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:if - xsl:if is always executed
+  -->
+  <xsl:template match="xsl-if">
+    <root>
+      <!-- Test succeeds -->
+      <xsl:if test=" 1 eq 1">
+        <node type="if">100</node>
+      </xsl:if>
+      <!-- Test fails but xsl:if still executed and is a hit-->
+      <xsl:if test=" 1 eq 2">
+        <node type="if">200</node>                                             <!-- Expected miss -->
+      </xsl:if>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-if-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-if-01.xsl
@@ -6,11 +6,11 @@
   <xsl:template match="xsl-if">
     <root>
       <!-- Test succeeds -->
-      <xsl:if test=" 1 eq 1">
+      <xsl:if test="1 eq 1">
         <node type="if">100</node>
       </xsl:if>
       <!-- Test fails but xsl:if still executed and is a hit-->
-      <xsl:if test=" 1 eq 2">
+      <xsl:if test="1 eq 2">
         <node type="if">200</node>                                             <!-- Expected miss -->
       </xsl:if>
     </root>

--- a/test/end-to-end/cases-coverage/xsl-if-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-if-01.xspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="xsl-if-01.xsl">
+   <x:scenario label="xsl:if Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-if/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="if">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-import-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-import-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:import Coverage Test Case (See imported stylesheet)
+  -->
+  <xsl:import href="xsl-import-01A.xsl" />
+  <xsl:template match="xsl-import">
+    <root>
+      <!-- Call template in imported stylesheet -->
+      <xsl:call-template name="importTemplate01" />
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-import-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-import-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-import-01.xsl">
+   <x:scenario label="xsl:import Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-import/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="import">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-import-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-import-01A.xsl
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <!-- xsl:import Template -->
+  <xsl:template name="importTemplate01">
+    <node type="import">
+      <xsl:text>100</xsl:text>
+    </node>
+  </xsl:template>
+ </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-include-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:include Coverage Test Case
+  -->
+  <!-- xsl:include -->
+  <xsl:include href="xsl-include-01A.xsl" />
+  <!-- Main template -->
+  <xsl:template match="xsl-include">
+    <root>
+      <xsl:call-template name="includeTemplate01" />
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-include-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-include-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-include-01.xsl">
+   <x:scenario label="xsl:include Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-include/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="include">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-include-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01A.xsl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
-  <!-- Caled Template in this include stylesheet -->
+  <!-- Called Template in this include stylesheet -->
   <xsl:template name="includeTemplate01">
     <node type="include">
       <xsl:text>100</xsl:text>

--- a/test/end-to-end/cases-coverage/xsl-include-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01A.xsl
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!-- Caled Template in this include stylesheet -->
+  <xsl:template name="includeTemplate01">
+    <node type="include">
+      <xsl:text>100</xsl:text>
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
@@ -67,7 +67,7 @@
           <xsl:with-param name="param01" select="$newValue" />
         </xsl:next-iteration>
       </xsl:iterate>
-      <!-- xsl:iterate with xsl:on-completion and xsl:break executed (xsl:on-completion not executed) -->
+      <!-- xsl:iterate with xsl:break executed and xsl:on-completion not executed -->
       <xsl:iterate select="node">
         <xsl:on-completion>                                                    <!-- Expected miss -->
           <node type="iterate/on-completion/break">                            <!-- Expected miss -->
@@ -81,7 +81,7 @@
           <xsl:break />
         </xsl:if>
       </xsl:iterate>
-      <!-- xsl:iterate with xsl:on-completion and xsl:break not executed -->
+      <!-- xsl:iterate with xsl:on-completion executed and xsl:break not executed -->
       <xsl:iterate select="node">
         <xsl:on-completion>
           <node type="iterate/on-completion/break">

--- a/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:iterate Coverage Test Case (includes xsl:next-iteration xsl:on-completion xsl:break)
+  -->
+  <xsl:template match="xsl-iterate">
+    <root>
+      <!-- Simple xsl:iterate with no xsl:next-iteration, xsl:on-competion or xsl:break -->
+      <xsl:iterate select="node">
+        <node type="iterate">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:iterate>
+      <!-- Simple xsl:iterate with just xsl:on-completion -->
+      <xsl:iterate select="node">
+        <xsl:on-completion>
+          <node type="iterate/on-completion">
+            <xsl:text>Complete</xsl:text>
+          </node>
+        </xsl:on-completion>
+        <node type="iterate/on-completion">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:iterate>
+      <!-- Simple xsl:iterate with just xsl:next-iteration -->
+      <xsl:iterate select="node">
+        <xsl:param name="param01" select="1" />
+        <xsl:variable name="newValue" select="$param01 * 2" />
+        <node type="iterate/next-iteration">
+          <xsl:value-of select=". * $newValue" />
+        </node>
+        <xsl:next-iteration>
+          <xsl:with-param name="param01" select="$newValue" />
+        </xsl:next-iteration>
+      </xsl:iterate>
+      <!-- Simple xsl:iterate with xsl:break executed -->
+      <xsl:iterate select="node">
+        <node type="iterate/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 150">
+          <xsl:break />
+        </xsl:if>
+      </xsl:iterate>
+      <!-- Simple xsl:iterate with xsl:break not executed -->
+      <xsl:iterate select="node">
+        <node type="iterate/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 2500">
+          <xsl:break />                                                        <!-- Expected miss -->
+        </xsl:if>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:next-iteration and xsl:on-completion -->
+      <xsl:iterate select="node">
+        <xsl:param name="param01" select="1" />
+        <xsl:on-completion>
+          <node type="iterate/next-iteration/on-completion">
+            <xsl:text>Complete</xsl:text>
+          </node>
+        </xsl:on-completion>
+        <xsl:variable name="newValue" select="$param01 * 2" />
+        <node type="iterate/next-iteration/on-completion">
+          <xsl:value-of select=". * $newValue" />
+        </node>
+        <xsl:next-iteration>
+          <xsl:with-param name="param01" select="$newValue" />
+        </xsl:next-iteration>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:on-completion and xsl:break executed (xsl:on-completion not executed) -->
+      <xsl:iterate select="node">
+        <xsl:on-completion>                                                    <!-- Expected miss -->
+          <node type="iterate/on-completion/break">                            <!-- Expected miss -->
+            <xsl:text>Complete</xsl:text>                                      <!-- Expected miss -->
+          </node>                                                              <!-- Expected miss -->
+        </xsl:on-completion>                                                   <!-- Expected miss -->
+        <node type="iterate/on-completion/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 150">
+          <xsl:break />
+        </xsl:if>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:on-completion and xsl:break not executed -->
+      <xsl:iterate select="node">
+        <xsl:on-completion>
+          <node type="iterate/on-completion/break">
+            <xsl:text>Complete</xsl:text>
+          </node>
+        </xsl:on-completion>
+        <node type="iterate/on-completion/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 2500">
+          <xsl:break />                                                        <!-- Expected miss -->
+        </xsl:if>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:break executed (xsl:break has select attribute) -->
+      <xsl:iterate select="node">
+        <node type="iterate/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 150">
+          <xsl:break select="'break executed'" />
+        </xsl:if>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:break executed (xsl:break has sequence constructor) -->
+      <xsl:iterate select="node">
+        <node type="iterate/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 150">
+          <xsl:break>
+            <node type="iterate/break">
+              <xsl:value-of select="." />
+            </node>
+          </xsl:break>
+        </xsl:if>
+      </xsl:iterate>
+      <!-- xsl:iterate with xsl:break not executed (xsl:break has sequence constructor) -->
+      <xsl:iterate select="node">
+        <node type="iterate/break">
+          <xsl:value-of select="." />
+        </node>
+        <xsl:if test=". &gt; 2400">
+          <xsl:break>                                                          <!-- Expected miss -->
+            <node type="iterate/break">                                        <!-- Expected miss -->
+              <xsl:value-of select="." />                                      <!-- Expected miss -->
+            </node>                                                            <!-- Expected miss -->
+          </xsl:break>                                                         <!-- Expected miss -->
+        </xsl:if>
+      </xsl:iterate>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-iterate-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-iterate-01.xspec
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-iterate-01.xsl">
+   <x:scenario label="xsl:iterate Coverage Test Case (including xsl:next-iteration, xsl:on-completion and xsl:break)">
+      <x:context>
+         <root>
+            <xsl-iterate>
+              <node>100</node>
+              <node>200</node>
+              <node>300</node>
+            </xsl-iterate>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="iterate">100</node>
+            <node type="iterate">200</node>
+            <node type="iterate">300</node>
+            <node type="iterate/on-completion">100</node>
+            <node type="iterate/on-completion">200</node>
+            <node type="iterate/on-completion">300</node>
+            <node type="iterate/on-completion">Complete</node>
+            <node type="iterate/next-iteration">200</node>
+            <node type="iterate/next-iteration">800</node>
+            <node type="iterate/next-iteration">2400</node>
+            <node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>
+            <node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>
+            <node type="iterate/break">300</node>
+            <node type="iterate/next-iteration/on-completion">200</node>
+            <node type="iterate/next-iteration/on-completion">800</node>
+            <node type="iterate/next-iteration/on-completion">2400</node>
+            <node type="iterate/next-iteration/on-completion">Complete</node>
+            <node type="iterate/on-completion/break">100</node>
+            <node type="iterate/on-completion/break">200</node>
+            <node type="iterate/on-completion/break">100</node>
+            <node type="iterate/on-completion/break">200</node>
+            <node type="iterate/on-completion/break">300</node>
+            <node type="iterate/on-completion/break">Complete</node>
+            <node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>break executed<node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>
+            <node type="iterate/break">200</node>
+            <node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>
+            <node type="iterate/break">300</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-iterate-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-iterate-01.xspec
@@ -40,7 +40,9 @@
             <node type="iterate/on-completion/break">300</node>
             <node type="iterate/on-completion/break">Complete</node>
             <node type="iterate/break">100</node>
-            <node type="iterate/break">200</node>break executed<node type="iterate/break">100</node>
+            <node type="iterate/break">200</node>
+            <x:text>break executed</x:text>
+            <node type="iterate/break">100</node>
             <node type="iterate/break">200</node>
             <node type="iterate/break">200</node>
             <node type="iterate/break">100</node>

--- a/test/end-to-end/cases-coverage/xsl-key-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-key-01.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:key Coverage Test Case
+  -->
+  <!-- xsl:key declaration -->
+  <xsl:key name="key01" match="node" use="@type" />
+  <!-- Main template -->
+  <xsl:template match="xsl-key">
+    <root>
+      <node type="key">
+        <xsl:value-of select="key('key01', 'B')" />
+      </node>
+      <node type="key">
+        <xsl:value-of select="key('key01', 'D')" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-key-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-key-01.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-key-01.xsl">
+   <x:scenario label="xsl:key Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-key>
+              <node type="A">100</node>
+              <node type="B">200</node>
+              <node type="C">300</node>
+              <node type="D">400</node>
+            </xsl-key>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="key">200</node>
+            <node type="key">400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!--
+      xsl:map Coverage Test Case (includes xsl:map)
+  -->
+  <xsl:template match="xsl-map">
+    <root>
+      <!-- Map construction, including xsl:map -->
+      <xsl:variable name="hundreds" as="map(xs:string, xs:integer)">
+        <xsl:map>
+          <!-- Using select attribute -->
+          <xsl:map-entry key="'One'" select="100"/>
+          <xsl:map-entry key="'Two'" select="200"/>
+          <!-- Using sequence constructor -->
+          <xsl:map-entry key="'Three'">
+            <xsl:sequence select="300" />
+          </xsl:map-entry>
+          <xsl:map-entry key="'Four'">
+            <xsl:sequence select="400" />
+          </xsl:map-entry>
+        </xsl:map>
+      </xsl:variable>
+      <!-- Use xsl:map values -->
+      <node type="map">
+        <xsl:value-of select="$hundreds('One')" />
+      </node>
+      <node type="map">
+        <xsl:value-of select="$hundreds('Three')" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xsl
@@ -1,33 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:myns="myNamespace">
   <!--
       xsl:map Coverage Test Case (includes xsl:map)
   -->
   <xsl:template match="xsl-map">
+    <!-- Map construction, including xsl:map -->
+    <xsl:param name="hundreds-param" as="map(xs:string, xs:integer)">
+      <xsl:map>
+        <!-- Using select attribute -->
+        <xsl:map-entry key="'One'" select="100"/>
+        <xsl:map-entry key="'Two'" select="200"/>
+        <!-- Using sequence constructor -->
+        <xsl:map-entry key="'Three'">
+          <xsl:sequence select="300" />
+        </xsl:map-entry>
+        <xsl:map-entry key="'Four'">
+          <xsl:sequence select="400" />
+        </xsl:map-entry>
+      </xsl:map>
+    </xsl:param>
+    <xsl:variable name="hundreds-variable" as="map(xs:string, xs:integer)">
+      <xsl:map>
+        <!-- Using select attribute -->
+        <xsl:map-entry key="'One'" select="100"/>
+        <xsl:map-entry key="'Two'" select="200"/>
+        <!-- Using sequence constructor -->
+        <xsl:map-entry key="'Three'">
+          <xsl:sequence select="300" />
+        </xsl:map-entry>
+        <xsl:map-entry key="'Four'">
+          <xsl:sequence select="400" />
+        </xsl:map-entry>
+      </xsl:map>
+    </xsl:variable>
+    <!-- Use xsl:map values -->
     <root>
-      <!-- Map construction, including xsl:map -->
-      <xsl:variable name="hundreds" as="map(xs:string, xs:integer)">
-        <xsl:map>
-          <!-- Using select attribute -->
-          <xsl:map-entry key="'One'" select="100"/>
-          <xsl:map-entry key="'Two'" select="200"/>
-          <!-- Using sequence constructor -->
-          <xsl:map-entry key="'Three'">
-            <xsl:sequence select="300" />
-          </xsl:map-entry>
-          <xsl:map-entry key="'Four'">
-            <xsl:sequence select="400" />
-          </xsl:map-entry>
-        </xsl:map>
-      </xsl:variable>
-      <!-- Use xsl:map values -->
-      <node type="map">
-        <xsl:value-of select="$hundreds('One')" />
+      <node type="param/map">
+        <xsl:value-of select="$hundreds-param('One')" />
       </node>
-      <node type="map">
-        <xsl:value-of select="$hundreds('Three')" />
+      <node type="param/map">
+        <xsl:value-of select="$hundreds-param('Three')" />
+      </node>
+      <node type="variable/map">
+        <xsl:value-of select="$hundreds-variable('One')" />
+      </node>
+      <node type="variable/map">
+        <xsl:value-of select="$hundreds-variable('Three')" />
+      </node>
+      <node type="function/map">
+        <xsl:value-of select="myns:returnMap()('One')" />
+      </node>
+      <node type="function/map">
+        <xsl:value-of select="myns:returnMap()('Three')" />
       </node>
     </root>
   </xsl:template>
+
+  <xsl:function name="myns:returnMap" as="map(xs:string, xs:integer)">
+    <xsl:map>
+      <!-- Using select attribute -->
+      <xsl:map-entry key="'One'" select="100"/>
+      <xsl:map-entry key="'Two'" select="200"/>
+      <!-- Using sequence constructor -->
+      <xsl:map-entry key="'Three'">
+        <xsl:sequence select="300" />
+      </xsl:map-entry>
+      <xsl:map-entry key="'Four'">
+        <xsl:sequence select="400" />
+      </xsl:map-entry>
+    </xsl:map>
+  </xsl:function>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xsl
@@ -3,7 +3,7 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:myns="myNamespace">
   <!--
-      xsl:map Coverage Test Case (includes xsl:map)
+      xsl:map Coverage Test Case (includes xsl:map-entry)
   -->
   <xsl:template match="xsl-map">
     <!-- Map construction, including xsl:map -->

--- a/test/end-to-end/cases-coverage/xsl-map-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-map-01.xsl">
+   <x:scenario label="xsl:map Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-map/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="map">100</node>
+            <node type="map">300</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xspec
@@ -2,7 +2,7 @@
 <?xspec-test enable-coverage?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="xsl-map-01.xsl">
-   <x:scenario label="xsl:map Coverage Test Case">
+   <x:scenario label="xsl:map Coverage Test Case (including xsl:map-entry)">
       <x:context>
          <root>
             <xsl-map/>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xspec
@@ -10,8 +10,12 @@
       </x:context>
       <x:expect label="Success">
          <root>
-            <node type="map">100</node>
-            <node type="map">300</node>
+            <node type="param/map">100</node>
+            <node type="param/map">300</node>
+            <node type="variable/map">100</node>
+            <node type="variable/map">300</node>
+            <node type="function/map">100</node>
+            <node type="function/map">300</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-merge-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-merge-01.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:merge Coverage Test Case (also includes xsl:merge-source, xsl:merge-key and xsl:merge-action)
+  -->
+  <xsl:template match="xsl-merge">
+    <root>
+        <!-- 2 data sets to be merged -->
+        <xsl:variable name="mergeSourceA">
+          <node>100</node>
+          <node>300</node>
+          <node>500</node>
+        </xsl:variable>
+        <xsl:variable name="mergeSourceB">
+          <node>200</node>
+          <node>400</node>
+          <node>600</node>
+        </xsl:variable>
+        <!-- 1st merge-key uses select attribute, 2nd uses sequence constructor -->
+        <xsl:merge>
+          <xsl:merge-source select="$mergeSourceA/*">
+            <xsl:merge-key select="." />
+          </xsl:merge-source>
+          <xsl:merge-source select="$mergeSourceB/*">
+            <xsl:merge-key>
+              <xsl:value-of select="." />
+            </xsl:merge-key>
+          </xsl:merge-source>
+          <xsl:merge-action>
+            <node type="merge">
+              <xsl:value-of select="current-merge-group()" />
+            </node>
+          </xsl:merge-action>
+        </xsl:merge>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-merge-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-merge-01.xspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-merge-01.xsl">
+   <x:scenario label="xsl:merge Coverage Test Case (including xsl:merge-source, xsl:merge-key and xsl:merge-action)">
+      <x:context>
+         <root>
+            <xsl-merge/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="merge">100</node>
+            <node type="merge">200</node>
+            <node type="merge">300</node>
+            <node type="merge">400</node>
+            <node type="merge">500</node>
+            <node type="merge">600</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xsl
@@ -17,6 +17,19 @@
           <xsl:text>Message: 200</xsl:text>
         </xsl:message>
       </node>
+      <!-- Terminate upon request -->
+      <xsl:if test="@terminate eq 'select'">
+        <xsl:message select="string('Terminating Message: 100')" terminate="yes"/>
+        <xsl:message select="string('After terminating message')"/>            <!-- Expected miss -->
+      </xsl:if>
+      <xsl:if test="@terminate eq 'sequence constructor'">
+        <xsl:message terminate="yes">
+          <xsl:text>Terminating Message: 200</xsl:text>
+        </xsl:message>
+        <xsl:message>                                                          <!-- Expected miss -->
+          <xsl:text>After terminating message</xsl:text>                       <!-- Expected miss -->
+        </xsl:message>                                                         <!-- Expected miss -->
+      </xsl:if>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:message Coverage Test Case
+  -->
+  <xsl:template match="xsl-message">
+    <root>
+      <!-- Using select attribute -->
+      <node type="message">
+        <xsl:text>100</xsl:text>
+        <xsl:message select="string('Message: 100')" />
+      </node>
+      <!-- Add content -->
+      <node type="message">
+        <xsl:text>200</xsl:text>
+        <xsl:message>
+          <xsl:text>Message: 200</xsl:text>
+        </xsl:message>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-message-01.xsl">
+   <x:scenario label="xsl:message Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-message/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="message">100</node>
+            <node type="message">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xspec
@@ -15,4 +15,27 @@
          </root>
       </x:expect>
    </x:scenario>
+
+   <x:scenario label="xsl:message Coverage Test Case for Terminating Message" catch="yes">
+      <x:scenario label="Using select attribute">
+         <x:context>
+            <root>
+               <xsl-message terminate="select"/>
+            </root>
+         </x:context>
+         <!-- XSpec catches the error and returns a map. -->
+         <x:expect label="Success" test="?err?value => string()"
+            select="'Terminating Message: 100'"/>
+      </x:scenario>
+      <x:scenario label="Using sequence constructor">
+         <x:context>
+            <root>
+               <xsl-message terminate="sequence constructor"/>
+            </root>
+         </x:context>
+         <!-- XSpec catches the error and returns a map. -->
+         <x:expect label="Success" test="?err?value => string()"
+            select="'Terminating Message: 200'"/>
+      </x:scenario>
+   </x:scenario>
 </x:description>

--- a/test/end-to-end/cases-coverage/xsl-mode-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-mode-01.xsl
@@ -4,6 +4,7 @@
       xsl:mode Coverage Test Case
   -->
   <xsl:mode name="modeUsed" />
+  <xsl:mode on-multiple-match="fail" />
   <!-- Mode not used -->
   <xsl:mode name="modeNotUsed" />
 

--- a/test/end-to-end/cases-coverage/xsl-mode-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-mode-01.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:mode Coverage Test Case
+  -->
+  <xsl:mode name="modeUsed" />
+  <!-- Mode not used -->
+  <xsl:mode name="modeNotUsed" />
+
+  <xsl:template match="xsl-mode">
+      <root>
+        <!-- Apply template using mode - xspec context has a node element -->
+        <xsl:apply-templates mode="modeUsed" />
+      </root>
+  </xsl:template>
+
+  <xsl:template match="node" mode="modeUsed">
+    <node type="mode">
+      <xsl:text>100</xsl:text>
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-mode-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-mode-01.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-mode-01.xsl">
+   <x:scenario label="xsl:mode Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-mode>
+              <node/>
+            </xsl-mode>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="mode">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-namespace-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-namespace-01.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:namespace Coverage Test Case
+  -->
+  <xsl:template match="xsl-namespace">
+    <root>
+      <!-- Using select attribute -->
+      <node type="namespace">
+        <xsl:namespace name="dummy" select="'namespaceURI'" />
+        <xsl:text>100</xsl:text>
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="namespace">
+        <xsl:namespace name="dummy">
+          <xsl:text>namespaceURI</xsl:text>
+        </xsl:namespace>
+        <xsl:text>200</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-namespace-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-namespace-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-namespace-01.xsl">
+   <x:scenario label="xsl:namespace Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-namespace/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="namespace" xmlns:dummy="namespaceURI">100</node>
+            <node type="namespace" xmlns:dummy="namespaceURI">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:myxslt="file://namespace.alias">
+  <!--
+      xsl:namespace-alias Coverage Test Case
+  -->
+  <xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" />
+
+  <xsl:template match="xsl-namespace-alias">
+    <root>
+      <!-- See myxslt namespace defined above. Also xsl namespace defined in xspec. -->
+      <myxslt:node type="namespace-alias">
+        <xsl:text>100</xsl:text>
+      </myxslt:node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-namespace-alias-01.xsl"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   <x:scenario label="xsl:namespace-alias Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-namespace-alias/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <xsl:node type="namespace-alias">100</xsl:node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
@@ -9,7 +9,7 @@
   <xsl:mode name="nextMatch" />
   <!-- Variable with the node to be processed -->
   <xsl:variable name="nextMatchNodes">
-    <node />
+    <node>content for built-in template</node>
   </xsl:variable>
   <!-- Main template -->
   <xsl:template match="xsl-next-match">
@@ -24,5 +24,8 @@
       <xsl:text>100</xsl:text>
     </node>
     <xsl:next-match />
+    <xsl:next-match>
+      <xsl:with-param name="param">300</xsl:with-param>
+    </xsl:next-match>
    </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:next-match Coverage Test Case - See imported template as well
+  -->
+  <!-- Import stylesheet with lower priority template -->
+  <xsl:import href="xsl-next-match-01A.xsl" />
+  <!-- Use a mode for matching -->
+  <xsl:mode name="nextMatch" />
+  <!-- Variable with the node to be processed -->
+  <xsl:variable name="nextMatchNodes">
+    <node />
+  </xsl:variable>
+  <!-- Main template -->
+  <xsl:template match="xsl-next-match">
+    <root>
+      <!-- Start processing node -->
+      <xsl:apply-templates select="$nextMatchNodes" mode="nextMatch" />
+    </root>
+  </xsl:template>
+  <!-- Initial template invoked for node -->
+  <xsl:template match="node" mode="nextMatch" priority="1">
+    <node type="next-match">
+      <xsl:text>100</xsl:text>
+    </node>
+    <xsl:next-match />
+   </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01.xspec
@@ -12,6 +12,9 @@
          <root>
             <node type="next-match">100</node>
             <node type="next-match">200</node>
+            <x:text>content for built-in template</x:text>
+            <node type="next-match">300</node>
+            <x:text>content for built-in template</x:text>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-next-match-01.xsl">
+   <x:scenario label="xsl:next-match Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-next-match/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="next-match">100</node>
+            <node type="next-match">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01A.xsl
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!-- Secondary template invoked for node -->
+  <xsl:template match="node" mode="nextMatch" priority="2">
+    <node type="next-match">
+      <xsl:text>200</xsl:text>
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01A.xsl
@@ -2,8 +2,11 @@
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <!-- Secondary template invoked for node -->
   <xsl:template match="node" mode="nextMatch" priority="2">
+    <xsl:param name="param" select="200" />
     <node type="next-match">
-      <xsl:text>200</xsl:text>
+      <xsl:value-of select="$param" />
     </node>
+    <!-- Next match is built-in template -->
+    <xsl:next-match />
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-number-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-number-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:number Coverage Test Case
+  -->
+  <xsl:template match="xsl-number">
+    <root>
+      <node type="number">
+        <xsl:number />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-number-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-number-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-number-01.xsl">
+   <x:scenario label="xsl:number Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-number/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="number">1</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-on-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-empty-01.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:on-empty Coverage Test Case
+  -->
+  <xsl:template match="xsl-on-empty">
+    <root>
+      <!-- Using select attribute -->
+      <node type="on-empty">
+        <xsl:on-empty select="200 idiv 2" />
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="on-empty">
+        <xsl:on-empty>
+          <xsl:text>200</xsl:text>
+        </xsl:on-empty>
+      </node>
+      <!-- NOT on-empty-->
+      <node type="on-empty">
+        <xsl:text>300</xsl:text>
+        <xsl:on-empty>                                                         <!-- Expected miss -->
+          <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
+        </xsl:on-empty>                                                        <!-- Expected miss -->
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-on-empty-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-on-empty-01.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-on-empty-01.xsl">
+   <x:scenario label="xsl:on-empty Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-on-empty/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="on-empty">100</node>
+            <node type="on-empty">200</node>
+            <node type="on-empty">300</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
@@ -23,6 +23,13 @@
           <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
         </xsl:on-non-empty>                                                    <!-- Expected miss -->
       </node>
+      <!-- NOT on-non-empty but static analysis cannot make that judgment --> 
+      <node type="on-non-empty">
+        <xsl:sequence select="@nonexistent-attribute" />
+        <xsl:on-non-empty>                                                     <!-- Expected miss -->
+          <xsl:text>400</xsl:text>                                             <!-- Expected miss -->
+        </xsl:on-non-empty>                                                    <!-- Expected miss -->
+      </node>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:on-non-empty Coverage Test Case
+  -->
+  <xsl:template match="xsl-on-non-empty">
+    <root>
+      <!-- Using select attribute -->
+      <node type="on-non-empty">
+        <xsl:text>1</xsl:text>
+        <xsl:on-non-empty select="'00'" />
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="on-non-empty">
+        <xsl:text>2</xsl:text>
+        <xsl:on-non-empty>
+          <xsl:text>00</xsl:text>
+        </xsl:on-non-empty>
+      </node>
+      <!-- NOT on-non-empty --><!-- Need to check if comments below affect the outcome - trace does. See https://saxonica.plan.io/issues/6428 -->
+      <node type="on-non-empty">
+        <xsl:on-non-empty>                                                     <!-- Expected miss -->
+          <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
+        </xsl:on-non-empty>                                                    <!-- Expected miss -->
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-on-non-empty-01.xsl">
+   <x:scenario label="xsl:on-non-empty Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-on-non-empty/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="on-non-empty">100</node>
+            <node type="on-non-empty">200</node>
+            <node type="on-non-empty">300</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xspec
@@ -12,7 +12,8 @@
          <root>
             <node type="on-non-empty">100</node>
             <node type="on-non-empty">200</node>
-            <node type="on-non-empty">300</node>
+            <node type="on-non-empty" />
+            <node type="on-non-empty" />
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-output-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-output-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:output Coverage Test Case
+  -->
+  <xsl:output method="xml" />
+
+  <xsl:template match="xsl-output">
+    <root>
+      <node type="output">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-output-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-output-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-output-01.xsl">
+   <x:scenario label="xsl:output Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-output/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="output">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -4,14 +4,19 @@
   <!--
       xsl:param Coverage Test Case
   -->
-  <!-- Global param -->
-  <xsl:param name="globalParam01" />
+  <!-- Global param overridden in XSpec -->
+  <xsl:param name="globalParam01">0</xsl:param>                                <!-- Expected miss -->
+  <!-- Global param not overridden in XSpec -->
+  <xsl:param name="globalParam02">0</xsl:param>
 
   <xsl:template match="xsl-param">
     <root>
       <!-- Global param -->
       <node type="param - global">
         <xsl:value-of select="$globalParam01" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParam02" />
       </node>
       <!-- Template param -->
       <xsl:call-template name="paramTemplate01">

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:myns="file://myNamespace">
+  <!--
+      xsl:param Coverage Test Case
+  -->
+  <!-- Global param -->
+  <xsl:param name="globalParam01" />
+
+  <xsl:template match="xsl-param">
+    <root>
+      <!-- Global param -->
+      <node type="param - global">
+        <xsl:value-of select="$globalParam01" />
+      </node>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate01">
+        <xsl:with-param name="templateParam01">200</xsl:with-param>
+      </xsl:call-template>
+      <!-- Function param -->
+      <node type="param - function">
+        <xsl:value-of select="myns:paramFunction01('300')" />
+      </node>
+      <!--Iterate param -->
+      <xsl:iterate select="node">
+        <xsl:param name="iterateParam01" select="4" />
+        <node type="param - iterate">
+          <xsl:value-of select="$iterateParam01 * 100" />
+        </node>
+      </xsl:iterate>
+    </root>
+  </xsl:template>
+  <!-- Template param -->
+  <xsl:template name="paramTemplate01">
+    <xsl:param name="templateParam01" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam01" />
+    </node>
+  </xsl:template>
+  <!-- Function param -->
+  <xsl:function name="myns:paramFunction01">
+    <xsl:param name="functionParam01" />
+    <xsl:value-of select="$functionParam01" />
+  </xsl:function>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-param-01.xsl">
+
+   <x:param name="globalParam01">100</x:param>
+
+   <x:scenario label="xsl:param Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-param>
+              <node />
+              <node />
+            </xsl-param>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="param - global">100</node>
+            <node type="param - template">200</node>
+            <node type="param - function">300</node>
+            <node type="param - iterate">400</node>
+            <node type="param - iterate">400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -17,6 +17,7 @@
       <x:expect label="Success">
          <root>
             <node type="param - global">100</node>
+            <node type="param - global">0</node>
             <node type="param - template">200</node>
             <node type="param - function">300</node>
             <node type="param - iterate">400</node>

--- a/test/end-to-end/cases-coverage/xsl-perform-sort-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-perform-sort-01.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!--
+      xsl:perform-sort Coverage Test Case
+  -->
+  <xsl:template match="xsl-perform-sort">
+    <root>
+      <!-- Using select attribute -->
+      <xsl:variable name="sortedSet1">
+        <xsl:perform-sort select="node">
+          <xsl:sort />
+        </xsl:perform-sort>
+      </xsl:variable>
+      <xsl:for-each select="$sortedSet1/*">
+        <node type="perform-sort">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:for-each>
+      <!-- Using sequence constructor (Didn't use xsl:sequence as it isn't traced so used xsl:copy-of.) -->
+      <xsl:variable name="sortedSet2" as="xs:string*">
+        <xsl:perform-sort>
+          <xsl:sort select="." />
+          <xsl:copy-of select="node" />
+        </xsl:perform-sort>
+      </xsl:variable>
+      <node type="perform-sort">
+        <xsl:value-of select="$sortedSet2" separator=" " />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-perform-sort-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-perform-sort-01.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-perform-sort-01.xsl">
+   <x:scenario label="xsl:perform-sort Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-perform-sort>
+              <node>400</node>
+              <node>200</node>
+              <node>100</node>
+              <node>300</node>
+            </xsl-perform-sort>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="perform-sort">100</node>
+            <node type="perform-sort">200</node>
+            <node type="perform-sort">300</node>
+            <node type="perform-sort">400</node>
+            <node type="perform-sort">100 200 300 400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-preserve-space-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-preserve-space-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:preserve-space Coverage Test Case
+  -->
+  <xsl:preserve-space elements="*" />
+
+  <xsl:template match="xsl-preserve-space">
+    <root>
+      <node type="preserve-space">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-preserve-space-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-preserve-space-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-preserve-space-01.xsl">
+   <x:scenario label="xsl:preserve-space Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-preserve-space/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="preserve-space">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:processing-instruction Coverage Test Case
+  -->
+  <xsl:template match="xsl-processing-instruction">
+    <!-- Using select attribute -->
+    <xsl:processing-instruction name="processing-instruction" select="'TestCase1'" />
+    <!-- Using sequence constructor -->
+    <xsl:processing-instruction name="processing-instruction">
+      <xsl:text>TestCase2="yes"</xsl:text>
+    </xsl:processing-instruction>
+    <root>
+      <!-- No content -->
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xspec
@@ -11,8 +11,7 @@
       <x:expect label="Success">
         <?processing-instruction TestCase1?>
         <?processing-instruction TestCase2="yes"?>
-         <root>
-         </root>
+         <root />
       </x:expect>
    </x:scenario>
 </x:description>

--- a/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-processing-instruction-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-processing-instruction-01.xsl">
+   <x:scenario label="xsl:processing-instruction Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-processing-instruction/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+        <?processing-instruction TestCase1?>
+        <?processing-instruction TestCase2="yes"?>
+         <root>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:sequence Coverage Test Case
+  -->
+  <xsl:template match="xsl-sequence">
+    <root>
+      <!-- Using select attribute -->
+      <node type="sequence">
+        <xsl:sequence select="'100'" />
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="sequence">
+        <xsl:sequence>
+          <xsl:text>200</xsl:text>
+        </xsl:sequence>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-sequence-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-sequence-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-sequence-01.xsl">
+   <x:scenario label="xsl:sequence Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-sequence/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="sequence">100</node>
+            <node type="sequence">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-sort-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sort-01.xsl
@@ -6,14 +6,14 @@
   <xsl:mode name="sortMode" />
   <xsl:template match="xsl-sort">
     <root>
-      <!-- xsl:for-each using select attribute -->
+      <!-- xsl:for-each child, using select attribute -->
       <xsl:for-each select="*">
         <xsl:sort select="." />
         <node type="sort - for-each">
           <xsl:value-of select="." />
         </node>
       </xsl:for-each>
-      <!-- xsl:for-each using sequence constructor -->
+      <!-- xsl:for-each child, using sequence constructor -->
       <xsl:for-each select="*">
         <xsl:sort>
           <xsl:value-of select="." />
@@ -22,14 +22,14 @@
           <xsl:value-of select="." />
         </node>
       </xsl:for-each>
-      <!-- xsl:for-each-group using select attribute -->
+      <!-- xsl:for-each-group child, using select attribute -->
       <xsl:for-each-group select="*" group-by="@type">
         <xsl:sort select="." />
         <node type="sort - for-each-group">
           <xsl:value-of select="sum(current-group()/.)" />
         </node>
       </xsl:for-each-group>
-      <!-- xsl:for-each-group using sequence constructor -->
+      <!-- xsl:for-each-group child, using sequence constructor -->
       <xsl:for-each-group select="*" group-by="@type">
         <xsl:sort>
           <xsl:value-of select="." />
@@ -38,7 +38,7 @@
           <xsl:value-of select="sum(current-group()/.)" />
         </node>
       </xsl:for-each-group>
-      <!-- apply-templates using select attribute -->
+      <!-- apply-templates child, using select attribute -->
       <xsl:apply-templates mode="sortMode">
         <xsl:sort select="." />
       </xsl:apply-templates>
@@ -48,7 +48,7 @@
           <xsl:value-of select="." />
         </xsl:sort>
       </xsl:apply-templates>
-      <!-- perform-sort -->
+      <!-- perform-sort child -->
       <xsl:variable name="sortedSet">
         <xsl:perform-sort select="node">
           <xsl:sort />

--- a/test/end-to-end/cases-coverage/xsl-sort-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sort-01.xsl
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:sort Coverage Test Case
+  -->
+  <xsl:mode name="sortMode" />
+  <xsl:template match="xsl-sort">
+    <root>
+      <!-- xsl:for-each using select attribute -->
+      <xsl:for-each select="*">
+        <xsl:sort select="." />
+        <node type="sort - for-each">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:for-each>
+      <!-- xsl:for-each using sequence constructor -->
+      <xsl:for-each select="*">
+        <xsl:sort>
+          <xsl:value-of select="." />
+        </xsl:sort>
+        <node type="sort - for-each">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:for-each>
+      <!-- xsl:for-each-group using select attribute -->
+      <xsl:for-each-group select="*" group-by="@type">
+        <xsl:sort select="." />
+        <node type="sort - for-each-group">
+          <xsl:value-of select="sum(current-group()/.)" />
+        </node>
+      </xsl:for-each-group>
+      <!-- xsl:for-each-group using sequence constructor -->
+      <xsl:for-each-group select="*" group-by="@type">
+        <xsl:sort>
+          <xsl:value-of select="." />
+        </xsl:sort>
+        <node type="sort - for-each-group">
+          <xsl:value-of select="sum(current-group()/.)" />
+        </node>
+      </xsl:for-each-group>
+      <!-- apply-templates using select attribute -->
+      <xsl:apply-templates mode="sortMode">
+        <xsl:sort select="." />
+      </xsl:apply-templates>
+      <!-- apply-templates using sequence constructor -->
+      <xsl:apply-templates mode="sortMode">
+        <xsl:sort>
+          <xsl:value-of select="." />
+        </xsl:sort>
+      </xsl:apply-templates>
+      <!-- perform-sort -->
+      <xsl:variable name="sortedSet">
+        <xsl:perform-sort select="node">
+          <xsl:sort />
+        </xsl:perform-sort>
+      </xsl:variable>
+      <xsl:for-each select="$sortedSet/*">
+        <node type="sort - perform-sort">
+          <xsl:value-of select="." />
+        </node>
+      </xsl:for-each>
+    </root>
+  </xsl:template>
+
+  <xsl:template match="node" mode="sortMode">
+    <node type="sort - apply-templates">
+      <xsl:value-of select="." />
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-sort-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-sort-01.xspec
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-sort-01.xsl">
+   <x:scenario label="xsl:sort Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-sort>
+              <node type="A">300</node>
+              <node type="A">100</node>
+              <node type="B">400</node>
+              <node type="B">200</node>
+            </xsl-sort>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="sort - for-each">100</node>
+            <node type="sort - for-each">200</node>
+            <node type="sort - for-each">300</node>
+            <node type="sort - for-each">400</node>
+            <node type="sort - for-each">100</node>
+            <node type="sort - for-each">200</node>
+            <node type="sort - for-each">300</node>
+            <node type="sort - for-each">400</node>
+            <node type="sort - for-each-group">400</node>
+            <node type="sort - for-each-group">600</node>
+            <node type="sort - for-each-group">400</node>
+            <node type="sort - for-each-group">600</node>
+            <node type="sort - apply-templates">100</node>
+            <node type="sort - apply-templates">200</node>
+            <node type="sort - apply-templates">300</node>
+            <node type="sort - apply-templates">400</node>
+            <node type="sort - apply-templates">100</node>
+            <node type="sort - apply-templates">200</node>
+            <node type="sort - apply-templates">300</node>
+            <node type="sort - apply-templates">400</node>
+            <node type="sort - perform-sort">100</node>
+            <node type="sort - perform-sort">200</node>
+            <node type="sort - perform-sort">300</node>
+            <node type="sort - perform-sort">400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-source-document-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-source-document-01.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:source-document Coverage Test Case (requires xsl-data-01.xml input file)
+  -->
+  <xsl:template match="xsl-source-document">
+    <root>
+      <xsl:source-document href="xsl-data-01.xml">
+        <node type="source-document">
+          <xsl:value-of select="root/node[1]" />
+        </node>
+        <node type="source-document">
+          <xsl:value-of select="root/node[2]" />
+        </node>
+      </xsl:source-document>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-source-document-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-source-document-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-source-document-01.xsl">
+   <x:scenario label="xsl:source-document Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-source-document/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="source-document">100</node>
+            <node type="source-document">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-strip-space-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-strip-space-01.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:strip-space Coverage Test Case
+  -->
+  <xsl:strip-space elements="*" />
+
+  <xsl:template match="xsl-strip-space">
+    <root>
+      <node type="strip-space">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-strip-space-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-strip-space-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-strip-space-01.xsl">
+   <x:scenario label="xsl:strip-space Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-strip-space/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="strip-space">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-stylesheet-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-stylesheet-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:stylesheet Coverage Test Case
+  -->
+  <xsl:template match="xsl-stylesheet">
+    <root>
+      <node type="stylesheet">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-stylesheet-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-stylesheet-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-stylesheet-01.xsl">
+   <x:scenario label="xsl:stylesheet Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-stylesheet/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="stylesheet">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-template-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-template-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:template Coverage Test Case
+  -->
+  <xsl:template match="xsl-template">
+    <root>
+      <node type="template">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-template-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-template-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-template-01.xsl">
+   <x:scenario label="xsl:template Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-template/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="template">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-text-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-text-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:text Coverage Test Case
+  -->
+  <xsl:template match="xsl-text">
+    <root>
+      <node type="text">
+        <xsl:text>100</xsl:text>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-text-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-text-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-text-01.xsl">
+   <x:scenario label="xsl:text Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-text/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="text">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-transform-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-transform-01.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:transform Coverage Test Case
+  -->
+  <xsl:template match="xsl-transform">
+      <root>
+        <node type="transform">
+          <xsl:text>100</xsl:text>
+        </node>
+      </root>
+  </xsl:template>
+</xsl:transform>

--- a/test/end-to-end/cases-coverage/xsl-transform-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-transform-01.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-transform-01.xsl">
+   <x:scenario label="xsl:transform Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-transform/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="transform">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-try-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-try-01.xsl
@@ -9,7 +9,7 @@
       <!-- Using xsl:try select attribute - xsl:catch not executed-->
       <node type="try">
         <xsl:try select="string(100)">
-          <xsl:catch />                                                        <!-- Expected miss -->
+          <xsl:catch select="'inside xsl:catch'" />                            <!-- Expected miss -->
         </xsl:try>
       </node>
       <!-- Using xsl:try sequence constructor - xsl:catch not executed -->
@@ -23,6 +23,12 @@
       <node type="try/catch">
         <xsl:try select="error()">
           <xsl:catch select="string(300)" />
+        </xsl:try>
+      </node>
+      <!-- Using xsl:try select attribute - xsl:catch executed but no-op-->
+      <node type="try/catch">
+        <xsl:try select="error()">
+          <xsl:catch />
         </xsl:try>
       </node>
       <!-- Using xsl:try sequence constructor - first xsl:catch sequence constructor executed-->

--- a/test/end-to-end/cases-coverage/xsl-try-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-try-01.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:err="http://www.w3.org/2005/xqt-errors">
+  <!--
+      xsl:try Coverage Test Case (includes xsl:catch)
+  -->
+  <xsl:template match="xsl-try">
+    <root>
+      <!-- Using xsl:try select attribute - xsl:catch not executed-->
+      <node type="try">
+        <xsl:try select="string(100)">
+          <xsl:catch />                                                        <!-- Expected miss -->
+        </xsl:try>
+      </node>
+      <!-- Using xsl:try sequence constructor - xsl:catch not executed -->
+      <node type="try">
+        <xsl:try>
+          <xsl:text>200</xsl:text>
+          <xsl:catch />                                                        <!-- Expected miss -->
+        </xsl:try>
+      </node>
+      <!-- Using xsl:try select attribute - xsl:catch select attribute executed-->
+      <node type="try/catch">
+        <xsl:try select="error()">
+          <xsl:catch select="string(300)" />
+        </xsl:try>
+      </node>
+      <!-- Using xsl:try sequence constructor - first xsl:catch sequence constructor executed-->
+      <node type="try/catch">
+        <xsl:try>
+          <xsl:value-of select="error()" />
+          <xsl:catch errors="err:FOER0000"> <!-- this is code for error() function by default -->
+            <xsl:text>400</xsl:text>
+          </xsl:catch>
+          <xsl:catch>                                                          <!-- Expected miss -->
+            <xsl:text>500</xsl:text>                                           <!-- Expected miss -->
+          </xsl:catch>                                                         <!-- Expected miss -->
+        </xsl:try>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-try-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-try-01.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-try-01.xsl">
+   <x:scenario label="xsl:try Coverage Test Case (including xsl:catch)">
+      <x:context>
+         <root>
+            <xsl-try/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="try">100</node>
+            <node type="try">200</node>
+            <node type="try/catch">300</node>
+            <node type="try/catch">400</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-try-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-try-01.xspec
@@ -13,6 +13,7 @@
             <node type="try">100</node>
             <node type="try">200</node>
             <node type="try/catch">300</node>
+            <node type="try/catch" />
             <node type="try/catch">400</node>
          </root>
       </x:expect>

--- a/test/end-to-end/cases-coverage/xsl-value-of-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-value-of-01.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:value-of Coverage Test Case
+  -->
+  <xsl:template match="xsl-value-of">
+    <root>
+      <!-- Using select attribute -->
+      <node type="value-of">
+        <xsl:value-of select="string('100')" />
+      </node>
+      <!-- Using sequence constructor -->
+      <node type="value-of">
+        <xsl:value-of>
+          <xsl:text>200</xsl:text>
+        </xsl:value-of>
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-value-of-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-value-of-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-value-of-01.xsl">
+   <x:scenario label="xsl:value-of Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-value-of/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="value-of">100</node>
+            <node type="value-of">200</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xsl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:variable Coverage Test Case
+  -->
+  <!-- Global variable -->
+  <xsl:variable name="variableGlobal01" select="string(100)" />
+  <xsl:variable name="variableGlobal02">
+    <xsl:text>200</xsl:text>
+  </xsl:variable>
+  <!-- Not used -->
+  <xsl:variable name="variableGlobal03">300</xsl:variable>                     <!-- Expected miss -->
+
+  <xsl:template match="xsl-variable">
+    <xsl:variable name="variableLocal01" select="string(400)" />
+    <xsl:variable name="variableLocal02">
+      <xsl:text>500</xsl:text>
+    </xsl:variable>
+    <!-- Not used -->
+    <xsl:variable name="variableLocal03">600</xsl:variable>                    <!-- Expected miss -->
+    <!-- Not used -->
+    <xsl:variable name="variableLocal04">                                      <!-- Expected miss -->
+      <xsl:text>700</xsl:text>                                                 <!-- Expected miss -->
+    </xsl:variable>                                                            <!-- Expected miss -->
+    <root>
+      <!-- Global variable used -->
+      <node type="variable - global">
+        <xsl:value-of select="$variableGlobal01" />
+      </node>
+      <!-- Global variable used -->
+      <node type="variable - global">
+        <xsl:value-of select="$variableGlobal02" />
+      </node>
+      <!-- Local variable used -->
+      <node type="variable - local">
+        <xsl:value-of select="$variableLocal01" />
+      </node>
+      <!-- Local variable used -->
+      <node type="variable - local">
+        <xsl:value-of select="$variableLocal02" />
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-variable-01.xsl">
+   <x:scenario label="xsl:variable Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-variable>
+              <node>100</node>
+            </xsl-variable>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="variable - global">100</node>
+            <node type="variable - global">200</node>
+            <node type="variable - local">400</node>
+            <node type="variable - local">500</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
@@ -8,7 +8,7 @@
       <!-- Data doesn't exist so node/copy-of not executed -->
       <node type="where-populated">
         <xsl:where-populated>
-          <xsl:copy-of select="nonExistantNode" />      <!-- node element is empty but this element is executed because it needs to see if there is any output -->
+          <xsl:copy-of select="nonExistentNode" />      <!-- node element is empty but this element is executed because it needs to see if there is any output -->
         </xsl:where-populated>
       </node>
       <!-- Data exists so node/copy-of executed -->

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:where-populated Test Case
+  -->
+  <xsl:template match="xsl-where-populated">
+    <root>
+      <!-- Data doesn't exist so node/copy-of not executed -->
+      <node type="where-populated">
+        <xsl:where-populated>
+          <xsl:copy-of select="nonExistantNode" />      <!-- node element is empty but this element is executed because it needs to see if there is any output -->
+        </xsl:where-populated>
+      </node>
+      <!-- Data exists so node/copy-of executed -->
+      <xsl:where-populated>
+        <node type="where-populated">
+          <xsl:copy-of select="node" />
+        </node>
+      </xsl:where-populated>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
@@ -12,11 +12,11 @@
         </xsl:where-populated>
       </node>
       <!-- Data exists so node/copy-of executed -->
-      <xsl:where-populated>
-        <node type="where-populated">
+      <node type="where-populated">
+        <xsl:where-populated>
           <xsl:copy-of select="node" />
-        </node>
-      </xsl:where-populated>
+        </xsl:where-populated>
+      </node>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:local="http://local/xslt"
+               stylesheet="xsl-where-populated-01.xsl">
+
+  <x:scenario label="xsl:where-populated Coverage Test Case">
+    <x:context>
+      <root>
+        <xsl-where-populated>
+          <node>100</node>
+          <node>200</node>
+          <node>300</node>
+          <node>400</node>
+        </xsl-where-populated>
+      </root>
+    </x:context>
+    <x:expect label="Success">
+      <root>
+        <node type="where-populated"/>
+          <node type="where-populated">
+          <node>100</node>
+          <node>200</node>
+          <node>300</node>
+          <node>400</node>
+        </node>
+      </root>
+    </x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
@@ -2,7 +2,6 @@
 <?xspec-test enable-coverage?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-               xmlns:local="http://local/xslt"
                stylesheet="xsl-where-populated-01.xsl">
 
   <x:scenario label="xsl:where-populated Coverage Test Case">

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
@@ -18,7 +18,7 @@
     <x:expect label="Success">
       <root>
         <node type="where-populated"/>
-          <node type="where-populated">
+        <node type="where-populated">
           <node>100</node>
           <node>200</node>
           <node>300</node>

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:with-param Coverage Test Case (Quite complex because it covers xsl:iterate, xsl:call-template, xsl:apply-templates, xsl:apply-import, xsl:next-match and xsl:evaluate)
+  -->
+  <xsl:import href="xsl-with-param-01A.xsl" />
+  <!-- xsl:mode for apply-templates -->
+  <xsl:mode name="withParamMode" />
+  <!-- xsl:mode for apply-imports -->
+  <xsl:mode name="withParamModeAI" />
+  <!-- xsl:mode for next-match -->
+  <xsl:mode name="withParamModeNM" />
+
+  <xsl:template match="xsl-with-param">
+      <root>
+      <!-- Numbers in brackets refer to the value in the node output -->
+      <!--Iterate with-param (100, 200, 300, 400) -->
+      <xsl:iterate select="node">
+        <xsl:param name="iterateParam01" select="100" />
+        <node type="with-param - iterate">
+          <xsl:value-of select="$iterateParam01" />
+        </node>
+        <xsl:next-iteration>
+          <xsl:with-param name="iterateParam01" select="$iterateParam01 + 100" />
+        </xsl:next-iteration>
+      </xsl:iterate>
+      <!-- Call Template with-param (500) -->
+      <xsl:call-template name="withParamTemplate01">
+        <xsl:with-param name="withParam-CT-Param01">500</xsl:with-param>
+      </xsl:call-template>
+      <!-- Apply Templates with-param (600, 700, 800, 900) -->
+      <xsl:apply-templates mode="withParamMode">
+        <xsl:with-param name="withParam-AT-Param01">500</xsl:with-param>
+      </xsl:apply-templates>
+      <!-- Apply Imports with-param (1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350) -->
+      <xsl:apply-templates select="*" mode="withParamModeAI">
+        <xsl:with-param name="withParam-AI-Param01">900</xsl:with-param>
+      </xsl:apply-templates>
+      <!-- Next Match with-param (1400, 1450, 1500, 1550, 1600, 1650, 1700, 1750) -->
+      <xsl:apply-templates select="*" mode="withParamModeNM">
+        <xsl:with-param name="withParam-NM-Param01">1300</xsl:with-param>
+      </xsl:apply-templates>
+    </root>
+  </xsl:template>
+  <!-- Call Template -->
+  <xsl:template name="withParamTemplate01">
+    <xsl:param name="withParam-CT-Param01" />
+    <node type="with-param - call-template">
+      <xsl:value-of select="$withParam-CT-Param01" />
+    </node>
+  </xsl:template>
+  <!-- Apply Templates Template -->
+  <xsl:template match="node" mode="withParamMode">
+    <xsl:param name="withParam-AT-Param01" />
+    <node type="with-param - apply-templates">
+      <xsl:value-of select="$withParam-AT-Param01 + ." />
+    </node>
+  </xsl:template>
+  <!-- Apply Imports Template -->
+  <xsl:template match="node" mode="withParamModeAI">
+    <xsl:param name="withParam-AI-Param01" />
+    <node type="with-param - apply-imports part 1">
+      <xsl:value-of select="$withParam-AI-Param01 + ." />
+    </node>
+    <xsl:apply-imports>
+      <xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" />
+    </xsl:apply-imports>
+  </xsl:template>
+  <!-- Next Match Template -->
+  <xsl:template match="node" mode="withParamModeNM" priority="1">
+    <xsl:param name="withParam-NM-Param01" />
+    <node type="with-param - next-match part 1">
+      <xsl:value-of select="$withParam-NM-Param01 + ." />
+    </node>
+    <xsl:next-match>
+      <xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" />
+    </xsl:next-match>
+   </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
@@ -12,7 +12,7 @@
   <xsl:mode name="withParamModeNM" />
 
   <xsl:template match="xsl-with-param">
-      <root>
+    <root>
       <!-- Numbers in brackets refer to the value in the node output -->
       <!--Iterate with-param (100, 200, 300, 400) -->
       <xsl:iterate select="node">
@@ -40,6 +40,17 @@
       <xsl:apply-templates select="*" mode="withParamModeNM">
         <xsl:with-param name="withParam-NM-Param01">1300</xsl:with-param>
       </xsl:apply-templates>
+      <!-- Evaluate with-param (200) -->
+      <xsl:variable name="index" select="2" />
+      <xsl:variable name="evaluatedExpressionParamChild">
+        <xsl:evaluate xpath="'string(node[$index])'" context-item=".">
+          <xsl:with-param name="index" select="$index" />
+          <xsl:with-param name="nonexistent">parameter not used in evaluation</xsl:with-param>
+        </xsl:evaluate>
+      </xsl:variable>
+      <node type="with-param - evaluate">
+        <xsl:value-of select="$evaluatedExpressionParamChild" />
+      </node>
     </root>
   </xsl:template>
   <!-- Call Template -->

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xspec
@@ -40,6 +40,7 @@
             <node type="with-param - next-match part 2">1650</node>
             <node type="with-param - next-match part 1">1700</node>
             <node type="with-param - next-match part 2">1750</node>
+            <node type="with-param - evaluate">200</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-with-param-01.xsl">
+   <x:scenario label="xsl:with-param Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-with-param>
+              <node>100</node>
+              <node>200</node>
+              <node>300</node>
+              <node>400</node>
+            </xsl-with-param>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="with-param - iterate">100</node>
+            <node type="with-param - iterate">200</node>
+            <node type="with-param - iterate">300</node>
+            <node type="with-param - iterate">400</node>
+            <node type="with-param - call-template">500</node>
+            <node type="with-param - apply-templates">600</node>
+            <node type="with-param - apply-templates">700</node>
+            <node type="with-param - apply-templates">800</node>
+            <node type="with-param - apply-templates">900</node>
+            <node type="with-param - apply-imports part 1">1000</node>
+            <node type="with-param - apply-imports part 2">1050</node>
+            <node type="with-param - apply-imports part 1">1100</node>
+            <node type="with-param - apply-imports part 2">1150</node>
+            <node type="with-param - apply-imports part 1">1200</node>
+            <node type="with-param - apply-imports part 2">1250</node>
+            <node type="with-param - apply-imports part 1">1300</node>
+            <node type="with-param - apply-imports part 2">1350</node>
+            <node type="with-param - next-match part 1">1400</node>
+            <node type="with-param - next-match part 2">1450</node>
+            <node type="with-param - next-match part 1">1500</node>
+            <node type="with-param - next-match part 2">1550</node>
+            <node type="with-param - next-match part 1">1600</node>
+            <node type="with-param - next-match part 2">1650</node>
+            <node type="with-param - next-match part 1">1700</node>
+            <node type="with-param - next-match part 2">1750</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-with-param-01A.xsl
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01A.xsl
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <!-- xsl:apply-imports Template -->
+  <xsl:template match="node" mode="withParamModeAI" >
+    <xsl:param name="withParam-AI-Param01" />
+    <node type="with-param - apply-imports part 2">
+      <xsl:value-of select="$withParam-AI-Param01 + . + 50" />
+    </node>
+  </xsl:template>
+
+  <!-- Secondary template invoked for node -->
+  <xsl:template match="node" mode="withParamModeNM" priority="2">
+    <xsl:param name="withParam-NM-Param01" />
+    <node type="with-param - next-match part 2">
+      <xsl:value-of select="$withParam-NM-Param01 + . + 50" />
+    </node>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This pull request establishes a baseline for end-to-end testing of XSLT code coverage reporting at a per-element level for most XSLT elements. Adrian Bird (@birdya22 in GitHub) did the majority of the design and development work; see 87f9ea6e7afab61110f3bb4275ac47d3f683591f and 74c6f4789d4a26852cbc2f434cb9d8b2357de8ed.

While reviewing, I added some additional test cases here and there and made minor tweaks.

### Notes

* Adrian, thank you so much for getting this effort started in such a systematic and well-thought-out way! Any of the changes that I made here are open for your review. There are a lot of files, but many of them are either generated or your originals. Consider using the Commits tab to look at changes in groups instead of scrolling through the file list.

* @AirQuick, I'm adding you as a code reviewer as well, although you haven't been active in this repo for several months. Your input is welcome, even if it's after this PR is merged.

* Some of the coverage reports in the `cases-coverage/expected/` directory are wrong due to bugs in either Saxon 12.4 or XSpec. Whenever we're able to resolve those issues in a subsequent pull request, the updates in the expected results will show the effect of the bug fixes.

* Some of the coverage reports in the `cases-coverage/expected/` directory might not reflect the desired design. Consider the files to be a baseline for future comparison if/when we change XSpec code for coverage reporting.

* In addition, `xsl-on-non-empty-01.xspec` has a test failure in Saxon-HE 12.4J that may be related to https://saxonica.plan.io/issues/6428 . With Saxon 12.3J, I also get different coverage XML and HTML, between the HE and EE editions. I'm not able to run Saxon-EE 12.4J, so I can't compare it with Saxon-HE 12.4J. The expected results in this pull request are from Saxon-HE 12.4J, which is also the version that runs in GitHub.

* Soon after this PR is complete, I would like to complete #1918. After that, we can work on other bug fixes and possible design changes, with these tests to help us understand effects and protect against regressions.