### PR TITLE
refactor(report): simplify XSLT computation of code coverage status

### DIFF
--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -42,22 +42,6 @@
         </xsl:accumulator-rule>
     </xsl:accumulator>
 
-    <xsl:function name="local:coverage" as="xs:string">
-        <xsl:param name="node" as="node()" />
-        <xsl:param name="module-id" as="xs:integer" />
-        
-        <xsl:variable name="coverage" as="xs:string+">
-            <xsl:apply-templates select="$node" mode="coverage"/>
-        </xsl:variable>
-        <xsl:if test="count($coverage) > 1">
-            <xsl:message terminate="yes">
-                <xsl:text>ERROR: more than one coverage identified for:</xsl:text>
-                <xsl:sequence select="$node" />
-            </xsl:message>
-        </xsl:if>
-        <xsl:sequence select="$coverage" />
-    </xsl:function>
-
     <!--
       mode="coverage"
    -->

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -14,7 +14,7 @@
     <xsl:accumulator name="category-based-on-trace-data" as="xs:string*" initial-value="()">
         <xsl:accumulator-rule match="element() | text()">
             <xsl:variable name="hits-on-node"
-                select="local:hits-on-node(., accumulator-before('module-id-for-node'))"/>
+                select="local:hits-on-node(.)"/>
             <xsl:choose>
                 <xsl:when test="exists($hits-on-node)">
                     <xsl:sequence select="'hit'"/>

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0"
+    xmlns:local="urn:x-xspec:reporter:coverage-report:local"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:XSLT="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="#all">
+
+    <!-- This file uses the "XSLT" prefix for names of elements in the stylesheet
+        whose coverage is being reported and the conventional "xsl" prefix for
+        the code in this stylesheet. -->
+
+    <!-- The category-based-on-trace-data accumulator is raw information about whether a node
+        is in the trace. Other logic builds upon this information. -->
+    <xsl:accumulator name="category-based-on-trace-data" as="xs:string*" initial-value="()">
+        <xsl:accumulator-rule match="element() | text()">
+            <xsl:variable name="hits-on-node"
+                select="local:hits-on-node(., accumulator-before('module-id-for-node'))"/>
+            <xsl:choose>
+                <xsl:when test="exists($hits-on-node)">
+                    <xsl:sequence select="'hit'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="'missed'"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:accumulator-rule>
+    </xsl:accumulator>
+
+    <!-- The module-id-for-node accumulator computes the module ID for a stylesheet.
+        The computation occurs only on the outermost element of a stylesheet module.
+        The value can be retrieved for any node of the module because accumulators
+        hold their values until they match a different accumulator rule. -->
+    <xsl:accumulator name="module-id-for-node" as="xs:integer?" initial-value="()">
+        <xsl:accumulator-rule match="XSLT:stylesheet | XSLT:transform">
+            <xsl:variable name="stylesheet-uri" as="xs:anyURI"
+                select="base-uri(.)" />
+            <xsl:variable name="uri" as="xs:string"
+                select="if (starts-with($stylesheet-uri, '/'))
+                then ('file:' || $stylesheet-uri)
+                else $stylesheet-uri" />
+            <xsl:sequence select="key('modules', $uri, $trace)/@moduleId" />            
+        </xsl:accumulator-rule>
+    </xsl:accumulator>
+
+    <xsl:function name="local:coverage" as="xs:string">
+        <xsl:param name="node" as="node()" />
+        <xsl:param name="module-id" as="xs:integer" />
+        
+        <xsl:variable name="coverage" as="xs:string+">
+            <xsl:apply-templates select="$node" mode="coverage"/>
+        </xsl:variable>
+        <xsl:if test="count($coverage) > 1">
+            <xsl:message terminate="yes">
+                <xsl:text>ERROR: more than one coverage identified for:</xsl:text>
+                <xsl:sequence select="$node" />
+            </xsl:message>
+        </xsl:if>
+        <xsl:sequence select="$coverage" />
+    </xsl:function>
+
+    <!--
+      mode="coverage"
+   -->
+    <xsl:mode name="coverage" on-multiple-match="fail" on-no-match="fail" />
+
+    <!-- Always Ignore -->
+    <!-- TODO: Design document suggests maybe switching to Always Hit rule for XSLT:stylesheet and XSLT:transform -->
+    <xsl:template match="
+        XSLT:stylesheet
+        | XSLT:transform
+        | text()[normalize-space() = '' and not(parent::XSLT:text)]
+        | processing-instruction()
+        | comment()
+        | document-node()"
+        mode="coverage"
+        as="xs:string">
+        <xsl:sequence select="'ignored'"/>
+    </xsl:template>
+
+    <!-- Use Child Data -->
+    <xsl:template
+        match="
+        XSLT:for-each
+        | XSLT:for-each-group
+        | XSLT:matching-substring
+        | XSLT:non-matching-substring
+        | XSLT:otherwise
+        | XSLT:when"
+        as="xs:string"
+        mode="coverage">
+        <xsl:choose>
+            <xsl:when test="child::node()/accumulator-before('category-based-on-trace-data') = 'hit'">
+                <xsl:sequence select="'hit'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="'missed'"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Use Parent Data -->
+    <xsl:template match="
+        XSLT:context-item (: xspec/xspec#1410 :)
+        | XSLT:param[not(parent::XSLT:stylesheet or parent::XSLT:transform)]"
+        as="xs:string"
+        mode="coverage">
+        <xsl:sequence select="parent::*/accumulator-before('category-based-on-trace-data')"/>
+    </xsl:template>
+
+    <!-- Use Trace Data -->
+    <xsl:template match="
+        XSLT:function
+        | XSLT:template"
+        as="xs:string"
+        mode="coverage">
+        <xsl:sequence select="accumulator-before('category-based-on-trace-data')"/>
+    </xsl:template>
+
+    <!-- Element-Specific rule for XSLT:variable -->
+    <xsl:template match="XSLT:variable"
+        as="xs:string"
+        mode="coverage">
+        <xsl:choose>
+            <xsl:when test="accumulator-before('category-based-on-trace-data') eq 'hit'">
+                <xsl:sequence select="'hit'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="following-sibling::*[not(self::XSLT:variable)][1]"
+                    mode="#current"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- General case. This template is like the one for the Use Trace Data rule, except
+        that xsl:when blocks after the first one provide the capability of doing
+        special handling. Eventually, maybe we should (a) move all the special handling
+        to other templates, (b) make the Use Trace Data template have match="element | text()",
+        and (c) delete this template. -->
+    <xsl:template match="element() | text()" as="xs:string" mode="coverage">
+        
+        <xsl:choose>
+            <xsl:when test="accumulator-before('category-based-on-trace-data') eq 'hit'">
+                <xsl:sequence select="'hit'"/>
+            </xsl:when>
+
+            <xsl:when test="ancestor::XSLT:variable">
+                <!-- Use status of nearest ancestor XSLT:variable (not always the same
+                    as Use Trace Data for that ancestor) -->
+                <xsl:apply-templates select="ancestor::XSLT:variable[1]" mode="#current"/>
+            </xsl:when>
+
+            <!-- A node within a top-level non-XSLT element -->
+            <!-- TODO: The next xsl:when block needs rework. Its @test also matches
+                top-level XSLT elements, which does more than the comment above indicates. -->
+            <xsl:when test="empty(ancestor::XSLT:*[parent::XSLT:stylesheet or parent::XSLT:transform])">
+                <xsl:sequence select="'ignored'"/>
+            </xsl:when>
+
+            <xsl:otherwise>
+                <xsl:sequence select="'missed'"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -26,6 +26,7 @@
    <xsl:include href="../common/uqname-utils.xsl" />
    <xsl:include href="../common/wrap.xsl" />
    <xsl:include href="format-utils.xsl" />
+   <xsl:include href="coverage-compute-status.xsl" />
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/coverage-report.xsl</pkg:import-uri>
 
@@ -320,70 +321,6 @@
    </xsl:template>
 
    <!--
-      mode="coverage"
-   -->
-   <xsl:mode name="coverage" on-multiple-match="fail" on-no-match="fail" />
-
-   <xsl:template match="text()[normalize-space() = '' and not(parent::xsl:text)]" as="xs:string"
-      mode="coverage">ignored</xsl:template>
-
-   <xsl:template match="processing-instruction() | comment()" as="xs:string"
-      mode="coverage">ignored</xsl:template>
-
-   <!-- A hit on these nodes doesn't really count; you have to hit
-      their contents to hit them -->
-   <xsl:template
-      match="
-         xsl:for-each
-         | xsl:for-each-group
-         | xsl:matching-substring
-         | xsl:non-matching-substring
-         | xsl:otherwise
-         | xsl:when"
-      as="xs:string"
-      mode="coverage">
-      <xsl:param name="module-id" tunnel="yes" as="xs:integer" required="yes" />
-
-      <xsl:variable name="hits-on-child-nodes" as="element(hit)*"
-         select="node() ! local:hits-on-node(., $module-id)" />
-      <xsl:choose>
-         <xsl:when test="exists($hits-on-child-nodes)">hit</xsl:when>
-         <xsl:otherwise>missed</xsl:otherwise>
-      </xsl:choose>
-   </xsl:template>
-
-   <xsl:template match="element() | text()" as="xs:string" mode="coverage">
-      <xsl:param name="module-id" tunnel="yes" as="xs:integer" required="yes" />
-
-      <xsl:variable name="hits" as="element(hit)*"
-         select="local:hits-on-node(., $module-id)" />
-      <xsl:choose>
-         <xsl:when test="exists($hits)">hit</xsl:when>
-         <xsl:when test="self::text() and normalize-space() = '' and not(parent::xsl:text)">ignored</xsl:when>
-         <xsl:when test="self::xsl:variable">
-            <xsl:sequence select="local:coverage(following-sibling::*[not(self::xsl:variable)][1], $module-id)" />
-         </xsl:when>
-         <xsl:when test="ancestor::xsl:variable">
-            <xsl:sequence select="local:coverage(ancestor::xsl:variable[1], $module-id)" />
-         </xsl:when>
-         <xsl:when test="self::xsl:stylesheet or self::xsl:transform">ignored</xsl:when>
-         <xsl:when test="self::xsl:function or self::xsl:template">missed</xsl:when>
-         <!-- A node within a top-level non-XSLT element -->
-         <xsl:when test="empty(ancestor::xsl:*[parent::xsl:stylesheet or parent::xsl:transform])">ignored</xsl:when>
-         <xsl:when test="self::xsl:param">
-            <xsl:sequence select="local:coverage(parent::*, $module-id)" />
-         </xsl:when>
-         <xsl:when test="self::xsl:context-item">
-            <!-- Saxon does not seem to call enter() for xsl:context-item (xspec/xspec#1410) -->
-            <xsl:sequence select="local:coverage(parent::xsl:template, $module-id)" />
-         </xsl:when>
-         <xsl:otherwise>missed</xsl:otherwise>
-      </xsl:choose>
-   </xsl:template>
-
-   <xsl:template match="document-node()" as="xs:string" mode="coverage">ignored</xsl:template>
-
-   <!--
       Local functions
    -->
 
@@ -400,24 +337,6 @@
             <xsl:sequence select="$stylesheets" />
          </xsl:otherwise>
       </xsl:choose>
-   </xsl:function>
-
-   <xsl:function name="local:coverage" as="xs:string">
-      <xsl:param name="node" as="node()" />
-      <xsl:param name="module-id" as="xs:integer" />
-
-      <xsl:variable name="coverage" as="xs:string+">
-         <xsl:apply-templates select="$node" mode="coverage">
-            <xsl:with-param name="module-id" tunnel="yes" select="$module-id" />
-         </xsl:apply-templates>
-      </xsl:variable>
-      <xsl:if test="count($coverage) > 1">
-         <xsl:message terminate="yes">
-            <xsl:text>ERROR: more than one coverage identified for:</xsl:text>
-            <xsl:sequence select="$node" />
-         </xsl:message>
-      </xsl:if>
-      <xsl:sequence select="$coverage[1]" />
    </xsl:function>
 
    <xsl:function name="local:hits-on-node" as="element(hit)*">

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -107,13 +107,8 @@
          select="string-length(xs:string($number-of-lines))" />
       <xsl:variable name="number-format" as="xs:string"
          select="string-join(for $i in 1 to $number-width return '0')" />
-      <xsl:variable name="module-id" as="xs:integer?">
-         <xsl:variable name="uri" as="xs:string"
-            select="if (starts-with($stylesheet-uri, '/'))
-                    then ('file:' || $stylesheet-uri)
-                    else $stylesheet-uri" />
-         <xsl:sequence select="key('modules', $uri, $trace)/@moduleId" />
-      </xsl:variable>
+      <xsl:variable name="module-id" as="xs:integer?"
+         select="accumulator-before('module-id-for-node')"/>
       <h2>
          <xsl:text expand-text="yes">module: {fmt:format-uri($stylesheet-uri)}; {$number-of-lines} lines</xsl:text>
       </h2>
@@ -128,7 +123,6 @@
                <xsl:call-template name="output-lines">
                   <xsl:with-param name="stylesheet-lines" select="$stylesheet-lines" />
                   <xsl:with-param name="number-format" select="$number-format" />
-                  <xsl:with-param name="module-id" select="$module-id" />
                </xsl:call-template>
             </pre>
          </xsl:otherwise>
@@ -205,7 +199,6 @@
 
       <xsl:param name="stylesheet-lines" as="xs:string+" required="yes" />
       <xsl:param name="number-format" as="xs:string" required="yes" />
-      <xsl:param name="module-id" as="xs:integer" required="yes" />
 
       <xsl:variable name="outermost-element" as="element()" select="." />
 
@@ -349,9 +342,10 @@
 
    <xsl:function name="local:hits-on-node" as="element(hit)*">
       <xsl:param name="node" as="node()" />
-      <xsl:param name="module-id" as="xs:integer" />
 
       <xsl:for-each select="$node">
+         <xsl:variable name="module-id" as="xs:integer"
+            select="accumulator-before('module-id-for-node')"/>
          <xsl:variable name="hits" as="element(hit)*"
             select="local:hits-on-line-column($module-id, x:line-number(.), x:column-number(.))" />
          <xsl:variable name="node-uqname" as="xs:string?" select="x:node-UQName(.)" />

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -257,8 +257,16 @@
                      $regex-group($groups('comment'))) or
                     ($node instance of processing-instruction() and
                      $regex-group($groups('pi')))" />
-         <xsl:variable name="coverage" as="xs:string"
-            select="if ($matches) then local:coverage($node, $module-id) else 'ignored'" />
+         <xsl:variable name="coverage" as="xs:string">
+            <xsl:choose>
+               <xsl:when test="$matches">
+                  <xsl:apply-templates select="$node" mode="coverage"/>
+               </xsl:when>
+               <xsl:otherwise>
+                  <xsl:sequence select="'ignored'"/>
+               </xsl:otherwise>
+            </xsl:choose>
+         </xsl:variable> 
          <xsl:for-each select="$construct-lines">
             <xsl:if test="position() != 1">
                <xsl:text expand-text="yes">&#x0A;{format-number($line-number + position(), $number-format)}: </xsl:text>


### PR DESCRIPTION
This pull request refactors the XSLT code that computes code coverage status based on the trace data produced by the Java trace listener. The goal is to make rules like "use trace data", "use child data", "use parent data", or element-specific logic more apparent and easier to maintain.

Between now and the next XSpec release, we plan to change some of the logic in this XSLT code in ways that will change the expected coverage reports. This pull request excludes any such changes -- even bug fixes. In other words, this pull request is pure refactoring.