### PR TITLE
test(report): additional coverage test cases for xsl:param

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -178,7 +178,7 @@
 168: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08" /&gt;</span>
 169: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
 170: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-171: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute of sequence constructor tests --&gt;</span>
+171: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute or sequence constructor tests --&gt;</span>
 172: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
 173: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
 174: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -7,56 +7,182 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-01.xsl">xsl-param-01.xsl</a></p>
-      <h2>module: xsl-param-01.xsl; 50 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
-03: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
-04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-05: <span class="ignored">      xsl:param Coverage Test Case</span>
-06: <span class="ignored">  --&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
-08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-09: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec --&gt;</span>
-10: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam02"&gt;</span><span class="missed">0</span><span class="hit">&lt;/xsl:param&gt;</span>
-11: 
-12: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
-13: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-14: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
-15: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-16: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
-17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-18: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-19: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
-20: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-21: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-22: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
-23: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">200</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-24: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-25: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-26: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
-27: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('300')" /&gt;</span>
-28: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-29: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param --&gt;</span>
-30: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-31: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="4" /&gt;</span>
-32: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-33: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-34: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-35: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-36: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-37: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-38: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-39: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
-40: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
-41: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-42: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
-43: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-44: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-45: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-46: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
-47: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
-48: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
-49: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
-50: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-param-01.xsl; 176 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+003: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
+004: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+005: <span class="ignored">      xsl:param Coverage Test Case</span>
+006: <span class="ignored">  --&gt;</span>
+007: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
+008: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+009: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default --&gt;</span>
+010: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam02" /&gt;</span>
+011: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with select attribute --&gt;</span>
+012: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam03" select="200" /&gt;</span>
+013: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with inline sequence constructor --&gt;</span>
+014: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam04"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
+015: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor--&gt;</span>
+016: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam05"&gt;</span>
+017: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
+018: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+019: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+020: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
+021: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor - not used --&gt;</span>
+022: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam06"&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+023: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">4</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+024: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+025: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+026: <span class="ignored">  </span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+027: 
+028: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+029: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+030: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+031: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+032: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
+033: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+034: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+035: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
+036: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+037: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+038: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam03" /&gt;</span>
+039: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+040: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+041: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam04" /&gt;</span>
+042: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+043: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+044: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam05" /&gt;</span>
+045: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+046: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+047: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
+048: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+049: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+050: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+051: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate02"&gt;</span>
+052: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam02"&gt;</span><span class="missed">600</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+054: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+055: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate03"&gt;</span>
+056: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+057: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+058: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+059: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate04"&gt;</span>
+060: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+061: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+062: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template using default xsl:param values --&gt;</span>
+063: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate05" /&gt;</span>
+064: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
+065: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
+066: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
+067: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+068: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
+069: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('1200')" /&gt;</span>
+070: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+071: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with select attribute --&gt;</span>
+072: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+073: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="13" /&gt;</span>
+074: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+075: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+076: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+077: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+078: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with inline sequence constructor --&gt;</span>
+079: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+080: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span><span class="missed">14</span><span class="hit">&lt;/xsl:param&gt;</span>
+081: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+082: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+083: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+084: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+085: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
+086: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+087: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span>
+088: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
+089: <span class="ignored">          </span><span class="missed">&lt;xsl:choose&gt;</span>
+090: <span class="ignored">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
+091: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
+092: <span class="ignored">            </span><span class="missed">&lt;/xsl:when&gt;</span>
+093: <span class="ignored">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
+094: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+095: <span class="ignored">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
+096: <span class="ignored">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
+097: <span class="ignored">        </span><span class="hit">&lt;/xsl:param&gt;</span>
+098: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+099: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+100: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+101: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+102: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+103: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+104: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
+105: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
+106: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+107: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+108: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+109: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+110: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+111: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+112: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
+113: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
+114: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
+115: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+116: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
+117: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+118: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+119: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
+120: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
+121: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03"&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">                          </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+122: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+123: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03" /&gt;</span>
+124: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+125: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+126: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
+127: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
+128: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
+129: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+130: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+131: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+132: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+133: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+134: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
+135: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+136: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+137: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
+138: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
+139: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
+140: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam05" /&gt;</span>
+141: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+142: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam05" /&gt;</span>
+143: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+144: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+145: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
+146: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
+147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam06" select="900" /&gt;</span>
+148: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+149: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam06" /&gt;</span>
+150: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+151: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+152: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller, relying on default value --&gt;</span>
+153: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
+154: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+155: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+156: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07" /&gt;</span>
+157: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+158: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+159: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value --&gt;</span>
+160: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
+161: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08"&gt;</span>
+162: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+163: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+164: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+165: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+166: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+167: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+168: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08" /&gt;</span>
+169: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+170: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+171: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute of sequence constructor tests --&gt;</span>
+172: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
+173: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
+174: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
+175: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+176: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
@@ -5,63 +5,144 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="12" columnNumber="35" moduleId="0" traceableId="0"/>
+   <hit lineNumber="28" columnNumber="35" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="13" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="15" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="31" columnNumber="35" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="15" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="31" columnNumber="35" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="16" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="18" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="18" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="34" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="35" columnNumber="49" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.GlobalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
-   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="37" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="37" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="38" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="12" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="40" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="40" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="41" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="35" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
-   <hit lineNumber="10" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="14" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="44" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="18" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="19" columnNumber="15" moduleId="0" traceableId="5"/>
    <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.CallTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
-   <hit lineNumber="22" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="47" columnNumber="49" moduleId="0" traceableId="6"/>
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.NamedTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="39" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="106" columnNumber="40" moduleId="0" traceableId="7"/>
    <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.LocalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="40" columnNumber="41" moduleId="0" traceableId="8"/>
-   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="42" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="23" columnNumber="48" moduleId="0" traceableId="5"/>
-   <hit lineNumber="26" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="26" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="27" columnNumber="62" moduleId="0" traceableId="3"/>
+   <hit lineNumber="107" columnNumber="41" moduleId="0" traceableId="8"/>
+   <hit lineNumber="108" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="108" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="109" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="48" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="51" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="113" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="114" columnNumber="0" moduleId="0" traceableId="8"/>
+   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="116" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="52" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="55" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="120" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="121" columnNumber="39" moduleId="0" traceableId="8"/>
+   <hit lineNumber="122" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="122" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="123" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="59" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="127" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="129" columnNumber="17" moduleId="0" traceableId="8"/>
+   <hit lineNumber="133" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="133" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="134" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="60" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="63" columnNumber="51" moduleId="0" traceableId="6"/>
+   <hit lineNumber="139" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="140" columnNumber="41" moduleId="0" traceableId="8"/>
+   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="142" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="6"/>
+   <hit lineNumber="146" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="147" columnNumber="0" moduleId="0" traceableId="8"/>
+   <hit lineNumber="148" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="148" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="149" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="65" columnNumber="51" moduleId="0" traceableId="6"/>
+   <hit lineNumber="153" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="154" columnNumber="39" moduleId="0" traceableId="8"/>
+   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="156" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="154" columnNumber="39" moduleId="0" traceableId="5"/>
+   <hit lineNumber="66" columnNumber="51" moduleId="0" traceableId="6"/>
+   <hit lineNumber="160" columnNumber="40" moduleId="0" traceableId="7"/>
+   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="8"/>
+   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="168" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="163" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="164" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="165" columnNumber="17" moduleId="0" traceableId="5"/>
+   <hit lineNumber="68" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="68" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="69" columnNumber="63" moduleId="0" traceableId="3"/>
    <traceable traceableId="9"
               class="net.sf.saxon.expr.instruct.UserFunction"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
-   <hit lineNumber="46" columnNumber="45" moduleId="0" traceableId="9"/>
-   <hit lineNumber="48" columnNumber="47" moduleId="0" traceableId="5"/>
+   <hit lineNumber="172" columnNumber="45" moduleId="0" traceableId="9"/>
+   <hit lineNumber="174" columnNumber="47" moduleId="0" traceableId="5"/>
    <traceable traceableId="10"
               class="net.sf.saxon.expr.instruct.IterateInstr"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
-   <hit lineNumber="30" columnNumber="34" moduleId="0" traceableId="10"/>
-   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="33" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="33" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="72" columnNumber="34" moduleId="0" traceableId="10"/>
+   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="75" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="75" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="79" columnNumber="34" moduleId="0" traceableId="10"/>
+   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="82" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="82" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="86" columnNumber="34" moduleId="0" traceableId="10"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="99" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="99" columnNumber="58" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -168,7 +168,7 @@
       <xsl:value-of select="$templateParam08" />
     </node>
   </xsl:template>
-  <!-- Function param - not allowed a default value so no select attribute of sequence constructor tests -->
+  <!-- Function param - not allowed a default value so no select attribute or sequence constructor tests -->
   <xsl:function name="myns:paramFunction01">
     <xsl:param name="functionParam01" />
     <xsl:value-of select="$functionParam01" />

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -6,8 +6,24 @@
   -->
   <!-- Global param overridden in XSpec -->
   <xsl:param name="globalParam01">0</xsl:param>                                <!-- Expected miss -->
-  <!-- Global param not overridden in XSpec -->
-  <xsl:param name="globalParam02">0</xsl:param>
+  <!-- Global param not overridden in XSpec - no default -->
+  <xsl:param name="globalParam02" />
+  <!-- Global param not overridden in XSpec - with select attribute -->
+  <xsl:param name="globalParam03" select="200" />
+  <!-- Global param not overridden in XSpec - with inline sequence constructor -->
+  <xsl:param name="globalParam04">300</xsl:param>
+  <!-- Global param not overridden in XSpec - with multiline sequence constructor-->
+  <xsl:param name="globalParam05">
+    <xsl:text>4</xsl:text>
+    <xsl:text>0</xsl:text>
+    <xsl:text>0</xsl:text>
+  </xsl:param>
+  <!-- Global param not overridden in XSpec - with multiline sequence constructor - not used -->
+  <xsl:param name="globalParam06">                                             <!-- Expected miss -->
+    <xsl:text>4</xsl:text>                                                     <!-- Expected miss -->
+    <xsl:text>0</xsl:text>                                                     <!-- Expected miss -->
+    <xsl:text>0</xsl:text>                                                     <!-- Expected miss -->
+  </xsl:param>                                                                 <!-- Expected miss -->
 
   <xsl:template match="xsl-param">
     <root>
@@ -18,31 +34,141 @@
       <node type="param - global">
         <xsl:value-of select="$globalParam02" />
       </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParam03" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParam04" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParam05" />
+      </node>
       <!-- Template param -->
       <xsl:call-template name="paramTemplate01">
-        <xsl:with-param name="templateParam01">200</xsl:with-param>
+        <xsl:with-param name="templateParam01">500</xsl:with-param>
       </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate02">
+        <xsl:with-param name="templateParam02">600</xsl:with-param>
+      </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate03">
+        <xsl:with-param name="templateParam03">700</xsl:with-param>
+      </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate04">
+        <xsl:with-param name="templateParam04">800</xsl:with-param>
+      </xsl:call-template>
+      <!-- Call Template using default xsl:param values -->
+      <xsl:call-template name="paramTemplate05" />
+      <xsl:call-template name="paramTemplate06" />
+      <xsl:call-template name="paramTemplate07" />
+      <xsl:call-template name="paramTemplate08" />
       <!-- Function param -->
       <node type="param - function">
-        <xsl:value-of select="myns:paramFunction01('300')" />
+        <xsl:value-of select="myns:paramFunction01('1200')" />
       </node>
-      <!--Iterate param -->
+      <!--Iterate param with select attribute -->
       <xsl:iterate select="node">
-        <xsl:param name="iterateParam01" select="4" />
+        <xsl:param name="iterateParam01" select="13" />
+        <node type="param - iterate">
+          <xsl:value-of select="$iterateParam01 * 100" />
+        </node>
+      </xsl:iterate>
+      <!--Iterate param with inline sequence constructor -->
+      <xsl:iterate select="node">
+        <xsl:param name="iterateParam01">14</xsl:param>
+        <node type="param - iterate">
+          <xsl:value-of select="$iterateParam01 * 100" />
+        </node>
+      </xsl:iterate>
+      <!--Iterate param with multiline sequence constructor -->
+      <xsl:iterate select="node">
+        <xsl:param name="iterateParam01">
+          <xsl:text>1</xsl:text>
+          <xsl:choose>
+            <xsl:when test="1 eq 1">
+              <xsl:text>5</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>99</xsl:text>                                          <!-- Expected miss -->
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:param>
         <node type="param - iterate">
           <xsl:value-of select="$iterateParam01 * 100" />
         </node>
       </xsl:iterate>
     </root>
   </xsl:template>
-  <!-- Template param -->
+  <!-- Templates where xsl:param value is provided by caller -->
+  <!-- Template param with no default - value provided by caller -->
   <xsl:template name="paramTemplate01">
     <xsl:param name="templateParam01" />
     <node type="param - template">
       <xsl:value-of select="$templateParam01" />
     </node>
   </xsl:template>
-  <!-- Function param -->
+  <!-- Template param with select attribute - value provided by caller -->
+  <xsl:template name="paramTemplate02">
+    <xsl:param name="templateParam02" select="999" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam02" />
+    </node>
+  </xsl:template>
+  <!-- Template param with inline sequence constructor - value provided by caller -->
+  <xsl:template name="paramTemplate03">
+    <xsl:param name="templateParam03">999</xsl:param>                          <!-- Expected miss for 999 -->
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - value provided by caller -->
+  <xsl:template name="paramTemplate04">
+    <xsl:param name="templateParam04">
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+    </xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam04" />
+    </node>
+  </xsl:template>
+  <!-- Templates where xsl:param default value is used -->
+  <!-- Template param with no default - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate05">
+    <xsl:param name="templateParam05" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam05" />
+    </node>
+  </xsl:template>
+  <!-- Template param with select attribute - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate06">
+    <xsl:param name="templateParam06" select="900" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam06" />
+    </node>
+  </xsl:template>
+  <!-- Template param with inline sequence constructor - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate07">
+    <xsl:param name="templateParam07">1000</xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate08">
+    <xsl:param name="templateParam08">
+      <xsl:text>1</xsl:text>
+      <xsl:text>1</xsl:text>
+      <xsl:text>0</xsl:text>
+      <xsl:text>0</xsl:text>
+    </xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08" />
+    </node>
+  </xsl:template>
+  <!-- Function param - not allowed a default value so no select attribute of sequence constructor tests -->
   <xsl:function name="myns:paramFunction01">
     <xsl:param name="functionParam01" />
     <xsl:value-of select="$functionParam01" />

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -17,11 +17,25 @@
       <x:expect label="Success">
          <root>
             <node type="param - global">100</node>
-            <node type="param - global">0</node>
-            <node type="param - template">200</node>
-            <node type="param - function">300</node>
-            <node type="param - iterate">400</node>
-            <node type="param - iterate">400</node>
+            <node type="param - global" />
+            <node type="param - global">200</node>
+            <node type="param - global">300</node>
+            <node type="param - global">400</node>
+            <node type="param - template">500</node>
+            <node type="param - template">600</node>
+            <node type="param - template">700</node>
+            <node type="param - template">800</node>
+            <node type="param - template" />
+            <node type="param - template">900</node>
+            <node type="param - template">1000</node>
+            <node type="param - template">1100</node>
+            <node type="param - function">1200</node>
+            <node type="param - iterate">1300</node>
+            <node type="param - iterate">1300</node>
+            <node type="param - iterate">1400</node>
+            <node type="param - iterate">1400</node>
+            <node type="param - iterate">1500</node>
+            <node type="param - iterate">1500</node>
          </root>
       </x:expect>
    </x:scenario>


### PR DESCRIPTION
This pull request is to shepherd some test updates from @birdya22 (attached to #1935 and explained there) through GitHub.

I reviewed the .xsl and .xspec files, and the only change I made was a typo fix in a code comment.

I regenerated expected result files in the usual way: from `test\end-to-end`, I ran `generate-expected.cmd -Dcases.dir=cases-coverage`. (The so-called expected results reflect some flaws in the underlying code coverage feature, not bugs in the test files in this PR. For more information, see the `## xsl:param` section in https://github.com/xspec/xspec/pull/1934/files .)

Adrian, thank you for your continued contributions to XSpec!

---

Fixes #1935.