### PR TITLE
fix(report): coverage rule "Ignore Element and All Descendants"

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -66,14 +66,14 @@ Package related.
 
 ## xsl:accumulator-rule
 
-|          |                                                                |
-| -------- | -------------------------------------------------------------- |
-| CATEGORY |                                                                |
-| PARENT   | xsl:accumulator                                                |
-| CHILDREN |                                                                |
-| CONTENT  |                                                                |
-| TRACE    | No                                                             |
-| RULE     | Element Specific - always ignore this node and any descendants |
+|          |                                    |
+| -------- | ---------------------------------- |
+| CATEGORY |                                    |
+| PARENT   | xsl:accumulator                    |
+| CHILDREN |                                    |
+| CONTENT  |                                    |
+| TRACE    | No                                 |
+| RULE     | Ignore Element and All Descendants |
 
 #### Comment
 
@@ -155,14 +155,14 @@ XSLT 4.0 proposal.
 
 ## xsl:attribute
 
-|          |                                                                                                                                 |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| CATEGORY | Instruction                                                                                                                     |
-| PARENT   |                                                                                                                                 |
-| CHILDREN |                                                                                                                                 |
-| CONTENT  |                                                                                                                                 |
-| TRACE    | Sometimes                                                                                                                       |
-| RULE     | Element Specific - Use Trace Data, except mark as 'ignored' if parent is xsl:attribute-set (xsl:attribute-set will be ignored). |
+|          |                                                                                                                   |
+| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| CATEGORY | Instruction                                                                                                       |
+| PARENT   |                                                                                                                   |
+| CHILDREN |                                                                                                                   |
+| CONTENT  |                                                                                                                   |
+| TRACE    | Sometimes                                                                                                         |
+| RULE     | Element Specific - If parent is xsl:attribute-set, Ignore Element and All Descendants. Otherwise, Use Trace Data. |
 
 #### Comment
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -82,9 +82,19 @@
     <xsl:template match="
         XSLT:stylesheet/*[not(namespace-uri() = 'http://www.w3.org/1999/XSL/Transform')]/descendant-or-self::node()
         | XSLT:transform/*[not(namespace-uri() = 'http://www.w3.org/1999/XSL/Transform')]/descendant-or-self::node()"
+        as="xs:string"
         mode="coverage"
-        priority="10"
-        as="xs:string">
+        priority="10">
+        <xsl:sequence select="'ignored'"/>
+    </xsl:template>
+
+    <!-- Ignore Element and All Descendants -->
+    <xsl:template match="
+        XSLT:attribute-set/XSLT:attribute/descendant-or-self::node()
+        | XSLT:accumulator-rule/descendant-or-self::node()"
+        as="xs:string"
+        mode="coverage"
+        priority="20">
         <xsl:sequence select="'ignored'"/>
     </xsl:template>
 

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -15,13 +15,13 @@
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator --&gt;</span>
 07: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span>
-08: <span class="ignored">    </span><span class="missed">&lt;xsl:accumulator-rule match="node"&gt;</span>
-09: <span class="ignored">      </span><span class="missed">&lt;xsl:value-of select="$value + 1" /&gt;</span>
-10: <span class="ignored">    </span><span class="missed">&lt;/xsl:accumulator-rule&gt;</span>
+08: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;xsl:value-of select="$value + 1" /&gt;</span>
+10: <span class="ignored">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span>
 11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
 12: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator not used --&gt;</span>
 13: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span>
-14: <span class="ignored">    </span><span class="missed">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span>
+14: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span>
 15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
 16: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for accumulator --&gt;</span>
 17: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -15,17 +15,17 @@
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- Single xsl:attribute in xsl:attribute-set --&gt;</span>
 07: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="type"&gt;</span>
-08: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type"&gt;</span><span class="missed">attribute</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+08: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="type"&gt;</span><span class="ignored">attribute</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 09: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 10: 
 11: <span class="ignored">  </span><span class="ignored">&lt;!-- Two xsl:attribute in xsl:attribute-set --&gt;</span>
 12: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="types"&gt;</span>
-13: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type1"&gt;</span>
-14: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">attribute1</span><span class="missed">&lt;/xsl:text&gt;</span>
-15: <span class="ignored">    </span><span class="missed">&lt;/xsl:attribute&gt;</span>
-16: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="type2"&gt;</span>
-17: <span class="ignored">      </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">attribute2</span><span class="missed">&lt;/xsl:text&gt;</span>
-18: <span class="ignored">    </span><span class="missed">&lt;/xsl:attribute&gt;</span>
+13: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="type1"&gt;</span>
+14: <span class="ignored">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute1</span><span class="ignored">&lt;/xsl:text&gt;</span>
+15: <span class="ignored">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span>
+16: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="type2"&gt;</span>
+17: <span class="ignored">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute2</span><span class="ignored">&lt;/xsl:text&gt;</span>
+18: <span class="ignored">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 19: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 20: 
 21: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-attribute"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -15,19 +15,19 @@
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- Single attribute --&gt;</span>
 07: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet01"&gt;</span>
-08: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr01"&gt;</span><span class="missed">attr01</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+08: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="attr01"&gt;</span><span class="ignored">attr01</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 09: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 10: <span class="ignored">  </span><span class="ignored">&lt;!-- Multiple attributes--&gt;</span>
 11: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet02"&gt;</span>
-12: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr02A"&gt;</span><span class="missed">attr02A</span><span class="missed">&lt;/xsl:attribute&gt;</span>
-13: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr02B"&gt;</span><span class="missed">attr02B</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+12: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="attr02A"&gt;</span><span class="ignored">attr02A</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
+13: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="attr02B"&gt;</span><span class="ignored">attr02B</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 14: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 15: <span class="ignored">  </span><span class="ignored">&lt;!-- Including another attribute set --&gt;</span>
 16: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B"&gt;</span>
-17: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr03A"&gt;</span><span class="missed">attr03A</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+17: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="attr03A"&gt;</span><span class="ignored">attr03A</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 18: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 19: <span class="ignored">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03B"&gt;</span>
-20: <span class="ignored">    </span><span class="missed">&lt;xsl:attribute name="attr03B"&gt;</span><span class="missed">attr03B</span><span class="missed">&lt;/xsl:attribute&gt;</span>
+20: <span class="ignored">    </span><span class="ignored">&lt;xsl:attribute name="attr03B"&gt;</span><span class="ignored">attr03B</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
 21: <span class="ignored">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
 22: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
 23: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-attribute-set"&gt;</span>


### PR DESCRIPTION
This pull request implements the XSLT code coverage status rule "Ignore Element and All Descendants". This rule is needed for the `xsl:accumulator-rule` element and for the  `xsl:attribute` element when it is a child of `xsl:attribute-set`.

I checked that the changes in results of end-to-end coverage tests are the same changes mentioned in #1939 and #1941.

Fixes #1939
Fixes #1941

---

Cc: @birdya22