### PR TITLE
test(xquery): external override of global XQuery variable

### DIFF
--- a/test/global-override-query.xspec
+++ b/test/global-override-query.xspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test saxon-custom-options={x-urn:test:xspec-global-override}external-value_vs_global-variable=override {x-urn:test:xspec-global-override}empty-external-value_vs_global-variable= {x-urn:test:xspec-global-override}non-external-value_vs_global-variable=override?>
+<x:description query="x-urn:test:xspec-global-override" query-at="global-override.xqm" xmlns:g="x-urn:test:xspec-global-override" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+	<!--
+		Checks to see if value passed in to XSpec externally 
+		overrides value of global variable declared in SUT.
+	-->
+
+	<x:scenario label="External value">
+		<x:call function="g:variable-values"/>
+		<x:expect label="overrides default value of external variable"
+			test="$x:result[1]"
+			select="'override'" />
+		<x:expect label="even if external value is empty (interpreted as string)"
+			test="$x:result[2]"
+			select="''" />
+		<x:expect label="but has no effect on non-external variable"
+			test="$x:result[3]"
+			select="'default'" />
+	</x:scenario>
+</x:description>

--- a/test/global-override.xqm
+++ b/test/global-override.xqm
@@ -1,0 +1,14 @@
+module namespace g = "x-urn:test:xspec-global-override";
+
+import module namespace mirror = "x-urn:test:mirror" at "mirror.xqm";
+
+declare variable $g:external-value_vs_global-variable as xs:string external := 'default';
+declare variable $g:empty-external-value_vs_global-variable as xs:string external := 'default';
+declare variable $g:non-external-value_vs_global-variable as xs:string := 'default';
+
+declare function g:variable-values() as xs:string+ {
+(
+$g:external-value_vs_global-variable,
+$g:empty-external-value_vs_global-variable,
+$g:non-external-value_vs_global-variable)
+};


### PR DESCRIPTION
If an XQuery variable is declared with the `external` keyword and you run the XSpec test with Saxon, you can pass in a value of the variable from outside XSpec and override the default value. This test demonstrates that capability using Saxon custom options.

(I could be wrong, but I don't think the BaseX harnesses in this repository support passing in an external variable value when running an XSpec test with BaseX. BaseX itself supports passing in such values, though; see my BaseX command below.)

### Local qualification

I ran the following commands on Windows, from the `test` directory. All verifications passed.
```
set SAXON_CUSTOM_OPTIONS={x-urn:test:xspec-global-override}external-value_vs_global-variable=override {x-urn:test:xspec-global-override}empty-external-value_vs_global-variable= {x-urn:test:xspec-global-override}non-external-value_vs_global-variable=override

..\bin\xspec.bat -q global-override-query.xspec
```

After I had the Saxon-compiled test file, I also ran the following with BaseX 11.0, and all verifications passed.
```
java -cp "%BASEX_JAR%"  org.basex.BaseX -bQ{x-urn:test:xspec-global-override}external-value_vs_global-variable=override -bQ{x-urn:test:xspec-global-override}empty-external-value_vs_global-variable= -bQ{x-urn:test:xspec-global-override}non-external-value_vs_global-variable=override -Qxspec\global-override-query-compiled.xq
```