### PR TITLE
test(report): additional coverage test cases for xsl:map

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -554,7 +554,7 @@ Inclined to say unknown and add a comment on the Code Coverage page.
 
 Tested as part of xsl:map.
 
-There is a trace entry for 1 xsl:map-entry element on line 13, column 0 in xsl-map-01.xsl but that seems to be related to the xsl:param and not xsl:map-entry.
+There is a trace entry in xsl-map-01.xsl for `<xsl:map-entry key="'One'" select="100"/>` but that seems to be related to the xsl:param and not xsl:map-entry.
 
 Difficult to know what to do here as it is never traced. Neither is xsl:map.
 

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -7,81 +7,127 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-map-01.xsl">xsl-map-01.xsl</a></p>
-      <h2>module: xsl-map-01.xsl; 75 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
-03: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
-04: <span class="ignored">                xmlns:myns="myNamespace"&gt;</span>
-05: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-06: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map-entry)</span>
-07: <span class="ignored">  --&gt;</span>
-08: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
-09: <span class="ignored">    </span><span class="ignored">&lt;!-- Map construction, including xsl:map --&gt;</span>
-10: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="hundreds-param" as="map(xs:string, xs:integer)"&gt;</span>
-11: <span class="ignored">      </span><span class="missed">&lt;xsl:map&gt;</span>
-12: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
-13: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
-14: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
-15: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
-16: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
-17: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="300" /&gt;</span>
-18: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
-19: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
-20: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
-21: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
-22: <span class="ignored">      </span><span class="missed">&lt;/xsl:map&gt;</span>
-23: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-24: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="hundreds-variable" as="map(xs:string, xs:integer)"&gt;</span>
-25: <span class="ignored">      </span><span class="hit">&lt;xsl:map&gt;</span>
-26: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
-27: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
-28: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
-29: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
-30: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
-31: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence select="300" /&gt;</span>
-32: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
-33: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Four'"&gt;</span>
-34: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence select="400" /&gt;</span>
-35: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
-36: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
-37: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
-38: <span class="ignored">    </span><span class="ignored">&lt;!-- Use xsl:map values --&gt;</span>
-39: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-40: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
-41: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('One')" /&gt;</span>
-42: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-43: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
-44: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('Three')" /&gt;</span>
-45: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-46: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
-47: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('One')" /&gt;</span>
-48: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-49: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
-50: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('Three')" /&gt;</span>
-51: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-52: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
-53: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('One')" /&gt;</span>
-54: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-55: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
-56: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('Three')" /&gt;</span>
-57: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-58: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-59: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-60: 
-61: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:returnMap" as="map(xs:string, xs:integer)"&gt;</span>
-62: <span class="ignored">    </span><span class="missed">&lt;xsl:map&gt;</span>
-63: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
-64: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
-65: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
-66: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
-67: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
-68: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="300" /&gt;</span>
-69: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
-70: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
-71: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
-72: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
-73: <span class="ignored">    </span><span class="missed">&lt;/xsl:map&gt;</span>
-74: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
-75: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-map-01.xsl; 121 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+003: <span class="ignored">                xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
+004: <span class="ignored">                xmlns:myns="myNamespace"&gt;</span>
+005: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+006: <span class="ignored">      xsl:map Coverage Test Case (includes xsl:map-entry)</span>
+007: <span class="ignored">  --&gt;</span>
+008: <span class="ignored">  </span><span class="ignored">&lt;!-- Create a variable containing the value 300. Copy this variable as an alternative to using xsl:sequence inside a xsl:map-entry.</span>
+009: <span class="ignored">       This is on the basis that xsl:sequence is not traced in Saxon 12.4 so it isn't possible to tell if child nodes are traced</span>
+010: <span class="ignored">       inside xsl:map-entry. --&gt;</span>
+011: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="mapValue300" as="xs:integer"&gt;</span>
+012: <span class="ignored">    </span><span class="hit">&lt;xsl:sequence select="300" /&gt;</span>
+013: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+014: 
+015: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-map"&gt;</span>
+016: <span class="ignored">    </span><span class="ignored">&lt;!-- Map construction, including xsl:map-entry --&gt;</span>
+017: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="hundreds-param" as="map(xs:string, xs:integer)"&gt;</span>
+018: <span class="ignored">      </span><span class="missed">&lt;xsl:map&gt;</span>
+019: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+020: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+021: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+022: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+023: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
+024: <span class="ignored">          </span><span class="hit">&lt;xsl:copy select="$mapValue300" /&gt;</span>
+025: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+026: <span class="ignored">        </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
+027: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+028: <span class="ignored">        </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+029: <span class="ignored">      </span><span class="missed">&lt;/xsl:map&gt;</span>
+030: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+031: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="hundreds-variable" as="map(xs:string, xs:integer)"&gt;</span>
+032: <span class="ignored">      </span><span class="hit">&lt;xsl:map&gt;</span>
+033: <span class="ignored">        </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+034: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+035: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+036: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+037: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
+038: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence&gt;</span>
+039: <span class="ignored">            </span><span class="hit">&lt;xsl:copy select="$mapValue300" /&gt;</span>
+040: <span class="ignored">          </span><span class="hit">&lt;/xsl:sequence&gt;</span>
+041: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+042: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Four'"&gt;</span>
+043: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence select="400" /&gt;</span>
+044: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+045: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
+046: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+047: <span class="ignored">    </span><span class="ignored">&lt;!-- xsl:map with child that is not xsl:map-entry --&gt;</span>
+048: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="map-variable01" as="map(xs:string, xs:decimal)"&gt;</span>
+049: <span class="ignored">      </span><span class="hit">&lt;xsl:map&gt;</span>
+050: <span class="ignored">        </span><span class="missed">&lt;xsl:for-each select="1 to 5"&gt;</span>
+051: <span class="ignored">          </span><span class="hit">&lt;xsl:map-entry key="string(.)" select="xs:decimal(. * 600 div 6)"/&gt;</span>
+052: <span class="ignored">        </span><span class="missed">&lt;/xsl:for-each&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
+054: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+055: <span class="ignored">    </span><span class="ignored">&lt;!-- xsl:map with xsl:map-entry child using select attribute. A simple test case. --&gt;</span>
+056: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="map-variable02" as="map(xs:string, xs:decimal)"&gt;</span>
+057: <span class="ignored">      </span><span class="hit">&lt;xsl:map&gt;</span>
+058: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Seven'" select="xs:decimal(700)" /&gt;</span>
+059: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
+060: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+061: <span class="ignored">    </span><span class="ignored">&lt;!-- xsl:map-entry not inside a xsl:map. Using select attribute --&gt;</span>
+062: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="map-entry-variable01" as="map(xs:string, xs:integer)"&gt;</span>
+063: <span class="ignored">      </span><span class="hit">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+064: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+065: <span class="ignored">    </span><span class="ignored">&lt;!-- xsl:map-entry not inside a xsl:map. Using sequence constructor --&gt;</span>
+066: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="map-entry-variable02" as="map(xs:string, xs:integer)"&gt;</span>
+067: <span class="ignored">      </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
+068: <span class="ignored">        </span><span class="hit">&lt;xsl:copy select="$mapValue300" /&gt;</span>
+069: <span class="ignored">      </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
+070: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+071: <span class="ignored">    </span><span class="ignored">&lt;!-- Use xsl:map values --&gt;</span>
+072: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+073: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
+074: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('One')" /&gt;</span>
+075: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+076: <span class="ignored">      </span><span class="hit">&lt;node type="param/map"&gt;</span>
+077: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-param('Three')" /&gt;</span>
+078: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+079: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+080: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('One')" /&gt;</span>
+081: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+082: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+083: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$hundreds-variable('Three')" /&gt;</span>
+084: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+085: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+086: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$map-variable01('5')" /&gt;</span>
+087: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+088: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map"&gt;</span>
+089: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$map-variable02('Seven')" /&gt;</span>
+090: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+091: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
+092: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('One')" /&gt;</span>
+093: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+094: <span class="ignored">      </span><span class="hit">&lt;node type="function/map"&gt;</span>
+095: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:returnMap()('Three')" /&gt;</span>
+096: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+097: <span class="ignored">    </span><span class="ignored">&lt;!-- Use xsl:map-entry values --&gt;</span>
+098: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map-entry"&gt;</span>
+099: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$map-entry-variable01('One')" /&gt;</span>
+100: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+101: <span class="ignored">      </span><span class="hit">&lt;node type="variable/map-entry"&gt;</span>
+102: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$map-entry-variable02('Three')" /&gt;</span>
+103: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+104: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+105: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+106: 
+107: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:returnMap" as="map(xs:string, xs:integer)"&gt;</span>
+108: <span class="ignored">    </span><span class="missed">&lt;xsl:map&gt;</span>
+109: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
+110: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'One'" select="100"/&gt;</span>
+111: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span>
+112: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
+113: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Three'"&gt;</span>
+114: <span class="ignored">        </span><span class="hit">&lt;xsl:copy select="$mapValue300" /&gt;</span>
+115: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+116: <span class="ignored">      </span><span class="missed">&lt;xsl:map-entry key="'Four'"&gt;</span>
+117: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+118: <span class="ignored">      </span><span class="missed">&lt;/xsl:map-entry&gt;</span>
+119: <span class="ignored">    </span><span class="missed">&lt;/xsl:map&gt;</span>
+120: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+121: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.xml
@@ -5,44 +5,73 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="8" columnNumber="33" moduleId="0" traceableId="0"/>
+   <hit lineNumber="15" columnNumber="33" moduleId="0" traceableId="0"/>
    <traceable traceableId="1"
               class="net.sf.saxon.expr.instruct.LocalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="13" columnNumber="0" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="0" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" class="net.sf.saxon.expr.LetExpression"/>
-   <hit lineNumber="24" columnNumber="76" moduleId="0" traceableId="2"/>
-   <traceable traceableId="3" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="39" columnNumber="11" moduleId="0" traceableId="3"/>
-   <hit lineNumber="40" columnNumber="30" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="76" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.GlobalVariable"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="11" columnNumber="52" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.TraceExpression"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
+   <hit lineNumber="39" columnNumber="47" moduleId="0" traceableId="4"/>
+   <hit lineNumber="56" columnNumber="73" moduleId="0" traceableId="4"/>
+   <hit lineNumber="62" columnNumber="79" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="79" moduleId="0" traceableId="4"/>
+   <hit lineNumber="72" columnNumber="11" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="72" columnNumber="11" moduleId="0" traceableId="5"/>
+   <hit lineNumber="73" columnNumber="30" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="40" columnNumber="30" moduleId="0" traceableId="4"/>
-   <traceable traceableId="5"
+   <hit lineNumber="73" columnNumber="30" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="41" columnNumber="57" moduleId="0" traceableId="5"/>
-   <hit lineNumber="43" columnNumber="30" moduleId="0" traceableId="3"/>
-   <hit lineNumber="43" columnNumber="30" moduleId="0" traceableId="4"/>
-   <hit lineNumber="44" columnNumber="59" moduleId="0" traceableId="5"/>
-   <hit lineNumber="46" columnNumber="33" moduleId="0" traceableId="3"/>
-   <hit lineNumber="46" columnNumber="33" moduleId="0" traceableId="4"/>
-   <hit lineNumber="47" columnNumber="60" moduleId="0" traceableId="5"/>
-   <hit lineNumber="49" columnNumber="33" moduleId="0" traceableId="3"/>
-   <hit lineNumber="49" columnNumber="33" moduleId="0" traceableId="4"/>
-   <hit lineNumber="50" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="52" columnNumber="33" moduleId="0" traceableId="3"/>
-   <hit lineNumber="52" columnNumber="33" moduleId="0" traceableId="4"/>
-   <hit lineNumber="53" columnNumber="58" moduleId="0" traceableId="5"/>
-   <traceable traceableId="6"
+   <hit lineNumber="74" columnNumber="57" moduleId="0" traceableId="7"/>
+   <hit lineNumber="24" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="76" columnNumber="30" moduleId="0" traceableId="5"/>
+   <hit lineNumber="76" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="77" columnNumber="59" moduleId="0" traceableId="7"/>
+   <hit lineNumber="79" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="79" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="80" columnNumber="60" moduleId="0" traceableId="7"/>
+   <hit lineNumber="82" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="82" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="83" columnNumber="62" moduleId="0" traceableId="7"/>
+   <hit lineNumber="85" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="85" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="86" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="50" columnNumber="39" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="88" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="89" columnNumber="59" moduleId="0" traceableId="7"/>
+   <hit lineNumber="91" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="91" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="92" columnNumber="58" moduleId="0" traceableId="7"/>
+   <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.UserFunction"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
-   <hit lineNumber="61" columnNumber="71" moduleId="0" traceableId="6"/>
-   <hit lineNumber="55" columnNumber="33" moduleId="0" traceableId="3"/>
-   <hit lineNumber="55" columnNumber="33" moduleId="0" traceableId="4"/>
-   <hit lineNumber="56" columnNumber="60" moduleId="0" traceableId="5"/>
-   <hit lineNumber="61" columnNumber="71" moduleId="0" traceableId="6"/>
+   <hit lineNumber="107" columnNumber="71" moduleId="0" traceableId="8"/>
+   <hit lineNumber="114" columnNumber="43" moduleId="0" traceableId="4"/>
+   <hit lineNumber="94" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="94" columnNumber="33" moduleId="0" traceableId="6"/>
+   <hit lineNumber="95" columnNumber="60" moduleId="0" traceableId="7"/>
+   <hit lineNumber="107" columnNumber="71" moduleId="0" traceableId="8"/>
+   <hit lineNumber="114" columnNumber="43" moduleId="0" traceableId="4"/>
+   <hit lineNumber="98" columnNumber="39" moduleId="0" traceableId="5"/>
+   <hit lineNumber="98" columnNumber="39" moduleId="0" traceableId="6"/>
+   <hit lineNumber="99" columnNumber="63" moduleId="0" traceableId="7"/>
+   <hit lineNumber="101" columnNumber="39" moduleId="0" traceableId="5"/>
+   <hit lineNumber="101" columnNumber="39" moduleId="0" traceableId="6"/>
+   <hit lineNumber="102" columnNumber="65" moduleId="0" traceableId="7"/>
+   <hit lineNumber="68" columnNumber="43" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xsl
@@ -5,8 +5,15 @@
   <!--
       xsl:map Coverage Test Case (includes xsl:map-entry)
   -->
+  <!-- Create a variable containing the value 300. Copy this variable as an alternative to using xsl:sequence inside a xsl:map-entry.
+       This is on the basis that xsl:sequence is not traced in Saxon 12.4 so it isn't possible to tell if child nodes are traced
+       inside xsl:map-entry. -->
+  <xsl:variable name="mapValue300" as="xs:integer">
+    <xsl:sequence select="300" />
+  </xsl:variable>
+
   <xsl:template match="xsl-map">
-    <!-- Map construction, including xsl:map -->
+    <!-- Map construction, including xsl:map-entry -->
     <xsl:param name="hundreds-param" as="map(xs:string, xs:integer)">
       <xsl:map>
         <!-- Using select attribute -->
@@ -14,7 +21,7 @@
         <xsl:map-entry key="'Two'" select="200"/>
         <!-- Using sequence constructor -->
         <xsl:map-entry key="'Three'">
-          <xsl:sequence select="300" />
+          <xsl:copy select="$mapValue300" />
         </xsl:map-entry>
         <xsl:map-entry key="'Four'">
           <xsl:sequence select="400" />
@@ -28,12 +35,38 @@
         <xsl:map-entry key="'Two'" select="200"/>
         <!-- Using sequence constructor -->
         <xsl:map-entry key="'Three'">
-          <xsl:sequence select="300" />
+          <xsl:sequence>
+            <xsl:copy select="$mapValue300" />
+          </xsl:sequence>
         </xsl:map-entry>
         <xsl:map-entry key="'Four'">
           <xsl:sequence select="400" />
         </xsl:map-entry>
       </xsl:map>
+    </xsl:variable>
+    <!-- xsl:map with child that is not xsl:map-entry -->
+    <xsl:variable name="map-variable01" as="map(xs:string, xs:decimal)">
+      <xsl:map>
+        <xsl:for-each select="1 to 5">
+          <xsl:map-entry key="string(.)" select="xs:decimal(. * 600 div 6)"/>
+        </xsl:for-each>
+      </xsl:map>
+    </xsl:variable>
+    <!-- xsl:map with xsl:map-entry child using select attribute. A simple test case. -->
+    <xsl:variable name="map-variable02" as="map(xs:string, xs:decimal)">
+      <xsl:map>
+        <xsl:map-entry key="'Seven'" select="xs:decimal(700)" />
+      </xsl:map>
+    </xsl:variable>
+    <!-- xsl:map-entry not inside a xsl:map. Using select attribute -->
+    <xsl:variable name="map-entry-variable01" as="map(xs:string, xs:integer)">
+      <xsl:map-entry key="'One'" select="100"/>
+    </xsl:variable>
+    <!-- xsl:map-entry not inside a xsl:map. Using sequence constructor -->
+    <xsl:variable name="map-entry-variable02" as="map(xs:string, xs:integer)">
+      <xsl:map-entry key="'Three'">
+        <xsl:copy select="$mapValue300" />
+      </xsl:map-entry>
     </xsl:variable>
     <!-- Use xsl:map values -->
     <root>
@@ -49,11 +82,24 @@
       <node type="variable/map">
         <xsl:value-of select="$hundreds-variable('Three')" />
       </node>
+      <node type="variable/map">
+        <xsl:value-of select="$map-variable01('5')" />
+      </node>
+      <node type="variable/map">
+        <xsl:value-of select="$map-variable02('Seven')" />
+      </node>
       <node type="function/map">
         <xsl:value-of select="myns:returnMap()('One')" />
       </node>
       <node type="function/map">
         <xsl:value-of select="myns:returnMap()('Three')" />
+      </node>
+    <!-- Use xsl:map-entry values -->
+      <node type="variable/map-entry">
+        <xsl:value-of select="$map-entry-variable01('One')" />
+      </node>
+      <node type="variable/map-entry">
+        <xsl:value-of select="$map-entry-variable02('Three')" />
       </node>
     </root>
   </xsl:template>
@@ -65,7 +111,7 @@
       <xsl:map-entry key="'Two'" select="200"/>
       <!-- Using sequence constructor -->
       <xsl:map-entry key="'Three'">
-        <xsl:sequence select="300" />
+        <xsl:copy select="$mapValue300" />
       </xsl:map-entry>
       <xsl:map-entry key="'Four'">
         <xsl:sequence select="400" />

--- a/test/end-to-end/cases-coverage/xsl-map-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xspec
@@ -14,8 +14,12 @@
             <node type="param/map">300</node>
             <node type="variable/map">100</node>
             <node type="variable/map">300</node>
+            <node type="variable/map">500</node>
+            <node type="variable/map">700</node>
             <node type="function/map">100</node>
             <node type="function/map">300</node>
+            <node type="variable/map-entry">100</node>
+            <node type="variable/map-entry">300</node>
          </root>
       </x:expect>
    </x:scenario>


### PR DESCRIPTION
This pull request is to shepherd some test updates from @birdya22 (attached to #1953 and explained there) through GitHub. Thank you, Adrian!

I reviewed the .xsl and .xspec files, making no changes.

I regenerated expected result files in the usual way: from `test\end-to-end`, I ran `generate-expected.cmd -Dcases.dir=cases-coverage`.

Fixes #1953. (I think we should have a separate issue in GitHub to discuss what the coverage logic for the map-related elements should be, and restrict #1953 to the test enhancement.)