### PR TITLE
fix(report): coverage updates for xsl:merge and descendants

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -588,66 +588,62 @@ Tested as part of xsl:analyze-string.
 
 #### Comment
 
-None of the xsl:merge children are traced.
-
-I don't know if it is safe to say if xsl:merge is hit then all the xsl:merge children are hit as well.
-
-There is a problem that the sequence constructor in xsl:merge-key is not traced even when it is executed (can we say that is hit if xsl:merge is hit?).
-
-The sequence constructor in xsl:merge-action is traced. If this is traced can the xsl:merge elements be marked as hit?
+Children of xsl:merge are not traced. However, xsl:merge has a well defined structure where the child elements are always present. Although only the xsl:merge element is traced, the coverage status of its children can be based on the status of the xsl:merge element.
 
 ## xsl:merge-action
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY |                |
-| PARENT   | xsl:merge      |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                 |
+| -------- | --------------- |
+| CATEGORY |                 |
+| PARENT   | xsl:merge       |
+| CHILDREN |                 |
+| CONTENT  |                 |
+| TRACE    | No              |
+| RULE     | Use Parent Data |
 
 #### Comment
 
 Tested as part of xsl:merge.
+
+If xsl:merge is hit then it is safe to say that xsl:merge-action is also hit. Note: It would be possible for xsl:merge-action to Use Child Data, but the suggestion is that it follow the same rule as other xsl:merge-\* descendants of xsl:merge.
 
 The sequence constructor in xsl:merge-action is traced.
 
-See comment on xsl:merge.
-
 ## xsl:merge-key
 
-|          |                        |
-| -------- | ---------------------- |
-| CATEGORY |                        |
-| PARENT   | xsl:merge-source       |
-| CHILDREN |                        |
-| CONTENT  |                        |
-| TRACE    | No                     |
-| RULE     | Element Specific - TBD |
+|          |                  |
+| -------- | ---------------- |
+| CATEGORY |                  |
+| PARENT   | xsl:merge-source |
+| CHILDREN |                  |
+| CONTENT  |                  |
+| TRACE    | No               |
+| RULE     | Element Specific |
 
 #### Comment
 
 Tested as part of xsl:merge.
 
-See comment on xsl:merge.
+If xsl:merge is hit then it is safe to say that the grandchild xsl:merge-key is also hit.
+
+xsl:merge-key can contain a sequence constructor. The sequence constructor is never traced. If xsl:merge-key is marked as 'missed', all elements in its sequence constructor are marked as 'missed'. If the xsl:merge-key is marked as 'hit', all elements in its sequence constructor are marked as 'unknown' because the sequence constructor could contain xsl:if, xsl:choose, etc., and there is no trace data about whether these descendants are executed.
 
 ## xsl:merge-source
 
-|          |                        |
-| -------- | ---------------------- |
-| CATEGORY |                        |
-| PARENT   | xsl:merge              |
-| CHILDREN | xsl:merge-key          |
-| CONTENT  |                        |
-| TRACE    | No                     |
-| RULE     | Element Specific - TBD |
+|          |                 |
+| -------- | --------------- |
+| CATEGORY |                 |
+| PARENT   | xsl:merge       |
+| CHILDREN | xsl:merge-key   |
+| CONTENT  |                 |
+| TRACE    | No              |
+| RULE     | Use Parent Data |
 
 #### Comment
 
 Tested as part of xsl:merge.
 
-See comment on xsl:merge.
+If xsl:merge is hit then it is safe to say that xsl:merge-source is also hit.
 
 ## xsl:message
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -75,7 +75,8 @@
         | comment()
         | document-node()"
         mode="coverage"
-        as="xs:string">
+        as="xs:string"
+        priority="30">
         <xsl:sequence select="'ignored'"/>
     </xsl:template>
 
@@ -124,6 +125,8 @@
     <!-- Use Parent Data -->
     <xsl:template match="
         XSLT:context-item (: xspec/xspec#1410 :)
+        | XSLT:merge-action
+        | XSLT:merge-source
         | XSLT:param[not(parent::XSLT:stylesheet or parent::XSLT:transform)]"
         as="xs:string"
         mode="coverage">
@@ -152,6 +155,31 @@
                     mode="#current"/>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+
+    <!-- Element-Specific rule for XSLT:merge-key -->
+    <xsl:template match="XSLT:merge-key"
+        as="xs:string"
+        mode="coverage">
+        <xsl:apply-templates select="ancestor::XSLT:merge[1]"
+            mode="#current"/>        
+    </xsl:template>
+
+    <!-- Element-Specific rule for descendants of XSLT:merge-key -->
+    <xsl:template match="XSLT:merge-key/descendant::node()"
+        as="xs:string"
+        mode="coverage"
+        priority="5">
+        <xsl:variable name="xsl-merge-status" as="xs:string">
+            <xsl:apply-templates select="ancestor::XSLT:merge[1]"
+                mode="#current"/>
+        </xsl:variable>
+        <xsl:sequence select="
+                if ($xsl-merge-status eq 'hit') then
+                    'unknown'
+                else
+                    'missed'
+                "/>
     </xsl:template>
 
     <!-- General case. This template is like the one for the Use Trace Data rule, except

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -28,19 +28,19 @@
 18: <span class="ignored">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
 19: <span class="ignored">      </span><span class="ignored">&lt;!-- 1st merge-key uses select attribute, 2nd uses sequence constructor --&gt;</span>
 20: <span class="ignored">      </span><span class="hit">&lt;xsl:merge&gt;</span>
-21: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span>
-22: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-key select="." /&gt;</span>
-23: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
-24: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
-25: <span class="ignored">          </span><span class="missed">&lt;xsl:merge-key&gt;</span>
-26: <span class="ignored">            </span><span class="missed">&lt;xsl:value-of select="." /&gt;</span>
-27: <span class="ignored">          </span><span class="missed">&lt;/xsl:merge-key&gt;</span>
-28: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-source&gt;</span>
-29: <span class="ignored">        </span><span class="missed">&lt;xsl:merge-action&gt;</span>
+21: <span class="ignored">        </span><span class="hit">&lt;xsl:merge-source select="$mergeSourceA/*"&gt;</span>
+22: <span class="ignored">          </span><span class="hit">&lt;xsl:merge-key select="." /&gt;</span>
+23: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge-source&gt;</span>
+24: <span class="ignored">        </span><span class="hit">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
+25: <span class="ignored">          </span><span class="hit">&lt;xsl:merge-key&gt;</span>
+26: <span class="ignored">            </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span>
+27: <span class="ignored">          </span><span class="hit">&lt;/xsl:merge-key&gt;</span>
+28: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge-source&gt;</span>
+29: <span class="ignored">        </span><span class="hit">&lt;xsl:merge-action&gt;</span>
 30: <span class="ignored">          </span><span class="hit">&lt;node type="merge"&gt;</span>
 31: <span class="ignored">            </span><span class="hit">&lt;xsl:value-of select="current-merge-group()" /&gt;</span>
 32: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
-33: <span class="ignored">        </span><span class="missed">&lt;/xsl:merge-action&gt;</span>
+33: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge-action&gt;</span>
 34: <span class="ignored">      </span><span class="hit">&lt;/xsl:merge&gt;</span>
 35: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="exists(merge-not-hit)"&gt;</span>
 36: <span class="ignored">        </span><span class="missed">&lt;xsl:merge&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -33,7 +33,7 @@
 23: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge-source&gt;</span>
 24: <span class="ignored">        </span><span class="hit">&lt;xsl:merge-source select="$mergeSourceB/*"&gt;</span>
 25: <span class="ignored">          </span><span class="hit">&lt;xsl:merge-key&gt;</span>
-26: <span class="ignored">            </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span>
+26: <span class="ignored">            </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 27: <span class="ignored">          </span><span class="hit">&lt;/xsl:merge-key&gt;</span>
 28: <span class="ignored">        </span><span class="hit">&lt;/xsl:merge-source&gt;</span>
 29: <span class="ignored">        </span><span class="hit">&lt;xsl:merge-action&gt;</span>

--- a/test/end-to-end/cases-coverage/xsl-merge-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-merge-01.xsl
@@ -23,7 +23,7 @@
         </xsl:merge-source>
         <xsl:merge-source select="$mergeSourceB/*">
           <xsl:merge-key>
-            <xsl:value-of select="." />
+            <xsl:value-of select="." />                                        <!-- Expected unknown -->
           </xsl:merge-key>
         </xsl:merge-source>
         <xsl:merge-action>


### PR DESCRIPTION
Fixes #1959.

Note: In the expected coverage report, line 26 has a CSS class of "unknown". That's correct, though it won't render distinctively because there is no style for that class yet in this repo's `master` branch. #1974 adds a CSS style for the "unknown" class.

---
Cc: @birdya22