### PR TITLE
test(report): use distinct template name in imported XSLT

### DIFF
--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -65,7 +65,7 @@
 10: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 11: 
 12: <span class="ignored">  </span><span class="ignored">&lt;!-- The non-XSLT element in the template should be missed, not ignored. --&gt;</span>
-13: <span class="ignored">  </span><span class="missed">&lt;xsl:template name="unhit"&gt;</span><span class="ignored">                                                  </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+13: <span class="ignored">  </span><span class="missed">&lt;xsl:template name="unhit-imported"&gt;</span><span class="ignored">                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 14: <span class="ignored">    </span><span class="missed">&lt;non-xsl-element/&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 15: <span class="ignored">  </span><span class="missed">&lt;/xsl:template&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 16: 

--- a/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
+++ b/test/end-to-end/cases-coverage/non-xsl-top-level-element-01A.xsl
@@ -10,7 +10,7 @@
   </xsl:template>
 
   <!-- The non-XSLT element in the template should be missed, not ignored. -->
-  <xsl:template name="unhit">                                                  <!-- Expected miss -->
+  <xsl:template name="unhit-imported">                                         <!-- Expected miss -->
     <non-xsl-element/>                                                         <!-- Expected miss -->
   </xsl:template>                                                              <!-- Expected miss -->
 


### PR DESCRIPTION
When evaluating the prototype Saxon listener linked from https://saxonica.plan.io/issues/6507, I realized that the unhit templates in `non-xsl-top-level-element-01.xsl` and `non-xsl-top-level-element-01A.xsl` should have distinct names. Otherwise, the latter file's template is shadowed by the importing stylesheet and an XSpec test can't possibly reach the template. My original intention with this test was for the template to be available but unreached. (The prototype listener considers the shadowed case as "unknown" but the available-unreached case as "missed.")