### PR TITLE
fix(report): coverage update for xsl:sequence

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -957,20 +957,22 @@ The sequence constructor, if present, is traced. The xsl:sort child is not trace
 
 ## xsl:sequence
 
-|          |                     |
-| -------- | ------------------- |
-| CATEGORY | Instruction         |
-| PARENT   |                     |
-| CHILDREN |                     |
-| CONTENT  |                     |
-| TRACE    | No                  |
-| RULE     | Use Descendant Data |
+|          |                  |
+| -------- | ---------------- |
+| CATEGORY | Instruction      |
+| PARENT   |                  |
+| CHILDREN |                  |
+| CONTENT  |                  |
+| TRACE    | No               |
+| RULE     | Element Specific |
 
 #### Comment
 
+If the trace data has a hit for this element, mark it as 'hit'. Otherwise, follow Use Descendant Data rule.
+
 Outstanding Saxon issue regarding tracing: https://saxonica.plan.io/issues/6295
 
-With a select attribute, there is no trace information.
+With a select attribute, there is usually no trace information, but exceptions can occur (https://github.com/xspec/xspec/issues/1945#issuecomment-2241593146).
 
 With a sequence constructor, children are traced if they are executed.
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -133,7 +133,8 @@
         | XSLT:when
         | XSLT:where-populated"
         as="xs:string"
-        mode="coverage">
+        mode="coverage"
+        name="use-descendant-data">
         <xsl:choose>
             <xsl:when test="empty(child::node())">
                 <xsl:sequence select="'unknown'"/>
@@ -247,6 +248,22 @@
                 else
                     'missed'
                 "/>
+    </xsl:template>
+
+    <!-- Element-Specific rule for XSLT:sequence -->
+    <!-- Usually, we expect to use descendant data in Saxon 12.4+, but if xsl:sequence
+        has a hit in the trace, use it. -->
+    <xsl:template match="XSLT:sequence"
+        as="xs:string"
+        mode="coverage">
+        <xsl:choose>
+            <xsl:when test="accumulator-before('category-based-on-trace-data') eq 'hit'">
+                <xsl:sequence select="'hit'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="use-descendant-data"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- Element-Specific rule for child elements of XSLT:sort -->

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -37,7 +37,7 @@
 27: <span class="ignored">        </span><span class="missed">&lt;/xsl:matching-substring&gt;</span><span class="ignored">                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 28: <span class="ignored">        </span><span class="hit">&lt;xsl:non-matching-substring&gt;</span>
 29: <span class="ignored">          </span><span class="hit">&lt;node type="non-matching-substring"&gt;</span>
-30: <span class="ignored">            </span><span class="missed">&lt;xsl:sequence select="string('No match')"/&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+30: <span class="ignored">            </span><span class="unknown">&lt;xsl:sequence select="string('No match')"/&gt;</span><span class="ignored">                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 31: <span class="ignored">          </span><span class="hit">&lt;/node&gt;</span>
 32: <span class="ignored">        </span><span class="hit">&lt;/xsl:non-matching-substring&gt;</span>
 33: <span class="ignored">      </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -49,7 +49,7 @@
 39: <span class="ignored">          </span><span class="hit">&lt;xsl:evaluate xpath="'string(data[xs:integer($index)])'" context-item="$data"&gt;</span>
 40: <span class="ignored">            </span><span class="hit">&lt;xsl:with-param name="index"&gt;</span>
 41: <span class="ignored">              </span><span class="hit">&lt;xsl:for-each select="1"&gt;</span>
-42: <span class="ignored">                </span><span class="missed">&lt;xsl:sequence select="$index"/&gt;</span>
+42: <span class="ignored">                </span><span class="unknown">&lt;xsl:sequence select="$index"/&gt;</span><span class="ignored">                                </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 43: <span class="ignored">              </span><span class="hit">&lt;/xsl:for-each&gt;</span>
 44: <span class="ignored">            </span><span class="hit">&lt;/xsl:with-param&gt;</span>
 45: <span class="ignored">            </span><span class="hit">&lt;xsl:with-param name="sortKey"&gt;</span><span class="missed">parameter not used in evaluation</span><span class="hit">&lt;/xsl:with-param&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -33,7 +33,7 @@
 023: <span class="ignored">          </span><span class="hit">&lt;/xsl:for-each&gt;</span>
 024: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
 025: <span class="ignored">        </span><span class="unknown">&lt;xsl:map-entry key="'Four'"&gt;</span>
-026: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+026: <span class="ignored">          </span><span class="unknown">&lt;xsl:sequence select="400" /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 027: <span class="ignored">        </span><span class="unknown">&lt;/xsl:map-entry&gt;</span>
 028: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
 029: <span class="ignored">    </span><span class="hit">&lt;/xsl:param&gt;</span>
@@ -44,14 +44,14 @@
 034: <span class="ignored">        </span><span class="unknown">&lt;xsl:map-entry key="'Two'" select="200"/&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 035: <span class="ignored">        </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
 036: <span class="ignored">        </span><span class="hit">&lt;xsl:map-entry key="'Three'"&gt;</span>
-037: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence&gt;</span>
+037: <span class="ignored">          </span><span class="hit">&lt;xsl:sequence&gt;</span>
 038: <span class="ignored">            </span><span class="hit">&lt;xsl:for-each select="1 to 1"&gt;</span>
 039: <span class="ignored">              </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
 040: <span class="ignored">            </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-041: <span class="ignored">          </span><span class="missed">&lt;/xsl:sequence&gt;</span>
+041: <span class="ignored">          </span><span class="hit">&lt;/xsl:sequence&gt;</span>
 042: <span class="ignored">        </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
 043: <span class="ignored">        </span><span class="unknown">&lt;xsl:map-entry key="'Four'"&gt;</span>
-044: <span class="ignored">          </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+044: <span class="ignored">          </span><span class="unknown">&lt;xsl:sequence select="400" /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 045: <span class="ignored">        </span><span class="unknown">&lt;/xsl:map-entry&gt;</span>
 046: <span class="ignored">      </span><span class="hit">&lt;/xsl:map&gt;</span>
 047: <span class="ignored">    </span><span class="hit">&lt;/xsl:variable&gt;</span>
@@ -129,7 +129,7 @@
 119: <span class="ignored">        </span><span class="hit">&lt;/xsl:for-each&gt;</span>
 120: <span class="ignored">      </span><span class="hit">&lt;/xsl:map-entry&gt;</span>
 121: <span class="ignored">      </span><span class="unknown">&lt;xsl:map-entry key="'Four'"&gt;</span>
-122: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="400" /&gt;</span>
+122: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="400" /&gt;</span><span class="ignored">                                          </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 123: <span class="ignored">      </span><span class="unknown">&lt;/xsl:map-entry&gt;</span>
 124: <span class="ignored">    </span><span class="hit">&lt;/xsl:map&gt;</span>
 125: <span class="ignored">  </span><span class="hit">&lt;/xsl:function&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -35,7 +35,7 @@
 25: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 26: <span class="ignored">      </span><span class="ignored">&lt;!-- NOT on-non-empty but static analysis cannot make that judgment --&gt;</span><span class="ignored"> </span>
 27: <span class="ignored">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
-28: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="@nonexistent-attribute" /&gt;</span>
+28: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="@nonexistent-attribute" /&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 29: <span class="ignored">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span><span class="ignored">                                                     </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 30: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">400</span><span class="hit">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 31: <span class="ignored">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span><span class="ignored">                                                    </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -17,13 +17,13 @@
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
-10: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence select="'100'" /&gt;</span>
+10: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="'100'" /&gt;</span>
 11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
 13: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
-14: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence&gt;</span>
+14: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence&gt;</span>
 15: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
-16: <span class="ignored">        </span><span class="missed">&lt;/xsl:sequence&gt;</span>
+16: <span class="ignored">        </span><span class="hit">&lt;/xsl:sequence&gt;</span>
 17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 18: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
 19: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-sequence-01.xsl">xsl-sequence-01.xsl</a></p>
-      <h2>module: xsl-sequence-01.xsl; 20 lines</h2>
+      <h2>module: xsl-sequence-01.xsl; 38 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -17,7 +17,7 @@
 07: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="ignored">      </span><span class="ignored">&lt;!-- Using select attribute --&gt;</span>
 09: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
-10: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="'100'" /&gt;</span>
+10: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="'100'" /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
 11: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
 12: <span class="ignored">      </span><span class="ignored">&lt;!-- Using sequence constructor --&gt;</span>
 13: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
@@ -25,8 +25,26 @@
 15: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
 16: <span class="ignored">        </span><span class="hit">&lt;/xsl:sequence&gt;</span>
 17: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-18: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-19: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-20: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+18: <span class="ignored">      </span><span class="ignored">&lt;!-- Untraceable descendant --&gt;</span>
+19: <span class="ignored">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
+20: <span class="ignored">        </span><span class="hit">&lt;xsl:sequence&gt;</span>
+21: <span class="ignored">          </span><span class="unknown">&lt;xsl:fallback/&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+22: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+23: <span class="ignored">        </span><span class="hit">&lt;/xsl:sequence&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- Repeat the patterns above, in a missed code block --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="exists(nonexistent)"&gt;</span>
+27: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence select="'100'" /&gt;</span><span class="ignored">                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+28: <span class="ignored">        </span><span class="missed">&lt;xsl:sequence&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+29: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">200</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+30: <span class="ignored">        </span><span class="missed">&lt;/xsl:sequence&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+31: <span class="ignored">        </span><span class="unknown">&lt;xsl:sequence&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+32: <span class="ignored">          </span><span class="unknown">&lt;xsl:fallback/&gt;</span><span class="ignored">                                                      </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+33: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">300</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+34: <span class="ignored">        </span><span class="unknown">&lt;/xsl:sequence&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected unknown --&gt;</span>
+35: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+36: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+37: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+38: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.xml
@@ -19,6 +19,13 @@
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}text"/>
    <hit lineNumber="15" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="19" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="19" columnNumber="29" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="21" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
+   <hit lineNumber="26" columnNumber="42" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
@@ -39,7 +39,7 @@
           <xsl:evaluate xpath="'string(data[xs:integer($index)])'" context-item="$data">
             <xsl:with-param name="index">
               <xsl:for-each select="1">
-                <xsl:sequence select="$index"/>
+                <xsl:sequence select="$index"/>                                <!-- Expected unknown -->
               </xsl:for-each>
             </xsl:with-param>
             <xsl:with-param name="sortKey">parameter not used in evaluation</xsl:with-param>

--- a/test/end-to-end/cases-coverage/xsl-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-map-01.xsl
@@ -23,7 +23,7 @@
           </xsl:for-each>
         </xsl:map-entry>
         <xsl:map-entry key="'Four'">
-          <xsl:sequence select="400" />
+          <xsl:sequence select="400" />                                        <!-- Expected unknown -->
         </xsl:map-entry>
       </xsl:map>
     </xsl:param>
@@ -41,7 +41,7 @@
           </xsl:sequence>
         </xsl:map-entry>
         <xsl:map-entry key="'Four'">
-          <xsl:sequence select="400" />
+          <xsl:sequence select="400" />                                        <!-- Expected unknown -->
         </xsl:map-entry>
       </xsl:map>
     </xsl:variable>
@@ -119,7 +119,7 @@
         </xsl:for-each>
       </xsl:map-entry>
       <xsl:map-entry key="'Four'">
-        <xsl:sequence select="400" />
+        <xsl:sequence select="400" />                                          <!-- Expected unknown -->
       </xsl:map-entry>
     </xsl:map>
   </xsl:function>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
@@ -25,7 +25,7 @@
       </node>
       <!-- NOT on-non-empty but static analysis cannot make that judgment --> 
       <node type="on-non-empty">
-        <xsl:sequence select="@nonexistent-attribute" />
+        <xsl:sequence select="@nonexistent-attribute" />                       <!-- Expected unknown -->
         <xsl:on-non-empty>                                                     <!-- Expected miss -->
           <xsl:text>400</xsl:text>                                             <!-- Expected miss -->
         </xsl:on-non-empty>                                                    <!-- Expected miss -->

--- a/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
@@ -7,7 +7,7 @@
     <root>
       <!-- Using select attribute -->
       <node type="sequence">
-        <xsl:sequence select="'100'" />
+        <xsl:sequence select="'100'" />                                        <!-- Expected unknown -->
       </node>
       <!-- Using sequence constructor -->
       <node type="sequence">
@@ -15,6 +15,24 @@
           <xsl:text>200</xsl:text>
         </xsl:sequence>
       </node>
+      <!-- Untraceable descendant -->
+      <node type="sequence">
+        <xsl:sequence>
+          <xsl:fallback/>                                                      <!-- Expected unknown -->
+          <xsl:text>300</xsl:text>
+        </xsl:sequence>
+      </node>
+      <!-- Repeat the patterns above, in a missed code block -->
+      <xsl:if test="exists(nonexistent)">
+        <xsl:sequence select="'100'" />                                        <!-- Expected unknown -->
+        <xsl:sequence>                                                         <!-- Expected miss -->
+          <xsl:text>200</xsl:text>                                             <!-- Expected miss -->
+        </xsl:sequence>                                                        <!-- Expected miss -->
+        <xsl:sequence>                                                         <!-- Expected unknown -->
+          <xsl:fallback/>                                                      <!-- Expected unknown -->
+          <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
+        </xsl:sequence>                                                        <!-- Expected unknown -->
+      </xsl:if>
     </root>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-sequence-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-sequence-01.xspec
@@ -12,6 +12,7 @@
          <root>
             <node type="sequence">100</node>
             <node type="sequence">200</node>
+            <node type="sequence">300</node>
          </root>
       </x:expect>
    </x:scenario>


### PR DESCRIPTION
This pull request marks `xsl:sequence` as 'hit' if the trace contains a hit for that element, and otherwise follows the **Use Descendant Data** rule. This pull request also adds more test cases to the coverage test for `xsl:sequence`.

At this point in the code base, the `getLocation` method is not part of the trace listener. I plan to return to #1983, currently in draft, afterward.

Fixes #1945.

---

Cc: @birdya22