### PR TITLE
feat(schematron): bump built-in SchXslt to v1.10.1

### DIFF
--- a/lib/schxslt/1.0/version.xsl
+++ b/lib/schxslt/1.0/version.xsl
@@ -7,7 +7,7 @@
                      xmlns:skos="http://www.w3.org/2004/02/skos/core#">
       <dct:creator>
         <dct:Agent>
-          <skos:prefLabel>SchXslt/1.10 (XSLT 1.0)</skos:prefLabel>
+          <skos:prefLabel>SchXslt/1.10.1 (XSLT 1.0)</skos:prefLabel>
         </dct:Agent>
       </dct:creator>
     </rdf:Description>

--- a/lib/schxslt/2.0/compile/compile-2.0.xsl
+++ b/lib/schxslt/2.0/compile/compile-2.0.xsl
@@ -64,10 +64,12 @@
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="version" as="element(rdf:Description)">
+    <xsl:variable name="version" as="element(rdf:Description)?">
+      <xsl:if test="$schxslt.compile.metadata">
       <xsl:call-template name="schxslt:version">
         <xsl:with-param name="xslt-version" as="xs:string" tunnel="yes" select="$xslt-version"/>
       </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <transform version="{$xslt-version}">

--- a/lib/schxslt/2.0/version.xsl
+++ b/lib/schxslt/2.0/version.xsl
@@ -18,7 +18,7 @@
   </xsl:template>
 
   <xsl:function name="schxslt:user-agent" as="xs:string">
-    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.10</xsl:variable>
+    <xsl:variable name="schxslt-ident" as="xs:string">SchXslt/1.10.1</xsl:variable>
     <xsl:variable name="xslt-ident" as="xs:string">
       <xsl:value-of separator="/" select="(system-property('xsl:product-name'), system-property('xsl:product-version'))"/>
     </xsl:variable>


### PR DESCRIPTION
Replace the built-in SchXslt v1.10 with v1.10.1, using download from https://github.com/schxslt/schxslt/releases/download/v1.10.1/schxslt-1.10.1-xslt-only.zip