### PR TITLE
test(report): enhance coverage tests for xsl:message

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-message-01.xsl">xsl-message-01.xsl</a></p>
-      <h2>module: xsl-message-01.xsl; 35 lines</h2>
+      <h2>module: xsl-message-01.xsl; 44 lines</h2>
       <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -20,28 +20,37 @@
 10: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">100</span><span class="hit">&lt;/xsl:text&gt;</span>
 11: <span class="ignored">        </span><span class="hit">&lt;xsl:message select="string('Message: 100')" /&gt;</span>
 12: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-13: <span class="ignored">      </span><span class="ignored">&lt;!-- Add content --&gt;</span>
+13: <span class="ignored">      </span><span class="ignored">&lt;!-- Add content in xsl:text --&gt;</span>
 14: <span class="ignored">      </span><span class="hit">&lt;node type="message"&gt;</span>
 15: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
 16: <span class="ignored">        </span><span class="hit">&lt;xsl:message&gt;</span>
-17: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
+17: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Message in xsl:text: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
 18: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
 19: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-20: <span class="ignored">      </span><span class="ignored">&lt;!-- Terminate upon request --&gt;</span>
-21: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'select'"&gt;</span>
-22: <span class="ignored">        </span><span class="hit">&lt;xsl:message select="string('Terminating Message: 100')" terminate="yes"/&gt;</span>
-23: <span class="ignored">        </span><span class="missed">&lt;xsl:message select="string('After terminating message')"/&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-24: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
-25: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'sequence constructor'"&gt;</span>
-26: <span class="ignored">        </span><span class="hit">&lt;xsl:message terminate="yes"&gt;</span>
-27: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Terminating Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
-28: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
-29: <span class="ignored">        </span><span class="missed">&lt;xsl:message&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-30: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">After terminating message</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-31: <span class="ignored">        </span><span class="missed">&lt;/xsl:message&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-32: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
-33: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-34: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-35: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+20: <span class="ignored">      </span><span class="ignored">&lt;!-- Add content in text node --&gt;</span>
+21: <span class="ignored">      </span><span class="hit">&lt;node type="message"&gt;</span>
+22: <span class="ignored">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+23: <span class="ignored">        </span><span class="hit">&lt;xsl:message&gt;</span><span class="hit">Message in text node: 300</span><span class="hit">&lt;/xsl:message&gt;</span>
+24: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+25: <span class="ignored">      </span><span class="ignored">&lt;!-- Terminate upon request --&gt;</span>
+26: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'select'"&gt;</span>
+27: <span class="ignored">        </span><span class="hit">&lt;xsl:message select="string('Terminating Message: 100')" terminate="yes"/&gt;</span>
+28: <span class="ignored">        </span><span class="missed">&lt;xsl:message select="string('After terminating message')"/&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+29: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+30: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'sequence constructor with xsl:text'"&gt;</span>
+31: <span class="ignored">        </span><span class="hit">&lt;xsl:message terminate="yes"&gt;</span>
+32: <span class="ignored">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">Terminating Message: 200</span><span class="hit">&lt;/xsl:text&gt;</span>
+33: <span class="ignored">        </span><span class="hit">&lt;/xsl:message&gt;</span>
+34: <span class="ignored">        </span><span class="missed">&lt;xsl:message&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+35: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">After terminating message</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                       </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+36: <span class="ignored">        </span><span class="missed">&lt;/xsl:message&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+37: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+38: <span class="ignored">      </span><span class="hit">&lt;xsl:if test="@terminate eq 'sequence constructor with text node'"&gt;</span>
+39: <span class="ignored">        </span><span class="hit">&lt;xsl:message terminate="yes"&gt;</span><span class="hit">Terminating Message: 300</span><span class="hit">&lt;/xsl:message&gt;</span>
+40: <span class="ignored">        </span><span class="missed">&lt;xsl:message&gt;</span><span class="missed">After terminating message</span><span class="missed">&lt;/xsl:message&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+41: <span class="ignored">      </span><span class="hit">&lt;/xsl:if&gt;</span>
+42: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+43: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+44: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.xml
@@ -26,11 +26,17 @@
    <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
    <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
    <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="3"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.Choose"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}if"/>
-   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
-   <hit lineNumber="25" columnNumber="59" moduleId="0" traceableId="5"/>
+   <hit lineNumber="26" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="73" moduleId="0" traceableId="5"/>
+   <hit lineNumber="38" columnNumber="74" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
@@ -45,8 +51,13 @@
    <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
    <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
    <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
-   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
-   <hit lineNumber="22" columnNumber="83" moduleId="0" traceableId="4"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="26" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="27" columnNumber="83" moduleId="0" traceableId="4"/>
    <util utilId="3" uri="../../../../../src/common/wrap.xsl"/>
    <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
    <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
@@ -59,8 +70,34 @@
    <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
    <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
    <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
-   <hit lineNumber="21" columnNumber="45" moduleId="0" traceableId="5"/>
-   <hit lineNumber="25" columnNumber="59" moduleId="0" traceableId="5"/>
-   <hit lineNumber="26" columnNumber="38" moduleId="0" traceableId="4"/>
-   <hit lineNumber="27" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="26" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="73" moduleId="0" traceableId="5"/>
+   <hit lineNumber="31" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="32" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="6" columnNumber="37" moduleId="0" traceableId="0"/>
+   <hit lineNumber="7" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="9" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="10" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="11" columnNumber="56" moduleId="0" traceableId="4"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="14" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="15" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="16" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="17" columnNumber="21" moduleId="0" traceableId="3"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="21" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="22" columnNumber="19" moduleId="0" traceableId="3"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="4"/>
+   <hit lineNumber="23" columnNumber="22" moduleId="0" traceableId="3"/>
+   <hit lineNumber="26" columnNumber="45" moduleId="0" traceableId="5"/>
+   <hit lineNumber="30" columnNumber="73" moduleId="0" traceableId="5"/>
+   <hit lineNumber="38" columnNumber="74" moduleId="0" traceableId="5"/>
+   <hit lineNumber="39" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="39" columnNumber="38" moduleId="0" traceableId="3"/>
 </trace>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <title>Test Coverage Report for xsl-message-02.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+   </head>
+   <body>
+      <h1>Test Coverage Report</h1>
+      <p>Stylesheet:  <a href="../../xsl-message-02.xsl">xsl-message-02.xsl</a></p>
+      <h2>module: xsl-message-02.xsl; 13 lines</h2>
+      <pre>01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
+03: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
+04: <span class="ignored">      xsl:message Coverage Test Case from https://saxonica.plan.io/issues/6492</span>
+05: <span class="ignored">  --&gt;</span>
+06: <span class="ignored">  </span><span class="hit">&lt;xsl:param name="globalBoolean" select="not(false())"/&gt;</span>
+07: <span class="ignored">  </span><span class="hit">&lt;xsl:template match="source"&gt;</span>
+08: <span class="ignored">    </span><span class="hit">&lt;xsl:param name="localBoolean" select="boolean(1)"/&gt;</span>
+09: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$globalBoolean"/&gt;</span>
+10: <span class="ignored">    </span><span class="hit">&lt;xsl:value-of select="$localBoolean"/&gt;</span>
+11: <span class="ignored">    </span><span class="hit">&lt;xsl:message&gt;</span><span class="hit">mes</span><span class="hit">&lt;/xsl:message&gt;</span>
+12: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+13: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+   </body>
+</html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trace xspec="../../xsl-message-02.xspec">
+   <compiled uri="xsl-message-02-compiled.xsl"/>
+   <module moduleId="0" uri="../../xsl-message-02.xsl"/>
+   <traceable traceableId="0"
+              class="net.sf.saxon.expr.instruct.TemplateRule"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
+   <hit lineNumber="7" columnNumber="32" moduleId="0" traceableId="0"/>
+   <traceable traceableId="1"
+              class="net.sf.saxon.expr.instruct.LocalParam"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}param"/>
+   <hit lineNumber="8" columnNumber="57" moduleId="0" traceableId="1"/>
+   <traceable traceableId="2"
+              class="net.sf.saxon.expr.instruct.ValueOf"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
+   <hit lineNumber="9" columnNumber="44" moduleId="0" traceableId="2"/>
+   <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.GlobalParam"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
+   <hit lineNumber="6" columnNumber="58" moduleId="0" traceableId="3"/>
+   <hit lineNumber="10" columnNumber="43" moduleId="0" traceableId="2"/>
+   <traceable traceableId="4"
+              class="net.sf.saxon.expr.instruct.MessageInstr"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}message"/>
+   <hit lineNumber="11" columnNumber="18" moduleId="0" traceableId="4"/>
+   <hit lineNumber="11" columnNumber="18" moduleId="0" traceableId="2"/>
+   <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
+   <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
+   <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>
+</trace>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xsl
@@ -10,25 +10,34 @@
         <xsl:text>100</xsl:text>
         <xsl:message select="string('Message: 100')" />
       </node>
-      <!-- Add content -->
+      <!-- Add content in xsl:text -->
       <node type="message">
         <xsl:text>200</xsl:text>
         <xsl:message>
-          <xsl:text>Message: 200</xsl:text>
+          <xsl:text>Message in xsl:text: 200</xsl:text>
         </xsl:message>
+      </node>
+      <!-- Add content in text node -->
+      <node type="message">
+        <xsl:text>300</xsl:text>
+        <xsl:message>Message in text node: 300</xsl:message>
       </node>
       <!-- Terminate upon request -->
       <xsl:if test="@terminate eq 'select'">
         <xsl:message select="string('Terminating Message: 100')" terminate="yes"/>
         <xsl:message select="string('After terminating message')"/>            <!-- Expected miss -->
       </xsl:if>
-      <xsl:if test="@terminate eq 'sequence constructor'">
+      <xsl:if test="@terminate eq 'sequence constructor with xsl:text'">
         <xsl:message terminate="yes">
           <xsl:text>Terminating Message: 200</xsl:text>
         </xsl:message>
         <xsl:message>                                                          <!-- Expected miss -->
           <xsl:text>After terminating message</xsl:text>                       <!-- Expected miss -->
         </xsl:message>                                                         <!-- Expected miss -->
+      </xsl:if>
+      <xsl:if test="@terminate eq 'sequence constructor with text node'">
+        <xsl:message terminate="yes">Terminating Message: 300</xsl:message>
+        <xsl:message>After terminating message</xsl:message>                   <!-- Expected miss -->
       </xsl:if>
     </root>
   </xsl:template>

--- a/test/end-to-end/cases-coverage/xsl-message-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-message-01.xspec
@@ -12,6 +12,7 @@
          <root>
             <node type="message">100</node>
             <node type="message">200</node>
+            <node type="message">300</node>
          </root>
       </x:expect>
    </x:scenario>
@@ -27,15 +28,25 @@
          <x:expect label="Success" test="?err?value => string()"
             select="'Terminating Message: 100'"/>
       </x:scenario>
-      <x:scenario label="Using sequence constructor">
+      <x:scenario label="Using sequence constructor with xsl:text">
          <x:context>
             <root>
-               <xsl-message terminate="sequence constructor"/>
+               <xsl-message terminate="sequence constructor with xsl:text"/>
             </root>
          </x:context>
          <!-- XSpec catches the error and returns a map. -->
          <x:expect label="Success" test="?err?value => string()"
             select="'Terminating Message: 200'"/>
+      </x:scenario>
+      <x:scenario label="Using sequence constructor with text node">
+         <x:context>
+            <root>
+               <xsl-message terminate="sequence constructor with text node"/>
+            </root>
+         </x:context>
+         <!-- XSpec catches the error and returns a map. -->
+         <x:expect label="Success" test="?err?value => string()"
+            select="'Terminating Message: 300'"/>
       </x:scenario>
    </x:scenario>
 </x:description>

--- a/test/end-to-end/cases-coverage/xsl-message-02.xsl
+++ b/test/end-to-end/cases-coverage/xsl-message-02.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!--
+      xsl:message Coverage Test Case from https://saxonica.plan.io/issues/6492
+  -->
+  <xsl:param name="globalBoolean" select="not(false())"/>
+  <xsl:template match="source">
+    <xsl:param name="localBoolean" select="boolean(1)"/>
+    <xsl:value-of select="$globalBoolean"/>
+    <xsl:value-of select="$localBoolean"/>
+    <xsl:message>mes</xsl:message>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/xsl-message-02.xspec
+++ b/test/end-to-end/cases-coverage/xsl-message-02.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="xsl-message-02.xsl">
+   <x:scenario label="xsl:message Coverage Test Case">
+      <x:context>
+         <source>
+            <number>3</number>
+            <number>4</number>
+         </source>
+      </x:context>
+      <x:expect label="Success">truetrue</x:expect>
+   </x:scenario>
+</x:description>


### PR DESCRIPTION
Based on https://github.com/xspec/xspec/issues/1963#issuecomment-2258477981, this pull request adds code coverage test cases for `xsl:message` with:

- Only text nodes as children.
- The example from https://saxonica.plan.io/issues/6492, which reports the expected coverage in Saxon 12.4 but not 12.5. I made that a separate XSLT file to simplify citing the Saxonica issue page for that XSLT code only.