### PR TITLE
feat(schematron): bump built-in SchXslt to v1.10

### DIFF
--- a/lib/schxslt/1.0/compile-for-svrl.xsl
+++ b/lib/schxslt/1.0/compile-for-svrl.xsl
@@ -13,6 +13,7 @@
     <xsl:param name="phase"/>
 
     <svrl:schematron-output>
+      <xsl:copy-of select="$schema/@xml:*"/>
       <xsl:copy-of select="$schema/@schemaVersion"/>
       <xsl:if test="$phase != '#ALL'">
         <xsl:attribute name="phase"><xsl:value-of select="$phase"/></xsl:attribute>
@@ -93,7 +94,8 @@
       </call-template>
     </variable>
     <svrl:failed-assert location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id | $assert/@see | $assert/@icon | $assert/@fpi | $assert/@xml:*"/>
+      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id | $assert/@see | $assert/@icon | $assert/@fpi"/>
+      <xsl:copy-of select="$assert/@xml:id | $assert/ancestor-or-self::*[@xml:lang]/@xml:lang"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -122,7 +124,8 @@
       </call-template>
     </variable>
     <svrl:successful-report location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id | $report/@see | $report/@icon | $report/@fpi | $report/@xml:*"/>
+      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id | $report/@see | $report/@icon | $report/@fpi"/>
+      <xsl:copy-of select="$report/@xml:id | $report/ancestor-or-self::*[@xml:lang]/@xml:lang"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>
@@ -185,12 +188,13 @@
 
     <svrl:diagnostic-reference diagnostic="{$head}">
       <svrl:text>
-        <xsl:copy-of select="key('schxslt:diagnostics', $head)/@*"/>
         <xsl:choose>
           <xsl:when test="$pattern/sch:diagnostics/sch:diagnostic[@id = $head]">
+            <xsl:copy-of select="$pattern/sch:diagnostics/sch:diagnostic[@id = $head]/@*"/>
             <xsl:apply-templates select="$pattern/sch:diagnostics/sch:diagnostic[@id = $head]/node()" mode="schxslt:message-template"/>
           </xsl:when>
           <xsl:otherwise>
+            <xsl:copy-of select="key('schxslt:diagnostics', $head)/@*"/>
             <xsl:apply-templates select="key('schxslt:diagnostics', $head)/node()" mode="schxslt:message-template"/>
           </xsl:otherwise>
         </xsl:choose>
@@ -226,14 +230,16 @@
 
     <svrl:property-reference property="{$head}">
       <xsl:copy-of select="key('schxslt:properties', $head)/@role"/>
-      <xsl:copy-of select="key('schxslt:properties', $head)/@schema"/>
-      <xsl:copy-of select="key('schxslt:properties', $head)/@xml:*"/>
+      <xsl:copy-of select="key('schxslt:properties', $head)/@scheme"/>
+
       <svrl:text>
         <xsl:choose>
           <xsl:when test="$pattern/sch:properties/sch:property[@id = $head]">
+            <xsl:copy-of select="$pattern/sch:properties/sch:property[@id = $head]/@*"/>
             <xsl:apply-templates select="$pattern/sch:properties/sch:property[@id = $head]/node()" mode="schxslt:message-template"/>
           </xsl:when>
           <xsl:otherwise>
+            <xsl:copy-of select="key('schxslt:properties', $head)/@*"/>
             <xsl:apply-templates select="key('schxslt:properties', $head)/node()" mode="schxslt:message-template"/>
           </xsl:otherwise>
         </xsl:choose>

--- a/lib/schxslt/1.0/include.xsl
+++ b/lib/schxslt/1.0/include.xsl
@@ -1,39 +1,100 @@
 <xsl:transform version="1.0"
+               xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-  <xsl:template match="node() | @*">
+  <xsl:template match="*">
+    <xsl:param name="sourceLang"/>
+
+    <xsl:variable name="thisLang">
+      <xsl:call-template name="schxslt:in-scope-language"/>
+    </xsl:variable>
+
+    <xsl:copy>
+      <xsl:if test="not(@xml:lang) and $thisLang != $sourceLang">
+        <xsl:attribute name="xml:lang">
+          <xsl:value-of select="$thisLang"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="comment() | processing-instruction() | @*">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="sch:extends[@href]">
+  <xsl:template match="sch:extends[@href][contains(@href, '#')]" priority="10">
+    <xsl:variable name="fragment" select="substring-after(current()/@href, '#')"/>
+    <xsl:variable name="sourceLang">
+      <xsl:call-template name="schxslt:in-scope-language"/>
+    </xsl:variable>
     <xsl:choose>
-      <xsl:when test="contains(@href, '#')">
-        <xsl:if test="local-name(..) = local-name(document(substring-before(@href, '#'), @href)//*[@xml:id = substring-after(current()/@href, '#')])">
-          <xsl:if test="namespace-uri(document(substring-before(@href, '#'), @href)//*[@xml:id = substring-after(current()/@href, '#')]) = 'http://purl.oclc.org/dsdl/schematron'">
-            <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@xml:id = substring-after(current()/@href, '#')]/*"/>
+      <xsl:when test="document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment]">
+        <xsl:if test="local-name(..) = local-name(document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment])">
+          <xsl:if test="namespace-uri(document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment]) = 'http://purl.oclc.org/dsdl/schematron'">
+            <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment]/node()">
+              <xsl:with-param name="sourceLang" select="$sourceLang"/>
+            </xsl:apply-templates>
           </xsl:if>
         </xsl:if>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:if test="local-name(..) = local-name(document(@href)/*) and namespace-uri(document(@href)/*) = 'http://purl.oclc.org/dsdl/schematron'">
-          <xsl:apply-templates select="document(@href)/*/*"/>
+        <xsl:if test="local-name(..) = local-name(document(substring-before(@href, '#'), @href)//*[@id = $fragment])">
+          <xsl:if test="namespace-uri(document(substring-before(@href, '#'), @href)//*[@id = $fragment]) = 'http://purl.oclc.org/dsdl/schematron'">
+            <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@id = $fragment]/node()">
+              <xsl:with-param name="sourceLang" select="$sourceLang"/>
+            </xsl:apply-templates>
+          </xsl:if>
         </xsl:if>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="sch:include">
+  <xsl:template match="sch:extends[@href]">
+    <xsl:variable name="sourceLang">
+      <xsl:call-template name="schxslt:in-scope-language"/>
+    </xsl:variable>
+    <xsl:apply-templates select="document(@href)/*/node()">
+      <xsl:with-param name="sourceLang" select="$sourceLang"/>
+    </xsl:apply-templates>
+  </xsl:template>
+
+  <xsl:template match="sch:include[contains(@href, '#')]">
+    <xsl:variable name="fragment" select="substring-after(current()/@href, '#')"/>
+    <xsl:variable name="sourceLang">
+      <xsl:call-template name="schxslt:in-scope-language"/>
+    </xsl:variable>
+
     <xsl:choose>
-      <xsl:when test="contains(@href, '#')">
-        <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@xml:id = substring-after(current()/@href, '#')]"/>
+      <xsl:when test="document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment]">
+        <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@xml:id = $fragment]">
+          <xsl:with-param name="sourceLang" select="$sourceLang"/>
+        </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:apply-templates select="document(@href)"/>
+        <xsl:apply-templates select="document(substring-before(@href, '#'), @href)//*[@id = $fragment]">
+          <xsl:with-param name="sourceLang" select="$sourceLang"/>
+        </xsl:apply-templates>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="sch:include">
+    <xsl:variable name="sourceLang">
+      <xsl:call-template name="schxslt:in-scope-language"/>
+    </xsl:variable>
+    <xsl:apply-templates select="document(@href)">
+      <xsl:with-param name="sourceLang" select="$sourceLang"/>
+    </xsl:apply-templates>
+  </xsl:template>
+
+  <xsl:template name="schxslt:in-scope-language">
+    <xsl:param name="context" select="."/>
+    <xsl:value-of select="$context/ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
   </xsl:template>
 
 </xsl:transform>

--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.9.5 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.10 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -29,6 +29,8 @@
   <xsl:variable name="schxslt.compile.typed-variables" as="xs:boolean" select="true()"/>
   <xsl:param name="schxslt.compile.streamable" as="xs:boolean" select="false()"/>
   <xsl:param name="schxslt.compile.metadata" as="xs:boolean" select="true()"/>
+  <xsl:param name="schxslt.compile.initial-document-function" as="xs:string" select="'document'"/>
+  <xsl:param name="schxslt.compile.default-query-binding" as="xs:string" select="'xslt'"/>
 
   <xsl:template match="/sch:schema">
     <xsl:call-template name="schxslt:compile">
@@ -39,7 +41,7 @@
   <xsl:template name="schxslt:compile">
     <xsl:param name="schematron" as="element(sch:schema)" required="yes"/>
 
-    <xsl:variable name="xslt-version" as="xs:string" select="schxslt:xslt-version($schematron)"/>
+    <xsl:variable name="xslt-version" as="xs:string" select="schxslt:xslt-version($schematron, $schxslt.compile.default-query-binding)"/>
     <xsl:variable name="effective-phase" select="schxslt:effective-phase($schematron, $phase)" as="xs:string"/>
     <xsl:variable name="active-patterns" select="schxslt:active-patterns($schematron, $effective-phase)" as="element(sch:pattern)+"/>
 
@@ -109,43 +111,60 @@
         <xsl:with-param name="typed-variables" as="xs:boolean" select="$schxslt.compile.typed-variables"/>
       </xsl:call-template>
 
+      <param name="schxslt.validate.initial-document-uri" as="xs:string?"/>
+
+      <template name="schxslt.validate">
+        <apply-templates select="{$schxslt.compile.initial-document-function}($schxslt.validate.initial-document-uri)"/>
+      </template>
+
       <template match="root()">
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
+        <param name="schxslt.validate.recursive-call" as="xs:boolean" select="false()"/>
 
-        <variable name="metadata" as="element()?">
-          <xsl:if test="$schxslt.compile.metadata">
-            <xsl:call-template name="schxslt-api:metadata">
+        <choose>
+          <when test="not($schxslt.validate.recursive-call) and (normalize-space($schxslt.validate.initial-document-uri) != '')">
+            <apply-templates select="{$schxslt.compile.initial-document-function}($schxslt.validate.initial-document-uri)">
+              <with-param name="schxslt.validate.recursive-call" as="xs:boolean" select="true()"/>
+            </apply-templates>
+          </when>
+          <otherwise>
+
+            <variable name="metadata" as="element()?">
+              <xsl:if test="$schxslt.compile.metadata">
+                <xsl:call-template name="schxslt-api:metadata">
+                  <xsl:with-param name="schema" as="element(sch:schema)" select="$schematron"/>
+                  <xsl:with-param name="source" as="element(rdf:Description)" select="$version"/>
+                  <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
+                </xsl:call-template>
+              </xsl:if>
+            </variable>
+
+            <variable name="report" as="element(schxslt:report)">
+              <schxslt:report>
+                <xsl:for-each select="distinct-values($validation-stylesheet-body/@name)">
+                  <call-template name="{.}"/>
+                </xsl:for-each>
+              </schxslt:report>
+            </variable>
+
+            <!-- Unwrap the intermediary report -->
+            <variable name="schxslt:report" as="node()*">
+              <sequence select="$metadata"/>
+              <for-each select="$report/schxslt:document">
+                <for-each select="schxslt:pattern">
+                  <sequence select="node()"/>
+                  <sequence select="../schxslt:rule[@pattern = current()/@id]/node()"/>
+                </for-each>
+              </for-each>
+            </variable>
+
+            <xsl:call-template name="schxslt-api:report">
               <xsl:with-param name="schema" as="element(sch:schema)" select="$schematron"/>
-              <xsl:with-param name="source" as="element(rdf:Description)" select="$version"/>
+              <xsl:with-param name="phase" as="xs:string" select="$effective-phase"/>
               <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
             </xsl:call-template>
-          </xsl:if>
-        </variable>
-
-        <variable name="report" as="element(schxslt:report)">
-          <schxslt:report>
-            <xsl:for-each select="distinct-values($validation-stylesheet-body/@name)">
-              <call-template name="{.}"/>
-            </xsl:for-each>
-          </schxslt:report>
-        </variable>
-
-        <!-- Unwrap the intermediary report -->
-        <variable name="schxslt:report" as="node()*">
-          <sequence select="$metadata"/>
-          <for-each select="$report/schxslt:document">
-            <for-each select="schxslt:pattern">
-              <sequence select="node()"/>
-              <sequence select="../schxslt:rule[@pattern = current()/@id]/node()"/>
-            </for-each>
-          </for-each>
-        </variable>
-
-        <xsl:call-template name="schxslt-api:report">
-          <xsl:with-param name="schema" as="element(sch:schema)" select="$schematron"/>
-          <xsl:with-param name="phase" as="xs:string" select="$effective-phase"/>
-          <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
-        </xsl:call-template>
+          </otherwise>
+        </choose>
 
       </template>
 

--- a/lib/schxslt/2.0/compile/functions.xsl
+++ b/lib/schxslt/2.0/compile/functions.xsl
@@ -51,20 +51,23 @@
 
     <xsl:choose>
       <xsl:when test="$phase eq '#ALL'">
-        <xsl:sequence select="$schema/sch:pattern[sch:rule]"/>
+        <xsl:sequence select="$schema/sch:pattern"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:sequence select="$schema/sch:pattern[@id = $schema/sch:phase[@id eq $phase]/sch:active/@pattern][sch:rule]"/>
+        <xsl:sequence select="$schema/sch:pattern[@id = $schema/sch:phase[@id eq $phase]/sch:active/@pattern]"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
 
   <xsl:function name="schxslt:xslt-version" as="xs:string">
     <xsl:param name="schema" as="element(sch:schema)"/>
+    <xsl:param name="defaultQueryBinding" as="xs:string"/>
 
-    <xsl:if test="not(lower-case($schema/@queryBinding) = ('xslt2', 'xslt3'))">
+    <xsl:variable name="queryBinding" as="xs:string"
+                  select="lower-case(($schema/@queryBinding, $defaultQueryBinding)[1])"/>
+    <xsl:if test="not($queryBinding = ('xslt2', 'xslt3'))">
       <xsl:variable name="message">
-        The query language '<xsl:value-of select="($schema/@queryBinding, 'xslt')[1]"/>' is not supported.
+        The query language '<xsl:value-of select="$queryBinding"/>' is not supported.
       </xsl:variable>
       <xsl:message terminate="yes" select="error(xs:QName('error:E0002'), normalize-space($message))"/>
     </xsl:if>

--- a/lib/schxslt/2.0/expand.xsl
+++ b/lib/schxslt/2.0/expand.xsl
@@ -19,7 +19,18 @@
   </xsl:template>
 
   <!-- Copy all other elements -->
-  <xsl:template match="node() | @*" mode="schxslt:expand">
+  <xsl:template match="*" mode="schxslt:expand">
+    <xsl:param name="lang" as="xs:string?"/>
+    <xsl:copy>
+      <xsl:if test="empty(@xml:lang) and schxslt:in-scope-language(.) != $lang">
+        <xsl:attribute name="xml:lang" select="schxslt:in-scope-language(.)"/>
+      </xsl:if>
+      <xsl:apply-templates select="@*" mode="schxslt:expand"/>
+      <xsl:apply-templates select="node()" mode="schxslt:expand"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="comment() | processing-instruction() | @*" mode="schxslt:expand">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*" mode="schxslt:expand"/>
     </xsl:copy>
@@ -38,7 +49,29 @@
         The current pattern defines no abstract rule named '<xsl:value-of select="@rule"/>'.
       </xsl:message>
     </xsl:if>
-    <xsl:sequence select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()"/>
+    <xsl:variable name="sourceLang" as="xs:string" select="schxslt:in-scope-language(.)"/>
+    <xsl:variable name="targetLang" as="xs:string" select="schxslt:in-scope-language(ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule])"/>
+    <xsl:choose>
+      <xsl:when test="$sourceLang = $targetLang">
+        <xsl:sequence select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/node()">
+          <xsl:choose>
+            <xsl:when test="self::* and not(@xml:lang)">
+              <xsl:copy>
+                <xsl:attribute name="xml:lang" select="$targetLang"/>
+                <xsl:sequence select="@*"/>
+                <xsl:sequence select="node()"/>
+              </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:sequence select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates select="ancestor::sch:schema/(sch:pattern | sch:rules)/sch:rule[@abstract = 'true'][@id = current()/@rule]/sch:extends" mode="#current"/>
   </xsl:template>
 
@@ -46,8 +79,13 @@
   <xsl:template match="sch:pattern[@is-a]" mode="schxslt:expand">
     <xsl:param name="abstract-patterns" tunnel="yes" as="element(sch:pattern)*"/>
     <xsl:variable name="is-a" select="$abstract-patterns[@id = current()/@is-a]"/>
+    <xsl:variable name="sourceLang" as="xs:string" select="schxslt:in-scope-language(.)"/>
+    <xsl:variable name="targetLang" as="xs:string" select="schxslt:in-scope-language($is-a)"/>
     <xsl:copy>
       <xsl:sequence select="@* except @is-a"/>
+      <xsl:if test="$sourceLang != $targetLang and not(@xml:lang)">
+        <xsl:attribute name="xml:lang" select="$targetLang"/>
+      </xsl:if>
       <xsl:apply-templates select="(if (not(@documents)) then $is-a/@documents else (), $is-a/node())" mode="schxslt:expand">
         <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
       </xsl:apply-templates>
@@ -57,6 +95,7 @@
         <sch:properties>
           <xsl:apply-templates select="../sch:properties/sch:property[@id = $ids]" mode="schxslt:expand">
             <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
+            <xsl:with-param name="lang" as="xs:string" select="schxslt:in-scope-language(.)"/>
           </xsl:apply-templates>
         </sch:properties>
       </xsl:if>
@@ -66,6 +105,7 @@
         <sch:diagnostics>
           <xsl:apply-templates select="../sch:diagnostics/sch:diagnostic[@id = $ids]" mode="schxslt:expand">
             <xsl:with-param name="schxslt:params" select="sch:param" tunnel="yes"/>
+            <xsl:with-param name="lang" as="xs:string" select="schxslt:in-scope-language(.)"/>
           </xsl:apply-templates>
         </sch:diagnostics>
       </xsl:if>
@@ -99,6 +139,11 @@
         <xsl:value-of select="schxslt:replace-params($src, $paramsSorted[position() > 1])"/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:function>
+
+  <xsl:function name="schxslt:in-scope-language" as="xs:string">
+    <xsl:param name="context" as="node()"/>
+    <xsl:value-of select="$context/ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
   </xsl:function>
 
 </xsl:transform>

--- a/lib/schxslt/2.0/pipeline.xsl
+++ b/lib/schxslt/2.0/pipeline.xsl
@@ -3,9 +3,9 @@
                xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+  <xsl:import href="expand.xsl"/>
   <xsl:include href="compile/compile-2.0.xsl"/>
   <xsl:include href="include.xsl"/>
-  <xsl:import href="expand.xsl"/>
 
   <xsl:template match="/sch:schema" priority="100">
     <xsl:call-template name="schxslt:compile">

--- a/lib/schxslt/2.0/svrl.xsl
+++ b/lib/schxslt/2.0/svrl.xsl
@@ -16,6 +16,7 @@
     <xsl:param name="phase" as="xs:string" required="yes"/>
 
     <svrl:schematron-output>
+      <xsl:sequence select="$schema/@xml:*"/>
       <xsl:sequence select="$schema/@schemaVersion"/>
       <xsl:if test="$phase ne '#ALL'">
         <xsl:attribute name="phase" select="$phase"/>
@@ -65,6 +66,10 @@
         <attribute name="context">
           <xsl:value-of select="$rule/@context"/>
         </attribute>
+        <variable name="documentUri" as="xs:anyURI?" select="document-uri()"/>
+        <if test="exists($documentUri)">
+          <attribute name="document" select="$documentUri"/>
+        </if>
       </svrl:fired-rule>
     </xsl:if>
   </xsl:template>
@@ -81,6 +86,10 @@
         <attribute name="context">
           <xsl:value-of select="$rule/@context"/>
         </attribute>
+        <variable name="documentUri" as="xs:anyURI?" select="document-uri()"/>
+        <if test="exists($documentUri)">
+          <attribute name="document" select="$documentUri"/>
+        </if>
       </svrl:suppressed-rule>
     </xsl:if>
   </xsl:template>
@@ -90,6 +99,7 @@
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:failed-assert location="{{{$location-function}({($assert/@subject, $assert/../@subject, '.')[1]})}}">
       <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id, $assert/@see, $assert/@icon, $assert/@fpi, $assert/@xml:*)"/>
+      <xsl:sequence select="$assert/@xml:id | $assert/ancestor-or-self::*[@xml:lang]/@xml:lang"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -103,7 +113,8 @@
     <xsl:param name="report" as="element(sch:report)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:successful-report location="{{{$location-function}({($report/@subject, $report/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi, $report/@xml:*)"/>
+      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi)"/>
+      <xsl:sequence select="$report/@xml:id | $report/ancestor-or-self::*[@xml:lang]/@xml:lang"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>
@@ -155,6 +166,7 @@
     <svrl:property-reference property="{.}">
       <xsl:sequence select="($property/@role, $property/@scheme, $property/@xml:*)"/>
       <svrl:text>
+        <xsl:sequence select="($property/@fpi, $property/@icon, $property/@see)"/>
         <xsl:apply-templates select="$property/node()" mode="schxslt:message-template">
           <xsl:with-param name="allow-xsl-copy-of" tunnel="yes" as="xs:boolean" select="true()"/>
         </xsl:apply-templates>

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.9.5</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.10</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>

--- a/lib/schxslt/README.md
+++ b/lib/schxslt/README.md
@@ -1,11 +1,10 @@
 SchXslt \[ʃˈɛksl̩t\] – An XSLT-based Schematron processor
 ==
 
-SchXslt is copyright (c) 2018–2021 by David Maus &lt;dmaus@dmaus.name&gt; and released under the terms of the MIT
+SchXslt is copyright (c) by David Maus &lt;dmaus@dmaus.name&gt; and released under the terms of the MIT
 license.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1495494.svg)](https://doi.org/10.5281/zenodo.1495494)
-[![Build Status](https://travis-ci.org/schxslt/schxslt.svg?branch=master)](https://travis-ci.org/schxslt/schxslt)
 
 SchXslt is a Schematron processor implemented entirely in XSLT. It transforms a Schematron schema document into an XSLT
 stylesheet that you apply to the document(s) to be validated.
@@ -66,7 +65,7 @@ This proposal adds support for the following XSLT elements:
 * xsl:include (XSLT 1.0, XSLT 2.0, XSLT 3.0)
 * xsl:use-package (XSLT 3.0)
 
-Installation
+Installing SchXslt
 --
 
 Depending on your environment there are several ways to install SchXslt.
@@ -81,6 +80,35 @@ Depending on your environment there are several ways to install SchXslt.
 
 * If you use [BaseX](https://basex.org) or [eXist](https://exist-db.org) you can download installable XQuery modulesq
   from [this repository's release page](https://github.com/schxslt/schxslt/releases) as well.
+
+Building SchXslt
+--
+
+SchXslt uses the [Maven](https://maven.apache.org) build tool to create installable packages. To create the packages for
+yourself clone this repository, install [Maven](https://maven.apache.org) and run it with the ```package``` phase.
+
+```
+dmaus@carbon ~ % git clone --recursive https://github.com/schxslt/schxslt.git
+Cloning into 'schxslt'...
+remote: Enumerating objects: 450, done.
+remote: Counting objects: 100% (450/450), done.
+remote: Compressing objects: 100% (298/298), done.
+remote: Total 3789 (delta 172), reused 374 (delta 111), pack-reused 3339
+Receiving objects: 100% (3789/3789), 470.87 KiB | 1.05 MiB/s, done.
+Resolving deltas: 100% (1607/1607), done.
+
+dmaus@carbon ~ % mvn package
+```
+
+This runs the unit tests and creates the following files:
+
+* ant/target/ant-schxslt-{VERSION}.jar (Java archive)
+* core/target/schxslt-{VERSION}.jar (Java archive)
+* core/target/schxslt-{VERSION}-xslt-only.zip (ZIP file with stylesheets)
+* exist/target/schxslt-exist-{VERSION}.xar (XQuery package for eXist)
+* basex/target/schxslt-basex-{VERSION}.xar (XQuery package for BaseX)
+
+Where {VERSION} is replaced with the current SchXslt version.
 
 Using SchXslt
 --
@@ -134,36 +162,47 @@ return
 
 ### Ant
 
-TBD
+The Ant module implements a task for [Apache Ant](https://ant.apache.org/) that performs Schematron validation with
+SchXslt. Download or compile the Jar file and define a new task using ```name.dmaus.schxslt.ant.Task``` as class name.
+
+```
+<project name="Test" basedir="." default="build">
+  <taskdef name="schematron" classname="name.dmaus.schxslt.ant.Task" classpath="/path/to/ant-schxslt-{VERSION}.jar"/>
+  <target name="build">
+    <schematron schema="schema.sch" file="document.xml" report="report.xml" phase="myPhase"/>
+  </target>
+</project>
+```
+
+The task supports the following options:
+
+<table>
+    <tbody>
+        <tr>
+            <th>file</th>
+            <td>Path to the file to be validated</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <th>schema</th>
+            <td>Path to the file containing the Schematron</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <th>phase</th>
+            <td>Validation phase</td>
+            <td>#ALL</td>
+        </tr>
+        <tr>
+            <th>report</th>
+            <td>Path to the file that the SVRL report should be written to</td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>
+
+SchXslt Ant uses [XML Resolver](https://xmlresolver.org) to support XML Catalog resolvers.
 
 ### Command line
 
 TBD
-
-Building
---
-
-SchXslt uses the [Maven](https://maven.apache.org) build tool to create installable packages. To create the packages for
-yourself clone this repository, install [Maven](https://maven.apache.org) and run it with the ```package``` phase.
-
-```
-dmaus@carbon ~ % git clone --recursive https://github.com/schxslt/schxslt.git
-Cloning into 'schxslt'...
-remote: Enumerating objects: 450, done.
-remote: Counting objects: 100% (450/450), done.
-remote: Compressing objects: 100% (298/298), done.
-remote: Total 3789 (delta 172), reused 374 (delta 111), pack-reused 3339
-Receiving objects: 100% (3789/3789), 470.87 KiB | 1.05 MiB/s, done.
-Resolving deltas: 100% (1607/1607), done.
-
-dmaus@carbon ~ % mvn package
-```
-
-This runs the unit tests and creates the following files:
-
-* core/target/schxslt-{VERSION}.jar (Java archive)
-* core/target/schxslt-{VERSION}-xslt-only.zip (ZIP file with stylesheets)
-* exist/target/schxslt-exist-{VERSION}.xar (XQuery package for eXist)
-* basex/target/schxslt-basex-{VERSION}.xar (XQuery package for BaseX)
-
-Where {VERSION} is replaced with the current SchXslt version.

--- a/test/do-nothing.sch
+++ b/test/do-nothing.sch
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
 	<!-- SchXslt 1.6.2 seems to require at least one sch:pattern to exist -->
-	<sch:pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME">
-		<!-- SchXslt 967c828 seems to require at least one sch:rule to exist -->
-		<sch:rule context="Dummy-rule-for-SchXslt___DO-NOT-USE-ME" />
-	</sch:pattern>
+	<sch:pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
+	
 </sch:schema>

--- a/test/schematron/schematron-019.sch
+++ b/test/schematron/schematron-019.sch
@@ -11,9 +11,6 @@
     </xsl:function>
 
     <!-- SchXslt 1.6.2 seems to require at least one sch:pattern to exist -->
-    <sch:pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME">
-        <!-- SchXslt 967c828 seems to require at least one sch:rule to exist -->
-        <sch:rule context="Dummy-rule-for-SchXslt___DO-NOT-USE-ME" />
-    </sch:pattern>
+    <sch:pattern id="Dummy-pattern-for-SchXslt___DO-NOT-USE-ME"/>
 
 </sch:schema>


### PR DESCRIPTION
Replace the built-in SchXslt v1.9.5 with v1.10, using download from
https://github.com/schxslt/schxslt/releases/download/v1.10/schxslt-1.10-xslt-only.zip

Seeing an item in the release notes about empty patterns (https://github.com/schxslt/schxslt/issues/341), I wondered if we could remove the dummy rules that exist in two Schematron schemas in our test suite. ada97f391cce4316267151680d18c5d4d696e18a does that. Note: Those files still need the dummy _pattern_, though, to avoid a hard error when running the XSpec test suite.