### PR TITLE
test: filtered result not limited to one item

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -306,8 +306,8 @@ xpath = xsd:string { minLength = "1" }
 
 assertion = 
 	## An assertion's test XPath can either return a boolean value, in which case the 
-	## assertion succeeds only if the test is true; or an item, in which case the
-	## assertion succeeds only if the item is equal to the one specified with the
+	## assertion succeeds only if the test is true; or a sequence, in which case the
+	## assertion succeeds only if the sequence is equal to the one specified with the
 	## href and select attributes or content of the <expect> element.
 	element expect { common-attributes,
 		label, pending-attribute?, test?, selection }

--- a/test/multiple-filtered-items.xspec
+++ b/test/multiple-filtered-items.xspec
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="mirror.xsl"
+	query="x-urn:test:mirror"
+	query-at="mirror.xqm"
+	xmlns:items="x-urn:test:xspec-items"
+	xmlns:mirror="x-urn:test:mirror"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<!-- Related tests where x:expect/@test selects multiple items:
+		issue-59_query.xspec, issue-59_stylesheet.xspec -->
+
+	<!-- Import the helper 'xspec-items' module.
+		XSLT should ignore query modules. XQuery should ignore stylesheets. -->
+	<x:helper query="x-urn:test:xspec-items" query-at="items.xqm" />
+	<x:helper stylesheet="items.xsl" />
+
+	<x:scenario label="x:expect/@test can select multiple items">
+		<x:call function="one-or-more">
+			<x:param as="item()+"
+				select="$items:all-nodes, $items:integer, true(), false()" />
+		</x:call>
+		<x:expect label="both node and atomic value"
+			test="$x:result[. instance of node() or . instance of xs:integer]"
+			select="$items:all-nodes, $items:integer" />
+		<x:expect label="nodes"
+			test="$x:result[. instance of node()]"
+			select="$items:all-nodes" />
+		<x:expect label="atomic values"
+			test="$x:result[. instance of xs:integer or . instance of xs:boolean]"
+			select="$items:integer, true(), false()" />
+		<x:expect label="sequence of multiple Boolean values (different from Boolean @test situation)"
+			test="$x:result[. instance of xs:boolean]"
+			select="true(), false()" />
+	</x:scenario>
+
+	<x:scenario label="x:expect/@test can select multiple nodes from a tree">
+		<x:call function="one-or-more">
+			<x:param as="element(a)">
+				<a>
+					<b>
+						<c/>
+					</b>
+					<wrapper>
+						<b>
+							<d/>
+						</b>
+					</wrapper>
+				</a>
+			</x:param>
+		</x:call>
+		<x:expect label="descendant 'b' elements from tree, now in a sequence"
+			test="$x:result//b"
+			as="element(b)+">
+			<b>
+				<c/>
+			</b>
+			<b>
+				<d/>
+			</b>
+		</x:expect>
+	</x:scenario>
+
+	<x:scenario label="x:expect/@test can select zero items">
+		<x:call function="one-or-more">
+			<x:param as="item()+"
+				select="$items:all-nodes, $items:integer, $items:integer, true(), false()" />
+		</x:call>
+		<x:expect label="where @as indicates an empty sequence"
+			test="$x:result[false()]"
+			as="empty-sequence()" />
+		<x:expect label="where @select indicates an empty sequence"
+			test="$x:result[false()]"
+			select="()" />
+		<x:expect label="where @select evaluates to an empty sequence"
+			test="$x:result[false()]"
+			select="/foo">
+			<bar/>
+		</x:expect>
+	</x:scenario>
+
+</x:description>

--- a/test/multiple-filtered-items_schematron.xspec
+++ b/test/multiple-filtered-items_schematron.xspec
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="do-nothing.sch"
+	xmlns:items="x-urn:test:xspec-items"
+	xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<x:helper stylesheet="items.xsl" />
+
+	<x:scenario label="x:expect/@test can select multiple items">
+		<x:context as="node()+"
+				select="$items:all-nodes" />
+		<x:expect label="both node and atomic value"
+			test="$items:all-nodes, $items:integer"
+			select="$items:all-nodes, $items:integer" />
+		<x:expect label="nodes"
+			test="$items:all-nodes"
+			select="$items:all-nodes" />
+		<x:expect label="SVRL nodes, obtained relative to result document (.)"
+			test="./svrl:*"
+			select="$x:result" />
+		<x:expect label="Aside: confirm that result document contains multiple SVRL child nodes"
+			test="count(./svrl:*) gt 1" />
+		<x:expect label="atomic values"
+			test="$items:integer, $items:integer, true(), false()"
+			select="$items:integer, $items:integer, true(), false()" />
+		<x:expect label="sequence of multiple Boolean values (different from Boolean @test situation)"
+			test="( (1 eq 1), (1 eq 2) )"
+			select="true(), false()" />
+	</x:scenario>
+
+	<x:scenario label="x:expect/@test can select zero items">
+		<x:context as="item()+"
+				select="$items:all-nodes" />
+		<x:expect label="where @as indicates an empty sequence"
+			test="//svrl:failed-assert"
+			as="empty-sequence()" />
+		<x:expect label="where @select indicates an empty sequence"
+			test="//svrl:failed-assert"
+			select="()" />
+		<x:expect label="where @select evaluates to an empty sequence"
+			test="//svrl:failed-assert"
+			select="//svrl:failed-assert">
+			<svrl:schematron-output/>
+		</x:expect>
+	</x:scenario>
+
+</x:description>


### PR DESCRIPTION
The schema annotation for `x:expect` said that when `@test` is used for filtering, it returns an item -- which suggests exactly one item. The wiki section https://github.com/xspec/xspec/wiki/Writing-Scenarios#describing-the-expected-result-and-filtering-the-actual-result doesn't mention multiplicity and its examples use one item per `<x:expect>` element.

However, it is fine if a non-Boolean `@test` returns zero items or multiple items. Tests for issue #59 exercise the multiple-item capability in the scenarios labeled "Multiple nodes", "Multiple values", and "Nodes and value".

- https://github.com/xspec/xspec/blob/e9d4527f200e776b84953230bef7280dc8488cef/test/issue-59_query.xspec
- https://github.com/xspec/xspec/blob/e9d4527f200e776b84953230bef7280dc8488cef/test/issue-59_stylesheet.xspec

The testing purpose of this pull request is to augment those tests by adding

- `@test` attributes that filter the actual result in some way, showing that the multiple-item behavior isn't limited to `test="$x:result"` and `test="."`. Filtering includes selecting multiple nodes from a tree, which was the original use case I had in mind.
- `@test` attributes that select zero items
- Schematron scenarios

The documentation purpose of this pull request is to generalize that schema annotation. After merging this PR, I'll update the wiki; maybe adding "as sequences" to form "If they are deep-equal as sequences, the test is Success." will convey that it's not limited to one item.
