### PR TITLE
build(oxygen): add-on v3.1.1

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,17 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.1.1</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>fix(report): XSLT code coverage reports for Saxon 12.4 have many bug fixes in the coverage status</li>
+					<li>feat(schematron): SchXslt 1.10 replaces 1.9.5 as the built-in Schematron implementation</li>
+					<li>Tested with Saxon 10.9, 11.6, and 12.5, except that detailed contents of XSLT code coverage reports are tested with Saxon 12.4</li>
+					<li>Tested with Oxygen 26.1</li>
+					<li>Tested with BaseX 11.2</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.0.3</h3>
 				<ul>
 					<li>Official release of v3.0</li>
@@ -81,14 +92,6 @@
 					<li>Removes Saxon 9.8 (and consequently Oxygen 20 and 21) support (<a
 							href="https://github.com/xspec/xspec/issues/1502">#1502</a>)</li>
 					<li>Minor refactoring and performance improvement</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.2.4</h3>
-				<ul>
-					<li>Official release of v2.2</li>
-					<li>Tested with Saxon 10.6</li>
-					<li>Tested with SchXslt 1.8.2</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/d8e9d6fd1eca26793a84bc77753a32593d5ad1b3.zip" />
+			href="https://github.com/xspec/xspec/archive/40905241867859b1c2def70251d61da69254873b.zip" />
 
-		<xt:version>3.0.3</xt:version>
+		<xt:version>3.1.1</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-d8e9d6fd1eca26793a84bc77753a32593d5ad1b3/xspec.framework/XSpec</String>
+                                    <String>4/xspec-40905241867859b1c2def70251d61da69254873b/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This v3.1.1 add-on has the changes we expect to be in XSpec v3.1.

I tested this change in Oxygen 26.1 build 2024031806 using https://github.com/galtm/xspec/raw/oxygen-addon-3-1-1/oxygen-addon.xml . I checked the subbullets under "Test the add-on 3.1.num with Oxygen 26.1" in #1912 and noticed no problems.