### PR TITLE
fix(report): coverage update for xsl:where-populated

### DIFF
--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -111,7 +111,8 @@
         | XSLT:non-matching-substring
         | XSLT:on-completion
         | XSLT:otherwise
-        | XSLT:when"
+        | XSLT:when
+        | XSLT:where-populated"
         as="xs:string"
         mode="coverage">
         <xsl:choose>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -47,8 +47,8 @@
 37: <span class="ignored">      </span><span class="hit">&lt;node type="matching-substring executed unknown, non-matching-substring unexecuted unknown"&gt;</span>
 38: <span class="ignored">        </span><span class="hit">&lt;xsl:analyze-string select="'abc 123'" regex="abc 123"&gt;</span>
 39: <span class="ignored">          </span><span class="unknown">&lt;xsl:matching-substring&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-40: <span class="ignored">            </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-41: <span class="ignored">            </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+40: <span class="ignored">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+41: <span class="ignored">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 42: <span class="ignored">          </span><span class="unknown">&lt;/xsl:matching-substring&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 43: <span class="ignored">        </span><span class="unknown">&lt;xsl:non-matching-substring&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 44: <span class="ignored">        </span><span class="unknown">&lt;/xsl:non-matching-substring&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
@@ -60,8 +60,8 @@
 50: <span class="ignored">          </span><span class="unknown">&lt;xsl:matching-substring&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 51: <span class="ignored">          </span><span class="unknown">&lt;/xsl:matching-substring&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 52: <span class="ignored">          </span><span class="unknown">&lt;xsl:non-matching-substring&gt;</span><span class="ignored">                                         </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-53: <span class="ignored">            </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-54: <span class="ignored">            </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+53: <span class="ignored">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+54: <span class="ignored">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 55: <span class="ignored">          </span><span class="unknown">&lt;/xsl:non-matching-substring&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 56: <span class="ignored">        </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
 57: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
@@ -71,8 +71,8 @@
 061: <span class="ignored">          </span><span class="ignored">&lt;!--untraced node--&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
 062: <span class="ignored">        </span><span class="unknown">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 063: <span class="ignored">        </span><span class="unknown">&lt;xsl:when test="exists(omitted)"&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-064: <span class="ignored">          </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-065: <span class="ignored">          </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+064: <span class="ignored">          </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+065: <span class="ignored">          </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 066: <span class="ignored">        </span><span class="unknown">&lt;/xsl:when&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 067: <span class="ignored">      </span><span class="hit">&lt;/xsl:choose&gt;</span>
 068: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:when executes, but status is unknown. --&gt;</span>
@@ -84,12 +84,12 @@
 074: <span class="ignored">              </span><span class="ignored">&lt;!--untraced node--&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
 075: <span class="ignored">            </span><span class="unknown">&lt;/xsl:when&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 076: <span class="ignored">            </span><span class="unknown">&lt;xsl:when test=". eq 2"&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-077: <span class="ignored">              </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-078: <span class="ignored">              </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+077: <span class="ignored">              </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+078: <span class="ignored">              </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 079: <span class="ignored">            </span><span class="unknown">&lt;/xsl:when&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 080: <span class="ignored">            </span><span class="unknown">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-081: <span class="ignored">              </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-082: <span class="ignored">              </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+081: <span class="ignored">              </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+082: <span class="ignored">              </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 083: <span class="ignored">            </span><span class="unknown">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 084: <span class="ignored">          </span><span class="hit">&lt;/xsl:choose&gt;</span>
 085: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
@@ -106,8 +106,8 @@
 096: <span class="ignored">        </span><span class="hit">&lt;xsl:choose&gt;</span>
 097: <span class="ignored">          </span><span class="unknown">&lt;xsl:when test="1 eq 2"&gt;</span><span class="unknown">&lt;/xsl:when&gt;</span><span class="ignored">                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 098: <span class="ignored">          </span><span class="unknown">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-099: <span class="ignored">            </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-100: <span class="ignored">            </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+099: <span class="ignored">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+100: <span class="ignored">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 101: <span class="ignored">          </span><span class="unknown">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 102: <span class="ignored">        </span><span class="hit">&lt;/xsl:choose&gt;</span>
 103: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -51,8 +51,8 @@
 41: <span class="ignored">        </span><span class="hit">&lt;node type="fallback executed unknown"&gt;</span>
 42: <span class="ignored">          </span><span class="missed">&lt;xsl:non-existent-instruction&gt;</span><span class="ignored">                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 43: <span class="ignored">            </span><span class="unknown">&lt;xsl:fallback&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-44: <span class="ignored">              </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-45: <span class="ignored">              </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+44: <span class="ignored">              </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+45: <span class="ignored">              </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 46: <span class="ignored">            </span><span class="unknown">&lt;/xsl:fallback&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 47: <span class="ignored">          </span><span class="missed">&lt;/xsl:non-existent-instruction&gt;</span><span class="ignored">                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span><span class="ignored">          </span>
 48: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>
@@ -71,8 +71,8 @@
 61: <span class="ignored">        </span><span class="hit">&lt;node type="fallback unexecuted unknown"&gt;</span>
 62: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of&gt;</span>
 63: <span class="ignored">            </span><span class="unknown">&lt;xsl:fallback&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-64: <span class="ignored">              </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-65: <span class="ignored">              </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+64: <span class="ignored">              </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+65: <span class="ignored">              </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 66: <span class="ignored">            </span><span class="unknown">&lt;/xsl:fallback&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 67: <span class="ignored">          </span><span class="hit">&lt;/xsl:value-of&gt;</span><span class="ignored">          </span>
 68: <span class="ignored">        </span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -146,8 +146,8 @@
 136: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion unexecuted unknown"&gt;</span>
 137: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
 138: <span class="ignored">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-139: <span class="ignored">            </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-140: <span class="ignored">            </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+139: <span class="ignored">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+140: <span class="ignored">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 141: <span class="ignored">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                   </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 142: <span class="ignored">          </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
 143: <span class="ignored">            </span><span class="hit">&lt;xsl:break /&gt;</span>
@@ -167,8 +167,8 @@
 157: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion executed unknown"&gt;</span>
 158: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
 159: <span class="ignored">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-160: <span class="ignored">            </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-161: <span class="ignored">            </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+160: <span class="ignored">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+161: <span class="ignored">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 162: <span class="ignored">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 163: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="concat(., ', ')" /&gt;</span>
 164: <span class="ignored">        </span><span class="hit">&lt;/xsl:iterate&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-where-populated-01.xsl">xsl-where-populated-01.xsl</a></p>
-      <h2>module: xsl-where-populated-01.xsl; 22 lines</h2>
+      <h2>module: xsl-where-populated-01.xsl; 35 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -16,19 +16,32 @@
 06: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-where-populated"&gt;</span>
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Data doesn't exist so node/copy-of not executed --&gt;</span>
-09: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated"&gt;</span>
-10: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span>
+09: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, child reached but not populated"&gt;</span>
+10: <span class="ignored">        </span><span class="hit">&lt;xsl:where-populated&gt;</span>
 11: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="nonExistentNode" /&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- node element is empty but this element is executed because it needs to see if there is any output --&gt;</span>
-12: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+12: <span class="ignored">        </span><span class="hit">&lt;/xsl:where-populated&gt;</span>
 13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 14: <span class="ignored">      </span><span class="ignored">&lt;!-- Data exists so node/copy-of executed --&gt;</span>
-15: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated"&gt;</span>
-16: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span>
+15: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, child reached and populated"&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;xsl:where-populated&gt;</span>
 17: <span class="ignored">          </span><span class="hit">&lt;xsl:copy-of select="node" /&gt;</span>
-18: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span>
+18: <span class="ignored">        </span><span class="hit">&lt;/xsl:where-populated&gt;</span>
 19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-20: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-21: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-22: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- Only untraceable descendants --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraced child reached but not populated"&gt;</span>
+22: <span class="ignored">        </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+23: <span class="ignored">          </span><span class="unknown">&lt;xsl:fallback /&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+24: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraced child reached and populated"&gt;</span>
+27: <span class="ignored">        </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+28: <span class="ignored">          </span><span class="missed">&lt;xsl:perform-sort select="node"&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+29: <span class="ignored">            </span><span class="missed">&lt;xsl:sort select="." /&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected miss--&gt;</span>
+30: <span class="ignored">          </span><span class="missed">&lt;/xsl:perform-sort&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+31: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+32: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span><span class="ignored">      </span>
+33: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+34: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+35: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
@@ -8,21 +8,26 @@
    <hit lineNumber="6" columnNumber="45" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="69" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="9" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="69" moduleId="0" traceableId="2"/>
    <traceable traceableId="3" class="net.sf.saxon.expr.instruct.WherePopulated"/>
    <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.CopyOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}copy-of"/>
    <hit lineNumber="11" columnNumber="51" moduleId="0" traceableId="4"/>
-   <hit lineNumber="15" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="15" columnNumber="36" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="65" moduleId="0" traceableId="1"/>
+   <hit lineNumber="15" columnNumber="65" moduleId="0" traceableId="2"/>
    <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="3"/>
    <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="78" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="78" moduleId="0" traceableId="2"/>
+   <hit lineNumber="26" columnNumber="74" moduleId="0" traceableId="1"/>
+   <hit lineNumber="26" columnNumber="74" moduleId="0" traceableId="2"/>
+   <hit lineNumber="28" columnNumber="4" moduleId="0" traceableId="3"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
@@ -6,17 +6,30 @@
   <xsl:template match="xsl-where-populated">
     <root>
       <!-- Data doesn't exist so node/copy-of not executed -->
-      <node type="where-populated">
+      <node type="where-populated, child reached but not populated">
         <xsl:where-populated>
           <xsl:copy-of select="nonExistentNode" />      <!-- node element is empty but this element is executed because it needs to see if there is any output -->
         </xsl:where-populated>
       </node>
       <!-- Data exists so node/copy-of executed -->
-      <node type="where-populated">
+      <node type="where-populated, child reached and populated">
         <xsl:where-populated>
           <xsl:copy-of select="node" />
         </xsl:where-populated>
       </node>
+      <!-- Only untraceable descendants -->
+      <node type="where-populated, untraced child reached but not populated">
+        <xsl:where-populated>                                                  <!-- Expected unknown -->
+          <xsl:fallback />                                                     <!-- Expected unknown -->
+        </xsl:where-populated>                                                 <!-- Expected unknown -->
+      </node>
+      <node type="where-populated, untraced child reached and populated">
+        <xsl:where-populated>                                                  <!-- Expected unknown -->
+          <xsl:perform-sort select="node">                                     <!-- Expected miss -->
+            <xsl:sort select="." />                                            <!-- Expected miss-->
+          </xsl:perform-sort>                                                  <!-- Expected miss -->
+        </xsl:where-populated>                                                 <!-- Expected unknown -->
+      </node>      
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
@@ -17,8 +17,15 @@
     </x:context>
     <x:expect label="Success">
       <root>
-        <node type="where-populated"/>
-        <node type="where-populated">
+        <node type="where-populated, child reached but not populated"/>
+        <node type="where-populated, child reached and populated">
+          <node>100</node>
+          <node>200</node>
+          <node>300</node>
+          <node>400</node>
+        </node>
+        <node type="where-populated, untraced child reached but not populated" />
+        <node type="where-populated, untraced child reached and populated">
           <node>100</node>
           <node>200</node>
           <node>300</node>


### PR DESCRIPTION
This pull request makes `xsl:where-populated` follow the Use Child Data rule and adds test cases for the "unknown" status that can result from that rule.

Note: This pull request does not include the changes in the open pull request #1978. Eventually, everything will get merged together, but I didn't want to make this simpler pull request depend on that more complicated one.

Fixes #1946.

---

Cc: @birdya22