### PR TITLE
feat(schema): add Schematron for ineffective pending/focus attributes

### DIFF
--- a/src/schemas/xspec.sch
+++ b/src/schemas/xspec.sch
@@ -8,7 +8,7 @@
 
 	<sch:ns prefix="x" uri="http://www.jenitennison.com/xslt/xspec" />
 
-	<sch:pattern>
+	<sch:pattern id="wsot-user-content">
 		<!-- When a whitespace-only text node is user-content and has no sibling nodes -->
 		<sch:rule
 			context="
@@ -83,7 +83,7 @@
 		</sch:rule>
 	</sch:pattern>
 
-	<sch:pattern>
+	<sch:pattern id="user-content">
 		<sch:rule context="*[x:is-user-content(.)]">
 			<sch:assert id="user-element-expand-text" role="warn" sqf:fix="sqf-rename-x-expand-text sqf-delete-expand-text"
 				test="empty(@expand-text)">Non-XSpec elements use x:expand-text, not expand-text, to control text value templates</sch:assert>
@@ -104,4 +104,35 @@
 			</sqf:fix>
 		</sch:rule>
 	</sch:pattern>
+
+	<sch:pattern id="pending-focus">
+		<sch:rule context="x:scenario[@focus]">
+			<sch:report id="focused-pending-scenario" role="warn" sqf:fix="sqf-delete-pending sqf-delete-focus"
+				test="exists(@pending) and not(@shared = ('1', 'yes', 'true'))"
+				>@pending has no effect because @focus takes precedence</sch:report>
+			<sch:report id="focused-shared-scenario" role="warn" sqf:fix="sqf-delete-focus"
+				test="@shared = ('1', 'yes', 'true')">@focus has no effect on scenario with shared=<sch:value-of
+					select="@shared"/></sch:report>
+			<sqf:fix id="sqf-delete-focus">
+				<sqf:description>
+					<sqf:title>Delete @focus</sqf:title>
+				</sqf:description>
+				<sqf:delete match="@focus"/>
+			</sqf:fix>
+		</sch:rule>
+		<sch:rule context="x:scenario[@pending]">
+			<sch:report id="pending-shared-scenario" role="warn" sqf:fix="sqf-delete-pending"
+				test="@shared = ('1', 'yes', 'true')">@pending has no effect on scenario with shared=<sch:value-of
+					select="@shared"/></sch:report>
+		</sch:rule>
+	</sch:pattern>
+
+	<sqf:fixes>
+		<sqf:fix id="sqf-delete-pending">
+			<sqf:description>
+				<sqf:title>Delete @pending</sqf:title>
+			</sqf:description>
+			<sqf:delete match="@pending"/>
+		</sqf:fix>		
+	</sqf:fixes>
 </sch:schema>

--- a/test/schematron/xspec-sch-pending-focus.xspec
+++ b/test/schematron/xspec-sch-pending-focus.xspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="">
+
+    <!--
+        This file is not runnable. It provides contexts for xspec-sch.xspec.
+    -->
+    <x:scenario label="Non-shared scenario with pending and focus"
+        pending="pending" focus="focus"/>
+    <x:scenario label="Non-shared scenario with pending but not focus"
+        pending="pending"/>
+    <x:scenario label="Non-shared scenario with focus but not pending"
+        focus="focus"/>
+    <x:scenario label="Non-shared scenario with neither pending nor focus"/>
+    
+    <x:scenario label="Shared scenario with pending and focus"
+        shared="yes" pending="pending" focus="focus"/>
+    <x:scenario label="Shared scenario with pending but not focus"
+        shared="yes" pending="pending"/>
+    <x:scenario label="Shared scenario with focus but not pending"
+        shared="yes" focus="focus"/>
+    <x:scenario label="Shared scenario with neither pending nor focus"
+        shared="yes" />
+    
+</x:description>

--- a/test/xspec-sch.xspec
+++ b/test/xspec-sch.xspec
@@ -69,5 +69,45 @@
 			<x:expect-assert id="user-element-expand-text" />
 		</x:scenario>
 	</x:scenario>
+	<x:scenario label="Ineffective pending and focus attributes">
+		<x:context href="schematron/xspec-sch-pending-focus.xspec"/>
+		<x:scenario label="Non-shared scenario">
+			<x:expect-report id="focused-pending-scenario"
+				location="//x:scenario[@label eq 'Non-shared scenario with pending and focus']"/>
+			<x:expect-not-report id="focused-pending-scenario"
+				location="//x:scenario[@label eq 'Non-shared scenario with pending but not focus']"/>
+			<x:expect-not-report id="focused-pending-scenario"
+				location="//x:scenario[@label eq 'Non-shared scenario with focus but not pending']"/>
+			<x:expect-not-report id="focused-pending-scenario"
+				location="//x:scenario[@label eq 'Non-shared scenario with neither pending nor focus']"/>
+		</x:scenario>
+		<x:scenario label="Shared scenario">
+			<x:scenario label="with both @focus and @pending">
+				<x:expect-report id="focused-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with pending and focus']"/>
+				<x:expect-not-report id="pending-shared-scenario"
+					label="(sch:rule for @focus shadows the one for @pending)"
+					location="//x:scenario[@label eq 'Shared scenario with pending and focus']"/>
+			</x:scenario>
+			<x:scenario label="with only @pending, not @focus">
+				<x:expect-report id="pending-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with pending but not focus']"/>
+				<x:expect-not-report id="focused-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with pending but not focus']"/>
+			</x:scenario>
+			<x:scenario label="with only @focus, not @pending">
+				<x:expect-report id="focused-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with focus but not pending']"/>
+				<x:expect-not-report id="pending-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with focus but not pending']"/>
+			</x:scenario>
+			<x:scenario label="with neither @focus nor @pending">
+				<x:expect-not-report id="focused-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with neither pending nor focus']"/>
+				<x:expect-not-report id="pending-shared-scenario"
+					location="//x:scenario[@label eq 'Shared scenario with neither pending nor focus']"/>
+			</x:scenario>
+		</x:scenario>
+	</x:scenario>
 
 </x:description>


### PR DESCRIPTION
This pull request addresses the part of #575 that says, "Consider creating Schematron rules for detecting meaningless `x:pending`, `@pending` or `@focus`".

This pull request includes Schematron warnings for low-hanging-fruit cases where `@focus` or `@pending` on `<x:scenario>` has no effect because of another attribute on the same element.

I considered adding a warning for `<x:pending>` all of whose child elements have `@focus` but didn't implement it. The wiki has documented `@focus` and `@pending` since 2015 (https://github.com/xspec/xspec/wiki/Writing-Scenarios/589e001005853dd24f8f6790c5f44b1ea8b8f9d1) or earlier, and I'm not aware that ineffective attributes are a large area of confusion for XSpec users.

I also considered whether an additional quick fix offer could be to remove the `@shared` attribute on a scenario that also has `@pending` and/or `@focus`. I rejected that idea because I think the most likely way you'd fix the situation is to keep the scenario shared and remove the other attribute(s). Offering a likely fix right next to an unlikely fix could make it look as if they are equally useful, and that could be confusing or distracting.

### Local qualification

I validated some sample XSpec files in Oxygen 26.1, including the `test/schematron/xspec-sch-pending-focus.xspec` file in this pull request. I manually tried the Schematron Quick Fixes, and they work. Note that for the case where a shared scenario has both `@focus` and `@pending`, you first get a warning and quick fix offer about `@focus`, and after you delete that attribute, you get a warning and quick fix offer about `@pending`.
