### PR TITLE
ci(deps): bump BaseX from 11.2 to 11.3

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.2
+BASEX_VERSION=11.3
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 11.3 (September 19, 2024) --------------------------------------

 - [ADD] New XQuery 4 features
 - [ADD] Options: LOG, support for stdout/stderr/slf4j targets
 - [ADD] XQuery: focus expression (A -> B; experimental)
 - [MOD] XQuery, processing single chars: reduced memory consumption
 - [MOD] XQuery, db:node-id, db:node-pre: faster retrieval
 - [FIX] XQuery: self-recursiveness of functions and variables revised
 - [FIX] XQuery: inspect:function has become more robust