### PR TITLE
fix(report): fix Use Child Data rule and rename as Use Descendant Data

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -29,7 +29,7 @@ The following list describes the rules used to determine the coverage status of 
 - **Always Ignore** - Mark node as 'ignored'. This rule is mainly for Declaration elements where Saxon does not produce trace output.
 - **Use Trace Data** - If the trace data has a "hit" element, mark node as a 'hit'. Otherwise, mark it as 'missed'.
 - **Use Parent Data** - If the trace data has a "hit" element for this node's parent, mark this node as a 'hit'. Otherwise, mark it as 'missed'. Rationale: This element is not traced in the XSpec trace file, but if it has been executed, then its parent is traced.
-- **Use Child Data** - If node has no children or only untraceable descendants, mark it as 'unknown'. If the trace data has a "hit" element for a descendant of this node, then mark this node as a 'hit'. Otherwise, mark this node as 'missed'. An untraceable node is one that Saxon never traces, regardless of what the XSpec test covers. Rationale: This element is untraceable in the XSpec trace file, but if it has been executed, then any traceable descendants are traced. NOTE: the fact that `xsl:sequence` is untraceable might cause this rule to produce the wrong result.
+- **Use Descendant Data** - If node has no children, mark it as 'unknown'. If the trace data has a "hit" element for a descendant of this node, then mark this node as a 'hit'. Otherwise, mark this node as either 'unknown' or 'missed', as follows: 'missed' if all executable descendants are traceable, else 'unknown'. An untraceable node is one that Saxon never traces, regardless of what the XSpec test covers. Non-executable descendants in this context are comments, processing instructions, and whitespace-only text nodes (except inside xsl:text). Rationale: This element is untraceable in the XSpec trace file, but if it has been executed, then any traceable executable descendants are traced. NOTE: the fact that `xsl:sequence` is untraceable might cause this rule to produce the wrong result.
 - **None** - The element is not supported by XSpec code coverage.
 - **TBD** -
 - **Element Specific** - The element does not fit into any of the other rules and has its own rule description.
@@ -144,14 +144,14 @@ XSLT 4.0 proposal.
 
 ## xsl:assert
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY | Instruction    |
-| PARENT   |                |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY | Instruction         |
+| PARENT   |                     |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 ## xsl:attribute
 
@@ -207,14 +207,14 @@ Tested as part of xsl:iterate.
 
 ## xsl:catch
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY |                |
-| PARENT   | xsl:try        |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:try             |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -361,14 +361,14 @@ Package related.
 
 ## xsl:fallback
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY | Instruction    |
-| PARENT   |                |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY | Instruction         |
+| PARENT   |                     |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 ## xsl:for-each
 
@@ -562,14 +562,14 @@ Inclined to say unknown and add a comment on the Code Coverage page.
 
 ## xsl:matching-substring
 
-|          |                    |
-| -------- | ------------------ |
-| CATEGORY |                    |
-| PARENT   | xsl:analyze-string |
-| CHILDREN |                    |
-| CONTENT  |                    |
-| TRACE    | No                 |
-| RULE     | Use Child Data     |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:analyze-string  |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -605,7 +605,7 @@ Children of xsl:merge are not traced. However, xsl:merge has a well defined stru
 
 Tested as part of xsl:merge.
 
-If xsl:merge is hit then it is safe to say that xsl:merge-action is also hit. Note: It would be possible for xsl:merge-action to Use Child Data, but the suggestion is that it follow the same rule as other xsl:merge-\* descendants of xsl:merge.
+If xsl:merge is hit then it is safe to say that xsl:merge-action is also hit. Note: It would be possible for xsl:merge-action to Use Descendant Data, but the suggestion is that it follow the same rule as other xsl:merge-\* descendants of xsl:merge.
 
 The sequence constructor in xsl:merge-action is traced.
 
@@ -717,14 +717,14 @@ Tested as part of xsl:iterate.
 
 ## xsl:non-matching-substring
 
-|          |                    |
-| -------- | ------------------ |
-| CATEGORY |                    |
-| PARENT   | xsl:analyze-string |
-| CHILDREN |                    |
-| CONTENT  |                    |
-| TRACE    | No                 |
-| RULE     | Use Child Data     |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:analyze-string  |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -743,14 +743,14 @@ Tested as part of xsl:analyze-string.
 
 ## xsl:on-completion
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY |                |
-| PARENT   | xsl:iterate    |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:iterate         |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -796,14 +796,14 @@ Suggest it is marked as 'unknown' including the children until the Saxon issue i
 
 ## xsl:otherwise
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY |                |
-| PARENT   | xsl:choose     |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:choose          |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -956,14 +956,14 @@ With a sequence constructor, children are traced, excluding xsl:sort. If the onl
 
 ## xsl:sequence
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY | Instruction    |
-| PARENT   |                |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY | Instruction         |
+| PARENT   |                     |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -1151,14 +1151,14 @@ With Non-global variables, it is difficult to assess and the best approach is pr
 
 ## xsl:when
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY |                |
-| PARENT   | xsl:choose     |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY |                     |
+| PARENT   | xsl:choose          |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 
@@ -1168,14 +1168,14 @@ Any children are traced.
 
 ## xsl:where-populated
 
-|          |                |
-| -------- | -------------- |
-| CATEGORY | Instruction    |
-| PARENT   |                |
-| CHILDREN |                |
-| CONTENT  |                |
-| TRACE    | No             |
-| RULE     | Use Child Data |
+|          |                     |
+| -------- | ------------------- |
+| CATEGORY | Instruction         |
+| PARENT   |                     |
+| CHILDREN |                     |
+| CONTENT  |                     |
+| TRACE    | No                  |
+| RULE     | Use Descendant Data |
 
 #### Comment
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -103,7 +103,7 @@
         <xsl:sequence select="'ignored'"/>
     </xsl:template>
 
-    <!-- Use Child Data -->
+    <!-- Use Descendant Data -->
     <xsl:template
         match="
         XSLT:fallback

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -285,6 +285,7 @@
         | XSLT:sort
         | XSLT:template/XSLT:param[@select]
         | XSLT:try
+        | XSLT:when
         | XSLT:where-populated
         | XSLT:with-param"
         mode="untraceable-in-instruction">

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-assert-01.xsl">xsl-assert-01.xsl</a></p>
-      <h2>module: xsl-assert-01.xsl; 27 lines</h2>
+      <h2>module: xsl-assert-01.xsl; 41 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -24,16 +24,30 @@
 14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 16: 
-17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-true"&gt;</span>
-18: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-19: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
-20: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
-21: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 gt 0"&gt;</span>
-22: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-23: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
-24: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-25: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-26: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-27: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-false-before-traceable"&gt;</span>
+18: <span class="ignored">      </span><span class="ignored">&lt;!-- Use Child Data case of untraceable executed combined with traceable unexecuted --&gt;</span>
+19: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion executed but unknown status --&gt;</span>
+20: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion executed unknown"&gt;</span>
+21: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="1"&gt;</span>
+22: <span class="ignored">          </span><span class="missed">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+23: <span class="ignored">            </span><span class="missed">&lt;xsl:assert test="100 lt 0" /&gt;</span>
+24: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">can't get here</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+25: <span class="ignored">          </span><span class="missed">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+26: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="concat(., ', ')" /&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;/xsl:iterate&gt;</span>
+28: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+29: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+30: 
+31: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-true"&gt;</span>
+32: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+33: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
+34: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
+35: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 gt 0"&gt;</span>
+36: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+37: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
+38: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+39: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+40: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+41: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -25,7 +25,7 @@
 15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 16: 
 17: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-assert" mode="xsl-assert-false-before-traceable"&gt;</span>
-18: <span class="ignored">      </span><span class="ignored">&lt;!-- Use Child Data case of untraceable executed combined with traceable unexecuted --&gt;</span>
+18: <span class="ignored">      </span><span class="ignored">&lt;!-- Use Descendant Data case of untraceable executed combined with traceable unexecuted --&gt;</span>
 19: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion executed but unknown status --&gt;</span>
 20: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion executed unknown"&gt;</span>
 21: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="1"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -29,10 +29,10 @@
 19: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:iterate with xsl:on-completion executed but unknown status --&gt;</span>
 20: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion executed unknown"&gt;</span>
 21: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="1"&gt;</span>
-22: <span class="ignored">          </span><span class="missed">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+22: <span class="ignored">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 23: <span class="ignored">            </span><span class="missed">&lt;xsl:assert test="100 lt 0" /&gt;</span>
 24: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">can't get here</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-25: <span class="ignored">          </span><span class="missed">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+25: <span class="ignored">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 26: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="concat(., ', ')" /&gt;</span>
 27: <span class="ignored">        </span><span class="hit">&lt;/xsl:iterate&gt;</span>
 28: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.xml
@@ -25,8 +25,17 @@
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/wrap.xsl"/>
    <util utilId="3" uri="../../../../../src/common/deep-equal.xsl"/>
-   <hit lineNumber="17" columnNumber="59" moduleId="0" traceableId="0"/>
-   <hit lineNumber="18" columnNumber="11" moduleId="0" traceableId="1"/>
-   <hit lineNumber="20" columnNumber="27" moduleId="0" traceableId="1"/>
-   <hit lineNumber="20" columnNumber="27" moduleId="0" traceableId="2"/>
+   <hit lineNumber="17" columnNumber="77" moduleId="0" traceableId="0"/>
+   <hit lineNumber="20" columnNumber="59" moduleId="0" traceableId="1"/>
+   <hit lineNumber="20" columnNumber="59" moduleId="0" traceableId="2"/>
+   <traceable traceableId="5"
+              class="net.sf.saxon.expr.instruct.IterateInstr"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}iterate"/>
+   <hit lineNumber="21" columnNumber="33" moduleId="0" traceableId="5"/>
+   <hit lineNumber="26" columnNumber="52" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="0" moduleId="0" traceableId="3"/>
+   <hit lineNumber="31" columnNumber="59" moduleId="0" traceableId="0"/>
+   <hit lineNumber="32" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="27" moduleId="0" traceableId="1"/>
+   <hit lineNumber="34" columnNumber="27" moduleId="0" traceableId="2"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -43,11 +43,11 @@
 33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span><span class="ignored">      </span>
 34: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:fallback is untraceable, while &lt;empty-element/&gt; is traceable but has no hit in trace. --&gt;</span>
 35: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraceable descendant and traceable descendant"&gt;</span>
-36: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+36: <span class="ignored">        </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 37: <span class="ignored">          </span><span class="missed">&lt;xsl:fallback&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 38: <span class="ignored">            </span><span class="missed">&lt;empty-element /&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 39: <span class="ignored">          </span><span class="missed">&lt;/xsl:fallback&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-40: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+40: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 42: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:fallback is untraceable, while &lt;xsl:text&gt; is traceable and has hit in trace. --&gt;</span>
 43: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraceable descendant and traceable descendant"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-where-populated-01.xsl">xsl-where-populated-01.xsl</a></p>
-      <h2>module: xsl-where-populated-01.xsl; 35 lines</h2>
+      <h2>module: xsl-where-populated-01.xsl; 51 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -33,15 +33,31 @@
 23: <span class="ignored">          </span><span class="unknown">&lt;xsl:fallback /&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 24: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-26: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraced child reached and populated"&gt;</span>
-27: <span class="ignored">        </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-28: <span class="ignored">          </span><span class="missed">&lt;xsl:perform-sort select="node"&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-29: <span class="ignored">            </span><span class="missed">&lt;xsl:sort select="." /&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected miss--&gt;</span>
-30: <span class="ignored">          </span><span class="missed">&lt;/xsl:perform-sort&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-31: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-32: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span><span class="ignored">      </span>
-33: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-34: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-35: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+26: <span class="ignored">      </span><span class="ignored">&lt;!-- Only untraceable descendants --&gt;</span>
+27: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraced child reached and populated"&gt;</span>
+28: <span class="ignored">        </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+29: <span class="ignored">          </span><span class="missed">&lt;xsl:perform-sort select="node"&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+30: <span class="ignored">            </span><span class="missed">&lt;xsl:sort select="." /&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected miss--&gt;</span>
+31: <span class="ignored">          </span><span class="missed">&lt;/xsl:perform-sort&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+32: <span class="ignored">        </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+33: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span><span class="ignored">      </span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:fallback is untraceable, while &lt;empty-element/&gt; is traceable but has no hit in trace. --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraceable descendant and traceable descendant"&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;xsl:where-populated&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+37: <span class="ignored">          </span><span class="missed">&lt;xsl:fallback&gt;</span><span class="ignored">                                                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+38: <span class="ignored">            </span><span class="missed">&lt;empty-element /&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+39: <span class="ignored">          </span><span class="missed">&lt;/xsl:fallback&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+40: <span class="ignored">        </span><span class="missed">&lt;/xsl:where-populated&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+41: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+42: <span class="ignored">      </span><span class="ignored">&lt;!-- xsl:fallback is untraceable, while &lt;xsl:text&gt; is traceable and has hit in trace. --&gt;</span>
+43: <span class="ignored">      </span><span class="hit">&lt;node type="where-populated, untraceable descendant and traceable descendant"&gt;</span>
+44: <span class="ignored">        </span><span class="hit">&lt;xsl:where-populated&gt;</span>
+45: <span class="ignored">          </span><span class="unknown">&lt;xsl:fallback /&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+46: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">500</span><span class="hit">&lt;/xsl:text&gt;</span>
+47: <span class="ignored">        </span><span class="hit">&lt;/xsl:where-populated&gt;</span>
+48: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+49: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+50: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+51: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.xml
@@ -25,9 +25,18 @@
    <hit lineNumber="17" columnNumber="40" moduleId="0" traceableId="4"/>
    <hit lineNumber="21" columnNumber="78" moduleId="0" traceableId="1"/>
    <hit lineNumber="21" columnNumber="78" moduleId="0" traceableId="2"/>
-   <hit lineNumber="26" columnNumber="74" moduleId="0" traceableId="1"/>
-   <hit lineNumber="26" columnNumber="74" moduleId="0" traceableId="2"/>
-   <hit lineNumber="28" columnNumber="4" moduleId="0" traceableId="3"/>
+   <hit lineNumber="27" columnNumber="74" moduleId="0" traceableId="1"/>
+   <hit lineNumber="27" columnNumber="74" moduleId="0" traceableId="2"/>
+   <hit lineNumber="29" columnNumber="4" moduleId="0" traceableId="3"/>
+   <hit lineNumber="35" columnNumber="85" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="85" moduleId="0" traceableId="2"/>
+   <hit lineNumber="43" columnNumber="85" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="85" moduleId="0" traceableId="2"/>
+   <hit lineNumber="46" columnNumber="21" moduleId="0" traceableId="3"/>
+   <traceable traceableId="5"
+              class="net.sf.saxon.expr.instruct.ValueOf"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
+   <hit lineNumber="46" columnNumber="21" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xsl
@@ -14,6 +14,20 @@
     </root>
   </xsl:template>
 
+  <xsl:template match="xsl-assert" mode="xsl-assert-false-before-traceable">
+      <!-- Use Child Data case of untraceable executed combined with traceable unexecuted -->
+      <!-- xsl:iterate with xsl:on-completion executed but unknown status -->
+      <node type="iterate/on-completion executed unknown">
+        <xsl:iterate select="1">
+          <xsl:on-completion>                                                  <!-- Expected unknown -->
+            <xsl:assert test="100 lt 0" />
+            <xsl:text>can't get here</xsl:text>                                <!-- Expected miss -->
+          </xsl:on-completion>                                                 <!-- Expected unknown -->
+          <xsl:value-of select="concat(., ', ')" />
+        </xsl:iterate>
+      </node>
+  </xsl:template>
+
   <xsl:template match="xsl-assert" mode="xsl-assert-true">
     <root>
       <!-- Assert true -->

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xsl
@@ -15,7 +15,7 @@
   </xsl:template>
 
   <xsl:template match="xsl-assert" mode="xsl-assert-false-before-traceable">
-      <!-- Use Child Data case of untraceable executed combined with traceable unexecuted -->
+      <!-- Use Descendant Data case of untraceable executed combined with traceable unexecuted -->
       <!-- xsl:iterate with xsl:on-completion executed but unknown status -->
       <node type="iterate/on-completion executed unknown">
         <xsl:iterate select="1">

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xspec
@@ -14,6 +14,19 @@
          select="'Assert Message: 100 lt 0'"/>
    </x:scenario>
 
+   <x:scenario
+      label="xsl:assert Coverage Test Case whose descendants are untraceable executed and traceable unexecuted"
+      catch="yes">
+      <x:context mode="xsl-assert-false-before-traceable">
+         <root>
+            <xsl-assert />
+         </root>
+      </x:context>
+      <!-- XSpec catches the error and returns a map. -->
+      <x:expect label="Success" test="?err?value => string()"
+         select="''"/>
+   </x:scenario>
+
    <x:scenario label="xsl:assert Coverage Test Case for true assertion">
       <x:context mode="xsl-assert-true">
          <root>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xsl
@@ -23,6 +23,7 @@
           <xsl:fallback />                                                     <!-- Expected unknown -->
         </xsl:where-populated>                                                 <!-- Expected unknown -->
       </node>
+      <!-- Only untraceable descendants -->
       <node type="where-populated, untraced child reached and populated">
         <xsl:where-populated>                                                  <!-- Expected unknown -->
           <xsl:perform-sort select="node">                                     <!-- Expected miss -->
@@ -30,6 +31,21 @@
           </xsl:perform-sort>                                                  <!-- Expected miss -->
         </xsl:where-populated>                                                 <!-- Expected unknown -->
       </node>      
+      <!-- xsl:fallback is untraceable, while <empty-element/> is traceable but has no hit in trace. -->
+      <node type="where-populated, untraceable descendant and traceable descendant">
+        <xsl:where-populated>                                                  <!-- Expected unknown -->
+          <xsl:fallback>                                                       <!-- Expected miss -->
+            <empty-element />                                                  <!-- Expected miss -->
+          </xsl:fallback>                                                      <!-- Expected miss -->
+        </xsl:where-populated>                                                 <!-- Expected unknown -->
+      </node>
+      <!-- xsl:fallback is untraceable, while <xsl:text> is traceable and has hit in trace. -->
+      <node type="where-populated, untraceable descendant and traceable descendant">
+        <xsl:where-populated>
+          <xsl:fallback />                                                     <!-- Expected unknown -->
+          <xsl:text>500</xsl:text>
+        </xsl:where-populated>
+      </node>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-where-populated-01.xspec
@@ -31,6 +31,8 @@
           <node>300</node>
           <node>400</node>
         </node>
+        <node type="where-populated, untraceable descendant and traceable descendant"/>
+        <node type="where-populated, untraceable descendant and traceable descendant">500</node>
       </root>
     </x:expect>
   </x:scenario>


### PR DESCRIPTION
- f2438cdba6fc11fcd9350af9183c728ee378eeaa adds test cases that reproduce #1980
- 90a1f71b5c197b56cb9a82982258aa2767686dfe fixes #1980
- ce2521974eca50d18bb7ab16b64b80c9e20f7fc9 updates the `xslt-code-coverage-by-element.md` file to reflect the fixed logic, and also changes the name of the rule to **Use Descendant Data**

---

Cc: @birdya22