### PR TITLE
feat(schema): constrain x:expand-text and help users fix expand-text

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -320,7 +320,7 @@ common-attributes = xml-ns-attributes,
 	attribute expand-text { boolean.datatype }?
 
 user-content = mixed { (user-element | text-element)* }
-user-element = element * - x:* { attribute * { text }*, user-content }
+user-element = element * - x:* { attribute * - x:expand-text { text }*, attribute x:expand-text { boolean.datatype }?, user-content }
 
 text-element =
 	## Works like <xsl:text>.

--- a/src/schemas/xspec.sch
+++ b/src/schemas/xspec.sch
@@ -82,4 +82,26 @@
 			</sqf:fix>
 		</sch:rule>
 	</sch:pattern>
+
+	<sch:pattern>
+		<sch:rule context="*[x:is-user-content(.)]">
+			<sch:assert id="user-element-expand-text" role="warn" sqf:fix="sqf-rename-x-expand-text sqf-delete-expand-text"
+				test="empty(@expand-text)">Non-XSpec elements use x:expand-text, not expand-text, to control text value templates</sch:assert>
+			<sqf:fix id="sqf-rename-x-expand-text" use-when="not(./@x:expand-text)">
+				<!-- If element does not already have x:expand-text, rename expand-text to x:expand-text -->
+				<sqf:description>
+					<sqf:title>Rename @expand-text as @x:expand-text</sqf:title>
+				</sqf:description>
+				<sqf:replace match="@expand-text" node-type="attribute" target="x:expand-text"
+					select="string(.)"/>
+			</sqf:fix>
+			<sqf:fix id="sqf-delete-expand-text" use-when="exists(./@x:expand-text)">
+				<!-- If element already has x:expand-text, delete expand-text. Leave x:expand-text as is. -->
+				<sqf:description>
+					<sqf:title>Delete @expand-text</sqf:title>
+				</sqf:description>
+				<sqf:delete match="@expand-text"/>
+			</sqf:fix>
+		</sch:rule>
+	</sch:pattern>
 </sch:schema>

--- a/test/tvt.xspec
+++ b/test/tvt.xspec
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+	xspec-sch.xspec uses this file for testing ../src/schemas/xspec.sch.
+	When modifying this file, check whether xspec-sch.xspec needs any additions or updates.
+-->
 <!-- xmlns:myfn is for ensuring that namespace prefixes take effect in TVT -->
 <x:description query="x-urn:test:mirror" query-at="mirror.xqm" stylesheet="mirror.xsl"
 	xmlns:mirror="x-urn:test:mirror" xmlns:myfn="http://www.w3.org/2005/xpath-functions"
@@ -14,9 +18,18 @@
 						<function-param-child x:expand-text="yes"
 							>}}{myfn:false()}{{</function-param-child>
 						<function-param-child expand-text="yes">}}{false()}{{</function-param-child>
+						<function-param-child x:expand-text="yes" expand-text="yes"
+							>}}{myfn:false()}{{</function-param-child>
 					</x:param>
 				</x:call>
 				<x:like label="user-content expect" />
+				<x:scenario label="element with both expand-text and x:expand-text">
+					<x:expect label="TVT is enabled" select="'}false{'"
+						test="$x:result[3]/string()" />
+					<x:expect label="@x:expand-text is discarded" test="empty($x:result//@x:expand-text)" />				
+					<x:expect label="@expand-text is kept" select="'yes'"
+						test="$x:result[3]/@expand-text/string()" />
+				</x:scenario>
 			</x:scenario>
 
 			<x:scenario label="@expand-text=yes on x:param">

--- a/test/tvt/detect-expand-text-user-content-xslt.xspec
+++ b/test/tvt/detect-expand-text-user-content-xslt.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <x:scenario label="Detect expand-text in user content that happens to be XSLT">
+        <x:context>
+            <xsl:text expand-text="yes">{ 1 + 1 }</xsl:text>
+        </x:context>
+    </x:scenario>
+</x:description>

--- a/test/xspec-sch.xspec
+++ b/test/xspec-sch.xspec
@@ -48,5 +48,26 @@
 			<x:expect-assert count="1" />
 		</x:scenario>
 	</x:scenario>
+	<x:scenario label="x:expand-text in user content">
+		<x:scenario label="Generic user content">
+			<x:context href="tvt.xspec" />
+			<x:expect-not-assert id="user-element-expand-text"
+				label="user element with x:expand-text"
+				location="//x:scenario[@label='function-param']//x:scenario[@label='@*:expand-text=yes within user-content']//function-param-child[1]"/>
+			<x:expect-assert id="user-element-expand-text"
+				label="user element with expand-text"
+				location="//x:scenario[@label='function-param']//x:scenario[@label='@*:expand-text=yes within user-content']//function-param-child[2]"/>
+			<x:expect-assert id="user-element-expand-text"
+				label="user element with both x:expand-text and expand-text"
+				location="//x:scenario[@label='function-param']//x:scenario[@label='@*:expand-text=yes within user-content']//function-param-child[3]"/>
+			<x:expect-not-assert id="user-element-expand-text"
+				label="user element with neither x:expand-text nor expand-text"
+				location="//x:scenario[@label='function-param']//x:scenario[@label='@expand-text=yes on x:param']//function-param-child"/>
+		</x:scenario>
+		<x:scenario label="User content that happens to be XSLT">
+			<x:context href="tvt/detect-expand-text-user-content-xslt.xspec" />
+			<x:expect-assert id="user-element-expand-text" />
+		</x:scenario>
+	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
**Background**: To control text value templates in XSpec from a user content element, `x:expand-text` is the correct attribute to use and it has an enumerated set of Boolean values. On a user content element, the `expand-text` attribute has no effect on text value templates in XSpec.

This pull request enhances the RelaxNG and Schematron schemas for XSpec to help users set these attributes correctly in user content.

1. RelaxNG enforces the Boolean values for `x:expand-text`. Without this change, an incorrect value leads to a fatal compiler error when you run the test, but the error message doesn't have a user perspective and doesn't say where the problem is in the user's file: 

```
...\xspec\src\common\yes-no-utils.xsl:16:0: Fatal Error! Conditional expression: None of the conditions is satisfied, so an empty sequence is returned, but this is not allowed as the result of a call to x:yes-no-synonym#1
```

2. Schematron detects `expand-text` on a user content element. Then, Schematron Quick Fix lets the user either delete it (if `x:expand-text` is already present) or rename it to `x:expand-text`.

To qualify this change, I interactively validated `test/tvt.xspec` in Oxygen 26.1 and exercised both quick fixes. Note that this file triggers the new Schematron warning in instances that should not be "fixed" because they serve a testing purpose.

**Possible false positive**: It could happen that user content includes an XSLT element that happens to have an `expand-text` attribute and the user isn't trying to control text value templates in XSpec. In this situation, the user should ignore the Schematron warning. I think this situation is less likely than the situation where the Schematron warning helpfully alerts the user to a mistake. If anyone thinks the false positive for XSLT elements in user content is common enough, I can have the Schematron code make an exception based on the namespace of the user content element.