### PR TITLE
fix(report): coverage update for xsl:assert

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -144,14 +144,18 @@ XSLT 4.0 proposal.
 
 ## xsl:assert
 
-|          |                     |
-| -------- | ------------------- |
-| CATEGORY | Instruction         |
-| PARENT   |                     |
-| CHILDREN |                     |
-| CONTENT  |                     |
-| TRACE    | No                  |
-| RULE     | Use Descendant Data |
+|          |                                    |
+| -------- | ---------------------------------- |
+| CATEGORY | Instruction                        |
+| PARENT   |                                    |
+| CHILDREN |                                    |
+| CONTENT  |                                    |
+| TRACE    | No                                 |
+| RULE     | Unknown, including all descendants |
+
+#### Comment
+
+For this element, Saxon 12.4 produces incorrect data (trace hit points to first child), while Saxon 12.5 produces no data.
 
 ## xsl:attribute
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -44,6 +44,12 @@
 
     <!--
       mode="coverage"
+
+      This mode implements the rules described in docs/xslt-code-coverage-by-element.md.
+
+      Priority values of templates in this mode ensure correct rule selection, such as
+      when templates match descendants via different paths. Tests for rule selection are
+      in test/end-to-end/cases-coverage.
    -->
     <xsl:mode name="coverage" on-multiple-match="fail" on-no-match="fail" />
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -103,6 +103,15 @@
         <xsl:sequence select="'ignored'"/>
     </xsl:template>
 
+    <!-- Unknown, Including All Descendants -->
+    <xsl:template match="
+        XSLT:assert/descendant-or-self::node()"
+        as="xs:string"
+        mode="coverage"
+        priority="8">
+        <xsl:sequence select="'unknown'"/>
+    </xsl:template>
+
     <!-- Use Descendant Data -->
     <xsl:template
         match="

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -7,13 +7,13 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../non-xsl-top-level-element-01.xsl">non-xsl-top-level-element-01.xsl</a></p>
-      <h2>module: non-xsl-top-level-element-01.xsl; 36 lines</h2>
+      <h2>module: non-xsl-top-level-element-01.xsl; 44 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 04: <span class="ignored">      Coverage Test Case for non-XSLT child of xsl:stylesheet</span>
 05: <span class="ignored">  --&gt;</span>
-06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="non-xsl-top-level-element-01A.xsl"/&gt;</span>
+06: <span class="ignored">  </span><span class="ignored">&lt;xsl:import href="non-xsl-top-level-element-01A.xsl"/&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
 07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="non-xsl-top-level-element"&gt;</span>
 08: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;xsl:copy&gt;</span>
@@ -28,23 +28,31 @@
 18: <span class="ignored">    </span><span class="missed">&lt;non-xsl-element/&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 19: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 20: 
-21: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace"&gt;</span>
-22: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-23: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/doc:para&gt;</span>
-24: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span>
-25: 
-26: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace"&gt;</span>
-27: <span class="ignored">    </span><span class="ignored">&lt;xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-28: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/xsl:para&gt;</span>
-29: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span>
-30: 
-31: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace"&gt;</span>
-32: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-33: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/para&gt;</span>
-34: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span>
-35: 
-36: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
-      <h2>module: non-xsl-top-level-element-01A.xsl; 32 lines</h2>
+21: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotXSLTNamespace"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+22: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+23: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+24: <span class="ignored">      </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored">&lt;/doc:para&gt;</span><span class="ignored">       </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+25: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+26: 
+27: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotXSLTNamespace"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+28: <span class="ignored">    </span><span class="ignored">&lt;xsl:text</span>
+29: <span class="ignored">      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+30: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+31: <span class="ignored">      </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored">&lt;/xsl:para&gt;</span><span class="ignored">       </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+32: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+33: 
+34: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotXSLTNamespace"&gt;</span><span class="ignored">         </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+35: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+36: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+37: <span class="ignored">      </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored">&lt;/para&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+38: <span class="ignored">    </span><span class="ignored">&lt;!-- Non-XSLT-top-level rule is higher priority than xsl:assert rule --&gt;</span>
+39: <span class="ignored">    </span><span class="ignored">&lt;xsl:assert test="false()"&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+40: <span class="ignored">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored, not unknown</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+41: <span class="ignored">    </span><span class="ignored">&lt;/xsl:assert&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+42: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span><span class="ignored">                                                                  </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+43: 
+44: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: non-xsl-top-level-element-01A.xsl; 40 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -61,21 +69,29 @@
 14: <span class="ignored">    </span><span class="missed">&lt;non-xsl-element/&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 15: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 16: 
-17: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace"&gt;</span>
-18: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-19: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/doc:para&gt;</span>
-20: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span>
-21: 
-22: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace"&gt;</span>
-23: <span class="ignored">    </span><span class="ignored">&lt;xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-24: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/xsl:para&gt;</span>
-25: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span>
-26: 
-27: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace"&gt;</span>
-28: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span>
-29: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored"> namespace</span><span class="ignored">&lt;/para&gt;</span>
-30: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span>
-31: 
-32: <span class="ignored">&lt;/xsl:transform&gt;</span></pre>
+17: <span class="ignored">  </span><span class="ignored">&lt;doc:template name="non-xsl-top-level-element" xmlns:doc="NotXSLTNamespace"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+18: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+19: <span class="ignored">    </span><span class="ignored">&lt;doc:para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+20: <span class="ignored">      </span><span class="ignored">&lt;doc:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/doc:uri&gt;</span><span class="ignored">&lt;/doc:para&gt;</span><span class="ignored">       </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+21: <span class="ignored">  </span><span class="ignored">&lt;/doc:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+22: 
+23: <span class="ignored">  </span><span class="ignored">&lt;xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotXSLTNamespace"&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+24: <span class="ignored">    </span><span class="ignored">&lt;xsl:text</span>
+25: <span class="ignored">      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">      </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+26: <span class="ignored">    </span><span class="ignored">&lt;xsl:para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+27: <span class="ignored">      </span><span class="ignored">&lt;xsl:uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/xsl:uri&gt;</span><span class="ignored">&lt;/xsl:para&gt;</span><span class="ignored">       </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+28: <span class="ignored">  </span><span class="ignored">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+29: 
+30: <span class="ignored">  </span><span class="ignored">&lt;template name="non-xsl-top-level-element" xmlns="NotXSLTNamespace"&gt;</span><span class="ignored">         </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+31: <span class="ignored">    </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+32: <span class="ignored">    </span><span class="ignored">&lt;para&gt;</span><span class="ignored">Top-level element is not in namespace</span>
+33: <span class="ignored">      </span><span class="ignored">&lt;uri&gt;</span><span class="ignored">http://www.w3.org/1999/XSL/Transform</span><span class="ignored">&lt;/uri&gt;</span><span class="ignored">&lt;/para&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+34: <span class="ignored">    </span><span class="ignored">&lt;!-- Non-XSLT-top-level rule is higher priority than xsl:assert rule --&gt;</span>
+35: <span class="ignored">    </span><span class="ignored">&lt;xsl:assert test="false()"&gt;</span><span class="ignored">                                                </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+36: <span class="ignored">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">Ignored, not unknown</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+37: <span class="ignored">    </span><span class="ignored">&lt;/xsl:assert&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+38: <span class="ignored">  </span><span class="ignored">&lt;/template&gt;</span><span class="ignored">                                                                  </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+39: 
+40: <span class="ignored">&lt;/xsl:transform&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -7,44 +7,53 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-accumulator-01.xsl">xsl-accumulator-01.xsl</a></p>
-      <h2>module: xsl-accumulator-01.xsl; 38 lines</h2>
+      <h2>module: xsl-accumulator-01.xsl; 47 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
 04: <span class="ignored">       xsl:accumulator Test Case</span>
 05: <span class="ignored">  --&gt;</span>
 06: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator --&gt;</span>
-07: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span>
-08: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span>
-09: <span class="ignored">      </span><span class="ignored">&lt;xsl:value-of select="$value + 1" /&gt;</span>
-10: <span class="ignored">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span>
-11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
+07: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+08: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+09: <span class="ignored">      </span><span class="ignored">&lt;xsl:value-of select="$value + 1" /&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+10: <span class="ignored">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+11: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
 12: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator not used --&gt;</span>
-13: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span>
-14: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span>
-15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span>
-16: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for accumulator --&gt;</span>
-17: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span>
-18: <span class="ignored">  </span><span class="ignored">&lt;!-- Make accumulator applicable in default mode, too, so that</span>
-19: <span class="ignored">    xsl-accumulator-01.xspec can run with run-as="external" or</span>
-20: <span class="ignored">    when imported by a test with that setting. --&gt;</span>
-21: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" /&gt;</span>
-22: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
-23: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
-24: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-25: <span class="ignored">      </span><span class="ignored">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
-26: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
-27: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-28: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-29: <span class="ignored">  </span><span class="ignored">&lt;!-- used in xsl:accumulator test --&gt;</span>
-30: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
-31: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
-32: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
-33: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
-34: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
-35: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
-36: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+13: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span><span class="ignored">                           </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+14: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span><span class="ignored">                </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+15: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+16: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:accumulator rules are higher priority than xsl:assert rule --&gt;</span>
+17: <span class="ignored">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorVsAssert" initial-value="()"&gt;</span><span class="ignored">              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+18: <span class="ignored">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+19: <span class="ignored">      </span><span class="ignored">&lt;xsl:assert test="true()"&gt;</span><span class="ignored">                                               </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+20: <span class="ignored">        </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">cannot get here</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="ignored">                                   </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+21: <span class="ignored">      </span><span class="ignored">&lt;/xsl:assert&gt;</span><span class="ignored">                                                            </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+22: <span class="ignored">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+23: <span class="ignored">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="ignored">                                                           </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+24: <span class="ignored"> </span>
+25: <span class="ignored">  </span><span class="ignored">&lt;!-- xsl:mode for accumulator --&gt;</span>
+26: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span><span class="ignored">           </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+27: <span class="ignored">  </span><span class="ignored">&lt;!-- Make accumulator applicable in default mode, too, so that</span>
+28: <span class="ignored">    xsl-accumulator-01.xspec can run with run-as="external" or</span>
+29: <span class="ignored">    when imported by a test with that setting. --&gt;</span>
+30: <span class="ignored">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" /&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected ignored --&gt;</span>
+31: <span class="ignored">  </span><span class="ignored">&lt;!-- Main template --&gt;</span>
+32: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
+33: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+34: <span class="ignored">      </span><span class="ignored">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
+36: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 37: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-38: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+38: <span class="ignored">  </span><span class="ignored">&lt;!-- used in xsl:accumulator test --&gt;</span>
+39: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
+40: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
+41: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
+42: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+43: <span class="ignored">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
+44: <span class="ignored">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
+45: <span class="ignored">    </span><span class="hit">&lt;/node&gt;</span>
+46: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+47: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
@@ -5,40 +5,40 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="23" columnNumber="41" moduleId="0" traceableId="0"/>
+   <hit lineNumber="32" columnNumber="41" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="24" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="33" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.ApplyTemplates"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
-   <hit lineNumber="26" columnNumber="60" moduleId="0" traceableId="2"/>
-   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="60" moduleId="0" traceableId="2"/>
+   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
-   <hit lineNumber="30" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="31" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="32" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="34" columnNumber="36" moduleId="0" traceableId="3"/>
-   <hit lineNumber="35" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="4"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="3"/>
+   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -17,9 +17,9 @@
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert false --&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
-10: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 lt 0"&gt;</span>
-11: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Assert Message: 100 lt 0</span><span class="hit">&lt;/xsl:text&gt;</span>
-12: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
+10: <span class="ignored">        </span><span class="unknown">&lt;xsl:assert test="100 lt 0"&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+11: <span class="ignored">          </span><span class="unknown">&lt;xsl:text&gt;</span><span class="unknown">Assert Message: 100 lt 0</span><span class="unknown">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+12: <span class="ignored">        </span><span class="unknown">&lt;/xsl:assert&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 13: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 14: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 15: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
@@ -30,7 +30,7 @@
 20: <span class="ignored">      </span><span class="hit">&lt;node type="iterate/on-completion executed unknown"&gt;</span>
 21: <span class="ignored">        </span><span class="hit">&lt;xsl:iterate select="1"&gt;</span>
 22: <span class="ignored">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
-23: <span class="ignored">            </span><span class="missed">&lt;xsl:assert test="100 lt 0" /&gt;</span>
+23: <span class="ignored">            </span><span class="unknown">&lt;xsl:assert test="100 lt 0" /&gt;</span><span class="ignored">                                     </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 24: <span class="ignored">            </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">can't get here</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 25: <span class="ignored">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 26: <span class="ignored">          </span><span class="hit">&lt;xsl:value-of select="concat(., ', ')" /&gt;</span>
@@ -42,9 +42,9 @@
 32: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 33: <span class="ignored">      </span><span class="ignored">&lt;!-- Assert true --&gt;</span>
 34: <span class="ignored">      </span><span class="hit">&lt;node type="assert"&gt;</span>
-35: <span class="ignored">        </span><span class="missed">&lt;xsl:assert test="100 gt 0"&gt;</span>
-36: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">Assert Message: 100 gt 0</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-37: <span class="ignored">        </span><span class="missed">&lt;/xsl:assert&gt;</span>
+35: <span class="ignored">        </span><span class="unknown">&lt;xsl:assert test="100 gt 0"&gt;</span><span class="ignored">                                           </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+36: <span class="ignored">          </span><span class="unknown">&lt;xsl:text&gt;</span><span class="unknown">Assert Message: 100 gt 0</span><span class="unknown">&lt;/xsl:text&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+37: <span class="ignored">        </span><span class="unknown">&lt;/xsl:assert&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 38: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 39: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 40: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01.xsl
@@ -3,7 +3,7 @@
   <!--
       Coverage Test Case for non-XSLT child of xsl:stylesheet
   -->
-  <xsl:import href="non-xsl-top-level-element-01A.xsl"/>
+  <xsl:import href="non-xsl-top-level-element-01A.xsl"/>                       <!-- Expected ignored -->
   <xsl:template match="non-xsl-top-level-element">
     <root>
       <xsl:copy>
@@ -18,19 +18,27 @@
     <non-xsl-element/>                                                         <!-- Expected miss -->
   </xsl:template>                                                              <!-- Expected miss -->
 
-  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace">
-    <xsl:text>Ignored</xsl:text>
-    <doc:para>Top-level element is not in <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri> namespace</doc:para>
-  </doc:template>
+  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotXSLTNamespace"> <!-- Expected ignored -->
+    <xsl:text>Ignored</xsl:text>                                               <!-- Expected ignored -->
+    <doc:para>Top-level element is not in namespace
+      <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri></doc:para>       <!-- Expected ignored -->
+  </doc:template>                                                              <!-- Expected ignored -->
 
-  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace">
-    <xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>
-    <xsl:para>Top-level element is not in <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri> namespace</xsl:para>
-  </xsl:template>
+  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotXSLTNamespace"> <!-- Expected ignored -->
+    <xsl:text
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>      <!-- Expected ignored -->
+    <xsl:para>Top-level element is not in namespace
+      <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri></xsl:para>       <!-- Expected ignored -->
+  </xsl:template>                                                              <!-- Expected ignored -->
 
-  <template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace">
-    <xsl:text>Ignored</xsl:text>
-    <para>Top-level element is not in <uri>http://www.w3.org/1999/XSL/Transform</uri> namespace</para>
-  </template>
+  <template name="non-xsl-top-level-element" xmlns="NotXSLTNamespace">         <!-- Expected ignored -->
+    <xsl:text>Ignored</xsl:text>                                               <!-- Expected ignored -->
+    <para>Top-level element is not in namespace
+      <uri>http://www.w3.org/1999/XSL/Transform</uri></para>                   <!-- Expected ignored -->
+    <!-- Non-XSLT-top-level rule is higher priority than xsl:assert rule -->
+    <xsl:assert test="false()">                                                <!-- Expected ignored -->
+      <xsl:text>Ignored, not unknown</xsl:text>                                <!-- Expected ignored -->
+    </xsl:assert>                                                              <!-- Expected ignored -->
+  </template>                                                                  <!-- Expected ignored -->
 
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
@@ -14,19 +14,27 @@
     <non-xsl-element/>                                                         <!-- Expected miss -->
   </xsl:template>                                                              <!-- Expected miss -->
 
-  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotTheXSLTNamespace">
-    <xsl:text>Ignored</xsl:text>
-    <doc:para>Top-level element is not in <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri> namespace</doc:para>
-  </doc:template>
+  <doc:template name="non-xsl-top-level-element" xmlns:doc="NotXSLTNamespace"> <!-- Expected ignored -->
+    <xsl:text>Ignored</xsl:text>                                               <!-- Expected ignored -->
+    <doc:para>Top-level element is not in namespace
+      <doc:uri>http://www.w3.org/1999/XSL/Transform</doc:uri></doc:para>       <!-- Expected ignored -->
+  </doc:template>                                                              <!-- Expected ignored -->
 
-  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotTheXSLTNamespace">
-    <xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>
-    <xsl:para>Top-level element is not in <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri> namespace</xsl:para>
-  </xsl:template>
+  <xsl:template name="non-xsl-top-level-element" xmlns:xsl="NotXSLTNamespace"> <!-- Expected ignored -->
+    <xsl:text
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">Ignored</xsl:text>      <!-- Expected ignored -->
+    <xsl:para>Top-level element is not in namespace
+      <xsl:uri>http://www.w3.org/1999/XSL/Transform</xsl:uri></xsl:para>       <!-- Expected ignored -->
+  </xsl:template>                                                              <!-- Expected ignored -->
 
-  <template name="non-xsl-top-level-element" xmlns="NotTheXSLTNamespace">
-    <xsl:text>Ignored</xsl:text>
-    <para>Top-level element is not in <uri>http://www.w3.org/1999/XSL/Transform</uri> namespace</para>
-  </template>
+  <template name="non-xsl-top-level-element" xmlns="NotXSLTNamespace">         <!-- Expected ignored -->
+    <xsl:text>Ignored</xsl:text>                                               <!-- Expected ignored -->
+    <para>Top-level element is not in namespace
+      <uri>http://www.w3.org/1999/XSL/Transform</uri></para>                   <!-- Expected ignored -->
+    <!-- Non-XSLT-top-level rule is higher priority than xsl:assert rule -->
+    <xsl:assert test="false()">                                                <!-- Expected ignored -->
+      <xsl:text>Ignored, not unknown</xsl:text>                                <!-- Expected ignored -->
+    </xsl:assert>                                                              <!-- Expected ignored -->
+  </template>                                                                  <!-- Expected ignored -->
 
 </xsl:transform>

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
@@ -4,21 +4,30 @@
        xsl:accumulator Test Case
   -->
   <!-- xsl:accumulator -->
-  <xsl:accumulator name="accumulatorTest" initial-value="0">
-    <xsl:accumulator-rule match="node">
-      <xsl:value-of select="$value + 1" />
-    </xsl:accumulator-rule>
-  </xsl:accumulator>
+  <xsl:accumulator name="accumulatorTest" initial-value="0">                   <!-- Expected ignored -->
+    <xsl:accumulator-rule match="node">                                        <!-- Expected ignored -->
+      <xsl:value-of select="$value + 1" />                                     <!-- Expected ignored -->
+    </xsl:accumulator-rule>                                                    <!-- Expected ignored -->
+  </xsl:accumulator>                                                           <!-- Expected ignored -->
   <!-- xsl:accumulator not used -->
-  <xsl:accumulator name="dummy01" initial-value="0">
-    <xsl:accumulator-rule match="node()" select="$value + 1" />
-  </xsl:accumulator>
+  <xsl:accumulator name="dummy01" initial-value="0">                           <!-- Expected ignored -->
+    <xsl:accumulator-rule match="node()" select="$value + 1" />                <!-- Expected ignored -->
+  </xsl:accumulator>                                                           <!-- Expected ignored -->
+  <!-- xsl:accumulator rules are higher priority than xsl:assert rule -->
+  <xsl:accumulator name="accumulatorVsAssert" initial-value="()">              <!-- Expected ignored -->
+    <xsl:accumulator-rule match="node">                                        <!-- Expected ignored -->
+      <xsl:assert test="true()">                                               <!-- Expected ignored -->
+        <xsl:text>cannot get here</xsl:text>                                   <!-- Expected ignored -->
+      </xsl:assert>                                                            <!-- Expected ignored -->
+    </xsl:accumulator-rule>                                                    <!-- Expected ignored -->
+  </xsl:accumulator>                                                           <!-- Expected ignored -->
+ 
   <!-- xsl:mode for accumulator -->
-  <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />
+  <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />           <!-- Expected ignored -->
   <!-- Make accumulator applicable in default mode, too, so that
     xsl-accumulator-01.xspec can run with run-as="external" or
     when imported by a test with that setting. -->
-  <xsl:mode use-accumulators="accumulatorTest" />
+  <xsl:mode use-accumulators="accumulatorTest" />                              <!-- Expected ignored -->
   <!-- Main template -->
   <xsl:template match="xsl-accumulator">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-assert-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-assert-01.xsl
@@ -7,9 +7,9 @@
     <root>
       <!-- Assert false -->
       <node type="assert">
-        <xsl:assert test="100 lt 0">
-          <xsl:text>Assert Message: 100 lt 0</xsl:text>
-        </xsl:assert>
+        <xsl:assert test="100 lt 0">                                           <!-- Expected unknown -->
+          <xsl:text>Assert Message: 100 lt 0</xsl:text>                        <!-- Expected unknown -->
+        </xsl:assert>                                                          <!-- Expected unknown -->
       </node>
     </root>
   </xsl:template>
@@ -20,7 +20,7 @@
       <node type="iterate/on-completion executed unknown">
         <xsl:iterate select="1">
           <xsl:on-completion>                                                  <!-- Expected unknown -->
-            <xsl:assert test="100 lt 0" />
+            <xsl:assert test="100 lt 0" />                                     <!-- Expected unknown -->
             <xsl:text>can't get here</xsl:text>                                <!-- Expected miss -->
           </xsl:on-completion>                                                 <!-- Expected unknown -->
           <xsl:value-of select="concat(., ', ')" />
@@ -32,9 +32,9 @@
     <root>
       <!-- Assert true -->
       <node type="assert">
-        <xsl:assert test="100 gt 0">
-          <xsl:text>Assert Message: 100 gt 0</xsl:text>                        <!-- Expected miss -->
-        </xsl:assert>
+        <xsl:assert test="100 gt 0">                                           <!-- Expected unknown -->
+          <xsl:text>Assert Message: 100 gt 0</xsl:text>                        <!-- Expected unknown -->
+        </xsl:assert>                                                          <!-- Expected unknown -->
       </node>
     </root>
   </xsl:template>


### PR DESCRIPTION
This pull request marks xsl:assert and all its descendants as "unknown" except where certain higher-priority templates apply. This pull request also adds some test cases that illustrate the xsl:assert rule being lower priority than another template.

Note: This pull request does not include the changes in the open pull request https://github.com/xspec/xspec/pull/1978.

Fixes https://github.com/xspec/xspec/issues/1940.

---

Cc: @birdya22