### PR TITLE
test: miscellaneous additions to coverage tests

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -65,12 +65,12 @@
 18: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
 19: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/doc:para&gt;</span>
 20: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span>
-21: <span class="ignored">  </span>
+21: 
 22: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace"&gt;</span>
 23: <span class="ignored">    </span><span class="ignored">&lt;xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
 24: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/xsl:para&gt;</span>
 25: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span>
-26: <span class="ignored">  </span>
+26: 
 27: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace"&gt;</span>
 28: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
 29: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/para&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for non-xsl-top-level-element-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../non-xsl-top-level-element-01.xsl">non-xsl-top-level-element-01.xsl</a></p>
+      <h2>module: non-xsl-top-level-element-01.xsl; 36 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      Coverage Test Case for non-XSLT child of xsl:stylesheet</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="non-xsl-top-level-element-01A.xsl"/&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="non-xsl-top-level-element"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:copy&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Child of xsl:stylesheet</span><span class="hit">&lt;/xsl:text&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;/xsl:copy&gt;</span>
+12: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-imports/&gt;</span>
+13: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: 
+16: <span class="ignored">  </span><span class="ignored">&lt;!-- The non-XSLT element in the template should be missed, not ignored. --&gt;</span>
+17: <span class="ignored">  </span><span class="missed">&lt;xsl:template name="unhit"&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+18: <span class="ignored">    </span><span class="missed">&lt;non-xsl-element/&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+19: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+20: 
+21: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace"&gt;</span>
+22: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+23: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/doc:para&gt;</span>
+24: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span>
+25: 
+26: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace"&gt;</span>
+27: <span class="ignored">    </span><span class="ignored">&lt;xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+28: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/xsl:para&gt;</span>
+29: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span>
+30: 
+31: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace"&gt;</span>
+32: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+33: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/para&gt;</span>
+34: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span>
+35: 
+36: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: non-xsl-top-level-element-01A.xsl; 32 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      Coverage Test Case for non-XSLT child of xsl:transform</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="non-xsl-top-level-element"&gt;</span>
+07: <span class="ignored">    </span><span class="hit">&lt;xsl:copy&gt;</span>
+08: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Child of xsl:transform</span><span class="hit">&lt;/xsl:text&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;/xsl:copy&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+11: 
+12: <span class="ignored">  </span><span class="ignored">&lt;!-- The non-XSLT element in the template should be missed, not ignored. --&gt;</span>
+13: <span class="ignored">  </span><span class="missed">&lt;xsl:template name="unhit"&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+14: <span class="ignored">    </span><span class="missed">&lt;non-xsl-element/&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+15: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+16: 
+17: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace"&gt;</span>
+18: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+19: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/doc:para&gt;</span>
+20: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span>
+21: <span class="ignored">  </span>
+22: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace"&gt;</span>
+23: <span class="ignored">    </span><span class="ignored">&lt;xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+24: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/xsl:para&gt;</span>
+25: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span>
+26: <span class="ignored">  </span>
+27: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace"&gt;</span>
+28: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
+29: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/para&gt;</span>
+30: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span>
+31: 
+32: <span class="ignored">&lt;/xsl:transform&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../non-xsl-top-level-element-01.xspec">
+   <compiled uri="non-xsl-top-level-element-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../non-xsl-top-level-element-01.xsl"/>
+   <traceable traceableId="0"
+              class="net.sf.saxon.expr.instruct.TemplateRule"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="51" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              class="net.sf.saxon.expr.instruct.Copy"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}copy"/>
+   <hit lineNumber="9" columnNumber="17" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.ValueOf"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.ApplyImports"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-imports"/>
+   <hit lineNumber="12" columnNumber="27" moduleId="0" traceableId="4"/>
+   <module moduleId="1" uri="../../non-xsl-top-level-element-01A.xsl"/>
+   <hit lineNumber="6" columnNumber="51" moduleId="1" traceableId="0"/>
+   <hit lineNumber="7" columnNumber="15" moduleId="1" traceableId="2"/>
+   <hit lineNumber="8" columnNumber="17" moduleId="1" traceableId="3"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for text-node-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../text-node-01.xsl">text-node-01.xsl</a></p>
+      <h2>module: text-node-01.xsl; 44 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet</span>
+03: <span class="ignored">  xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
+04: <span class="ignored">  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+05: <span class="ignored">  version="3.0"&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+07: <span class="ignored">      Coverage Test Case for Text Nodes</span>
+08: <span class="ignored">  --&gt;</span>
+09: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="param-text"&gt;</span><span class="missed">100</span><span class="hit">&lt;/xsl:param&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variable-text"&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:variable&gt;</span>
+11: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="text-node"&gt;</span>
+12: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span><span class="missed">100</span><span class="hit">&lt;/node&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+16: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+17: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:sequence&gt;</span><span class="ignored">        </span>
+19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+21: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:value-of&gt;</span><span class="ignored">    </span>
+22: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+23: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+24: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="string(100)"/&gt;</span><span class="ignored">   </span>
+25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;node type="text" xsl:expand-text="yes"&gt;</span><span class="missed">{</span>
+27: <span class="missed">        $param-text</span>
+28: <span class="missed">      }</span><span class="hit">&lt;/node&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;node type="text" xsl:expand-text="yes"&gt;</span><span class="missed">{</span>
+30: <span class="missed">        $variable-text</span>
+31: <span class="missed">        }</span><span class="hit">&lt;/node&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;node type="text" xsl:expand-text="yes"&gt;</span><span class="missed">{100}</span><span class="hit">&lt;/node&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+34: <span class="ignored">        </span><span class="hit">&lt;xsl:text expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">        </span>
+35: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+36: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+37: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:sequence&gt;</span><span class="ignored">        </span>
+38: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+39: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
+40: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:value-of&gt;</span><span class="ignored">        </span>
+41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+42: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+43: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+44: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
@@ -25,13 +25,13 @@
 15: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:text&gt;</span>
 16: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 17: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-18: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:sequence&gt;</span><span class="ignored">        </span>
+18: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:sequence&gt;</span>
 19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 20: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-21: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:value-of&gt;</span><span class="ignored">    </span>
+21: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:value-of&gt;</span>
 22: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 23: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-24: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="string(100)"/&gt;</span><span class="ignored">   </span>
+24: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="string(100)"/&gt;</span>
 25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 26: <span class="ignored">      </span><span class="hit">&lt;node type="text" xsl:expand-text="yes"&gt;</span><span class="missed">{</span>
 27: <span class="missed">        $param-text</span>
@@ -41,13 +41,13 @@
 31: <span class="missed">        }</span><span class="hit">&lt;/node&gt;</span>
 32: <span class="ignored">      </span><span class="hit">&lt;node type="text" xsl:expand-text="yes"&gt;</span><span class="missed">{100}</span><span class="hit">&lt;/node&gt;</span>
 33: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-34: <span class="ignored">        </span><span class="hit">&lt;xsl:text expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">        </span>
+34: <span class="ignored">        </span><span class="hit">&lt;xsl:text expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:text&gt;</span>
 35: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 36: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-37: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:sequence&gt;</span><span class="ignored">        </span>
+37: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:sequence&gt;</span>
 38: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 39: <span class="ignored">      </span><span class="hit">&lt;node type="text"&gt;</span>
-40: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:value-of&gt;</span><span class="ignored">        </span>
+40: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of expand-text="yes"&gt;</span><span class="missed">{ $variable-text }</span><span class="hit">&lt;/xsl:value-of&gt;</span>
 41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 42: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 43: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../text-node-01.xspec">
+   <compiled uri="text-node-01-compiled.xsl"/>
+   <module moduleId="0" uri="../../text-node-01.xsl"/>
+   <traceable traceableId="0"
+              class="net.sf.saxon.expr.instruct.TemplateRule"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="11" columnNumber="35" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="12" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              class="net.sf.saxon.expr.instruct.FixedAttribute"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.ValueOf"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="13" columnNumber="25" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="17" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="17" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="18" columnNumber="23" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="21" columnNumber="23" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="23" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="24" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="26" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="26" columnNumber="47" moduleId="0" traceableId="2"/>
+   <hit lineNumber="26" columnNumber="47" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.GlobalParam"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="9" columnNumber="32" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
+              class="net.sf.saxon.expr.instruct.TraceExpression"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="9" columnNumber="32" moduleId="0" traceableId="5"/>
+   <hit lineNumber="29" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="29" columnNumber="47" moduleId="0" traceableId="2"/>
+   <hit lineNumber="29" columnNumber="47" moduleId="0" traceableId="3"/>
+   <traceable traceableId="6"
+              class="net.sf.saxon.expr.instruct.GlobalVariable"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="10" columnNumber="38" moduleId="0" traceableId="6"/>
+   <hit lineNumber="10" columnNumber="38" moduleId="0" traceableId="5"/>
+   <hit lineNumber="32" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="47" moduleId="0" traceableId="2"/>
+   <hit lineNumber="32" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="33" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="33" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="34" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="36" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="36" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="37" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="39" columnNumber="25" moduleId="0" traceableId="1"/>
+   <hit lineNumber="39" columnNumber="25" moduleId="0" traceableId="2"/>
+   <hit lineNumber="40" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="40" columnNumber="41" moduleId="0" traceableId="5"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-context-item-01.xsl">xsl-context-item-01.xsl</a></p>
-      <h2>module: xsl-context-item-01.xsl; 14 lines</h2>
+      <h2>module: xsl-context-item-01.xsl; 22 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -21,6 +21,14 @@
 11: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 12: <span class="ignored">      </span><span class="hit">&lt;/root&gt;</span>
 13: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+14: <span class="ignored">  </span><span class="missed">&lt;xsl:template name="template-not-hit"&gt;</span><span class="ignored">                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+15: <span class="ignored">    </span><span class="missed">&lt;xsl:context-item use="required" as="item()" /&gt;</span><span class="ignored">                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+16: <span class="ignored">    </span><span class="missed">&lt;root&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+17: <span class="ignored">      </span><span class="missed">&lt;node&gt;</span><span class="ignored">                                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+18: <span class="ignored">        </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">not hit</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+19: <span class="ignored">      </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+20: <span class="ignored">    </span><span class="missed">&lt;/root&gt;</span><span class="ignored">                                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+21: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-merge-01.xsl">xsl-merge-01.xsl</a></p>
-      <h2>module: xsl-merge-01.xsl; 37 lines</h2>
+      <h2>module: xsl-merge-01.xsl; 54 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -15,35 +15,52 @@
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-merge"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-08: <span class="ignored">        </span><span class="ignored">&lt;!-- 2 data sets to be merged --&gt;</span>
-09: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="mergeSourceA"&gt;</span>
-10: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">100</span><span class="hit">&lt;/node&gt;</span>
-11: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">300</span><span class="hit">&lt;/node&gt;</span>
-12: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">500</span><span class="hit">&lt;/node&gt;</span>
-13: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
-14: <span class="ignored">        </span><span class="hit">&lt;xsl:variable name="mergeSourceB"&gt;</span>
-15: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">200</span><span class="hit">&lt;/node&gt;</span>
-16: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">400</span><span class="hit">&lt;/node&gt;</span>
-17: <span class="ignored">          </span><span class="hit">&lt;node&gt;</span><span class="hit">600</span><span class="hit">&lt;/node&gt;</span>
-18: <span class="ignored">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
-19: <span class="ignored">        </span><span class="ignored">&lt;!-- 1st merge-key uses select attribute, 2nd uses sequence constructor --&gt;</span>
-20: <span class="ignored">        </span><span class="hit">&lt;xsl:merge&gt;</span>
-21: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span>
-22: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key select="." /&gt;</span>
-23: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
-24: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
-25: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key&gt;</span>
-26: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
-27: <span class="ignored">            </span><span class="missed">&lt;/xsl:merge-key&gt;</span>
-28: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
-29: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-action&gt;</span>
-30: <span class="ignored">            </span><span class="hit">&lt;node type="merge"&gt;</span>
-31: <span class="ignored">              </span><span class="hit">&lt;xsl:value-of select="current-merge-group()" /&gt;</span>
-32: <span class="ignored">            </span><span class="hit">&lt;/node&gt;</span>
-33: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-action&gt;</span>
-34: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge&gt;</span>
-35: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-36: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-37: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- 2 data sets to be merged --&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="mergeSourceA"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">100</span><span class="hit">&lt;/node&gt;</span>
+11: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">300</span><span class="hit">&lt;/node&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">500</span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="mergeSourceB"&gt;</span>
+15: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">200</span><span class="hit">&lt;/node&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">400</span><span class="hit">&lt;/node&gt;</span>
+17: <span class="ignored">        </span><span class="hit">&lt;node&gt;</span><span class="hit">600</span><span class="hit">&lt;/node&gt;</span>
+18: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+19: <span class="ignored">      </span><span class="ignored">&lt;!-- 1st merge-key uses select attribute, 2nd uses sequence constructor --&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;xsl:merge&gt;</span>
+21: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span>
+22: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-key select="." /&gt;</span>
+23: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
+24: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
+25: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-key&gt;</span>
+26: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
+27: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-key&gt;</span>
+28: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
+29: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-action&gt;</span>
+30: <span class="ignored">          </span><span class="hit">&lt;node type="merge"&gt;</span>
+31: <span class="ignored">            </span><span class="hit">&lt;xsl:value-of select="current-merge-group()" /&gt;</span>
+32: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
+33: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-action&gt;</span>
+34: <span class="ignored">      </span><span class="hit">&lt;/xsl:merge&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="exists(merge-not-hit)"&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;xsl:merge&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+37: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span><span class="ignored">                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+38: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key select="." /&gt;</span><span class="ignored">                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+39: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+40: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span><span class="ignored">                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+41: <span class="ignored">            </span><span class="missed">&lt;xsl:merge-key&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+42: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+43: <span class="ignored">            </span><span class="missed">&lt;/xsl:merge-key&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+44: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-source&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+45: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-action&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+46: <span class="ignored">            </span><span class="missed">&lt;node type="merge"&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+47: <span class="ignored">              </span><span class="missed">&lt;xsl:value-of select="current-merge-group()" /&gt;</span><span class="ignored">                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+48: <span class="ignored">            </span><span class="missed">&lt;/node&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+49: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-action&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+50: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+51: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+52: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+53: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+54: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.xml
@@ -9,53 +9,57 @@
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" class="net.sf.saxon.expr.LetExpression"/>
-   <hit lineNumber="9" columnNumber="43" moduleId="0" traceableId="2"/>
-   <hit lineNumber="14" columnNumber="43" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="41" moduleId="0" traceableId="2"/>
+   <hit lineNumber="14" columnNumber="41" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.sort.MergeInstr"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}merge"/>
-   <hit lineNumber="20" columnNumber="20" moduleId="0" traceableId="3"/>
+   <hit lineNumber="20" columnNumber="18" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
-   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="10" columnNumber="15" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="15" moduleId="0" traceableId="1"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="10" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="11" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="11" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="12" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="12" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="15" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="16" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="16" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="11" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="12" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="15" columnNumber="15" moduleId="0" traceableId="4"/>
+   <hit lineNumber="15" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="16" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="16" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
    <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="32" moduleId="0" traceableId="6"/>
-   <hit lineNumber="31" columnNumber="62" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="4"/>
+   <hit lineNumber="30" columnNumber="30" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="60" moduleId="0" traceableId="5"/>
+   <traceable traceableId="7"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="35" columnNumber="44" moduleId="0" traceableId="7"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -7,94 +7,124 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-01.xsl">xsl-param-01.xsl</a></p>
-      <h2>module: xsl-param-01.xsl; 88 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
-03: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
-04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-05: <span class="ignored">      xsl:param Coverage Test Case for child of xsl:stylesheet, xsl:iterate, xsl:function</span>
-06: <span class="ignored">  --&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
-08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-09: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default --&gt;</span>
-10: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam02" /&gt;</span>
-11: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with select attribute --&gt;</span>
-12: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam03" select="200" /&gt;</span>
-13: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with inline sequence constructor --&gt;</span>
-14: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam04"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
-15: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor--&gt;</span>
-16: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam05"&gt;</span>
-17: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
-18: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-19: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-20: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
-21: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor - not used --&gt;</span>
-22: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam06"&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-23: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">4</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-24: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-25: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-26: <span class="ignored">  </span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-27: 
-28: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
-29: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-30: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
-31: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-32: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
-33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-34: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-35: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
-36: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-37: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-38: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam03" /&gt;</span>
-39: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-40: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-41: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam04" /&gt;</span>
-42: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-43: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-44: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam05" /&gt;</span>
-45: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-46: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-47: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
-48: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('1200')" /&gt;</span>
-49: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-50: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with select attribute --&gt;</span>
-51: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-52: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="13" /&gt;</span>
-53: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-54: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-55: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-56: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-57: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with inline sequence constructor --&gt;</span>
-58: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-59: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span><span class="missed">14</span><span class="hit">&lt;/xsl:param&gt;</span>
-60: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-61: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-62: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-63: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-64: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
-65: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-66: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span>
-67: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
-68: <span class="ignored">          </span><span class="missed">&lt;xsl:choose&gt;</span>
-69: <span class="ignored">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
-70: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
-71: <span class="ignored">            </span><span class="missed">&lt;/xsl:when&gt;</span>
-72: <span class="ignored">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
-73: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-74: <span class="ignored">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
-75: <span class="ignored">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
-76: <span class="ignored">        </span><span class="hit">&lt;/xsl:param&gt;</span>
-77: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-78: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-79: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-80: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-81: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-82: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-83: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute or sequence constructor tests --&gt;</span>
-84: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
-85: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
-86: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
-87: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
-88: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-param-01.xsl; 118 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:myns="file://myNamespace"</span>
+003: <span class="ignored">  xmlns:xs="http://www.w3.org/2001/XMLSchema"</span>
+004: <span class="ignored">  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"</span>
+005: <span class="ignored">  version="3.0"&gt;</span>
+006: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+007: <span class="ignored">      xsl:param Coverage Test Case for child of xsl:stylesheet, xsl:iterate, xsl:function</span>
+008: <span class="ignored">  --&gt;</span>
+009: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
+010: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+011: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default provided --&gt;</span>
+012: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamEmptyString01" /&gt;</span>
+013: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default provided but @as is present--&gt;</span>
+014: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamEmptySequence01" as="text()?" /&gt;</span>
+015: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with select attribute --&gt;</span>
+016: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamSelect01" select="200" /&gt;</span>
+017: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with inline sequence constructor --&gt;</span>
+018: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamDocNode01"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
+019: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamAs01" as="text()"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
+020: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor--&gt;</span>
+021: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamDocNode02"&gt;</span>
+022: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
+023: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+024: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+025: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
+026: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParamAs02" as="text()+"&gt;</span>
+027: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
+028: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+029: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+030: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
+031: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor - not used --&gt;</span>
+032: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam06"&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+033: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">4</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+034: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+035: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+036: <span class="ignored">  </span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+037: 
+038: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+039: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+040: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+041: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+042: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
+043: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+044: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+045: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($globalParamEmptyString01)" /&gt;</span>
+046: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+047: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+048: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($globalParamEmptySequence01)" /&gt;</span>
+049: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+050: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+051: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParamSelect01" /&gt;</span>
+052: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+054: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParamDocNode01" /&gt;</span>
+055: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+056: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+057: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParamAs01" /&gt;</span>
+058: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+059: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+060: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParamDocNode02" /&gt;</span>
+061: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+062: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+063: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParamAs02" /&gt;</span>
+064: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+065: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+066: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
+067: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('1200')" /&gt;</span>
+068: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+069: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with select attribute --&gt;</span>
+070: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+071: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="13" /&gt;</span>
+072: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+073: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+074: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+075: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+076: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with inline sequence constructor --&gt;</span>
+077: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+078: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamDocNode01"&gt;</span><span class="missed">14</span><span class="hit">&lt;/xsl:param&gt;</span>
+079: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamAs01" as="xs:integer" select="14" /&gt;</span>
+080: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+081: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParamDocNode01 * 100 + $iterateParamAs01" /&gt;</span>
+082: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+083: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+084: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
+085: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+086: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamDocNode01"&gt;</span>
+087: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
+088: <span class="ignored">          </span><span class="missed">&lt;xsl:choose&gt;</span>
+089: <span class="ignored">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
+090: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
+091: <span class="ignored">            </span><span class="missed">&lt;/xsl:when&gt;</span>
+092: <span class="ignored">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
+093: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+094: <span class="ignored">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
+095: <span class="ignored">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
+096: <span class="ignored">        </span><span class="hit">&lt;/xsl:param&gt;</span>
+097: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamAs01" as="xs:integer" select="15" /&gt;</span>
+098: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+099: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParamDocNode01 * 100 + $iterateParamAs01" /&gt;</span>
+100: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+101: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+102: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with empty string and empty sequence --&gt;</span>
+103: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+104: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamEmptySequence01" as="xs:string?" /&gt;</span>
+105: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParamEmptyString01" /&gt;</span>
+106: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+107: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="count($iterateParamEmptySequence01)" /&gt;</span>
+108: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="count($iterateParamEmptyString01)" /&gt;</span>
+109: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+110: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+111: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+112: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+113: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute or sequence constructor tests --&gt;</span>
+114: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
+115: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
+116: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
+117: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+118: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -7,182 +7,94 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-01.xsl">xsl-param-01.xsl</a></p>
-      <h2>module: xsl-param-01.xsl; 176 lines</h2>
-      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
-003: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
-004: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-005: <span class="ignored">      xsl:param Coverage Test Case</span>
-006: <span class="ignored">  --&gt;</span>
-007: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
-008: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-009: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default --&gt;</span>
-010: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam02" /&gt;</span>
-011: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with select attribute --&gt;</span>
-012: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam03" select="200" /&gt;</span>
-013: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with inline sequence constructor --&gt;</span>
-014: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam04"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
-015: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor--&gt;</span>
-016: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam05"&gt;</span>
-017: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
-018: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-019: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-020: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
-021: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor - not used --&gt;</span>
-022: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam06"&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-023: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">4</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-024: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-025: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-026: <span class="ignored">  </span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-027: 
-028: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
-029: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-030: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
-031: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-032: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
-033: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-034: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-035: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
-036: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-037: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-038: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam03" /&gt;</span>
-039: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-040: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-041: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam04" /&gt;</span>
-042: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-043: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
-044: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam05" /&gt;</span>
-045: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-046: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-047: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
-048: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-049: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-050: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-051: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate02"&gt;</span>
-052: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam02"&gt;</span><span class="missed">600</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-053: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-054: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-055: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate03"&gt;</span>
-056: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-057: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-058: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-059: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate04"&gt;</span>
-060: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-061: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-062: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template using default xsl:param values --&gt;</span>
-063: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate05" /&gt;</span>
-064: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
-065: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
-066: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
-067: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
-068: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
-069: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('1200')" /&gt;</span>
-070: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-071: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with select attribute --&gt;</span>
-072: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-073: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="13" /&gt;</span>
-074: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-075: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-076: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-077: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-078: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with inline sequence constructor --&gt;</span>
-079: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-080: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span><span class="missed">14</span><span class="hit">&lt;/xsl:param&gt;</span>
-081: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-082: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-083: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-084: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-085: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
-086: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-087: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span>
-088: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
-089: <span class="ignored">          </span><span class="missed">&lt;xsl:choose&gt;</span>
-090: <span class="ignored">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
-091: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
-092: <span class="ignored">            </span><span class="missed">&lt;/xsl:when&gt;</span>
-093: <span class="ignored">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
-094: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-095: <span class="ignored">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
-096: <span class="ignored">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
-097: <span class="ignored">        </span><span class="hit">&lt;/xsl:param&gt;</span>
-098: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
-099: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
-100: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-101: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-102: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-103: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-104: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
-105: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
-106: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
-107: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
-108: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-109: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
-110: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-111: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-112: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
-113: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
-114: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
-115: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-116: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
-117: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-118: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-119: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
-120: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
-121: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03"&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">                          </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-122: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-123: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03" /&gt;</span>
-124: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-125: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-126: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
-127: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
-128: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
-129: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-130: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-131: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-132: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-133: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-134: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
-135: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-136: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-137: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
-138: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
-139: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
-140: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam05" /&gt;</span>
-141: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-142: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam05" /&gt;</span>
-143: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-144: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-145: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
-146: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
-147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam06" select="900" /&gt;</span>
-148: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-149: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam06" /&gt;</span>
-150: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-151: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-152: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller, relying on default value --&gt;</span>
-153: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
-154: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
-155: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-156: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07" /&gt;</span>
-157: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-158: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-159: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value --&gt;</span>
-160: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
-161: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08"&gt;</span>
-162: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-163: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-164: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-165: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-166: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-167: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-168: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08" /&gt;</span>
-169: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-170: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-171: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute or sequence constructor tests --&gt;</span>
-172: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
-173: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
-174: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
-175: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
-176: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-param-01.xsl; 88 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+03: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
+04: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+05: <span class="ignored">      xsl:param Coverage Test Case for child of xsl:stylesheet, xsl:iterate, xsl:function</span>
+06: <span class="ignored">  --&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param overridden in XSpec --&gt;</span>
+08: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam01"&gt;</span><span class="missed">0</span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+09: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - no default --&gt;</span>
+10: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam02" /&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with select attribute --&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam03" select="200" /&gt;</span>
+13: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with inline sequence constructor --&gt;</span>
+14: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam04"&gt;</span><span class="missed">300</span><span class="hit">&lt;/xsl:param&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor--&gt;</span>
+16: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalParam05"&gt;</span>
+17: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">4</span><span class="hit">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+19: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+20: <span class="ignored">  </span><span class="hit">&lt;/xsl:param&gt;</span>
+21: <span class="ignored">  </span><span class="ignored">&lt;!-- Global param not overridden in XSpec - with multiline sequence constructor - not used --&gt;</span>
+22: <span class="ignored">  </span><span class="ignored">&lt;xsl:param name="globalParam06"&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+23: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">4</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+24: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">    </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+26: <span class="ignored">  </span><span class="ignored">&lt;/xsl:param&gt;</span><span class="ignored">                                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+27: 
+28: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+29: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+30: <span class="ignored">      </span><span class="ignored">&lt;!-- Global param --&gt;</span>
+31: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+32: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam01" /&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+34: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+35: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam02" /&gt;</span>
+36: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+37: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+38: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam03" /&gt;</span>
+39: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+40: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+41: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam04" /&gt;</span>
+42: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+43: <span class="ignored">      </span><span class="hit">&lt;node type="param - global"&gt;</span>
+44: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$globalParam05" /&gt;</span>
+45: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+46: <span class="ignored">      </span><span class="ignored">&lt;!-- Function param --&gt;</span>
+47: <span class="ignored">      </span><span class="hit">&lt;node type="param - function"&gt;</span>
+48: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="myns:paramFunction01('1200')" /&gt;</span>
+49: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+50: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with select attribute --&gt;</span>
+51: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+52: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="13" /&gt;</span>
+53: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+54: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+55: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+56: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+57: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with inline sequence constructor --&gt;</span>
+58: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+59: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span><span class="missed">14</span><span class="hit">&lt;/xsl:param&gt;</span>
+60: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+61: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+62: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+63: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+64: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
+65: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+66: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01"&gt;</span>
+67: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
+68: <span class="ignored">          </span><span class="missed">&lt;xsl:choose&gt;</span>
+69: <span class="ignored">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
+70: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
+71: <span class="ignored">            </span><span class="missed">&lt;/xsl:when&gt;</span>
+72: <span class="ignored">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
+73: <span class="ignored">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+74: <span class="ignored">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
+75: <span class="ignored">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
+76: <span class="ignored">        </span><span class="hit">&lt;/xsl:param&gt;</span>
+77: <span class="ignored">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>
+78: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01 * 100" /&gt;</span>
+79: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+80: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+81: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+82: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+83: <span class="ignored">  </span><span class="ignored">&lt;!-- Function param - not allowed a default value so no select attribute or sequence constructor tests --&gt;</span>
+84: <span class="ignored">  </span><span class="hit">&lt;xsl:function name="myns:paramFunction01"&gt;</span>
+85: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="functionParam01" /&gt;</span>
+86: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$functionParam01" /&gt;</span>
+87: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>
+88: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
@@ -44,105 +44,38 @@
    <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
    <hit lineNumber="18" columnNumber="15" moduleId="0" traceableId="5"/>
    <hit lineNumber="19" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="47" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="47" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="48" columnNumber="63" moduleId="0" traceableId="3"/>
    <traceable traceableId="6"
-              class="net.sf.saxon.expr.instruct.CallTemplate"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
-   <hit lineNumber="47" columnNumber="49" moduleId="0" traceableId="6"/>
-   <traceable traceableId="7"
-              class="net.sf.saxon.expr.instruct.NamedTemplate"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="106" columnNumber="40" moduleId="0" traceableId="7"/>
-   <traceable traceableId="8"
-              class="net.sf.saxon.expr.instruct.LocalParam"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="107" columnNumber="41" moduleId="0" traceableId="8"/>
-   <hit lineNumber="108" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="108" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="109" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="48" columnNumber="48" moduleId="0" traceableId="5"/>
-   <hit lineNumber="51" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="113" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="114" columnNumber="0" moduleId="0" traceableId="8"/>
-   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="116" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="52" columnNumber="48" moduleId="0" traceableId="5"/>
-   <hit lineNumber="55" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="120" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="121" columnNumber="39" moduleId="0" traceableId="8"/>
-   <hit lineNumber="122" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="122" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="123" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="48" moduleId="0" traceableId="5"/>
-   <hit lineNumber="59" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="127" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="129" columnNumber="17" moduleId="0" traceableId="8"/>
-   <hit lineNumber="133" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="133" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="134" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="60" columnNumber="48" moduleId="0" traceableId="5"/>
-   <hit lineNumber="63" columnNumber="51" moduleId="0" traceableId="6"/>
-   <hit lineNumber="139" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="140" columnNumber="41" moduleId="0" traceableId="8"/>
-   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="142" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="6"/>
-   <hit lineNumber="146" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="147" columnNumber="0" moduleId="0" traceableId="8"/>
-   <hit lineNumber="148" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="148" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="149" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="65" columnNumber="51" moduleId="0" traceableId="6"/>
-   <hit lineNumber="153" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="154" columnNumber="39" moduleId="0" traceableId="8"/>
-   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="156" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="154" columnNumber="39" moduleId="0" traceableId="5"/>
-   <hit lineNumber="66" columnNumber="51" moduleId="0" traceableId="6"/>
-   <hit lineNumber="160" columnNumber="40" moduleId="0" traceableId="7"/>
-   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="8"/>
-   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="168" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="163" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="164" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="165" columnNumber="17" moduleId="0" traceableId="5"/>
-   <hit lineNumber="68" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="68" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="69" columnNumber="63" moduleId="0" traceableId="3"/>
-   <traceable traceableId="9"
               class="net.sf.saxon.expr.instruct.UserFunction"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
-   <hit lineNumber="172" columnNumber="45" moduleId="0" traceableId="9"/>
-   <hit lineNumber="174" columnNumber="47" moduleId="0" traceableId="5"/>
-   <traceable traceableId="10"
+   <hit lineNumber="84" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="86" columnNumber="47" moduleId="0" traceableId="5"/>
+   <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.IterateInstr"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
-   <hit lineNumber="72" columnNumber="34" moduleId="0" traceableId="10"/>
-   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="75" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="74" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="75" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="79" columnNumber="34" moduleId="0" traceableId="10"/>
-   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="82" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="81" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="82" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="86" columnNumber="34" moduleId="0" traceableId="10"/>
-   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="99" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="99" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="51" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="54" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="54" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="58" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="65" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="78" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="78" columnNumber="58" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.xml
@@ -5,77 +5,102 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="28" columnNumber="35" moduleId="0" traceableId="0"/>
+   <hit lineNumber="38" columnNumber="35" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="29" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="31" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="39" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="31" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="41" columnNumber="35" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="32" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="34" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="34" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="35" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="42" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="44" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="44" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="45" columnNumber="67" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.GlobalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
-   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="4"/>
-   <hit lineNumber="37" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="37" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="38" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="12" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="40" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="40" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="41" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="14" columnNumber="35" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="48" moduleId="0" traceableId="4"/>
+   <hit lineNumber="47" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="47" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="48" columnNumber="69" moduleId="0" traceableId="3"/>
+   <hit lineNumber="14" columnNumber="63" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="51" columnNumber="55" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="56" moduleId="0" traceableId="4"/>
+   <hit lineNumber="53" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="53" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="54" columnNumber="56" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="42" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
-   <hit lineNumber="14" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="2"/>
-   <hit lineNumber="44" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="16" columnNumber="35" moduleId="0" traceableId="4"/>
-   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
-   <hit lineNumber="17" columnNumber="15" moduleId="0" traceableId="5"/>
-   <hit lineNumber="18" columnNumber="15" moduleId="0" traceableId="5"/>
-   <hit lineNumber="19" columnNumber="15" moduleId="0" traceableId="5"/>
-   <hit lineNumber="47" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="47" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="48" columnNumber="63" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="42" moduleId="0" traceableId="5"/>
+   <hit lineNumber="56" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="56" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="57" columnNumber="51" moduleId="0" traceableId="3"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="19" columnNumber="49" moduleId="0" traceableId="5"/>
+   <hit lineNumber="59" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="59" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="60" columnNumber="56" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="42" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="22" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="24" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="62" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="62" columnNumber="35" moduleId="0" traceableId="2"/>
+   <hit lineNumber="63" columnNumber="51" moduleId="0" traceableId="3"/>
+   <hit lineNumber="26" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="27" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="28" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="29" columnNumber="15" moduleId="0" traceableId="5"/>
+   <hit lineNumber="66" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="67" columnNumber="63" moduleId="0" traceableId="3"/>
    <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.UserFunction"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}function"/>
-   <hit lineNumber="84" columnNumber="45" moduleId="0" traceableId="6"/>
-   <hit lineNumber="86" columnNumber="47" moduleId="0" traceableId="5"/>
+   <hit lineNumber="114" columnNumber="45" moduleId="0" traceableId="6"/>
+   <hit lineNumber="116" columnNumber="47" moduleId="0" traceableId="5"/>
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.IterateInstr"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
-   <hit lineNumber="51" columnNumber="34" moduleId="0" traceableId="7"/>
-   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="54" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="53" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="54" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="58" columnNumber="34" moduleId="0" traceableId="7"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="65" columnNumber="34" moduleId="0" traceableId="7"/>
-   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="78" columnNumber="58" moduleId="0" traceableId="3"/>
-   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="1"/>
-   <hit lineNumber="77" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="78" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="70" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="73" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="77" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="80" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="80" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="81" columnNumber="85" moduleId="0" traceableId="3"/>
+   <hit lineNumber="80" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="80" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="81" columnNumber="85" moduleId="0" traceableId="3"/>
+   <hit lineNumber="85" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="99" columnNumber="85" moduleId="0" traceableId="3"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="98" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="99" columnNumber="85" moduleId="0" traceableId="3"/>
+   <hit lineNumber="103" columnNumber="34" moduleId="0" traceableId="7"/>
+   <hit lineNumber="106" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="106" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="107" columnNumber="72" moduleId="0" traceableId="3"/>
+   <hit lineNumber="108" columnNumber="70" moduleId="0" traceableId="3"/>
+   <hit lineNumber="106" columnNumber="38" moduleId="0" traceableId="1"/>
+   <hit lineNumber="106" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="107" columnNumber="72" moduleId="0" traceableId="3"/>
+   <hit lineNumber="108" columnNumber="70" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -156,7 +156,7 @@
 146: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
 147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
 148: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
-149: <span class="ignored">    </span>
+149: 
 150: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
 151: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
 152: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
@@ -196,7 +196,7 @@
 186: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
 187: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond2"</span>
 188: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1100</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
-189: <span class="ignored">    </span>
+189: 
 190: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
 191: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el1" /&gt;</span>
 192: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-param-02.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-param-02.xsl">xsl-param-02.xsl</a></p>
+      <h2>module: xsl-param-02.xsl; 183 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
+003: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
+004: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+005: <span class="ignored">      xsl:param Coverage Test Case for child of xsl:template</span>
+006: <span class="ignored">  --&gt;</span>
+007: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+008: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+009: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+010: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
+011: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+012: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+013: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+014: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate02"&gt;</span>
+015: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam02"&gt;</span><span class="missed">600</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+016: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+017: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+018: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate03"&gt;</span>
+019: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+020: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+021: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+022: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+023: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems3"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+024: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+025: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+026: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+027: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+028: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate04"&gt;</span>
+029: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+030: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04-cond1"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+031: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+032: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template using default xsl:param values --&gt;</span>
+033: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate05" /&gt;</span>
+034: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
+035: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
+036: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
+037: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+038: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+039: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
+040: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
+041: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+042: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+043: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+044: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+045: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+046: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+047: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
+048: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
+049: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
+050: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+051: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
+052: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+053: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+054: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
+055: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
+056: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el1"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+057: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+058: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+059: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems2"&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+060: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; --&gt;</span>
+061: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond1"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="1"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+062: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond2"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+063: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+064: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el1" /&gt;</span>
+065: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+066: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+067: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el2" /&gt;</span>
+068: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+069: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+070: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems1" /&gt;</span>
+071: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+072: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+073: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems2" /&gt;</span>
+074: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+075: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+076: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems3" /&gt;</span>
+077: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+078: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+079: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond1" /&gt;</span>
+080: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+081: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+082: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond2" /&gt;</span>
+083: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+084: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+085: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
+086: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
+087: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
+088: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+089: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+090: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+091: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+092: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04-cond1"&gt;</span>
+093: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+094: <span class="ignored">      </span><span class="missed">&lt;xsl:choose&gt;</span><span class="ignored">                                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+095: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="exists(irrelevant)"&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+096: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:value-of&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+097: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+098: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+099: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">998</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+100: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+101: <span class="ignored">      </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+102: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+103: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+104: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
+105: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+106: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+107: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04-cond1" /&gt;</span>
+108: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+109: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+110: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
+111: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
+112: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
+113: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam05" /&gt;</span>
+114: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+115: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam05" /&gt;</span>
+116: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+117: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+118: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
+119: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
+120: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam06" select="900" /&gt;</span>
+121: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+122: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam06" /&gt;</span>
+123: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+124: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+125: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller, relying on default value --&gt;</span>
+126: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
+127: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el1"&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+128: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+129: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+130: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems2"&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+131: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+132: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+133: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
+134: <span class="ignored">    </span>
+135: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+136: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
+137: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+138: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+139: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el2" /&gt;</span>
+140: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+141: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+142: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems1" /&gt;</span>
+143: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+144: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+145: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems2" /&gt;</span>
+146: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+147: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+148: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems3" /&gt;</span>
+149: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+150: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+151: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond1" /&gt;</span>
+152: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+153: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+154: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond2" /&gt;</span>
+155: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+156: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+157: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value --&gt;</span>
+158: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
+159: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08"&gt;</span>
+160: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+161: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+162: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+163: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+164: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+165: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond1"&gt;</span>
+166: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span>
+167: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+168: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
+169: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1100</span><span class="hit">&lt;/xsl:text&gt;</span>
+170: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+171: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+172: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+173: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+174: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+175: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+176: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+177: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08" /&gt;</span>
+178: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+179: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+180: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond1" /&gt;</span>
+181: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+182: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+183: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -7,14 +7,14 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-02.xsl">xsl-param-02.xsl</a></p>
-      <h2>module: xsl-param-02.xsl; 266 lines</h2>
+      <h2>module: xsl-param-02.xsl; 268 lines</h2>
       <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
 003: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
 004: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 005: <span class="ignored">      xsl:param Coverage Test Case for child of xsl:template</span>
 006: <span class="ignored">  --&gt;</span>
-007: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param"&gt;</span>
+007: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-param-template"&gt;</span>
 008: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 009: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
 010: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate01"&gt;</span>
@@ -28,251 +28,253 @@
 018: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate03"&gt;</span>
 019: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
 020: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-021: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-022: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-023: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems3"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-024: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-025: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-026: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-027: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
-028: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate04"&gt;</span>
-029: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-030: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04-cond1"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-031: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-032: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template using default xsl:param values --&gt;</span>
-033: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate05" /&gt;</span>
-034: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
-035: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
-036: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
-037: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate09" /&gt;</span>
-038: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate10" /&gt;</span>
-039: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-040: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-041: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
-042: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
-043: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
-044: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
-045: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-046: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
-047: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-048: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-049: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
-050: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
-051: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
-052: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-053: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
-054: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-055: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-056: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
-057: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
-058: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el1"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-059: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-060: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el3" as="node()+"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-061: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el4" as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-062: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
-063: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems2"&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
-064: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; --&gt;</span>
-065: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond1"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="1"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
-066: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond2"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
-067: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-068: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el1" /&gt;</span>
-069: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-070: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-071: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el2" /&gt;</span>
-072: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-073: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-074: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el3" /&gt;</span>
-075: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-076: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-077: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el4" /&gt;</span>
-078: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-079: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-080: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems1" /&gt;</span>
-081: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-082: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-083: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems2" /&gt;</span>
-084: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-085: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-086: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems3" /&gt;</span>
-087: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-088: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-089: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond1" /&gt;</span>
-090: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-091: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-092: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond2" /&gt;</span>
-093: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-094: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-095: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
-096: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
-097: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
-098: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-099: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-100: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-101: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-102: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04-cond1"&gt;</span>
-103: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-104: <span class="ignored">      </span><span class="missed">&lt;xsl:choose&gt;</span><span class="ignored">                                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-105: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="exists(irrelevant)"&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-106: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:value-of&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-107: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-108: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-109: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">998</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-110: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-111: <span class="ignored">      </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-112: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-113: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-114: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
-115: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-116: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-117: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04-cond1" /&gt;</span>
-118: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-119: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-120: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
-121: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
-122: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
-123: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptyString01" /&gt;</span>
-124: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptySequence01" as="text()?" /&gt;</span>
-125: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-126: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptyString01)" /&gt;</span>
-127: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-128: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-129: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptySequence01)" /&gt;</span>
-130: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-131: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-132: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
-133: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
-134: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamSelect01" select="900" /&gt;</span>
-135: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-136: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParamSelect01" /&gt;</span>
-137: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-138: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-139: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
-140: <span class="ignored">    relying on default value --&gt;</span>
-141: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
-142: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el1"&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-143: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
-144: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems1"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
-145: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems2"&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-146: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-148: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
-149: 
-150: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-151: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
-152: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-153: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-154: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el2" /&gt;</span>
-155: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-156: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-157: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems1" /&gt;</span>
-158: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-159: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-160: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems2" /&gt;</span>
-161: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-162: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-163: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems3" /&gt;</span>
-164: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-165: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-166: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond1" /&gt;</span>
-167: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-168: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-169: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond2" /&gt;</span>
-170: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-171: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-172: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
-173: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
-174: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
-175: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el1"</span>
-176: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-177: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el2"</span>
-178: <span class="hit">      as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
-179: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems1"</span>
-180: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
-181: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems2"</span>
-182: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-183: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems3"</span>
-184: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-185: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond1"</span>
-186: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-187: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond2"</span>
-188: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1100</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
-189: 
-190: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-191: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el1" /&gt;</span>
-192: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-193: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-194: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el2" /&gt;</span>
-195: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-196: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-197: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems1" /&gt;</span>
-198: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-199: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-200: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems2" /&gt;</span>
-201: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-202: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-203: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems3" /&gt;</span>
-204: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-205: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-206: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond1" /&gt;</span>
-207: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-208: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-209: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond2" /&gt;</span>
-210: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-211: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-212: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
-213: <span class="ignored">    relying on default value. Absence of @as in xsl:param leads to document node. --&gt;</span>
-214: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate09"&gt;</span>
-215: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09"&gt;</span>
-216: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-217: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">2</span><span class="hit">&lt;/xsl:text&gt;</span>
-218: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-219: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-220: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-221: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09-cond1"&gt;</span>
-222: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
-223: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
-224: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
-225: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1200</span><span class="hit">&lt;/xsl:text&gt;</span>
-226: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
-227: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-228: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-229: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-230: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
-231: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-232: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-233: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09" /&gt;</span>
-234: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-235: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-236: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09-cond1" /&gt;</span>
-237: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-238: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-239: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
-240: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
-241: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate10"&gt;</span>
-242: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10" as="text()+"&gt;</span>
-243: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-244: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">3</span><span class="hit">&lt;/xsl:text&gt;</span>
-245: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-246: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-247: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-248: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10-cond1" as="node()+"&gt;</span>
-249: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
-250: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
-251: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
-252: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1300</span><span class="hit">&lt;/xsl:text&gt;</span>
-253: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
-254: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-255: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-256: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-257: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
-258: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-259: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-260: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10" /&gt;</span>
-261: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-262: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-263: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10-cond1" /&gt;</span>
-264: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-265: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-266: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+021: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el3"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+022: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-no-el4"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+023: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+024: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+025: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-elems3"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+026: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond1"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+027: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam03-cond2"&gt;</span><span class="missed">700</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+028: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+029: <span class="ignored">      </span><span class="ignored">&lt;!-- Template param --&gt;</span>
+030: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate04"&gt;</span>
+031: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+032: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="templateParam04-cond1"&gt;</span><span class="missed">800</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+033: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+034: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template using default xsl:param values --&gt;</span>
+035: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate05" /&gt;</span>
+036: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
+037: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
+038: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
+039: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate09" /&gt;</span>
+040: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate10" /&gt;</span>
+041: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+042: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+043: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
+044: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
+045: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+046: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+047: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+048: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+049: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+050: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+051: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
+052: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
+053: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
+054: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+055: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
+056: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+057: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+058: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
+059: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
+060: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el1"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+061: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+062: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el3" as="node()+"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+063: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el4" as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+064: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+065: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems2"&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+066: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; --&gt;</span>
+067: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond1"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="1"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+068: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond2"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+069: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+070: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el1" /&gt;</span>
+071: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+072: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+073: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el2" /&gt;</span>
+074: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+075: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+076: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el3" /&gt;</span>
+077: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+078: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+079: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el4" /&gt;</span>
+080: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+081: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+082: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems1" /&gt;</span>
+083: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+084: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+085: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems2" /&gt;</span>
+086: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+087: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+088: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems3" /&gt;</span>
+089: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+090: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+091: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond1" /&gt;</span>
+092: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+093: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+094: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond2" /&gt;</span>
+095: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+096: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+097: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
+098: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
+099: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
+100: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+101: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+102: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+103: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+104: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04-cond1"&gt;</span>
+105: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+106: <span class="ignored">      </span><span class="missed">&lt;xsl:choose&gt;</span><span class="ignored">                                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+107: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="exists(irrelevant)"&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+108: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:value-of&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+109: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+110: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+111: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">998</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+112: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+113: <span class="ignored">      </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+114: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+115: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+116: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
+117: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+118: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+119: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04-cond1" /&gt;</span>
+120: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+121: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+122: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
+123: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
+124: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
+125: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptyString01" /&gt;</span>
+126: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptySequence01" as="text()?" /&gt;</span>
+127: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+128: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptyString01)" /&gt;</span>
+129: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+130: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+131: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptySequence01)" /&gt;</span>
+132: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+133: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+134: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
+135: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
+136: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamSelect01" select="900" /&gt;</span>
+137: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+138: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParamSelect01" /&gt;</span>
+139: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+140: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+141: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
+142: <span class="ignored">    relying on default value --&gt;</span>
+143: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
+144: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el1"&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+145: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+146: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems1"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems2"&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+148: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+149: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+150: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
+151: 
+152: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+153: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
+154: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+155: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+156: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el2" /&gt;</span>
+157: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+158: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+159: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems1" /&gt;</span>
+160: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+161: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+162: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems2" /&gt;</span>
+163: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+164: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+165: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems3" /&gt;</span>
+166: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+167: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+168: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond1" /&gt;</span>
+169: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+170: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+171: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond2" /&gt;</span>
+172: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+173: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+174: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
+175: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
+176: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
+177: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el1"</span>
+178: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+179: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el2"</span>
+180: <span class="hit">      as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
+181: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems1"</span>
+182: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
+183: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems2"</span>
+184: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+185: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems3"</span>
+186: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+187: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond1"</span>
+188: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+189: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond2"</span>
+190: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1100</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
+191: 
+192: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+193: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el1" /&gt;</span>
+194: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+195: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+196: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el2" /&gt;</span>
+197: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+198: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+199: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems1" /&gt;</span>
+200: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+201: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+202: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems2" /&gt;</span>
+203: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+204: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+205: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems3" /&gt;</span>
+206: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+207: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+208: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond1" /&gt;</span>
+209: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+210: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+211: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond2" /&gt;</span>
+212: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+213: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+214: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
+215: <span class="ignored">    relying on default value. Absence of @as in xsl:param leads to document node. --&gt;</span>
+216: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate09"&gt;</span>
+217: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09"&gt;</span>
+218: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+219: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">2</span><span class="hit">&lt;/xsl:text&gt;</span>
+220: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+221: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+222: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+223: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09-cond1"&gt;</span>
+224: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
+225: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+226: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
+227: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1200</span><span class="hit">&lt;/xsl:text&gt;</span>
+228: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+229: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+230: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+231: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+232: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+233: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+234: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+235: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09" /&gt;</span>
+236: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+237: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+238: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09-cond1" /&gt;</span>
+239: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+240: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+241: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
+242: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
+243: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate10"&gt;</span>
+244: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10" as="text()+"&gt;</span>
+245: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+246: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">3</span><span class="hit">&lt;/xsl:text&gt;</span>
+247: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+248: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+249: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+250: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10-cond1" as="node()+"&gt;</span>
+251: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
+252: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+253: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
+254: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1300</span><span class="hit">&lt;/xsl:text&gt;</span>
+255: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+256: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+257: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+258: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+259: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+260: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+261: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+262: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10" /&gt;</span>
+263: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+264: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+265: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10-cond1" /&gt;</span>
+266: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+267: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+268: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-param-02.xsl">xsl-param-02.xsl</a></p>
-      <h2>module: xsl-param-02.xsl; 183 lines</h2>
+      <h2>module: xsl-param-02.xsl; 266 lines</h2>
       <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"</span>
 003: <span class="ignored">                xmlns:myns="file://myNamespace"&gt;</span>
@@ -44,152 +44,235 @@
 034: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate06" /&gt;</span>
 035: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate07" /&gt;</span>
 036: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate08" /&gt;</span>
-037: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-038: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-039: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
-040: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
-041: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
-042: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
-043: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-044: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
-045: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-046: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-047: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
-048: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
-049: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
-050: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-051: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
-052: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-053: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-054: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
-055: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
-056: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el1"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-057: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
-058: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
-059: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems2"&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
-060: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; --&gt;</span>
-061: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond1"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="1"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
-062: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond2"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
-063: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-064: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el1" /&gt;</span>
-065: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-066: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-067: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el2" /&gt;</span>
-068: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-069: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-070: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems1" /&gt;</span>
-071: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-072: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-073: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems2" /&gt;</span>
-074: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-075: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-076: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems3" /&gt;</span>
-077: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-078: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-079: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond1" /&gt;</span>
-080: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-081: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-082: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond2" /&gt;</span>
-083: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-084: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-085: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
-086: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
-087: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
-088: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-089: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-090: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-091: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-092: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04-cond1"&gt;</span>
-093: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-094: <span class="ignored">      </span><span class="missed">&lt;xsl:choose&gt;</span><span class="ignored">                                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-095: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="exists(irrelevant)"&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-096: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:value-of&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-097: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-098: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-099: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">998</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-100: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-101: <span class="ignored">      </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-102: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-103: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-104: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
-105: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-106: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-107: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04-cond1" /&gt;</span>
-108: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-109: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-110: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
-111: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
-112: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
-113: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam05" /&gt;</span>
-114: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-115: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam05" /&gt;</span>
-116: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-117: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-118: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
-119: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
-120: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam06" select="900" /&gt;</span>
-121: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-122: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam06" /&gt;</span>
-123: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-124: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-125: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller, relying on default value --&gt;</span>
-126: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
-127: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el1"&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-128: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
-129: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
-130: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems2"&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="missed">1000</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-131: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-132: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
-133: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
-134: <span class="ignored">    </span>
+037: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate09" /&gt;</span>
+038: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="paramTemplate10" /&gt;</span>
+039: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+040: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+041: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param value is provided by caller --&gt;</span>
+042: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - value provided by caller --&gt;</span>
+043: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate01"&gt;</span>
+044: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam01" /&gt;</span>
+045: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+046: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam01" /&gt;</span>
+047: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+048: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+049: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - value provided by caller --&gt;</span>
+050: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate02"&gt;</span>
+051: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam02" select="999" /&gt;</span>
+052: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam02" /&gt;</span>
+054: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+055: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+056: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - value provided by caller --&gt;</span>
+057: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate03"&gt;</span>
+058: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el1"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+059: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+060: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el3" as="node()+"&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+061: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-no-el4" as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 --&gt;</span>
+062: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems1"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+063: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems2"&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="missed">999</span><span class="missed">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; and 999 --&gt;</span>
+064: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-elems3"&gt;</span><span class="hit">&lt;a/&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss for &lt;a/&gt; --&gt;</span>
+065: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond1"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="1"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+066: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam03-cond2"&gt;</span><span class="missed">999</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for 999 and xsl:if --&gt;</span>
+067: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+068: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el1" /&gt;</span>
+069: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+070: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+071: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el2" /&gt;</span>
+072: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+073: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+074: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el3" /&gt;</span>
+075: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+076: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+077: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-no-el4" /&gt;</span>
+078: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+079: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+080: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems1" /&gt;</span>
+081: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+082: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+083: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems2" /&gt;</span>
+084: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+085: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+086: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-elems3" /&gt;</span>
+087: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+088: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+089: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond1" /&gt;</span>
+090: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+091: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+092: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam03-cond2" /&gt;</span>
+093: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+094: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+095: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - value provided by caller --&gt;</span>
+096: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate04"&gt;</span>
+097: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04"&gt;</span>
+098: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">9</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+099: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+100: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">9</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+101: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+102: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam04-cond1"&gt;</span>
+103: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span><span class="ignored">                                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+104: <span class="ignored">      </span><span class="missed">&lt;xsl:choose&gt;</span><span class="ignored">                                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+105: <span class="ignored">        </span><span class="missed">&lt;xsl:when test="exists(irrelevant)"&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+106: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of&gt;</span><span class="missed">999</span><span class="missed">&lt;/xsl:value-of&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+107: <span class="ignored">        </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+108: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+109: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">998</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+110: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+111: <span class="ignored">      </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+112: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+113: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+114: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04" /&gt;</span>
+115: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+116: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+117: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam04-cond1" /&gt;</span>
+118: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+119: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+120: <span class="ignored">  </span><span class="ignored">&lt;!-- Templates where xsl:param default value is used --&gt;</span>
+121: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with no default - no value provided by caller, relying on default value --&gt;</span>
+122: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate05"&gt;</span>
+123: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptyString01" /&gt;</span>
+124: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamEmptySequence01" as="text()?" /&gt;</span>
+125: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+126: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptyString01)" /&gt;</span>
+127: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+128: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+129: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="count($templateParamEmptySequence01)" /&gt;</span>
+130: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+131: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+132: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with select attribute - no value provided by caller, relying on default value --&gt;</span>
+133: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate06"&gt;</span>
+134: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParamSelect01" select="900" /&gt;</span>
 135: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-136: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
+136: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParamSelect01" /&gt;</span>
 137: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-138: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-139: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el2" /&gt;</span>
-140: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-141: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-142: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems1" /&gt;</span>
-143: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-144: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-145: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems2" /&gt;</span>
-146: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-147: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-148: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems3" /&gt;</span>
-149: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+138: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+139: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
+140: <span class="ignored">    relying on default value --&gt;</span>
+141: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate07"&gt;</span>
+142: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el1"&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+143: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-no-el2"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+144: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems1"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:param&gt;</span>
+145: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems2"&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1000</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+146: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-elems3"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+147: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1000</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+148: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam07-cond2"&gt;</span><span class="missed">1000</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1000</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
+149: <span class="ignored">    </span>
 150: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-151: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond1" /&gt;</span>
+151: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el1" /&gt;</span>
 152: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
 153: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-154: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond2" /&gt;</span>
+154: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-no-el2" /&gt;</span>
 155: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-156: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-157: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value --&gt;</span>
-158: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
-159: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08"&gt;</span>
-160: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-161: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-162: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-163: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
-164: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-165: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond1"&gt;</span>
-166: <span class="ignored">      </span><span class="hit">&lt;a/&gt;</span>
-167: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
-168: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
-169: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1100</span><span class="hit">&lt;/xsl:text&gt;</span>
-170: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
-171: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-172: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-173: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-174: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
-175: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
-176: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-177: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08" /&gt;</span>
-178: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-179: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
-180: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond1" /&gt;</span>
-181: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-182: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-183: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+156: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+157: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems1" /&gt;</span>
+158: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+159: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+160: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems2" /&gt;</span>
+161: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+162: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+163: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-elems3" /&gt;</span>
+164: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+165: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+166: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond1" /&gt;</span>
+167: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+168: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+169: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam07-cond2" /&gt;</span>
+170: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+171: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+172: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with inline sequence constructor - no value provided by caller,</span>
+173: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
+174: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate08"&gt;</span>
+175: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el1"</span>
+176: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+177: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-no-el2"</span>
+178: <span class="hit">      as="node()+"&gt;</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="ignored">&lt;!--abc--&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
+179: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems1"</span>
+180: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:param&gt;</span>
+181: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems2"</span>
+182: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="missed">1100</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+183: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-elems3"</span>
+184: <span class="hit">      as="node()+"&gt;</span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+185: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond1"</span>
+186: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="hit">&lt;xsl:if test="1"&gt;</span><span class="missed">1100</span><span class="hit">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span>
+187: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam08-cond2"</span>
+188: <span class="hit">      as="node()+"&gt;</span><span class="missed">1100</span><span class="missed">&lt;xsl:if test="0"&gt;</span><span class="missed">1100</span><span class="missed">&lt;/xsl:if&gt;</span><span class="hit">&lt;/xsl:param&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss for xsl:if and child --&gt;</span>
+189: <span class="ignored">    </span>
+190: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+191: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el1" /&gt;</span>
+192: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+193: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+194: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-no-el2" /&gt;</span>
+195: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+196: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+197: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems1" /&gt;</span>
+198: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+199: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+200: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems2" /&gt;</span>
+201: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+202: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+203: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-elems3" /&gt;</span>
+204: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+205: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+206: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond1" /&gt;</span>
+207: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+208: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+209: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam08-cond2" /&gt;</span>
+210: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+211: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+212: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
+213: <span class="ignored">    relying on default value. Absence of @as in xsl:param leads to document node. --&gt;</span>
+214: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate09"&gt;</span>
+215: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09"&gt;</span>
+216: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+217: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">2</span><span class="hit">&lt;/xsl:text&gt;</span>
+218: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+219: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+220: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+221: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam09-cond1"&gt;</span>
+222: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
+223: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+224: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
+225: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1200</span><span class="hit">&lt;/xsl:text&gt;</span>
+226: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+227: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+228: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+229: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+230: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+231: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+232: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+233: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09" /&gt;</span>
+234: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+235: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+236: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam09-cond1" /&gt;</span>
+237: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+238: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+239: <span class="ignored">  </span><span class="ignored">&lt;!-- Template param with multi-line sequence constructor - no value provided by caller,</span>
+240: <span class="ignored">    relying on default value, and xsl:param uses @as --&gt;</span>
+241: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="paramTemplate10"&gt;</span>
+242: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10" as="text()+"&gt;</span>
+243: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
+244: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">3</span><span class="hit">&lt;/xsl:text&gt;</span>
+245: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+246: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">0</span><span class="hit">&lt;/xsl:text&gt;</span>
+247: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+248: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="templateParam10-cond1" as="node()+"&gt;</span>
+249: <span class="ignored">      </span><span class="hit">&lt;a&gt;</span><span class="hit">a</span><span class="hit">&lt;/a&gt;</span>
+250: <span class="ignored">      </span><span class="hit">&lt;xsl:choose&gt;</span>
+251: <span class="ignored">        </span><span class="hit">&lt;xsl:when test="empty(irrelevant)"&gt;</span>
+252: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1300</span><span class="hit">&lt;/xsl:text&gt;</span>
+253: <span class="ignored">        </span><span class="hit">&lt;/xsl:when&gt;</span>
+254: <span class="ignored">        </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+255: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">missed</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+256: <span class="ignored">        </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+257: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
+258: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
+259: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+260: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10" /&gt;</span>
+261: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+262: <span class="ignored">    </span><span class="hit">&lt;node type="param - template"&gt;</span>
+263: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$templateParam10-cond1" /&gt;</span>
+264: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+265: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+266: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
@@ -15,163 +15,251 @@
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.NamedTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="41" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="43" columnNumber="40" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.LocalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="42" columnNumber="41" moduleId="0" traceableId="4"/>
-   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="44" columnNumber="41" moduleId="0" traceableId="4"/>
+   <hit lineNumber="45" columnNumber="35" moduleId="0" traceableId="1"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="45" columnNumber="35" moduleId="0" traceableId="5"/>
    <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="44" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="46" columnNumber="49" moduleId="0" traceableId="6"/>
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
    <hit lineNumber="11" columnNumber="48" moduleId="0" traceableId="7"/>
    <hit lineNumber="14" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="48" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="49" columnNumber="0" moduleId="0" traceableId="4"/>
-   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="51" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="50" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="51" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="52" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="52" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="53" columnNumber="49" moduleId="0" traceableId="6"/>
    <hit lineNumber="15" columnNumber="48" moduleId="0" traceableId="7"/>
    <hit lineNumber="18" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="55" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="56" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="57" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="58" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="57" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="58" columnNumber="46" moduleId="0" traceableId="4"/>
    <hit lineNumber="59" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="60" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="61" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="62" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="63" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="63" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="64" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="60" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="61" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="62" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="63" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="64" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="65" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="67" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="67" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="68" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="19" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="66" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="67" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="70" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="70" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="71" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="20" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="70" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="73" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="73" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="74" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="60" columnNumber="59" moduleId="0" traceableId="7"/>
+   <hit lineNumber="76" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="76" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="77" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="61" columnNumber="59" moduleId="0" traceableId="7"/>
+   <hit lineNumber="79" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="79" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="80" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="21" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="73" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="82" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="82" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="83" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="22" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="76" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="85" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="85" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="86" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="23" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="79" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="88" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="88" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="89" columnNumber="55" moduleId="0" traceableId="6"/>
    <hit lineNumber="24" columnNumber="54" moduleId="0" traceableId="7"/>
-   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="82" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="91" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="91" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="92" columnNumber="55" moduleId="0" traceableId="6"/>
    <hit lineNumber="25" columnNumber="54" moduleId="0" traceableId="7"/>
    <hit lineNumber="28" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="86" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="88" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="93" columnNumber="11" moduleId="0" traceableId="4"/>
-   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="96" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="98" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="103" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="113" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="113" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="114" columnNumber="49" moduleId="0" traceableId="6"/>
    <hit lineNumber="29" columnNumber="48" moduleId="0" traceableId="7"/>
-   <hit lineNumber="106" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="106" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="107" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="116" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="116" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="117" columnNumber="55" moduleId="0" traceableId="6"/>
    <hit lineNumber="30" columnNumber="54" moduleId="0" traceableId="7"/>
    <hit lineNumber="33" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="112" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="113" columnNumber="41" moduleId="0" traceableId="4"/>
-   <hit lineNumber="114" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="114" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="115" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="122" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="123" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="124" columnNumber="67" moduleId="0" traceableId="4"/>
+   <hit lineNumber="125" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="125" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="126" columnNumber="67" moduleId="0" traceableId="6"/>
+   <hit lineNumber="128" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="128" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="129" columnNumber="69" moduleId="0" traceableId="6"/>
    <hit lineNumber="34" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="119" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="120" columnNumber="0" moduleId="0" traceableId="4"/>
-   <hit lineNumber="121" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="121" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="122" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="35" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="126" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="127" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="128" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="133" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="133" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="134" columnNumber="0" moduleId="0" traceableId="4"/>
    <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="1"/>
    <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="136" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="127" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="138" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="138" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="139" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="128" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="142" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="7"/>
-   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="1"/>
-   <hit lineNumber="129" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="129" columnNumber="58" moduleId="0" traceableId="1"/>
-   <hit lineNumber="129" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="144" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="144" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="145" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="130" columnNumber="54" moduleId="0" traceableId="1"/>
-   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="130" columnNumber="62" moduleId="0" traceableId="1"/>
-   <hit lineNumber="147" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="147" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="148" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="7"/>
-   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="136" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="35" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="141" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="142" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="143" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="148" columnNumber="45" moduleId="0" traceableId="4"/>
    <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="1"/>
    <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="151" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="7"/>
-   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="7"/>
-   <hit lineNumber="132" columnNumber="66" moduleId="0" traceableId="7"/>
+   <hit lineNumber="151" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="142" columnNumber="46" moduleId="0" traceableId="7"/>
    <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="1"/>
    <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="154" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="133" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="154" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="143" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="156" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="156" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="157" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="7"/>
+   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="61" moduleId="0" traceableId="1"/>
+   <hit lineNumber="144" columnNumber="61" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="159" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="159" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="160" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="145" columnNumber="53" moduleId="0" traceableId="1"/>
+   <hit lineNumber="145" columnNumber="53" moduleId="0" traceableId="6"/>
+   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="145" columnNumber="65" moduleId="0" traceableId="1"/>
+   <hit lineNumber="145" columnNumber="65" moduleId="0" traceableId="6"/>
+   <hit lineNumber="162" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="162" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="163" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="7"/>
+   <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="165" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="165" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="166" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="147" columnNumber="66" moduleId="0" traceableId="7"/>
+   <hit lineNumber="168" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="168" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="169" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="148" columnNumber="45" moduleId="0" traceableId="7"/>
    <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="158" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="4"/>
-   <hit lineNumber="176" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="176" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="177" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="161" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="163" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="179" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="179" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="180" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="7"/>
-   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="174" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="176" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="178" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="186" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="188" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="190" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="190" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="191" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="176" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="193" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="193" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="194" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="178" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="196" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="196" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="197" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="7"/>
+   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="180" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="180" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="180" columnNumber="35" moduleId="0" traceableId="6"/>
+   <hit lineNumber="180" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="199" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="199" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="200" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="27" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="27" moduleId="0" traceableId="6"/>
+   <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="39" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="39" moduleId="0" traceableId="6"/>
+   <hit lineNumber="202" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="202" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="203" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="7"/>
+   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="205" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="205" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="206" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="186" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="186" columnNumber="41" moduleId="0" traceableId="7"/>
+   <hit lineNumber="208" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="208" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="209" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="188" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="37" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="214" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="4"/>
+   <hit lineNumber="232" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="232" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="233" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="217" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="218" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="219" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="235" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="235" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="236" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="7"/>
+   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="1"/>
+   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="6"/>
    <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.Choose"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
-   <hit lineNumber="167" columnNumber="19" moduleId="0" traceableId="8"/>
-   <hit lineNumber="169" columnNumber="21" moduleId="0" traceableId="6"/>
+   <hit lineNumber="223" columnNumber="19" moduleId="0" traceableId="8"/>
+   <hit lineNumber="225" columnNumber="21" moduleId="0" traceableId="6"/>
+   <hit lineNumber="38" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="241" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="243" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="4"/>
+   <hit lineNumber="259" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="259" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="260" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="243" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="244" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="245" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="246" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="262" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="262" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="263" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="7"/>
+   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="6"/>
+   <hit lineNumber="250" columnNumber="19" moduleId="0" traceableId="7"/>
+   <hit lineNumber="252" columnNumber="21" moduleId="0" traceableId="7"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+   <util utilId="3" uri="../../../../../src/common/wrap.xsl"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-param-02.xspec">
+   <compiled uri="xsl-param-02-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-param-02.xsl"/>
+   <traceable traceableId="0"
+              class="net.sf.saxon.expr.instruct.TemplateRule"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="35" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              class="net.sf.saxon.expr.instruct.CallTemplate"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
+   <hit lineNumber="10" columnNumber="49" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.NamedTemplate"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="41" columnNumber="40" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.LocalParam"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="42" columnNumber="41" moduleId="0" traceableId="4"/>
+   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="1"/>
+   <traceable traceableId="5"
+              class="net.sf.saxon.expr.instruct.FixedAttribute"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
+   <hit lineNumber="43" columnNumber="35" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
+              class="net.sf.saxon.expr.instruct.ValueOf"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="44" columnNumber="49" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
+              class="net.sf.saxon.expr.instruct.TraceExpression"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="11" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="14" columnNumber="49" moduleId="0" traceableId="2"/>
+   <hit lineNumber="48" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="49" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="50" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="51" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="15" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="18" columnNumber="49" moduleId="0" traceableId="2"/>
+   <hit lineNumber="55" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="56" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="57" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="58" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="59" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="60" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="61" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="62" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="63" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="63" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="64" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="19" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="66" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="66" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="67" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="20" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="70" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="21" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="73" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="22" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="76" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="23" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="79" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="24" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="82" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="25" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="28" columnNumber="49" moduleId="0" traceableId="2"/>
+   <hit lineNumber="86" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="93" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="103" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="29" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="106" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="106" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="107" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="30" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="33" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="112" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="113" columnNumber="41" moduleId="0" traceableId="4"/>
+   <hit lineNumber="114" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="114" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="115" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="34" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="119" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="120" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="121" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="121" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="122" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="35" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="126" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="127" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="128" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="133" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="136" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="127" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="138" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="138" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="139" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="128" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="141" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="142" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="7"/>
+   <hit lineNumber="129" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="129" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="129" columnNumber="58" moduleId="0" traceableId="1"/>
+   <hit lineNumber="129" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="144" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="145" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="130" columnNumber="54" moduleId="0" traceableId="1"/>
+   <hit lineNumber="130" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="130" columnNumber="62" moduleId="0" traceableId="1"/>
+   <hit lineNumber="147" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="147" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="148" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="7"/>
+   <hit lineNumber="131" columnNumber="50" moduleId="0" traceableId="1"/>
+   <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="151" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="132" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="132" columnNumber="66" moduleId="0" traceableId="7"/>
+   <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="154" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="133" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="158" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="176" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="176" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="177" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="160" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="161" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="162" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="163" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="179" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="179" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="180" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="7"/>
+   <hit lineNumber="166" columnNumber="11" moduleId="0" traceableId="1"/>
+   <traceable traceableId="8"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
+   <hit lineNumber="167" columnNumber="19" moduleId="0" traceableId="8"/>
+   <hit lineNumber="169" columnNumber="21" moduleId="0" traceableId="6"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.xml
@@ -5,7 +5,7 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="7" columnNumber="35" moduleId="0" traceableId="0"/>
+   <hit lineNumber="7" columnNumber="44" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="8" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
@@ -15,251 +15,250 @@
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.NamedTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="43" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="45" columnNumber="40" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.LocalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="44" columnNumber="41" moduleId="0" traceableId="4"/>
-   <hit lineNumber="45" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="46" columnNumber="41" moduleId="0" traceableId="4"/>
+   <hit lineNumber="47" columnNumber="35" moduleId="0" traceableId="1"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="45" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="47" columnNumber="35" moduleId="0" traceableId="5"/>
    <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="46" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="48" columnNumber="49" moduleId="0" traceableId="6"/>
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
    <hit lineNumber="11" columnNumber="48" moduleId="0" traceableId="7"/>
    <hit lineNumber="14" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="50" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="51" columnNumber="0" moduleId="0" traceableId="4"/>
-   <hit lineNumber="52" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="52" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="53" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="52" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="53" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="54" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="54" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="55" columnNumber="49" moduleId="0" traceableId="6"/>
    <hit lineNumber="15" columnNumber="48" moduleId="0" traceableId="7"/>
    <hit lineNumber="18" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="57" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="58" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="59" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="60" columnNumber="59" moduleId="0" traceableId="4"/>
-   <hit lineNumber="61" columnNumber="59" moduleId="0" traceableId="4"/>
-   <hit lineNumber="62" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="63" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="59" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="60" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="61" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="62" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="63" columnNumber="59" moduleId="0" traceableId="4"/>
    <hit lineNumber="64" columnNumber="50" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="66" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="67" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="67" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="68" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="66" columnNumber="50" moduleId="0" traceableId="4"/>
+   <hit lineNumber="67" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="68" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="69" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="70" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="19" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="70" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="70" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="71" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="73" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="20" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="73" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="73" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="74" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="60" columnNumber="59" moduleId="0" traceableId="7"/>
-   <hit lineNumber="76" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="76" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="77" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="61" columnNumber="59" moduleId="0" traceableId="7"/>
-   <hit lineNumber="79" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="79" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="80" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="75" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="76" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="21" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="82" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="82" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="83" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="78" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="79" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="22" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="85" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="85" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="86" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="81" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="82" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="23" columnNumber="55" moduleId="0" traceableId="7"/>
-   <hit lineNumber="88" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="88" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="89" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="24" columnNumber="54" moduleId="0" traceableId="7"/>
-   <hit lineNumber="91" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="91" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="92" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="25" columnNumber="54" moduleId="0" traceableId="7"/>
-   <hit lineNumber="28" columnNumber="49" moduleId="0" traceableId="2"/>
-   <hit lineNumber="96" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="98" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="103" columnNumber="11" moduleId="0" traceableId="4"/>
-   <hit lineNumber="113" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="113" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="114" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="29" columnNumber="48" moduleId="0" traceableId="7"/>
-   <hit lineNumber="116" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="116" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="117" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="30" columnNumber="54" moduleId="0" traceableId="7"/>
-   <hit lineNumber="33" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="122" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="123" columnNumber="52" moduleId="0" traceableId="4"/>
-   <hit lineNumber="124" columnNumber="67" moduleId="0" traceableId="4"/>
-   <hit lineNumber="125" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="125" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="126" columnNumber="67" moduleId="0" traceableId="6"/>
-   <hit lineNumber="128" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="128" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="129" columnNumber="69" moduleId="0" traceableId="6"/>
-   <hit lineNumber="34" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="133" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="134" columnNumber="0" moduleId="0" traceableId="4"/>
-   <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="135" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="136" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="84" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="84" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="85" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="24" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="87" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="88" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="25" columnNumber="55" moduleId="0" traceableId="7"/>
+   <hit lineNumber="90" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="90" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="91" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="26" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="93" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="93" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="94" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="27" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="2"/>
+   <hit lineNumber="98" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="100" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="105" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="115" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="116" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="31" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="118" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="118" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="119" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="32" columnNumber="54" moduleId="0" traceableId="7"/>
    <hit lineNumber="35" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="141" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="142" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="143" columnNumber="46" moduleId="0" traceableId="4"/>
-   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="124" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="125" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="126" columnNumber="67" moduleId="0" traceableId="4"/>
+   <hit lineNumber="127" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="127" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="128" columnNumber="67" moduleId="0" traceableId="6"/>
+   <hit lineNumber="130" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="130" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="131" columnNumber="69" moduleId="0" traceableId="6"/>
+   <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="135" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="136" columnNumber="0" moduleId="0" traceableId="4"/>
+   <hit lineNumber="137" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="137" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="138" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="37" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="143" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="4"/>
    <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="4"/>
    <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="4"/>
-   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="148" columnNumber="45" moduleId="0" traceableId="4"/>
-   <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="150" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="151" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="142" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="153" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="154" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="143" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="156" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="156" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="157" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="7"/>
-   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="144" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="144" columnNumber="61" moduleId="0" traceableId="1"/>
-   <hit lineNumber="144" columnNumber="61" moduleId="0" traceableId="6"/>
-   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="159" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="159" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="160" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="46" moduleId="0" traceableId="4"/>
+   <hit lineNumber="148" columnNumber="49" moduleId="0" traceableId="4"/>
+   <hit lineNumber="149" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="150" columnNumber="45" moduleId="0" traceableId="4"/>
+   <hit lineNumber="152" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="152" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="153" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="155" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="156" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="145" columnNumber="53" moduleId="0" traceableId="1"/>
-   <hit lineNumber="145" columnNumber="53" moduleId="0" traceableId="6"/>
-   <hit lineNumber="145" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="145" columnNumber="65" moduleId="0" traceableId="1"/>
-   <hit lineNumber="145" columnNumber="65" moduleId="0" traceableId="6"/>
-   <hit lineNumber="162" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="162" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="163" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="158" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="158" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="159" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="7"/>
    <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="1"/>
    <hit lineNumber="146" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="165" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="165" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="166" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="7"/>
-   <hit lineNumber="147" columnNumber="45" moduleId="0" traceableId="7"/>
-   <hit lineNumber="147" columnNumber="66" moduleId="0" traceableId="7"/>
-   <hit lineNumber="168" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="168" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="169" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="148" columnNumber="45" moduleId="0" traceableId="7"/>
-   <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="174" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="176" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="146" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="146" columnNumber="61" moduleId="0" traceableId="1"/>
+   <hit lineNumber="146" columnNumber="61" moduleId="0" traceableId="6"/>
+   <hit lineNumber="146" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="161" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="161" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="162" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="46" moduleId="0" traceableId="7"/>
+   <hit lineNumber="147" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="53" moduleId="0" traceableId="1"/>
+   <hit lineNumber="147" columnNumber="53" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="147" columnNumber="65" moduleId="0" traceableId="1"/>
+   <hit lineNumber="147" columnNumber="65" moduleId="0" traceableId="6"/>
+   <hit lineNumber="164" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="164" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="165" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="148" columnNumber="49" moduleId="0" traceableId="7"/>
+   <hit lineNumber="148" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="148" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="167" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="168" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="149" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="149" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="149" columnNumber="66" moduleId="0" traceableId="7"/>
+   <hit lineNumber="170" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="170" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="171" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="150" columnNumber="45" moduleId="0" traceableId="7"/>
+   <hit lineNumber="38" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="176" columnNumber="40" moduleId="0" traceableId="3"/>
    <hit lineNumber="178" columnNumber="20" moduleId="0" traceableId="4"/>
-   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="4"/>
-   <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="4"/>
-   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="4"/>
-   <hit lineNumber="186" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="180" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="182" columnNumber="23" moduleId="0" traceableId="4"/>
+   <hit lineNumber="184" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="186" columnNumber="23" moduleId="0" traceableId="4"/>
    <hit lineNumber="188" columnNumber="20" moduleId="0" traceableId="4"/>
-   <hit lineNumber="190" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="190" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="191" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="176" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="193" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="193" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="194" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="190" columnNumber="20" moduleId="0" traceableId="4"/>
+   <hit lineNumber="192" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="192" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="193" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="178" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="196" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="196" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="197" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="7"/>
-   <hit lineNumber="180" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="195" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="195" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="196" columnNumber="56" moduleId="0" traceableId="6"/>
    <hit lineNumber="180" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="180" columnNumber="35" moduleId="0" traceableId="7"/>
-   <hit lineNumber="180" columnNumber="35" moduleId="0" traceableId="6"/>
-   <hit lineNumber="180" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="199" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="199" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="200" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="198" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="198" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="199" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="182" columnNumber="23" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="23" moduleId="0" traceableId="6"/>
    <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="182" columnNumber="27" moduleId="0" traceableId="7"/>
-   <hit lineNumber="182" columnNumber="27" moduleId="0" traceableId="6"/>
+   <hit lineNumber="182" columnNumber="35" moduleId="0" traceableId="7"/>
+   <hit lineNumber="182" columnNumber="35" moduleId="0" traceableId="6"/>
    <hit lineNumber="182" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="182" columnNumber="39" moduleId="0" traceableId="7"/>
-   <hit lineNumber="182" columnNumber="39" moduleId="0" traceableId="6"/>
-   <hit lineNumber="202" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="202" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="203" columnNumber="56" moduleId="0" traceableId="6"/>
-   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="7"/>
-   <hit lineNumber="184" columnNumber="23" moduleId="0" traceableId="6"/>
-   <hit lineNumber="205" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="205" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="206" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="186" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="186" columnNumber="41" moduleId="0" traceableId="7"/>
-   <hit lineNumber="208" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="208" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="209" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="201" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="201" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="202" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="184" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="184" columnNumber="27" moduleId="0" traceableId="7"/>
+   <hit lineNumber="184" columnNumber="27" moduleId="0" traceableId="6"/>
+   <hit lineNumber="184" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="184" columnNumber="39" moduleId="0" traceableId="7"/>
+   <hit lineNumber="184" columnNumber="39" moduleId="0" traceableId="6"/>
+   <hit lineNumber="204" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="204" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="205" columnNumber="56" moduleId="0" traceableId="6"/>
+   <hit lineNumber="186" columnNumber="23" moduleId="0" traceableId="7"/>
+   <hit lineNumber="186" columnNumber="23" moduleId="0" traceableId="6"/>
+   <hit lineNumber="207" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="207" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="208" columnNumber="55" moduleId="0" traceableId="6"/>
    <hit lineNumber="188" columnNumber="20" moduleId="0" traceableId="7"/>
-   <hit lineNumber="37" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="214" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="4"/>
-   <hit lineNumber="232" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="232" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="233" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="216" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="217" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="188" columnNumber="41" moduleId="0" traceableId="7"/>
+   <hit lineNumber="210" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="210" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="211" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="190" columnNumber="20" moduleId="0" traceableId="7"/>
+   <hit lineNumber="39" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="216" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="218" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="224" columnNumber="10" moduleId="0" traceableId="4"/>
+   <hit lineNumber="234" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="234" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="235" columnNumber="49" moduleId="0" traceableId="6"/>
+   <hit lineNumber="218" columnNumber="17" moduleId="0" traceableId="7"/>
    <hit lineNumber="218" columnNumber="17" moduleId="0" traceableId="7"/>
    <hit lineNumber="219" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="235" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="235" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="236" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="7"/>
-   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="1"/>
-   <hit lineNumber="222" columnNumber="10" moduleId="0" traceableId="6"/>
+   <hit lineNumber="220" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="221" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="237" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="237" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="238" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="224" columnNumber="10" moduleId="0" traceableId="7"/>
+   <hit lineNumber="224" columnNumber="10" moduleId="0" traceableId="1"/>
+   <hit lineNumber="224" columnNumber="10" moduleId="0" traceableId="6"/>
    <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.Choose"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
-   <hit lineNumber="223" columnNumber="19" moduleId="0" traceableId="8"/>
-   <hit lineNumber="225" columnNumber="21" moduleId="0" traceableId="6"/>
-   <hit lineNumber="38" columnNumber="51" moduleId="0" traceableId="2"/>
-   <hit lineNumber="241" columnNumber="40" moduleId="0" traceableId="3"/>
-   <hit lineNumber="243" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="4"/>
-   <hit lineNumber="259" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="259" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="260" columnNumber="49" moduleId="0" traceableId="6"/>
-   <hit lineNumber="243" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="244" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="225" columnNumber="19" moduleId="0" traceableId="8"/>
+   <hit lineNumber="227" columnNumber="21" moduleId="0" traceableId="6"/>
+   <hit lineNumber="40" columnNumber="51" moduleId="0" traceableId="2"/>
+   <hit lineNumber="243" columnNumber="40" moduleId="0" traceableId="3"/>
+   <hit lineNumber="245" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="251" columnNumber="10" moduleId="0" traceableId="4"/>
+   <hit lineNumber="261" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="261" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="262" columnNumber="49" moduleId="0" traceableId="6"/>
    <hit lineNumber="245" columnNumber="17" moduleId="0" traceableId="7"/>
    <hit lineNumber="246" columnNumber="17" moduleId="0" traceableId="7"/>
-   <hit lineNumber="262" columnNumber="35" moduleId="0" traceableId="1"/>
-   <hit lineNumber="262" columnNumber="35" moduleId="0" traceableId="5"/>
-   <hit lineNumber="263" columnNumber="55" moduleId="0" traceableId="6"/>
-   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="7"/>
-   <hit lineNumber="249" columnNumber="10" moduleId="0" traceableId="6"/>
-   <hit lineNumber="250" columnNumber="19" moduleId="0" traceableId="7"/>
-   <hit lineNumber="252" columnNumber="21" moduleId="0" traceableId="7"/>
+   <hit lineNumber="247" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="248" columnNumber="17" moduleId="0" traceableId="7"/>
+   <hit lineNumber="264" columnNumber="35" moduleId="0" traceableId="1"/>
+   <hit lineNumber="264" columnNumber="35" moduleId="0" traceableId="5"/>
+   <hit lineNumber="265" columnNumber="55" moduleId="0" traceableId="6"/>
+   <hit lineNumber="251" columnNumber="10" moduleId="0" traceableId="7"/>
+   <hit lineNumber="251" columnNumber="10" moduleId="0" traceableId="6"/>
+   <hit lineNumber="252" columnNumber="19" moduleId="0" traceableId="7"/>
+   <hit lineNumber="254" columnNumber="21" moduleId="0" traceableId="7"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
-   <util utilId="3" uri="../../../../../src/common/wrap.xsl"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-sort-01.xsl">xsl-sort-01.xsl</a></p>
-      <h2>module: xsl-sort-01.xsl; 70 lines</h2>
+      <h2>module: xsl-sort-01.xsl; 93 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -69,14 +69,37 @@
 59: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
 60: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
 61: <span class="ignored">      </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-62: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-63: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-64: 
-65: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="sortMode"&gt;</span>
-66: <span class="ignored">    </span><span class="hit">&lt;node type="sort - apply-templates"&gt;</span>
-67: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
-68: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-69: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-70: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+62: <span class="ignored">      </span><span class="ignored">&lt;!-- Constructs in which parent of xsl:sort is not hit --&gt;</span>
+63: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="exists(parent-of-sort-not-hit)"&gt;</span>
+64: <span class="ignored">        </span><span class="missed">&lt;xsl:for-each select="*"&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+65: <span class="ignored">          </span><span class="missed">&lt;xsl:sort&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+66: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+67: <span class="ignored">          </span><span class="missed">&lt;/xsl:sort&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+68: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+69: <span class="ignored">        </span><span class="missed">&lt;/xsl:for-each&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+70: <span class="ignored">        </span><span class="missed">&lt;xsl:for-each-group select="*" group-by="@type"&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+71: <span class="ignored">          </span><span class="missed">&lt;xsl:sort&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+72: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+73: <span class="ignored">          </span><span class="missed">&lt;/xsl:sort&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+74: <span class="ignored">          </span><span class="missed">&lt;xsl:value-of select="sum(current-group()/.)" /&gt;</span><span class="ignored">                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+75: <span class="ignored">        </span><span class="missed">&lt;/xsl:for-each-group&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+76: <span class="ignored">        </span><span class="missed">&lt;xsl:apply-templates mode="sortMode"&gt;</span><span class="ignored">                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+77: <span class="ignored">          </span><span class="missed">&lt;xsl:sort&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+78: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+79: <span class="ignored">          </span><span class="missed">&lt;/xsl:sort&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+80: <span class="ignored">        </span><span class="missed">&lt;/xsl:apply-templates&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+81: <span class="ignored">        </span><span class="missed">&lt;xsl:perform-sort select="node"&gt;</span><span class="ignored">                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+82: <span class="ignored">          </span><span class="missed">&lt;xsl:sort /&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+83: <span class="ignored">        </span><span class="missed">&lt;/xsl:perform-sort&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+84: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+85: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+86: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+87: 
+88: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="sortMode"&gt;</span>
+89: <span class="ignored">    </span><span class="hit">&lt;node type="sort - apply-templates"&gt;</span>
+90: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="." /&gt;</span>
+91: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+92: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+93: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.xml
@@ -64,45 +64,46 @@
               class="net.sf.saxon.expr.instruct.ApplyTemplates"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
    <hit lineNumber="42" columnNumber="44" moduleId="0" traceableId="6"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
    <hit lineNumber="46" columnNumber="44" moduleId="0" traceableId="6"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="0"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="41" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="34" moduleId="0" traceableId="4"/>
-   <traceable traceableId="7"
-              class="net.sf.saxon.expr.instruct.TraceExpression"
-              uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="46" moduleId="0" traceableId="0"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="1"/>
+   <hit lineNumber="89" columnNumber="41" moduleId="0" traceableId="3"/>
+   <hit lineNumber="90" columnNumber="34" moduleId="0" traceableId="4"/>
+   <traceable traceableId="7" class="net.sf.saxon.expr.instruct.Block"/>
    <hit lineNumber="57" columnNumber="43" moduleId="0" traceableId="7"/>
    <hit lineNumber="57" columnNumber="43" moduleId="0" traceableId="2"/>
-   <hit lineNumber="53" columnNumber="4" moduleId="0" traceableId="7"/>
+   <traceable traceableId="8"
+              class="net.sf.saxon.expr.instruct.TraceExpression"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
+   <hit lineNumber="53" columnNumber="4" moduleId="0" traceableId="8"/>
    <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
    <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
    <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
@@ -115,6 +116,10 @@
    <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="1"/>
    <hit lineNumber="58" columnNumber="42" moduleId="0" traceableId="3"/>
    <hit lineNumber="59" columnNumber="38" moduleId="0" traceableId="4"/>
+   <traceable traceableId="9"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="63" columnNumber="53" moduleId="0" traceableId="9"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -38,7 +38,7 @@
 028: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptySequenceUnused01" as="element()?" /&gt;</span><span class="ignored">  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 029: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
 030: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptyStringUnused01" /&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-031: <span class="ignored">  </span>
+031: 
 032: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-variable"&gt;</span>
 033: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalSelect01" select="string(400)" /&gt;</span>
 034: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalDocNode01"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -7,50 +7,107 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-variable-01.xsl">xsl-variable-01.xsl</a></p>
-      <h2>module: xsl-variable-01.xsl; 44 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
-03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-04: <span class="ignored">      xsl:variable Coverage Test Case</span>
-05: <span class="ignored">  --&gt;</span>
-06: <span class="ignored">  </span><span class="ignored">&lt;!-- Global variable --&gt;</span>
-07: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal01" select="string(100)" /&gt;</span>
-08: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal02"&gt;</span>
-09: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
-10: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
-11: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
-12: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobal03"&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-13: 
-14: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-variable"&gt;</span>
-15: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal01" select="string(400)" /&gt;</span>
-16: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal02"&gt;</span>
-17: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">500</span><span class="hit">&lt;/xsl:text&gt;</span>
-18: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
-19: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
-20: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal03"&gt;</span><span class="hit">600</span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-21: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
-22: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocal04"&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-23: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">700</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-24: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-25: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-26: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-27: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-28: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobal01" /&gt;</span>
-29: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-30: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-31: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-32: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobal02" /&gt;</span>
-33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-34: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-35: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-36: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocal01" /&gt;</span>
-37: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-38: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-39: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-40: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocal02" /&gt;</span>
-41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-42: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-43: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-44: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-variable-01.xsl; 101 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+003: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+004: <span class="ignored">      xsl:variable Coverage Test Case</span>
+005: <span class="ignored">  --&gt;</span>
+006: <span class="ignored">  </span><span class="ignored">&lt;!-- Global variable --&gt;</span>
+007: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalSelect01" select="string(100)" /&gt;</span>
+008: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalDocNode01"&gt;</span>
+009: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">20</span><span class="hit">&lt;/xsl:text&gt;</span>
+010: <span class="ignored">    </span><span class="hit">&lt;element&gt;</span><span class="hit">0</span><span class="hit">&lt;/element&gt;</span>
+011: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+012: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalAs01" as="text()"&gt;</span>
+013: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+014: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span>
+015: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptySequence01" as="element()?" /&gt;</span>
+016: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptyString01" /&gt;</span>
+017: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+018: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalSelectUnused01" select="string(300)" /&gt;</span><span class="ignored">    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+019: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalDocNodeUnused01"&gt;</span><span class="ignored">                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+020: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">40</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+021: <span class="ignored">    </span><span class="hit">&lt;element&gt;</span><span class="hit">0</span><span class="hit">&lt;/element&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+022: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+023: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+024: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalAsUnused01" as="text()"&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+025: <span class="ignored">    </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">400</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+026: <span class="ignored">  </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+027: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+028: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptySequenceUnused01" as="element()?" /&gt;</span><span class="ignored">  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+029: <span class="ignored">  </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+030: <span class="ignored">  </span><span class="hit">&lt;xsl:variable name="variableGlobalEmptyStringUnused01" /&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+031: <span class="ignored">  </span>
+032: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-variable"&gt;</span>
+033: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalSelect01" select="string(400)" /&gt;</span>
+034: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalDocNode01"&gt;</span>
+035: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">50</span><span class="hit">&lt;/xsl:text&gt;</span>
+036: <span class="ignored">      </span><span class="hit">&lt;element&gt;</span><span class="hit">0</span><span class="hit">&lt;/element&gt;</span>
+037: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+038: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalAs01" as="text()"&gt;</span>
+039: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">500</span><span class="hit">&lt;/xsl:text&gt;</span>
+040: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
+041: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptySequence01" as="element()?" /&gt;</span>
+042: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptyString01" /&gt;</span>
+043: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+044: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalSelectUnused01" select="string(600)" /&gt;</span><span class="ignored">   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+045: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+046: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalDocNodeUnused01"&gt;</span><span class="ignored">                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+047: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">70</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+048: <span class="ignored">      </span><span class="hit">&lt;element&gt;</span><span class="hit">0</span><span class="hit">&lt;/element&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+049: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+050: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+051: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalasUnused01" as="text()"&gt;</span><span class="ignored">                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+052: <span class="ignored">      </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">700</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+053: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+054: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+055: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptySequenceUnused01" as="element()?" /&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+056: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
+057: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptyStringUnused01" /&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+058: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+059: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+060: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+061: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalSelect01" /&gt;</span>
+062: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+063: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+064: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+065: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalDocNode01" /&gt;</span>
+066: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+067: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+068: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+069: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalAs01" /&gt;</span>
+070: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+071: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+072: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+073: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptySequence01)" /&gt;</span>
+074: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+075: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+076: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+077: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptyString01)" /&gt;</span>
+078: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+079: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+080: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+081: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalSelect01" /&gt;</span>
+082: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+083: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+084: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+085: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalDocNode01" /&gt;</span>
+086: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+087: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+088: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+089: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalAs01" /&gt;</span>
+090: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+091: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+092: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+093: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptySequence01)" /&gt;</span>
+094: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+095: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+096: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+097: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptyString01)" /&gt;</span>
+098: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+099: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+100: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+101: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
@@ -5,39 +5,74 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="14" columnNumber="38" moduleId="0" traceableId="0"/>
+   <hit lineNumber="32" columnNumber="38" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.TraceExpression"/>
-   <hit lineNumber="16" columnNumber="42" moduleId="0" traceableId="1"/>
-   <hit lineNumber="20" columnNumber="42" moduleId="0" traceableId="1"/>
-   <hit lineNumber="22" columnNumber="42" moduleId="0" traceableId="1"/>
-   <hit lineNumber="25" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="38" columnNumber="56" moduleId="0" traceableId="1"/>
+   <hit lineNumber="41" columnNumber="73" moduleId="0" traceableId="1"/>
+   <hit lineNumber="42" columnNumber="55" moduleId="0" traceableId="1"/>
+   <hit lineNumber="44" columnNumber="77" moduleId="0" traceableId="1"/>
+   <hit lineNumber="46" columnNumber="55" moduleId="0" traceableId="1"/>
+   <hit lineNumber="51" columnNumber="62" moduleId="0" traceableId="1"/>
+   <hit lineNumber="55" columnNumber="79" moduleId="0" traceableId="1"/>
+   <hit lineNumber="57" columnNumber="61" moduleId="0" traceableId="1"/>
+   <hit lineNumber="58" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="25" columnNumber="11" moduleId="0" traceableId="2"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="58" columnNumber="11" moduleId="0" traceableId="2"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="27" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="28" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.GlobalVariable"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
-   <hit lineNumber="7" columnNumber="64" moduleId="0" traceableId="5"/>
-   <hit lineNumber="31" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="31" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="32" columnNumber="52" moduleId="0" traceableId="4"/>
-   <hit lineNumber="8" columnNumber="41" moduleId="0" traceableId="5"/>
+   <hit lineNumber="7" columnNumber="70" moduleId="0" traceableId="5"/>
+   <hit lineNumber="64" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="64" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="65" columnNumber="59" moduleId="0" traceableId="4"/>
+   <hit lineNumber="8" columnNumber="48" moduleId="0" traceableId="5"/>
    <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="1"/>
-   <hit lineNumber="35" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="35" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="36" columnNumber="51" moduleId="0" traceableId="4"/>
-   <hit lineNumber="39" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="39" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="40" columnNumber="51" moduleId="0" traceableId="4"/>
-   <hit lineNumber="17" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="4"/>
+   <hit lineNumber="10" columnNumber="14" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="14" moduleId="0" traceableId="4"/>
+   <hit lineNumber="68" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="68" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="69" columnNumber="54" moduleId="0" traceableId="4"/>
+   <hit lineNumber="12" columnNumber="55" moduleId="0" traceableId="5"/>
+   <hit lineNumber="13" columnNumber="15" moduleId="0" traceableId="1"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="73" columnNumber="72" moduleId="0" traceableId="4"/>
+   <hit lineNumber="15" columnNumber="72" moduleId="0" traceableId="5"/>
+   <hit lineNumber="76" columnNumber="38" moduleId="0" traceableId="2"/>
+   <hit lineNumber="76" columnNumber="38" moduleId="0" traceableId="3"/>
+   <hit lineNumber="77" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="16" columnNumber="54" moduleId="0" traceableId="5"/>
+   <hit lineNumber="80" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="80" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="81" columnNumber="57" moduleId="0" traceableId="4"/>
+   <hit lineNumber="84" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="84" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="85" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="35" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="17" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="16" moduleId="0" traceableId="2"/>
+   <hit lineNumber="36" columnNumber="16" moduleId="0" traceableId="4"/>
+   <hit lineNumber="88" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="88" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="89" columnNumber="53" moduleId="0" traceableId="4"/>
+   <hit lineNumber="39" columnNumber="17" moduleId="0" traceableId="1"/>
+   <hit lineNumber="92" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="92" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="93" columnNumber="71" moduleId="0" traceableId="4"/>
+   <hit lineNumber="96" columnNumber="37" moduleId="0" traceableId="2"/>
+   <hit lineNumber="96" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="97" columnNumber="69" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -7,97 +7,118 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-with-param-01.xsl">xsl-with-param-01.xsl</a></p>
-      <h2>module: xsl-with-param-01.xsl; 90 lines</h2>
-      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
-02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
-03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
-04: <span class="ignored">      xsl:with-param Coverage Test Case (Quite complex because it covers xsl:iterate, xsl:call-template, xsl:apply-templates, xsl:apply-import, xsl:next-match and xsl:evaluate)</span>
-05: <span class="ignored">  --&gt;</span>
-06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-with-param-01A.xsl" /&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-templates --&gt;</span>
-08: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamMode" /&gt;</span>
-09: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-imports --&gt;</span>
-10: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeAI" /&gt;</span>
-11: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for next-match --&gt;</span>
-12: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeNM" /&gt;</span>
-13: 
-14: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-with-param"&gt;</span>
-15: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-16: <span class="ignored">      </span><span class="ignored">&lt;!-- Numbers in brackets refer to the value in the node output --&gt;</span>
-17: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate with-param (100, 200, 300, 400) --&gt;</span>
-18: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-19: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="100" /&gt;</span>
-20: <span class="ignored">        </span><span class="hit">&lt;node type="with-param - iterate"&gt;</span>
-21: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01" /&gt;</span>
-22: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
-23: <span class="ignored">        </span><span class="hit">&lt;xsl:next-iteration&gt;</span>
-24: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="iterateParam01" select="$iterateParam01 + 100" /&gt;</span>
-25: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
-26: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
-27: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template with-param (500) --&gt;</span>
-28: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="withParamTemplate01"&gt;</span>
-29: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-CT-Param01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-30: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
-31: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Templates with-param (600, 700, 800, 900) --&gt;</span>
-32: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="withParamMode"&gt;</span>
-33: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-AT-Param01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-34: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
-35: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Imports with-param (1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350) --&gt;</span>
-36: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeAI"&gt;</span>
-37: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-AI-Param01"&gt;</span><span class="missed">900</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-38: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
-39: <span class="ignored">      </span><span class="ignored">&lt;!-- Next Match with-param (1400, 1450, 1500, 1550, 1600, 1650, 1700, 1750) --&gt;</span>
-40: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeNM"&gt;</span>
-41: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-NM-Param01"&gt;</span><span class="missed">1300</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-42: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
-43: <span class="ignored">      </span><span class="ignored">&lt;!-- Evaluate with-param (200) --&gt;</span>
-44: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
-45: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
-46: <span class="ignored">        </span><span class="hit">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span>
-47: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="index" select="$index" /&gt;</span>
-48: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="nonexistent"&gt;</span><span class="hit">parameter not used in evaluation</span><span class="hit">&lt;/xsl:with-param&gt;</span>
-49: <span class="ignored">        </span><span class="hit">&lt;/xsl:evaluate&gt;</span>
-50: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
-51: <span class="ignored">      </span><span class="hit">&lt;node type="with-param - evaluate"&gt;</span>
-52: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span>
-53: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-54: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-55: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-56: <span class="ignored">  </span><span class="ignored">&lt;!-- Call Template --&gt;</span>
-57: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="withParamTemplate01"&gt;</span>
-58: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-CT-Param01" /&gt;</span>
-59: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - call-template"&gt;</span>
-60: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-CT-Param01" /&gt;</span>
-61: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-62: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-63: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Templates Template --&gt;</span>
-64: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamMode"&gt;</span>
-65: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AT-Param01" /&gt;</span>
-66: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-templates"&gt;</span>
-67: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AT-Param01 + ." /&gt;</span>
-68: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-69: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-70: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Imports Template --&gt;</span>
-71: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI"&gt;</span>
-72: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
-73: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 1"&gt;</span>
-74: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + ." /&gt;</span>
-75: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-76: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports&gt;</span>
-77: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" /&gt;</span>
-78: <span class="ignored">    </span><span class="hit">&lt;/xsl:apply-imports&gt;</span>
-79: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-80: <span class="ignored">  </span><span class="ignored">&lt;!-- Next Match Template --&gt;</span>
-81: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="1"&gt;</span>
-82: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
-83: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 1"&gt;</span>
-84: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + ." /&gt;</span>
-85: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-86: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
-87: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" /&gt;</span>
-88: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
-89: <span class="ignored">   </span><span class="hit">&lt;/xsl:template&gt;</span>
-90: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-with-param-01.xsl; 111 lines</h2>
+      <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+003: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+004: <span class="ignored">      xsl:with-param Coverage Test Case (Quite complex because it covers xsl:iterate, xsl:call-template, xsl:apply-templates, xsl:apply-import, xsl:next-match and xsl:evaluate)</span>
+005: <span class="ignored">  --&gt;</span>
+006: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="xsl-with-param-01A.xsl" /&gt;</span>
+007: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-templates --&gt;</span>
+008: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamMode" /&gt;</span>
+009: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for apply-imports --&gt;</span>
+010: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeAI" /&gt;</span>
+011: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for next-match --&gt;</span>
+012: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode name="withParamModeNM" /&gt;</span>
+013: 
+014: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-with-param"&gt;</span>
+015: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+016: <span class="ignored">      </span><span class="ignored">&lt;!-- Numbers in brackets refer to the value in the node output --&gt;</span>
+017: <span class="ignored">      </span><span class="ignored">&lt;!--Iterate with-param (100, 200, 300, 400) --&gt;</span>
+018: <span class="ignored">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
+019: <span class="ignored">        </span><span class="hit">&lt;xsl:param name="iterateParam01" select="100" /&gt;</span>
+020: <span class="ignored">        </span><span class="hit">&lt;node type="with-param - iterate"&gt;</span>
+021: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="$iterateParam01" /&gt;</span>
+022: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
+023: <span class="ignored">        </span><span class="hit">&lt;xsl:next-iteration&gt;</span>
+024: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="iterateParam01" select="$iterateParam01 + 100" /&gt;</span>
+025: <span class="ignored">        </span><span class="hit">&lt;/xsl:next-iteration&gt;</span>
+026: <span class="ignored">      </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+027: <span class="ignored">      </span><span class="ignored">&lt;!-- Call Template with-param (500) --&gt;</span>
+028: <span class="ignored">      </span><span class="hit">&lt;xsl:call-template name="withParamTemplate01"&gt;</span>
+029: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-CT-Param01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+030: <span class="ignored">      </span><span class="hit">&lt;/xsl:call-template&gt;</span>
+031: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Templates with-param (600, 700, 800, 900) --&gt;</span>
+032: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates mode="withParamMode"&gt;</span>
+033: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-AT-Param01"&gt;</span><span class="missed">500</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+034: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+035: <span class="ignored">      </span><span class="ignored">&lt;!-- Apply Imports with-param (1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350) --&gt;</span>
+036: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeAI"&gt;</span>
+037: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-AI-Param01"&gt;</span><span class="missed">900</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+038: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+039: <span class="ignored">      </span><span class="ignored">&lt;!-- Next Match with-param (1400, 1450, 1500, 1550, 1600, 1650, 1700, 1750) --&gt;</span>
+040: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="withParamModeNM"&gt;</span>
+041: <span class="ignored">        </span><span class="hit">&lt;xsl:with-param name="withParam-NM-Param01"&gt;</span><span class="missed">1300</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+042: <span class="ignored">      </span><span class="hit">&lt;/xsl:apply-templates&gt;</span>
+043: <span class="ignored">      </span><span class="ignored">&lt;!-- Evaluate with-param (200) --&gt;</span>
+044: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
+045: <span class="ignored">      </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
+046: <span class="ignored">        </span><span class="hit">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span>
+047: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="index" select="$index" /&gt;</span>
+048: <span class="ignored">          </span><span class="hit">&lt;xsl:with-param name="nonexistent"&gt;</span><span class="hit">parameter not used in evaluation</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+049: <span class="ignored">        </span><span class="hit">&lt;/xsl:evaluate&gt;</span>
+050: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
+051: <span class="ignored">      </span><span class="hit">&lt;node type="with-param - evaluate"&gt;</span>
+052: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span>
+053: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+054: <span class="ignored">      </span><span class="ignored">&lt;!-- Constructs in which parent of xsl:with-param is not hit --&gt;</span>
+055: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="exists(parent-of-with-param-not-hit)"&gt;</span>
+056: <span class="ignored">        </span><span class="missed">&lt;xsl:call-template name="withParamTemplate01"&gt;</span><span class="ignored">                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+057: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="withParam-CT-Param01"&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:with-param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+058: <span class="ignored">        </span><span class="missed">&lt;/xsl:call-template&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+059: <span class="ignored">        </span><span class="missed">&lt;xsl:apply-templates mode="withParamMode"&gt;</span><span class="ignored">                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+060: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="withParam-AT-Param01"&gt;</span><span class="missed">500</span><span class="missed">&lt;/xsl:with-param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+061: <span class="ignored">        </span><span class="missed">&lt;/xsl:apply-templates&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+062: <span class="ignored">        </span><span class="missed">&lt;xsl:apply-templates select="*" mode="withParamModeAI"&gt;</span><span class="ignored">                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+063: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01"&gt;</span><span class="missed">900</span><span class="missed">&lt;/xsl:with-param&gt;</span><span class="ignored">     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+064: <span class="ignored">        </span><span class="missed">&lt;/xsl:apply-templates&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+065: <span class="ignored">        </span><span class="missed">&lt;xsl:next-match&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+066: <span class="ignored">          </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="0" /&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+067: <span class="ignored">        </span><span class="missed">&lt;/xsl:next-match&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+068: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+069: <span class="ignored">          </span><span class="missed">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span><span class="ignored">       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+070: <span class="ignored">            </span><span class="missed">&lt;xsl:with-param name="index" select="$index" /&gt;</span><span class="ignored">                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+071: <span class="ignored">          </span><span class="missed">&lt;/xsl:evaluate&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+072: <span class="ignored">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+073: <span class="ignored">        </span><span class="missed">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span><span class="ignored">               </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+074: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+075: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+076: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+077: <span class="ignored">  </span><span class="ignored">&lt;!-- Call Template --&gt;</span>
+078: <span class="ignored">  </span><span class="hit">&lt;xsl:template name="withParamTemplate01"&gt;</span>
+079: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-CT-Param01" /&gt;</span>
+080: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - call-template"&gt;</span>
+081: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-CT-Param01" /&gt;</span>
+082: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+083: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+084: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Templates Template --&gt;</span>
+085: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamMode"&gt;</span>
+086: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AT-Param01" /&gt;</span>
+087: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-templates"&gt;</span>
+088: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AT-Param01 + ." /&gt;</span>
+089: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+090: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+091: <span class="ignored">  </span><span class="ignored">&lt;!-- Apply Imports Template --&gt;</span>
+092: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeAI"&gt;</span>
+093: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-AI-Param01" /&gt;</span>
+094: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - apply-imports part 1"&gt;</span>
+095: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-AI-Param01 + ." /&gt;</span>
+096: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+097: <span class="ignored">    </span><span class="hit">&lt;xsl:apply-imports&gt;</span>
+098: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-AI-Param01" select="$withParam-AI-Param01" /&gt;</span>
+099: <span class="ignored">    </span><span class="hit">&lt;/xsl:apply-imports&gt;</span>
+100: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+101: <span class="ignored">  </span><span class="ignored">&lt;!-- Next Match Template --&gt;</span>
+102: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="withParamModeNM" priority="1"&gt;</span>
+103: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="withParam-NM-Param01" /&gt;</span>
+104: <span class="ignored">    </span><span class="hit">&lt;node type="with-param - next-match part 1"&gt;</span>
+105: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="$withParam-NM-Param01 + ." /&gt;</span>
+106: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+107: <span class="ignored">    </span><span class="hit">&lt;xsl:next-match&gt;</span>
+108: <span class="ignored">      </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" /&gt;</span>
+109: <span class="ignored">    </span><span class="hit">&lt;/xsl:next-match&gt;</span>
+110: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+111: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       <h2>module: xsl-with-param-01A.xsl; 19 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.xml
@@ -44,14 +44,14 @@
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.NamedTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="57" columnNumber="44" moduleId="0" traceableId="7"/>
+   <hit lineNumber="78" columnNumber="44" moduleId="0" traceableId="7"/>
    <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.LocalParam"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
-   <hit lineNumber="58" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="59" columnNumber="45" moduleId="0" traceableId="1"/>
-   <hit lineNumber="59" columnNumber="45" moduleId="0" traceableId="3"/>
-   <hit lineNumber="60" columnNumber="54" moduleId="0" traceableId="4"/>
+   <hit lineNumber="79" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="80" columnNumber="45" moduleId="0" traceableId="1"/>
+   <hit lineNumber="80" columnNumber="45" moduleId="0" traceableId="3"/>
+   <hit lineNumber="81" columnNumber="54" moduleId="0" traceableId="4"/>
    <traceable traceableId="9"
               class="net.sf.saxon.expr.instruct.TraceExpression"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}document"/>
@@ -60,121 +60,133 @@
               class="net.sf.saxon.expr.instruct.ApplyTemplates"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
    <hit lineNumber="32" columnNumber="49" moduleId="0" traceableId="10"/>
-   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="85" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="86" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="33" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="64" columnNumber="51" moduleId="0" traceableId="0"/>
-   <hit lineNumber="65" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="1"/>
-   <hit lineNumber="66" columnNumber="47" moduleId="0" traceableId="3"/>
-   <hit lineNumber="67" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="85" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="86" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="85" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="86" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="85" columnNumber="51" moduleId="0" traceableId="0"/>
+   <hit lineNumber="86" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="1"/>
+   <hit lineNumber="87" columnNumber="47" moduleId="0" traceableId="3"/>
+   <hit lineNumber="88" columnNumber="58" moduleId="0" traceableId="4"/>
    <hit lineNumber="36" columnNumber="62" moduleId="0" traceableId="10"/>
-   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="92" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="93" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="37" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="95" columnNumber="58" moduleId="0" traceableId="4"/>
    <traceable traceableId="11"
               class="net.sf.saxon.expr.instruct.ApplyImports"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-imports"/>
-   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="97" columnNumber="24" moduleId="0" traceableId="11"/>
    <module moduleId="1" uri="../../xsl-with-param-01A.xsl"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="92" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="93" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="95" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="97" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="92" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="93" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="95" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="97" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="71" columnNumber="53" moduleId="0" traceableId="0"/>
-   <hit lineNumber="72" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="1"/>
-   <hit lineNumber="73" columnNumber="52" moduleId="0" traceableId="3"/>
-   <hit lineNumber="74" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="76" columnNumber="24" moduleId="0" traceableId="11"/>
+   <hit lineNumber="92" columnNumber="53" moduleId="0" traceableId="0"/>
+   <hit lineNumber="93" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="1"/>
+   <hit lineNumber="94" columnNumber="52" moduleId="0" traceableId="3"/>
+   <hit lineNumber="95" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="97" columnNumber="24" moduleId="0" traceableId="11"/>
    <hit lineNumber="5" columnNumber="54" moduleId="1" traceableId="0"/>
    <hit lineNumber="6" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="1"/>
    <hit lineNumber="7" columnNumber="52" moduleId="1" traceableId="3"/>
    <hit lineNumber="8" columnNumber="63" moduleId="1" traceableId="4"/>
    <hit lineNumber="40" columnNumber="62" moduleId="0" traceableId="10"/>
-   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="102" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="103" columnNumber="46" moduleId="0" traceableId="8"/>
    <hit lineNumber="41" columnNumber="53" moduleId="0" traceableId="9"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="105" columnNumber="58" moduleId="0" traceableId="4"/>
    <traceable traceableId="12"
               class="net.sf.saxon.expr.instruct.NextMatch"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}next-match"/>
-   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="107"
+        columnNumber="21"
+        moduleId="0"
+        traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="102" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="103" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="105" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="107"
+        columnNumber="21"
+        moduleId="0"
+        traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="102" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="103" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="105" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="107"
+        columnNumber="21"
+        moduleId="0"
+        traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="3"/>
    <hit lineNumber="16" columnNumber="63" moduleId="1" traceableId="4"/>
-   <hit lineNumber="81" columnNumber="66" moduleId="0" traceableId="0"/>
-   <hit lineNumber="82" columnNumber="46" moduleId="0" traceableId="8"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="1"/>
-   <hit lineNumber="83" columnNumber="49" moduleId="0" traceableId="3"/>
-   <hit lineNumber="84" columnNumber="58" moduleId="0" traceableId="4"/>
-   <hit lineNumber="86" columnNumber="21" moduleId="0" traceableId="12"/>
+   <hit lineNumber="102" columnNumber="66" moduleId="0" traceableId="0"/>
+   <hit lineNumber="103" columnNumber="46" moduleId="0" traceableId="8"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="1"/>
+   <hit lineNumber="104" columnNumber="49" moduleId="0" traceableId="3"/>
+   <hit lineNumber="105" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="107"
+        columnNumber="21"
+        moduleId="0"
+        traceableId="12"/>
    <hit lineNumber="13" columnNumber="66" moduleId="1" traceableId="0"/>
    <hit lineNumber="14" columnNumber="46" moduleId="1" traceableId="8"/>
    <hit lineNumber="15" columnNumber="49" moduleId="1" traceableId="1"/>
@@ -189,6 +201,10 @@
    <hit lineNumber="51" columnNumber="42" moduleId="0" traceableId="1"/>
    <hit lineNumber="51" columnNumber="42" moduleId="0" traceableId="3"/>
    <hit lineNumber="52" columnNumber="65" moduleId="0" traceableId="4"/>
+   <traceable traceableId="15"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="55" columnNumber="59" moduleId="0" traceableId="15"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      Coverage Test Case for non-XSLT child of xsl:stylesheet
+  -->
+  <xsl:import href="non-xsl-top-level-element-01A.xsl"/>
+  <xsl:template match="non-xsl-top-level-element">
+    <root>
+      <xsl:copy>
+        <xsl:text>Child of xsl:stylesheet</xsl:text>
+      </xsl:copy>
+      <xsl:apply-imports/>
+    </root>
+  </xsl:template>
+
+  <!-- The non-XSLT element in the template should be missed, not ignored. -->
+  <xsl:template name="unhit">                                                  <!-- Expected miss -->
+    <non-xsl-element/>                                                         <!-- Expected miss -->
+  </xsl:template>                                                              <!-- Expected miss -->
+
+  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace">
+    <xsl:text>Ignored</xsl:text>
+    <doc:para>Top-level element is not in <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri> namespace</doc:para>
+  </doc:template>
+
+  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace">
+    <xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>
+    <xsl:para>Top-level element is not in <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri> namespace</xsl:para>
+  </xsl:template>
+
+  <template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace">
+    <xsl:text>Ignored</xsl:text>
+    <para>Top-level element is not in <uri>http://www.w3.org/1999/XSL/Transform</uri> namespace</para>
+  </template>
+
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xspec
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="non-xsl-top-level-element-01.xsl">
+   <x:scenario label="Coverage Test Case for non-XSLT child of xsl:stylesheet">
+      <x:context>
+         <root>
+            <non-xsl-top-level-element/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <non-xsl-top-level-element>Child of xsl:stylesheet</non-xsl-top-level-element>
+            <non-xsl-top-level-element>Child of xsl:transform</non-xsl-top-level-element>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      Coverage Test Case for non-XSLT child of xsl:transform
+  -->
+  <xsl:template match="non-xsl-top-level-element">
+    <xsl:copy>
+      <xsl:text>Child of xsl:transform</xsl:text>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- The non-XSLT element in the template should be missed, not ignored. -->
+  <xsl:template name="unhit">                                                  <!-- Expected miss -->
+    <non-xsl-element/>                                                         <!-- Expected miss -->
+  </xsl:template>                                                              <!-- Expected miss -->
+
+  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace">
+    <xsl:text>Ignored</xsl:text>
+    <doc:para>Top-level element is not in <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri> namespace</doc:para>
+  </doc:template>
+  
+  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace">
+    <xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>
+    <xsl:para>Top-level element is not in <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri> namespace</xsl:para>
+  </xsl:template>
+  
+  <template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace">
+    <xsl:text>Ignored</xsl:text>
+    <para>Top-level element is not in <uri>http://www.w3.org/1999/XSL/Transform</uri> namespace</para>
+  </template>
+
+</xsl:transform>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
@@ -18,12 +18,12 @@
     <xsl:text>Ignored</xsl:text>
     <doc:para>Top-level element is not in <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri> namespace</doc:para>
   </doc:template>
-  
+
   <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace">
     <xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>
     <xsl:para>Top-level element is not in <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri> namespace</xsl:para>
   </xsl:template>
-  
+
   <template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace">
     <xsl:text>Ignored</xsl:text>
     <para>Top-level element is not in <uri>http://www.w3.org/1999/XSL/Transform</uri> namespace</para>

--- a/test/end-to-end/cases-coverage/text-node-01.xsl
+++ b/test/end-to-end/cases-coverage/text-node-01.xsl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  version="3.0">
+  <!--
+      Coverage Test Case for Text Nodes
+  -->
+  <xsl:param name="param-text">100</xsl:param>
+  <xsl:variable name="variable-text">100</xsl:variable>
+  <xsl:template match="text-node">
+    <root>
+      <node type="text">100</node>
+      <node type="text">
+        <xsl:text>100</xsl:text>
+      </node>
+      <node type="text">
+        <xsl:sequence>100</xsl:sequence>        
+      </node>
+      <node type="text">
+        <xsl:value-of>100</xsl:value-of>    
+      </node>
+      <node type="text">
+        <xsl:value-of select="string(100)"/>   
+      </node>
+      <node type="text" xsl:expand-text="yes">{
+        $param-text
+      }</node>
+      <node type="text" xsl:expand-text="yes">{
+        $variable-text
+        }</node>
+      <node type="text" xsl:expand-text="yes">{100}</node>
+      <node type="text">
+        <xsl:text expand-text="yes">{ $variable-text }</xsl:text>        
+      </node>
+      <node type="text">
+        <xsl:sequence expand-text="yes">{ $variable-text }</xsl:sequence>        
+      </node>
+      <node type="text">
+        <xsl:value-of expand-text="yes">{ $variable-text }</xsl:value-of>        
+      </node>
+    </root>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/text-node-01.xsl
+++ b/test/end-to-end/cases-coverage/text-node-01.xsl
@@ -15,13 +15,13 @@
         <xsl:text>100</xsl:text>
       </node>
       <node type="text">
-        <xsl:sequence>100</xsl:sequence>        
+        <xsl:sequence>100</xsl:sequence>
       </node>
       <node type="text">
-        <xsl:value-of>100</xsl:value-of>    
+        <xsl:value-of>100</xsl:value-of>
       </node>
       <node type="text">
-        <xsl:value-of select="string(100)"/>   
+        <xsl:value-of select="string(100)"/>
       </node>
       <node type="text" xsl:expand-text="yes">{
         $param-text
@@ -31,13 +31,13 @@
         }</node>
       <node type="text" xsl:expand-text="yes">{100}</node>
       <node type="text">
-        <xsl:text expand-text="yes">{ $variable-text }</xsl:text>        
+        <xsl:text expand-text="yes">{ $variable-text }</xsl:text>
       </node>
       <node type="text">
-        <xsl:sequence expand-text="yes">{ $variable-text }</xsl:sequence>        
+        <xsl:sequence expand-text="yes">{ $variable-text }</xsl:sequence>
       </node>
       <node type="text">
-        <xsl:value-of expand-text="yes">{ $variable-text }</xsl:value-of>        
+        <xsl:value-of expand-text="yes">{ $variable-text }</xsl:value-of>
       </node>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/text-node-01.xspec
+++ b/test/end-to-end/cases-coverage/text-node-01.xspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="text-node-01.xsl">
+   <x:scenario label="Text Node Coverage Test Case">
+      <x:context>
+         <root>
+            <text-node/>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+            <node type="text">100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-context-item-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-context-item-01.xsl
@@ -11,4 +11,12 @@
         </node>
       </root>
   </xsl:template>
+  <xsl:template name="template-not-hit">                                       <!-- Expected miss -->
+    <xsl:context-item use="required" as="item()" />                            <!-- Expected miss -->
+    <root>                                                                     <!-- Expected miss -->
+      <node>                                                                   <!-- Expected miss -->
+        <xsl:text>not hit</xsl:text>                                           <!-- Expected miss -->
+      </node>                                                                  <!-- Expected miss -->
+    </root>                                                                    <!-- Expected miss -->
+  </xsl:template>                                                              <!-- Expected miss -->
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-merge-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-merge-01.xsl
@@ -5,33 +5,50 @@
   -->
   <xsl:template match="xsl-merge">
     <root>
-        <!-- 2 data sets to be merged -->
-        <xsl:variable name="mergeSourceA">
-          <node>100</node>
-          <node>300</node>
-          <node>500</node>
-        </xsl:variable>
-        <xsl:variable name="mergeSourceB">
-          <node>200</node>
-          <node>400</node>
-          <node>600</node>
-        </xsl:variable>
-        <!-- 1st merge-key uses select attribute, 2nd uses sequence constructor -->
-        <xsl:merge>
-          <xsl:merge-source select="$mergeSourceA/*">
-            <xsl:merge-key select="." />
-          </xsl:merge-source>
-          <xsl:merge-source select="$mergeSourceB/*">
-            <xsl:merge-key>
-              <xsl:value-of select="." />
-            </xsl:merge-key>
-          </xsl:merge-source>
-          <xsl:merge-action>
-            <node type="merge">
-              <xsl:value-of select="current-merge-group()" />
-            </node>
-          </xsl:merge-action>
-        </xsl:merge>
+      <!-- 2 data sets to be merged -->
+      <xsl:variable name="mergeSourceA">
+        <node>100</node>
+        <node>300</node>
+        <node>500</node>
+      </xsl:variable>
+      <xsl:variable name="mergeSourceB">
+        <node>200</node>
+        <node>400</node>
+        <node>600</node>
+      </xsl:variable>
+      <!-- 1st merge-key uses select attribute, 2nd uses sequence constructor -->
+      <xsl:merge>
+        <xsl:merge-source select="$mergeSourceA/*">
+          <xsl:merge-key select="." />
+        </xsl:merge-source>
+        <xsl:merge-source select="$mergeSourceB/*">
+          <xsl:merge-key>
+            <xsl:value-of select="." />
+          </xsl:merge-key>
+        </xsl:merge-source>
+        <xsl:merge-action>
+          <node type="merge">
+            <xsl:value-of select="current-merge-group()" />
+          </node>
+        </xsl:merge-action>
+      </xsl:merge>
+      <xsl:if test="exists(merge-not-hit)">
+        <xsl:merge>                                                            <!-- Expected miss -->
+          <xsl:merge-source select="$mergeSourceA/*">                          <!-- Expected miss -->
+            <xsl:merge-key select="." />                                       <!-- Expected miss -->
+          </xsl:merge-source>                                                  <!-- Expected miss -->
+          <xsl:merge-source select="$mergeSourceB/*">                          <!-- Expected miss -->
+            <xsl:merge-key>                                                    <!-- Expected miss -->
+              <xsl:value-of select="." />                                      <!-- Expected miss -->
+            </xsl:merge-key>                                                   <!-- Expected miss -->
+          </xsl:merge-source>                                                  <!-- Expected miss -->
+          <xsl:merge-action>                                                   <!-- Expected miss -->
+            <node type="merge">                                                <!-- Expected miss -->
+              <xsl:value-of select="current-merge-group()" />                  <!-- Expected miss -->
+            </node>                                                            <!-- Expected miss -->
+          </xsl:merge-action>                                                  <!-- Expected miss -->
+        </xsl:merge>                                                           <!-- Expected miss -->
+      </xsl:if>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
-                xmlns:myns="file://myNamespace">
+<xsl:stylesheet xmlns:myns="file://myNamespace"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  version="3.0">
   <!--
       xsl:param Coverage Test Case for child of xsl:stylesheet, xsl:iterate, xsl:function
   -->
   <!-- Global param overridden in XSpec -->
   <xsl:param name="globalParam01">0</xsl:param>                                <!-- Expected miss -->
-  <!-- Global param not overridden in XSpec - no default -->
-  <xsl:param name="globalParam02" />
+  <!-- Global param not overridden in XSpec - no default provided -->
+  <xsl:param name="globalParamEmptyString01" />
+  <!-- Global param not overridden in XSpec - no default provided but @as is present-->
+  <xsl:param name="globalParamEmptySequence01" as="text()?" />
   <!-- Global param not overridden in XSpec - with select attribute -->
-  <xsl:param name="globalParam03" select="200" />
+  <xsl:param name="globalParamSelect01" select="200" />
   <!-- Global param not overridden in XSpec - with inline sequence constructor -->
-  <xsl:param name="globalParam04">300</xsl:param>
+  <xsl:param name="globalParamDocNode01">300</xsl:param>
+  <xsl:param name="globalParamAs01" as="text()">300</xsl:param>
   <!-- Global param not overridden in XSpec - with multiline sequence constructor-->
-  <xsl:param name="globalParam05">
+  <xsl:param name="globalParamDocNode02">
+    <xsl:text>4</xsl:text>
+    <xsl:text>0</xsl:text>
+    <xsl:text>0</xsl:text>
+  </xsl:param>
+  <xsl:param name="globalParamAs02" as="text()+">
     <xsl:text>4</xsl:text>
     <xsl:text>0</xsl:text>
     <xsl:text>0</xsl:text>
@@ -32,16 +42,25 @@
         <xsl:value-of select="$globalParam01" />
       </node>
       <node type="param - global">
-        <xsl:value-of select="$globalParam02" />
+        <xsl:value-of select="count($globalParamEmptyString01)" />
       </node>
       <node type="param - global">
-        <xsl:value-of select="$globalParam03" />
+        <xsl:value-of select="count($globalParamEmptySequence01)" />
       </node>
       <node type="param - global">
-        <xsl:value-of select="$globalParam04" />
+        <xsl:value-of select="$globalParamSelect01" />
       </node>
       <node type="param - global">
-        <xsl:value-of select="$globalParam05" />
+        <xsl:value-of select="$globalParamDocNode01" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParamAs01" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParamDocNode02" />
+      </node>
+      <node type="param - global">
+        <xsl:value-of select="$globalParamAs02" />
       </node>
       <!-- Function param -->
       <node type="param - function">
@@ -56,14 +75,15 @@
       </xsl:iterate>
       <!--Iterate param with inline sequence constructor -->
       <xsl:iterate select="node">
-        <xsl:param name="iterateParam01">14</xsl:param>
+        <xsl:param name="iterateParamDocNode01">14</xsl:param>
+        <xsl:param name="iterateParamAs01" as="xs:integer" select="14" />
         <node type="param - iterate">
-          <xsl:value-of select="$iterateParam01 * 100" />
+          <xsl:value-of select="$iterateParamDocNode01 * 100 + $iterateParamAs01" />
         </node>
       </xsl:iterate>
       <!--Iterate param with multiline sequence constructor -->
       <xsl:iterate select="node">
-        <xsl:param name="iterateParam01">
+        <xsl:param name="iterateParamDocNode01">
           <xsl:text>1</xsl:text>
           <xsl:choose>
             <xsl:when test="1 eq 1">
@@ -74,8 +94,18 @@
             </xsl:otherwise>
           </xsl:choose>
         </xsl:param>
+        <xsl:param name="iterateParamAs01" as="xs:integer" select="15" />
         <node type="param - iterate">
-          <xsl:value-of select="$iterateParam01 * 100" />
+          <xsl:value-of select="$iterateParamDocNode01 * 100 + $iterateParamAs01" />
+        </node>
+      </xsl:iterate>
+      <!--Iterate param with empty string and empty sequence -->
+      <xsl:iterate select="node">
+        <xsl:param name="iterateParamEmptySequence01" as="xs:string?" />
+        <xsl:param name="iterateParamEmptyString01" />
+        <node type="param - iterate">
+          <xsl:value-of select="count($iterateParamEmptySequence01)" />
+          <xsl:value-of select="count($iterateParamEmptyString01)" />
         </node>
       </xsl:iterate>
     </root>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
                 xmlns:myns="file://myNamespace">
   <!--
-      xsl:param Coverage Test Case
+      xsl:param Coverage Test Case for child of xsl:stylesheet, xsl:iterate, xsl:function
   -->
   <!-- Global param overridden in XSpec -->
   <xsl:param name="globalParam01">0</xsl:param>                                <!-- Expected miss -->
@@ -43,27 +43,6 @@
       <node type="param - global">
         <xsl:value-of select="$globalParam05" />
       </node>
-      <!-- Template param -->
-      <xsl:call-template name="paramTemplate01">
-        <xsl:with-param name="templateParam01">500</xsl:with-param>
-      </xsl:call-template>
-      <!-- Template param -->
-      <xsl:call-template name="paramTemplate02">
-        <xsl:with-param name="templateParam02">600</xsl:with-param>
-      </xsl:call-template>
-      <!-- Template param -->
-      <xsl:call-template name="paramTemplate03">
-        <xsl:with-param name="templateParam03">700</xsl:with-param>
-      </xsl:call-template>
-      <!-- Template param -->
-      <xsl:call-template name="paramTemplate04">
-        <xsl:with-param name="templateParam04">800</xsl:with-param>
-      </xsl:call-template>
-      <!-- Call Template using default xsl:param values -->
-      <xsl:call-template name="paramTemplate05" />
-      <xsl:call-template name="paramTemplate06" />
-      <xsl:call-template name="paramTemplate07" />
-      <xsl:call-template name="paramTemplate08" />
       <!-- Function param -->
       <node type="param - function">
         <xsl:value-of select="myns:paramFunction01('1200')" />
@@ -100,73 +79,6 @@
         </node>
       </xsl:iterate>
     </root>
-  </xsl:template>
-  <!-- Templates where xsl:param value is provided by caller -->
-  <!-- Template param with no default - value provided by caller -->
-  <xsl:template name="paramTemplate01">
-    <xsl:param name="templateParam01" />
-    <node type="param - template">
-      <xsl:value-of select="$templateParam01" />
-    </node>
-  </xsl:template>
-  <!-- Template param with select attribute - value provided by caller -->
-  <xsl:template name="paramTemplate02">
-    <xsl:param name="templateParam02" select="999" />
-    <node type="param - template">
-      <xsl:value-of select="$templateParam02" />
-    </node>
-  </xsl:template>
-  <!-- Template param with inline sequence constructor - value provided by caller -->
-  <xsl:template name="paramTemplate03">
-    <xsl:param name="templateParam03">999</xsl:param>                          <!-- Expected miss for 999 -->
-    <node type="param - template">
-      <xsl:value-of select="$templateParam03" />
-    </node>
-  </xsl:template>
-  <!-- Template param with multi-line sequence constructor - value provided by caller -->
-  <xsl:template name="paramTemplate04">
-    <xsl:param name="templateParam04">
-      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
-      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
-      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
-    </xsl:param>
-    <node type="param - template">
-      <xsl:value-of select="$templateParam04" />
-    </node>
-  </xsl:template>
-  <!-- Templates where xsl:param default value is used -->
-  <!-- Template param with no default - no value provided by caller, relying on default value -->
-  <xsl:template name="paramTemplate05">
-    <xsl:param name="templateParam05" />
-    <node type="param - template">
-      <xsl:value-of select="$templateParam05" />
-    </node>
-  </xsl:template>
-  <!-- Template param with select attribute - no value provided by caller, relying on default value -->
-  <xsl:template name="paramTemplate06">
-    <xsl:param name="templateParam06" select="900" />
-    <node type="param - template">
-      <xsl:value-of select="$templateParam06" />
-    </node>
-  </xsl:template>
-  <!-- Template param with inline sequence constructor - no value provided by caller, relying on default value -->
-  <xsl:template name="paramTemplate07">
-    <xsl:param name="templateParam07">1000</xsl:param>
-    <node type="param - template">
-      <xsl:value-of select="$templateParam07" />
-    </node>
-  </xsl:template>
-  <!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value -->
-  <xsl:template name="paramTemplate08">
-    <xsl:param name="templateParam08">
-      <xsl:text>1</xsl:text>
-      <xsl:text>1</xsl:text>
-      <xsl:text>0</xsl:text>
-      <xsl:text>0</xsl:text>
-    </xsl:param>
-    <node type="param - template">
-      <xsl:value-of select="$templateParam08" />
-    </node>
   </xsl:template>
   <!-- Function param - not allowed a default value so no select attribute or sequence constructor tests -->
   <xsl:function name="myns:paramFunction01">

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -17,17 +17,22 @@
       <x:expect label="Success">
          <root>
             <node type="param - global">100</node>
-            <node type="param - global" />
+            <node type="param - global">1</node>
+            <node type="param - global">0</node>
             <node type="param - global">200</node>
             <node type="param - global">300</node>
+            <node type="param - global">300</node>
+            <node type="param - global">400</node>
             <node type="param - global">400</node>
             <node type="param - function">1200</node>
             <node type="param - iterate">1300</node>
             <node type="param - iterate">1300</node>
-            <node type="param - iterate">1400</node>
-            <node type="param - iterate">1400</node>
-            <node type="param - iterate">1500</node>
-            <node type="param - iterate">1500</node>
+            <node type="param - iterate">1414</node>
+            <node type="param - iterate">1414</node>
+            <node type="param - iterate">1515</node>
+            <node type="param - iterate">1515</node>
+            <node type="param - iterate">01</node>
+            <node type="param - iterate">01</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -5,7 +5,7 @@
 
    <x:param name="globalParam01">100</x:param>
 
-   <x:scenario label="xsl:param Coverage Test Case">
+   <x:scenario label="xsl:param Coverage Test Case (01, excluding template parameters)">
       <x:context>
          <root>
             <xsl-param>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xspec
@@ -21,14 +21,6 @@
             <node type="param - global">200</node>
             <node type="param - global">300</node>
             <node type="param - global">400</node>
-            <node type="param - template">500</node>
-            <node type="param - template">600</node>
-            <node type="param - template">700</node>
-            <node type="param - template">800</node>
-            <node type="param - template" />
-            <node type="param - template">900</node>
-            <node type="param - template">1000</node>
-            <node type="param - template">1100</node>
             <node type="param - function">1200</node>
             <node type="param - iterate">1300</node>
             <node type="param - iterate">1300</node>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xsl
@@ -146,7 +146,7 @@
     <xsl:param name="templateParam07-elems3"><a>a</a></xsl:param>
     <xsl:param name="templateParam07-cond1">1000<xsl:if test="1">1000</xsl:if></xsl:param>
     <xsl:param name="templateParam07-cond2">1000<xsl:if test="0">1000</xsl:if></xsl:param> <!-- Expected miss for xsl:if and child -->
-    
+
     <node type="param - template">
       <xsl:value-of select="$templateParam07-no-el1" />
     </node>
@@ -186,7 +186,7 @@
       as="node()+">1100<xsl:if test="1">1100</xsl:if></xsl:param>
     <xsl:param name="templateParam08-cond2"
       as="node()+">1100<xsl:if test="0">1100</xsl:if></xsl:param> <!-- Expected miss for xsl:if and child -->
-    
+
     <node type="param - template">
       <xsl:value-of select="$templateParam08-no-el1" />
     </node>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xsl
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:myns="file://myNamespace">
+  <!--
+      xsl:param Coverage Test Case for child of xsl:template
+  -->
+  <xsl:template match="xsl-param">
+    <root>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate01">
+        <xsl:with-param name="templateParam01">500</xsl:with-param>
+      </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate02">
+        <xsl:with-param name="templateParam02">600</xsl:with-param>
+      </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate03">
+        <xsl:with-param name="templateParam03">700</xsl:with-param>
+      </xsl:call-template>
+      <!-- Template param -->
+      <xsl:call-template name="paramTemplate04">
+        <xsl:with-param name="templateParam04">800</xsl:with-param>
+      </xsl:call-template>
+      <!-- Call Template using default xsl:param values -->
+      <xsl:call-template name="paramTemplate05" />
+      <xsl:call-template name="paramTemplate06" />
+      <xsl:call-template name="paramTemplate07" />
+      <xsl:call-template name="paramTemplate08" />
+    </root>
+  </xsl:template>
+  <!-- Templates where xsl:param value is provided by caller -->
+  <!-- Template param with no default - value provided by caller -->
+  <xsl:template name="paramTemplate01">
+    <xsl:param name="templateParam01" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam01" />
+    </node>
+  </xsl:template>
+  <!-- Template param with select attribute - value provided by caller -->
+  <xsl:template name="paramTemplate02">
+    <xsl:param name="templateParam02" select="999" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam02" />
+    </node>
+  </xsl:template>
+  <!-- Template param with inline sequence constructor - value provided by caller -->
+  <xsl:template name="paramTemplate03">
+    <xsl:param name="templateParam03">999</xsl:param>                          <!-- Expected miss for 999 -->
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - value provided by caller -->
+  <xsl:template name="paramTemplate04">
+    <xsl:param name="templateParam04">
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+      <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
+    </xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam04" />
+    </node>
+  </xsl:template>
+  <!-- Templates where xsl:param default value is used -->
+  <!-- Template param with no default - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate05">
+    <xsl:param name="templateParam05" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam05" />
+    </node>
+  </xsl:template>
+  <!-- Template param with select attribute - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate06">
+    <xsl:param name="templateParam06" select="900" />
+    <node type="param - template">
+      <xsl:value-of select="$templateParam06" />
+    </node>
+  </xsl:template>
+  <!-- Template param with inline sequence constructor - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate07">
+    <xsl:param name="templateParam07">1000</xsl:param>
+    
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value -->
+  <xsl:template name="paramTemplate08">
+    <xsl:param name="templateParam08">
+      <xsl:text>1</xsl:text>
+      <xsl:text>1</xsl:text>
+      <xsl:text>0</xsl:text>
+      <xsl:text>0</xsl:text>
+    </xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08" />
+    </node>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xsl
@@ -34,6 +34,8 @@
       <xsl:call-template name="paramTemplate06" />
       <xsl:call-template name="paramTemplate07" />
       <xsl:call-template name="paramTemplate08" />
+      <xsl:call-template name="paramTemplate09" />
+      <xsl:call-template name="paramTemplate10" />
     </root>
   </xsl:template>
   <!-- Templates where xsl:param value is provided by caller -->
@@ -55,6 +57,8 @@
   <xsl:template name="paramTemplate03">
     <xsl:param name="templateParam03-no-el1">999<!--abc-->999</xsl:param>   <!-- Expected miss for 999 -->
     <xsl:param name="templateParam03-no-el2"><!--abc-->999<!--abc-->999</xsl:param> <!-- Expected miss for 999 -->
+    <xsl:param name="templateParam03-no-el3" as="node()+">999<!--abc-->999</xsl:param>   <!-- Expected miss for 999 -->
+    <xsl:param name="templateParam03-no-el4" as="node()+"><!--abc-->999<!--abc-->999</xsl:param> <!-- Expected miss for 999 -->
     <xsl:param name="templateParam03-elems1"><a/>999<a/>999</xsl:param>     <!-- Expected miss for <a/> and 999 -->
     <xsl:param name="templateParam03-elems2">999<a/>999<a/></xsl:param>     <!-- Expected miss for <a/> and 999 -->
     <xsl:param name="templateParam03-elems3"><a/></xsl:param>               <!-- Expected miss for <a/> -->
@@ -65,6 +69,12 @@
     </node>
     <node type="param - template">
       <xsl:value-of select="$templateParam03-no-el2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-no-el3" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-no-el4" />
     </node>
     <node type="param - template">
       <xsl:value-of select="$templateParam03-elems1" />
@@ -110,25 +120,30 @@
   <!-- Templates where xsl:param default value is used -->
   <!-- Template param with no default - no value provided by caller, relying on default value -->
   <xsl:template name="paramTemplate05">
-    <xsl:param name="templateParam05" />
+    <xsl:param name="templateParamEmptyString01" />
+    <xsl:param name="templateParamEmptySequence01" as="text()?" />
     <node type="param - template">
-      <xsl:value-of select="$templateParam05" />
+      <xsl:value-of select="count($templateParamEmptyString01)" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="count($templateParamEmptySequence01)" />
     </node>
   </xsl:template>
   <!-- Template param with select attribute - no value provided by caller, relying on default value -->
   <xsl:template name="paramTemplate06">
-    <xsl:param name="templateParam06" select="900" />
+    <xsl:param name="templateParamSelect01" select="900" />
     <node type="param - template">
-      <xsl:value-of select="$templateParam06" />
+      <xsl:value-of select="$templateParamSelect01" />
     </node>
   </xsl:template>
-  <!-- Template param with inline sequence constructor - no value provided by caller, relying on default value -->
+  <!-- Template param with inline sequence constructor - no value provided by caller,
+    relying on default value -->
   <xsl:template name="paramTemplate07">
     <xsl:param name="templateParam07-no-el1">1000<!--abc-->1000<!--abc--></xsl:param>
     <xsl:param name="templateParam07-no-el2"><!--abc-->1000<!--abc-->1000</xsl:param>
-    <xsl:param name="templateParam07-elems1"><a/>1000<a/>1000</xsl:param>
-    <xsl:param name="templateParam07-elems2">1000<a/>1000<a/></xsl:param>
-    <xsl:param name="templateParam07-elems3"><a/></xsl:param>
+    <xsl:param name="templateParam07-elems1"><a>a</a>1000<a>a</a>1000</xsl:param>
+    <xsl:param name="templateParam07-elems2">1000<a>a</a>1000<a>a</a></xsl:param>
+    <xsl:param name="templateParam07-elems3"><a>a</a></xsl:param>
     <xsl:param name="templateParam07-cond1">1000<xsl:if test="1">1000</xsl:if></xsl:param>
     <xsl:param name="templateParam07-cond2">1000<xsl:if test="0">1000</xsl:if></xsl:param> <!-- Expected miss for xsl:if and child -->
     
@@ -154,19 +169,60 @@
       <xsl:value-of select="$templateParam07-cond2" />
     </node>
   </xsl:template>
-  <!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value -->
+  <!-- Template param with inline sequence constructor - no value provided by caller,
+    relying on default value, and xsl:param uses @as -->
   <xsl:template name="paramTemplate08">
-    <xsl:param name="templateParam08">
+    <xsl:param name="templateParam08-no-el1"
+      as="node()+">1100<!--abc-->1100<!--abc--></xsl:param>
+    <xsl:param name="templateParam08-no-el2"
+      as="node()+"><!--abc-->1100<!--abc-->1100</xsl:param>
+    <xsl:param name="templateParam08-elems1"
+      as="node()+"><a>a</a>1100<a>a</a>1100</xsl:param>
+    <xsl:param name="templateParam08-elems2"
+      as="node()+">1100<a>a</a>1100<a>a</a></xsl:param>
+    <xsl:param name="templateParam08-elems3"
+      as="node()+"><a>a</a></xsl:param>
+    <xsl:param name="templateParam08-cond1"
+      as="node()+">1100<xsl:if test="1">1100</xsl:if></xsl:param>
+    <xsl:param name="templateParam08-cond2"
+      as="node()+">1100<xsl:if test="0">1100</xsl:if></xsl:param> <!-- Expected miss for xsl:if and child -->
+    
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-no-el1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-no-el2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-elems1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-elems2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-elems3" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-cond1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-cond2" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - no value provided by caller,
+    relying on default value. Absence of @as in xsl:param leads to document node. -->
+  <xsl:template name="paramTemplate09">
+    <xsl:param name="templateParam09">
       <xsl:text>1</xsl:text>
-      <xsl:text>1</xsl:text>
+      <xsl:text>2</xsl:text>
       <xsl:text>0</xsl:text>
       <xsl:text>0</xsl:text>
     </xsl:param>
-    <xsl:param name="templateParam08-cond1">
-      <a/>
+    <xsl:param name="templateParam09-cond1">
+      <a>a</a>
       <xsl:choose>
         <xsl:when test="empty(irrelevant)">
-          <xsl:text>1100</xsl:text>
+          <xsl:text>1200</xsl:text>
         </xsl:when>
         <xsl:otherwise>                                                        <!-- Expected miss -->
           <xsl:text>missed</xsl:text>                                          <!-- Expected miss -->
@@ -174,10 +230,37 @@
       </xsl:choose>
     </xsl:param>
     <node type="param - template">
-      <xsl:value-of select="$templateParam08" />
+      <xsl:value-of select="$templateParam09" />
     </node>
     <node type="param - template">
-      <xsl:value-of select="$templateParam08-cond1" />
+      <xsl:value-of select="$templateParam09-cond1" />
+    </node>
+  </xsl:template>
+  <!-- Template param with multi-line sequence constructor - no value provided by caller,
+    relying on default value, and xsl:param uses @as -->
+  <xsl:template name="paramTemplate10">
+    <xsl:param name="templateParam10" as="text()+">
+      <xsl:text>1</xsl:text>
+      <xsl:text>3</xsl:text>
+      <xsl:text>0</xsl:text>
+      <xsl:text>0</xsl:text>
+    </xsl:param>
+    <xsl:param name="templateParam10-cond1" as="node()+">
+      <a>a</a>
+      <xsl:choose>
+        <xsl:when test="empty(irrelevant)">
+          <xsl:text>1300</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>                                                        <!-- Expected miss -->
+          <xsl:text>missed</xsl:text>                                          <!-- Expected miss -->
+        </xsl:otherwise>                                                       <!-- Expected miss -->
+      </xsl:choose>
+    </xsl:param>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam10" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam10-cond1" />
     </node>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xsl
@@ -4,7 +4,7 @@
   <!--
       xsl:param Coverage Test Case for child of xsl:template
   -->
-  <xsl:template match="xsl-param">
+  <xsl:template match="xsl-param-template">
     <root>
       <!-- Template param -->
       <xsl:call-template name="paramTemplate01">
@@ -18,6 +18,8 @@
       <xsl:call-template name="paramTemplate03">
         <xsl:with-param name="templateParam03-no-el1">700</xsl:with-param>
         <xsl:with-param name="templateParam03-no-el2">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-no-el3">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-no-el4">700</xsl:with-param>
         <xsl:with-param name="templateParam03-elems1">700</xsl:with-param>
         <xsl:with-param name="templateParam03-elems2">700</xsl:with-param>
         <xsl:with-param name="templateParam03-elems3">700</xsl:with-param>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xsl
@@ -16,11 +16,18 @@
       </xsl:call-template>
       <!-- Template param -->
       <xsl:call-template name="paramTemplate03">
-        <xsl:with-param name="templateParam03">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-no-el1">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-no-el2">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-elems1">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-elems2">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-elems3">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-cond1">700</xsl:with-param>
+        <xsl:with-param name="templateParam03-cond2">700</xsl:with-param>
       </xsl:call-template>
       <!-- Template param -->
       <xsl:call-template name="paramTemplate04">
         <xsl:with-param name="templateParam04">800</xsl:with-param>
+        <xsl:with-param name="templateParam04-cond1">800</xsl:with-param>
       </xsl:call-template>
       <!-- Call Template using default xsl:param values -->
       <xsl:call-template name="paramTemplate05" />
@@ -46,9 +53,33 @@
   </xsl:template>
   <!-- Template param with inline sequence constructor - value provided by caller -->
   <xsl:template name="paramTemplate03">
-    <xsl:param name="templateParam03">999</xsl:param>                          <!-- Expected miss for 999 -->
+    <xsl:param name="templateParam03-no-el1">999<!--abc-->999</xsl:param>   <!-- Expected miss for 999 -->
+    <xsl:param name="templateParam03-no-el2"><!--abc-->999<!--abc-->999</xsl:param> <!-- Expected miss for 999 -->
+    <xsl:param name="templateParam03-elems1"><a/>999<a/>999</xsl:param>     <!-- Expected miss for <a/> and 999 -->
+    <xsl:param name="templateParam03-elems2">999<a/>999<a/></xsl:param>     <!-- Expected miss for <a/> and 999 -->
+    <xsl:param name="templateParam03-elems3"><a/></xsl:param>               <!-- Expected miss for <a/> -->
+    <xsl:param name="templateParam03-cond1">999<xsl:if test="1">999</xsl:if></xsl:param> <!-- Expected miss for 999 and xsl:if -->
+    <xsl:param name="templateParam03-cond2">999<xsl:if test="0">999</xsl:if></xsl:param> <!-- Expected miss for 999 and xsl:if -->
     <node type="param - template">
-      <xsl:value-of select="$templateParam03" />
+      <xsl:value-of select="$templateParam03-no-el1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-no-el2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-elems1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-elems2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-elems3" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-cond1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam03-cond2" />
     </node>
   </xsl:template>
   <!-- Template param with multi-line sequence constructor - value provided by caller -->
@@ -58,8 +89,22 @@
       <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
       <xsl:text>9</xsl:text>                                                   <!-- Expected miss -->
     </xsl:param>
+    <xsl:param name="templateParam04-cond1">
+      <a/>                                                                     <!-- Expected miss -->
+      <xsl:choose>                                                             <!-- Expected miss -->
+        <xsl:when test="exists(irrelevant)">                                   <!-- Expected miss -->
+          <xsl:value-of>999</xsl:value-of>                                     <!-- Expected miss -->
+        </xsl:when>                                                            <!-- Expected miss -->
+        <xsl:otherwise>                                                        <!-- Expected miss -->
+          <xsl:text>998</xsl:text>                                             <!-- Expected miss -->
+        </xsl:otherwise>                                                       <!-- Expected miss -->
+      </xsl:choose>                                                            <!-- Expected miss -->
+    </xsl:param>
     <node type="param - template">
       <xsl:value-of select="$templateParam04" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam04-cond1" />
     </node>
   </xsl:template>
   <!-- Templates where xsl:param default value is used -->
@@ -79,10 +124,34 @@
   </xsl:template>
   <!-- Template param with inline sequence constructor - no value provided by caller, relying on default value -->
   <xsl:template name="paramTemplate07">
-    <xsl:param name="templateParam07">1000</xsl:param>
+    <xsl:param name="templateParam07-no-el1">1000<!--abc-->1000<!--abc--></xsl:param>
+    <xsl:param name="templateParam07-no-el2"><!--abc-->1000<!--abc-->1000</xsl:param>
+    <xsl:param name="templateParam07-elems1"><a/>1000<a/>1000</xsl:param>
+    <xsl:param name="templateParam07-elems2">1000<a/>1000<a/></xsl:param>
+    <xsl:param name="templateParam07-elems3"><a/></xsl:param>
+    <xsl:param name="templateParam07-cond1">1000<xsl:if test="1">1000</xsl:if></xsl:param>
+    <xsl:param name="templateParam07-cond2">1000<xsl:if test="0">1000</xsl:if></xsl:param> <!-- Expected miss for xsl:if and child -->
     
     <node type="param - template">
-      <xsl:value-of select="$templateParam07" />
+      <xsl:value-of select="$templateParam07-no-el1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-no-el2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-elems1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-elems2" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-elems3" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-cond1" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam07-cond2" />
     </node>
   </xsl:template>
   <!-- Template param with multi-line sequence constructor - no value provided by caller, relying on default value -->
@@ -93,8 +162,22 @@
       <xsl:text>0</xsl:text>
       <xsl:text>0</xsl:text>
     </xsl:param>
+    <xsl:param name="templateParam08-cond1">
+      <a/>
+      <xsl:choose>
+        <xsl:when test="empty(irrelevant)">
+          <xsl:text>1100</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>                                                        <!-- Expected miss -->
+          <xsl:text>missed</xsl:text>                                          <!-- Expected miss -->
+        </xsl:otherwise>                                                       <!-- Expected miss -->
+      </xsl:choose>
+    </xsl:param>
     <node type="param - template">
       <xsl:value-of select="$templateParam08" />
+    </node>
+    <node type="param - template">
+      <xsl:value-of select="$templateParam08-cond1" />
     </node>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xspec
@@ -3,19 +3,21 @@
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
                stylesheet="xsl-param-02.xsl">
 
-   <x:scenario label="xsl:param Coverage Test Case">
+   <x:scenario label="xsl:param Coverage Test Case (02, for template parameters)">
       <x:context>
          <root>
-            <xsl-param>
+            <xsl-param-template>
               <node />
               <node />
-            </xsl-param>
+            </xsl-param-template>
          </root>
       </x:context>
       <x:expect label="Success">
          <root>
             <node type="param - template">500</node>
             <node type="param - template">600</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
             <node type="param - template">700</node>
             <node type="param - template">700</node>
             <node type="param - template">700</node>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-param-02.xsl">
+
+   <x:scenario label="xsl:param Coverage Test Case">
+      <x:context>
+         <root>
+            <xsl-param>
+              <node />
+              <node />
+            </xsl-param>
+         </root>
+      </x:context>
+      <x:expect label="Success">
+         <root>
+            <node type="param - template">500</node>
+            <node type="param - template">600</node>
+            <node type="param - template">700</node>
+            <node type="param - template">800</node>
+            <node type="param - template" />
+            <node type="param - template">900</node>
+            <node type="param - template">1000</node>
+            <node type="param - template">1100</node>
+         </root>
+      </x:expect>
+   </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xspec
@@ -25,17 +25,27 @@
             <node type="param - template">700</node>
             <node type="param - template">800</node>
             <node type="param - template">800</node>
-            <node type="param - template" />
+            <node type="param - template">1</node>
+            <node type="param - template">0</node>
             <node type="param - template">900</node>
             <node type="param - template">10001000</node>
             <node type="param - template">10001000</node>
-            <node type="param - template">10001000</node>
-            <node type="param - template">10001000</node>
-            <node type="param - template" />
+            <node type="param - template">a1000a1000</node>
+            <node type="param - template">1000a1000a</node>
+            <node type="param - template">a</node>
             <node type="param - template">10001000</node>
             <node type="param - template">1000</node>
+            <node type="param - template">11001100</node>
+            <node type="param - template">11001100</node>
+            <node type="param - template">a 1100 a 1100</node>
+            <node type="param - template">1100 a 1100 a</node>
+            <node type="param - template">a</node>
+            <node type="param - template">11001100</node>
             <node type="param - template">1100</node>
-            <node type="param - template">1100</node>
+            <node type="param - template">1200</node>
+            <node type="param - template">a1200</node>
+            <node type="param - template">1300</node>
+            <node type="param - template">a 1300</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-param-02.xspec
+++ b/test/end-to-end/cases-coverage/xsl-param-02.xspec
@@ -17,10 +17,24 @@
             <node type="param - template">500</node>
             <node type="param - template">600</node>
             <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">700</node>
+            <node type="param - template">800</node>
             <node type="param - template">800</node>
             <node type="param - template" />
             <node type="param - template">900</node>
+            <node type="param - template">10001000</node>
+            <node type="param - template">10001000</node>
+            <node type="param - template">10001000</node>
+            <node type="param - template">10001000</node>
+            <node type="param - template" />
+            <node type="param - template">10001000</node>
             <node type="param - template">1000</node>
+            <node type="param - template">1100</node>
             <node type="param - template">1100</node>
          </root>
       </x:expect>

--- a/test/end-to-end/cases-coverage/xsl-sort-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sort-01.xsl
@@ -59,6 +59,29 @@
           <xsl:value-of select="." />
         </node>
       </xsl:for-each>
+      <!-- Constructs in which parent of xsl:sort is not hit -->
+      <xsl:if test="exists(parent-of-sort-not-hit)">
+        <xsl:for-each select="*">                                              <!-- Expected miss -->
+          <xsl:sort>                                                           <!-- Expected miss -->
+            <xsl:value-of select="." />                                        <!-- Expected miss -->
+          </xsl:sort>                                                          <!-- Expected miss -->
+          <xsl:value-of select="." />                                          <!-- Expected miss -->
+        </xsl:for-each>                                                        <!-- Expected miss -->
+        <xsl:for-each-group select="*" group-by="@type">                       <!-- Expected miss -->
+          <xsl:sort>                                                           <!-- Expected miss -->
+            <xsl:value-of select="." />                                        <!-- Expected miss -->
+          </xsl:sort>                                                          <!-- Expected miss -->
+          <xsl:value-of select="sum(current-group()/.)" />                     <!-- Expected miss -->
+        </xsl:for-each-group>                                                  <!-- Expected miss -->
+        <xsl:apply-templates mode="sortMode">                                  <!-- Expected miss -->
+          <xsl:sort>                                                           <!-- Expected miss -->
+            <xsl:value-of select="." />                                        <!-- Expected miss -->
+          </xsl:sort>                                                          <!-- Expected miss -->
+        </xsl:apply-templates>                                                 <!-- Expected miss -->
+        <xsl:perform-sort select="node">                                       <!-- Expected miss -->
+          <xsl:sort />                                                         <!-- Expected miss -->
+        </xsl:perform-sort>                                                    <!-- Expected miss -->
+      </xsl:if>
     </root>
   </xsl:template>
 

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xsl
@@ -4,40 +4,97 @@
       xsl:variable Coverage Test Case
   -->
   <!-- Global variable -->
-  <xsl:variable name="variableGlobal01" select="string(100)" />
-  <xsl:variable name="variableGlobal02">
+  <xsl:variable name="variableGlobalSelect01" select="string(100)" />
+  <xsl:variable name="variableGlobalDocNode01">
+    <xsl:text>20</xsl:text>
+    <element>0</element>
+  </xsl:variable>
+  <xsl:variable name="variableGlobalAs01" as="text()">
     <xsl:text>200</xsl:text>
   </xsl:variable>
+  <xsl:variable name="variableGlobalEmptySequence01" as="element()?" />
+  <xsl:variable name="variableGlobalEmptyString01" />
   <!-- Not used -->
-  <xsl:variable name="variableGlobal03">300</xsl:variable>                     <!-- Expected miss -->
-
+  <xsl:variable name="variableGlobalSelectUnused01" select="string(300)" />    <!-- Expected miss -->
+  <xsl:variable name="variableGlobalDocNodeUnused01">                          <!-- Expected miss -->
+    <xsl:text>40</xsl:text>                                                    <!-- Expected miss -->
+    <element>0</element>                                                       <!-- Expected miss -->
+  </xsl:variable>                                                              <!-- Expected miss -->
+  <!-- Not used -->
+  <xsl:variable name="variableGlobalAsUnused01" as="text()">                   <!-- Expected miss -->
+    <xsl:text>400</xsl:text>                                                   <!-- Expected miss -->
+  </xsl:variable>                                                              <!-- Expected miss -->
+  <!-- Not used -->
+  <xsl:variable name="variableGlobalEmptySequenceUnused01" as="element()?" />  <!-- Expected miss -->
+  <!-- Not used -->
+  <xsl:variable name="variableGlobalEmptyStringUnused01" />                    <!-- Expected miss -->
+  
   <xsl:template match="xsl-variable">
-    <xsl:variable name="variableLocal01" select="string(400)" />
-    <xsl:variable name="variableLocal02">
+    <xsl:variable name="variableLocalSelect01" select="string(400)" />
+    <xsl:variable name="variableLocalDocNode01">
+      <xsl:text>50</xsl:text>
+      <element>0</element>
+    </xsl:variable>
+    <xsl:variable name="variableLocalAs01" as="text()">
       <xsl:text>500</xsl:text>
     </xsl:variable>
+    <xsl:variable name="variableLocalEmptySequence01" as="element()?" />
+    <xsl:variable name="variableLocalEmptyString01" />
     <!-- Not used -->
-    <xsl:variable name="variableLocal03">600</xsl:variable>                    <!-- Expected miss -->
+    <xsl:variable name="variableLocalSelectUnused01" select="string(600)" />   <!-- Expected miss -->
     <!-- Not used -->
-    <xsl:variable name="variableLocal04">                                      <!-- Expected miss -->
+    <xsl:variable name="variableLocalDocNodeUnused01">                         <!-- Expected miss -->
+      <xsl:text>70</xsl:text>                                                  <!-- Expected miss -->
+      <element>0</element>                                                     <!-- Expected miss -->
+    </xsl:variable>                                                            <!-- Expected miss -->
+    <!-- Not used -->
+    <xsl:variable name="variableLocalasUnused01" as="text()">                  <!-- Expected miss -->
       <xsl:text>700</xsl:text>                                                 <!-- Expected miss -->
     </xsl:variable>                                                            <!-- Expected miss -->
+    <!-- Not used -->
+    <xsl:variable name="variableLocalEmptySequenceUnused01" as="element()?" /> <!-- Expected miss -->
+    <!-- Not used -->
+    <xsl:variable name="variableLocalEmptyStringUnused01" />                   <!-- Expected miss -->
     <root>
       <!-- Global variable used -->
       <node type="variable - global">
-        <xsl:value-of select="$variableGlobal01" />
+        <xsl:value-of select="$variableGlobalSelect01" />
       </node>
       <!-- Global variable used -->
       <node type="variable - global">
-        <xsl:value-of select="$variableGlobal02" />
+        <xsl:value-of select="$variableGlobalDocNode01" />
+      </node>
+      <!-- Global variable used -->
+      <node type="variable - global">
+        <xsl:value-of select="$variableGlobalAs01" />
+      </node>
+      <!-- Global variable used -->
+      <node type="variable - global">
+        <xsl:value-of select="count($variableGlobalEmptySequence01)" />
+      </node>
+      <!-- Global variable used -->
+      <node type="variable - global">
+        <xsl:value-of select="count($variableGlobalEmptyString01)" />
       </node>
       <!-- Local variable used -->
       <node type="variable - local">
-        <xsl:value-of select="$variableLocal01" />
+        <xsl:value-of select="$variableLocalSelect01" />
       </node>
       <!-- Local variable used -->
       <node type="variable - local">
-        <xsl:value-of select="$variableLocal02" />
+        <xsl:value-of select="$variableLocalDocNode01" />
+      </node>
+      <!-- Local variable used -->
+      <node type="variable - local">
+        <xsl:value-of select="$variableLocalAs01" />
+      </node>
+      <!-- Local variable used -->
+      <node type="variable - local">
+        <xsl:value-of select="count($variableLocalEmptySequence01)" />
+      </node>
+      <!-- Local variable used -->
+      <node type="variable - local">
+        <xsl:value-of select="count($variableLocalEmptyString01)" />
       </node>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xsl
@@ -28,7 +28,7 @@
   <xsl:variable name="variableGlobalEmptySequenceUnused01" as="element()?" />  <!-- Expected miss -->
   <!-- Not used -->
   <xsl:variable name="variableGlobalEmptyStringUnused01" />                    <!-- Expected miss -->
-  
+
   <xsl:template match="xsl-variable">
     <xsl:variable name="variableLocalSelect01" select="string(400)" />
     <xsl:variable name="variableLocalDocNode01">

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xspec
@@ -14,8 +14,14 @@
          <root>
             <node type="variable - global">100</node>
             <node type="variable - global">200</node>
+            <node type="variable - global">200</node>
+            <node type="variable - global">0</node>
+            <node type="variable - global">1</node>
             <node type="variable - local">400</node>
             <node type="variable - local">500</node>
+            <node type="variable - local">500</node>
+            <node type="variable - local">0</node>
+            <node type="variable - local">1</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
@@ -51,6 +51,27 @@
       <node type="with-param - evaluate">
         <xsl:value-of select="$evaluatedExpressionParamChild" />
       </node>
+      <!-- Constructs in which parent of xsl:with-param is not hit -->
+      <xsl:if test="exists(parent-of-with-param-not-hit)">
+        <xsl:call-template name="withParamTemplate01">                         <!-- Expected miss -->
+          <xsl:with-param name="withParam-CT-Param01">500</xsl:with-param>     <!-- Expected miss -->
+        </xsl:call-template>                                                   <!-- Expected miss -->
+        <xsl:apply-templates mode="withParamMode">                             <!-- Expected miss -->
+          <xsl:with-param name="withParam-AT-Param01">500</xsl:with-param>     <!-- Expected miss -->
+        </xsl:apply-templates>                                                 <!-- Expected miss -->
+        <xsl:apply-templates select="*" mode="withParamModeAI">                <!-- Expected miss -->
+          <xsl:with-param name="withParam-AI-Param01">900</xsl:with-param>     <!-- Expected miss -->
+        </xsl:apply-templates>                                                 <!-- Expected miss -->
+        <xsl:next-match>                                                       <!-- Expected miss -->
+          <xsl:with-param name="withParam-NM-Param01" select="0" />            <!-- Expected miss -->
+        </xsl:next-match>                                                      <!-- Expected miss -->
+        <xsl:variable name="evaluatedExpressionParamChild">                    <!-- Expected miss -->
+          <xsl:evaluate xpath="'string(node[$index])'" context-item=".">       <!-- Expected miss -->
+            <xsl:with-param name="index" select="$index" />                    <!-- Expected miss -->
+          </xsl:evaluate>                                                      <!-- Expected miss -->
+        </xsl:variable>                                                        <!-- Expected miss -->
+        <xsl:value-of select="$evaluatedExpressionParamChild" />               <!-- Expected miss -->
+      </xsl:if>
     </root>
   </xsl:template>
   <!-- Call Template -->
@@ -86,5 +107,5 @@
     <xsl:next-match>
       <xsl:with-param name="withParam-NM-Param01" select="$withParam-NM-Param01" />
     </xsl:next-match>
-   </xsl:template>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
This pull request adds various test cases to the suite of end-to-end tests for XSLT code coverage:

- Non-XSLT children of `xsl:stylesheet` and `xsl:transform`
- Variations on the child nodes of `xsl:param` for template parameters
- Cases that include `as` attribute in `xsl:param` and `xsl:variable`
- Various ways of creating text nodes
- Parents not hit, for certain elements where we apply or might start to apply the "use parent data" rule (`xsl:context-item`, `xsl:with-param`, `xsl:sort`)

When creating names for new items in existing test files, I sometimes used words instead of numbers because keeping all the numbers in order would make the code and its history churn more than necessary. I'm open to feedback if you think any of the choices here make the tests confusing.

Cc: @birdya22