### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver from 5.2.3 to 5.2.4

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -24,4 +24,4 @@ XMLCALABASH_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.3
+XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.4


### PR DESCRIPTION
Release notes:

https://github.com/xmlresolver/xmlresolver/releases/tag/5.2.4