### PR TITLE
ci(deps): bump BaseX from 11.0 to 11.2

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.0
+BASEX_VERSION=11.2
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
#1988 mentioned a problem testing with BaseX 11.1 in server mode. This pull request moves to 11.2, which doesn't seem to have the same problem.

---

From https://github.com/BaseXdb/basex/blob/main/CHANGELOG :

VERSION 11.2 (August 15, 2024) -----------------------------------------

 - [ADD] New XQuery 4 features
 - [ADD] XQuery: proc:system: new 'environment' option
 - [MOD] GUI: Global Ctrl-ENTER shortcut
 - [MOD] XQuery: faster evaluation of recursive functions
 - [MOD] XQuery: faster invocation of HOF function parameters
 - [MOD] XQuery: distinct-values: faster processing of numeric input
 - [MOD] XQuery: fewer redundant type checks
 - [FIX] XQuery: circularity/self-dependency checks revised
 - [FIX] WebSockets (Jetty 11): Idle timeout increased to 1 hour

VERSION 11.1 (July 10, 2024) -------------------------------------------

 - [FIX] Duplicate libraries removed from distribution packages
 - [FIX] XQuery, inspect:module and inspect:xqdoc
 - [FIX] WebSocket, ws:broadcast, ws:emit: send maps and arrays
 - [FIX] HTTP Payloads: handling multipart messages
 - [ADD] XQuery: support for union node tests
 - [MOD] XQuery: Better coercion for arrays and maps
 - [MIN] Updated to Jetty 11.0.22 and Markup Blitz 1.4