### PR TITLE
fix(report): coverage for xsl:output-character

### DIFF
--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -52,6 +52,7 @@
     <xsl:template match="
         XSLT:stylesheet
         | XSLT:transform
+
         | XSLT:accumulator
         | XSLT:attribute-set
         | XSLT:character-map
@@ -66,6 +67,9 @@
         | XSLT:output
         | XSLT:preserve-space
         | XSLT:strip-space
+
+        | XSLT:output-character
+
         | text()[normalize-space() = '' and not(parent::XSLT:text)]
         | processing-instruction()
         | comment()

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -16,12 +16,12 @@
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- character map does not do any mapping changes (confident that it is used in Saxon).</span>
 07: <span class="ignored">       But xspec doesn't do character-map without some additional effort (which isn't done here)--&gt;</span>
 08: <span class="ignored">  </span><span class="ignored">&lt;xsl:character-map name="charMap01" use-character-maps="charMap01A"&gt;</span>
-09: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="0" string="0" /&gt;</span>
-10: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="&amp;#xE003;" string="3" /&gt;</span>
+09: <span class="ignored">    </span><span class="ignored">&lt;xsl:output-character character="0" string="0" /&gt;</span>
+10: <span class="ignored">    </span><span class="ignored">&lt;xsl:output-character character="&amp;#xE003;" string="3" /&gt;</span>
 11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
 12: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:character-map included in one above --&gt;</span>
 13: <span class="ignored">  </span><span class="ignored">&lt;xsl:character-map name="charMap01A"&gt;</span>
-14: <span class="ignored">    </span><span class="missed">&lt;xsl:output-character character="1" string="1" /&gt;</span>
+14: <span class="ignored">    </span><span class="ignored">&lt;xsl:output-character character="1" string="1" /&gt;</span>
 15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
 16: 
 17: <span class="ignored">  </span><span class="ignored">&lt;xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" /&gt;</span>


### PR DESCRIPTION
This pull request fixes #1944 by including `xsl:output-character` in the `match` attribute of the template rule that implements the "Always Ignore" code coverage rule.

I inserted some blank lines in the lengthy `match` attribute just to make it easier to see groupings:

- `xsl:stylesheet` and `xsl:transform`, which are the same
- Top-level declarations
- `xsl:output-character`, which is a child of a top-level declaration
- Non-element node types

---

Cc: @birdya22