### PR TITLE
test(report): additional coverage test cases for xsl:element

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-element-01.xsl">xsl-element-01.xsl</a></p>
-      <h2>module: xsl-element-01.xsl; 14 lines</h2>
+      <h2>module: xsl-element-01.xsl; 31 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -15,12 +15,29 @@
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-element"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-08: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="node"&gt;</span>
-09: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">element</span><span class="hit">&lt;/xsl:attribute&gt;</span>
-10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:text&gt;</span>
-11: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
-12: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-13: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+08: <span class="ignored">      </span><span class="ignored">&lt;!-- Element name as string value inline --&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;!-- Compile time expression --&gt;</span>
+10: <span class="ignored">      </span><span class="ignored">&lt;!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.FixedElement --&gt;</span>
+11: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="node"&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">element</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+13: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:text&gt;</span>
+14: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+15: <span class="ignored">      </span><span class="ignored">&lt;!-- Element name as simple AVT (attribute value template) --&gt;</span>
+16: <span class="ignored">      </span><span class="ignored">&lt;!-- Compile time expression --&gt;</span>
+17: <span class="ignored">      </span><span class="ignored">&lt;!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.FixedElement --&gt;</span>
+18: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="{'node'}"&gt;</span>
+19: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">element</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+20: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+22: <span class="ignored">      </span><span class="ignored">&lt;!-- Element name as function in AVT (attribute value template) --&gt;</span>
+23: <span class="ignored">      </span><span class="ignored">&lt;!-- Run-time expression --&gt;</span>
+24: <span class="ignored">      </span><span class="ignored">&lt;!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.ComputedElement --&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;xsl:element name="{string-join(('n','o','d','e'))}"&gt;</span>
+26: <span class="ignored">        </span><span class="hit">&lt;xsl:attribute name="type"&gt;</span><span class="missed">element</span><span class="hit">&lt;/xsl:attribute&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;/xsl:element&gt;</span>
+29: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+30: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+31: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.xml
@@ -8,15 +8,24 @@
    <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="8" columnNumber="32" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="32" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="36" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
-   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="13" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="18" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="20" columnNumber="19" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.ComputedElement"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}element"/>
+   <hit lineNumber="25" columnNumber="60" moduleId="0" traceableId="4"/>
+   <hit lineNumber="26" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="27" columnNumber="19" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-element-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-element-01.xsl
@@ -7,21 +7,21 @@
     <root>
       <!-- Element name as string value inline -->
       <!-- Compile time expression -->
-      <!-- Saxon class is net.sf.saxon.expr.instruct.FixedElement -->
+      <!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.FixedElement -->
       <xsl:element name="node">
         <xsl:attribute name="type">element</xsl:attribute>
         <xsl:text>100</xsl:text>
       </xsl:element>
-      <!-- Element name as simple ATV (attribute value template) -->
+      <!-- Element name as simple AVT (attribute value template) -->
       <!-- Compile time expression -->
-      <!-- Saxon class is net.sf.saxon.expr.instruct.FixedElement -->
+      <!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.FixedElement -->
       <xsl:element name="{'node'}">
         <xsl:attribute name="type">element</xsl:attribute>
         <xsl:text>200</xsl:text>
       </xsl:element>
-      <!-- Element name as function in ATV (attribute value template) -->
+      <!-- Element name as function in AVT (attribute value template) -->
       <!-- Run-time expression -->
-      <!-- Saxon class is net.sf.saxon.expr.instruct.ComputedElement -->
+      <!-- Saxon (v12.4) class is net.sf.saxon.expr.instruct.ComputedElement -->
       <xsl:element name="{string-join(('n','o','d','e'))}">
         <xsl:attribute name="type">element</xsl:attribute>
         <xsl:text>300</xsl:text>

--- a/test/end-to-end/cases-coverage/xsl-element-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-element-01.xsl
@@ -5,9 +5,26 @@
   -->
   <xsl:template match="xsl-element">
     <root>
+      <!-- Element name as string value inline -->
+      <!-- Compile time expression -->
+      <!-- Saxon class is net.sf.saxon.expr.instruct.FixedElement -->
       <xsl:element name="node">
         <xsl:attribute name="type">element</xsl:attribute>
         <xsl:text>100</xsl:text>
+      </xsl:element>
+      <!-- Element name as simple ATV (attribute value template) -->
+      <!-- Compile time expression -->
+      <!-- Saxon class is net.sf.saxon.expr.instruct.FixedElement -->
+      <xsl:element name="{'node'}">
+        <xsl:attribute name="type">element</xsl:attribute>
+        <xsl:text>200</xsl:text>
+      </xsl:element>
+      <!-- Element name as function in ATV (attribute value template) -->
+      <!-- Run-time expression -->
+      <!-- Saxon class is net.sf.saxon.expr.instruct.ComputedElement -->
+      <xsl:element name="{string-join(('n','o','d','e'))}">
+        <xsl:attribute name="type">element</xsl:attribute>
+        <xsl:text>300</xsl:text>
       </xsl:element>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-element-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-element-01.xspec
@@ -11,6 +11,8 @@
       <x:expect label="Success">
          <root>
             <node type="element">100</node>
+            <node type="element">200</node>
+            <node type="element">300</node>
          </root>
       </x:expect>
    </x:scenario>


### PR DESCRIPTION
This pull request is to shepherd some test updates from @birdya22 (attached to #1964 and explained there) through GitHub. Thanks, Adrian!

I reviewed the .xsl and .xspec files, making no changes other than tweaking code comments.

I regenerated expected result files in the usual way: from `test\end-to-end`, I ran `generate-expected.cmd -Dcases.dir=cases-coverage`.

Fixes #1964.