### PR TITLE
docs(xquery): make whitespace helper file self-contained

### DIFF
--- a/tutorial/helper/ws-only-text/test-helper.xqm
+++ b/tutorial/helper/ws-only-text/test-helper.xqm
@@ -1,8 +1,5 @@
 module namespace test-helper = "x-urn:tutorial:helper:ws-only-text:test-helper";
 
-import module namespace x = "http://www.jenitennison.com/xslt/xspec"
-at "../../../src/common/common-utils.xqm";
-
 (:
 	This test helper function just removes whitespace-only text nodes from the input node.
 	All the other nodes are kept intact.
@@ -22,7 +19,8 @@ as node()?
 		case element()
 			return
 				element {node-name($node)} {
-					x:copy-of-additional-namespaces($node),
+					in-scope-prefixes($node)[. ne 'xml'] !
+					namespace {.} {namespace-uri-for-prefix(., $node)},
 					$node/attribute(),
 					$node/node() ! test-helper:remove-whitespace-only-text(.)
 				}


### PR DESCRIPTION
I can imagine users copying the whitespace helper files from the XSpec tutorial directory for use in their own projects. They might want to copy only the helper file they need, plus the license file -- instead of copying the entire set of end-user files. It would be helpful if each of the helper files was self-contained. In the XSLT case, it already is. In the XQuery case, the helper module depends on one of the files under `src/`. This pull request replaces that import with similar code directly in the helper module, making the helper module self-contained.

The replacement code is not exactly the same, as the original also sorts namespace declarations and excludes the `xml` namespace. I think the helper module doesn't need these extra pieces of functionality, so I opted to make the replacement code simpler.

For reference: [Link](https://github.com/xspec/xspec/blob/d2f1345f84f54f44ef9a17a0d7039488e891c25d/src/common/common-utils.xqm#L95) to `x:copy-of-additional-namespaces`
