### PR TITLE
fix(report): mark variable without siblings as missed 

### DIFF
--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -13,7 +13,7 @@
         is in the trace. Other logic builds upon this information. -->
     <xsl:accumulator name="category-based-on-trace-data" as="xs:string*" initial-value="()">
         <xsl:accumulator-rule match="element() | text()">
-            <xsl:variable name="hits-on-node"
+            <xsl:variable name="hits-on-node" as="element(hit)*"
                 select="local:hits-on-node(.)"/>
             <xsl:choose>
                 <xsl:when test="exists($hits-on-node)">
@@ -327,7 +327,7 @@
 
     <!-- Low-priority fallback template rule -->
     <xsl:template match="node()" mode="untraceable-in-instruction"
-        priority="-10">
+        as="xs:string" priority="-10">
         <xsl:sequence select="'traceable executable'"/>
     </xsl:template>
 
@@ -366,7 +366,8 @@
         | XSLT:when
         | XSLT:where-populated
         | XSLT:with-param"
-        mode="untraceable-in-instruction">
+        mode="untraceable-in-instruction"
+        as="xs:string">
         <!--
             Some of the elements listed in the match attribute are not strictly needed
             in order to achieve the caller's objective, because the elements have a

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -218,9 +218,13 @@
                 <!-- Global variables effectively follow the Use Trace Data rule. -->
                 <xsl:sequence select="'missed'"/>
             </xsl:when>
-            <xsl:otherwise>
+            <xsl:when test="following-sibling::*[not(self::XSLT:variable)]">
                 <xsl:apply-templates select="following-sibling::*[not(self::XSLT:variable)][1]"
                     mode="#current"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- Local variable with no following siblings except other local variables -->
+                <xsl:sequence select="'missed'"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -7,7 +7,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-variable-01.xsl">xsl-variable-01.xsl</a></p>
-      <h2>module: xsl-variable-01.xsl; 101 lines</h2>
+      <h2>module: xsl-variable-01.xsl; 149 lines</h2>
       <pre>001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 003: <span class="ignored">  </span><span class="ignored">&lt;!--</span>
@@ -65,49 +65,97 @@
 055: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptySequenceUnused01" as="element()?" /&gt;</span><span class="ignored"> </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
 056: <span class="ignored">    </span><span class="ignored">&lt;!-- Not used --&gt;</span>
 057: <span class="ignored">    </span><span class="hit">&lt;xsl:variable name="variableLocalEmptyStringUnused01" /&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
-058: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
-059: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-060: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-061: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalSelect01" /&gt;</span>
-062: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-063: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-064: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-065: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalDocNode01" /&gt;</span>
-066: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-067: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-068: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-069: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalAs01" /&gt;</span>
-070: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-071: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-072: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-073: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptySequence01)" /&gt;</span>
-074: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-075: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
-076: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
-077: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptyString01)" /&gt;</span>
-078: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-079: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-080: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-081: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalSelect01" /&gt;</span>
-082: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-083: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-084: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-085: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalDocNode01" /&gt;</span>
-086: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-087: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-088: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-089: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalAs01" /&gt;</span>
-090: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-091: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-092: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-093: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptySequence01)" /&gt;</span>
-094: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-095: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
-096: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
-097: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptyString01)" /&gt;</span>
-098: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
-099: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
-100: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-101: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+058: 
+059: <span class="ignored">    </span><span class="hit">&lt;xsl:choose&gt;</span>
+060: <span class="ignored">      </span><span class="missed">&lt;xsl:when test="1 eq 2"&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+061: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+062: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalSelectNoEffect01" select="string(1600)" /&gt;</span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+063: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+064: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalDocNodeNoEffect01"&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+065: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">170</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+066: <span class="ignored">          </span><span class="missed">&lt;element&gt;</span><span class="missed">0</span><span class="missed">&lt;/element&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+067: <span class="ignored">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+068: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+069: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalasNoEffect01" as="text()"&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+070: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1700</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+071: <span class="ignored">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+072: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+073: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalEmptySequenceNoEffect01" as="element()?" /&gt;</span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+074: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+075: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalEmptyStringNoEffect01" /&gt;</span><span class="ignored">             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+076: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings; warning from Saxon --&gt;</span>
+077: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalSeq" as="item()+"</span>
+078: <span class="missed">          select="($variableLocalSelectNoEffect01, $variableLocalDocNodeNoEffect01,</span>
+079: <span class="missed">          $variableLocalasNoEffect01, $variableLocalEmptySequenceNoEffect01,</span>
+080: <span class="missed">          $variableLocalEmptyStringNoEffect01)"/&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+081: <span class="ignored">      </span><span class="missed">&lt;/xsl:when&gt;</span><span class="ignored">                                                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+082: <span class="ignored">      </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="ignored">                                                          </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+083: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+084: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalSelectNoEffect02" select="string(1600)" /&gt;</span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+085: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+086: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalDocNodeNoEffect02"&gt;</span><span class="ignored">                   </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+087: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">170</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+088: <span class="ignored">          </span><span class="missed">&lt;element&gt;</span><span class="missed">0</span><span class="missed">&lt;/element&gt;</span><span class="ignored">                                                 </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+089: <span class="ignored">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+090: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+091: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalasNoEffect02" as="text()"&gt;</span><span class="ignored">            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+092: <span class="ignored">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1700</span><span class="missed">&lt;/xsl:text&gt;</span><span class="ignored">                                            </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+093: <span class="ignored">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="ignored">                                                        </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+094: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+095: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalEmptySequenceNoEffect02" as="element()?" /&gt;</span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+096: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings --&gt;</span>
+097: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalEmptyStringNoEffect02" /&gt;</span><span class="ignored">             </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+098: <span class="ignored">        </span><span class="ignored">&lt;!-- No relevant following siblings; warning from Saxon --&gt;</span>
+099: <span class="ignored">        </span><span class="missed">&lt;xsl:variable name="variableLocalSeq" as="item()+"</span>
+100: <span class="missed">          select="($variableLocalSelectNoEffect02, $variableLocalDocNodeNoEffect02,</span>
+101: <span class="missed">          $variableLocalasNoEffect02, $variableLocalEmptySequenceNoEffect02,</span>
+102: <span class="missed">          $variableLocalEmptyStringNoEffect02)"/&gt;</span><span class="ignored">                              </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+103: <span class="ignored">      </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="ignored">                                                         </span><span class="ignored">&lt;!-- Expected miss --&gt;</span>
+104: <span class="ignored">    </span><span class="hit">&lt;/xsl:choose&gt;</span>
+105: 
+106: <span class="ignored">    </span><span class="hit">&lt;root&gt;</span>
+107: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+108: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+109: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalSelect01" /&gt;</span>
+110: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+111: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+112: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+113: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalDocNode01" /&gt;</span>
+114: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+115: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+116: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+117: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableGlobalAs01" /&gt;</span>
+118: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+119: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+120: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+121: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptySequence01)" /&gt;</span>
+122: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+123: <span class="ignored">      </span><span class="ignored">&lt;!-- Global variable used --&gt;</span>
+124: <span class="ignored">      </span><span class="hit">&lt;node type="variable - global"&gt;</span>
+125: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableGlobalEmptyString01)" /&gt;</span>
+126: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+127: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+128: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+129: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalSelect01" /&gt;</span>
+130: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+131: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+132: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+133: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalDocNode01" /&gt;</span>
+134: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+135: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+136: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+137: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="$variableLocalAs01" /&gt;</span>
+138: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+139: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+140: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+141: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptySequence01)" /&gt;</span>
+142: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+143: <span class="ignored">      </span><span class="ignored">&lt;!-- Local variable used --&gt;</span>
+144: <span class="ignored">      </span><span class="hit">&lt;node type="variable - local"&gt;</span>
+145: <span class="ignored">        </span><span class="hit">&lt;xsl:value-of select="count($variableLocalEmptyString01)" /&gt;</span>
+146: <span class="ignored">      </span><span class="hit">&lt;/node&gt;</span>
+147: <span class="ignored">    </span><span class="hit">&lt;/root&gt;</span>
+148: <span class="ignored">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+149: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.xml
@@ -16,63 +16,68 @@
    <hit lineNumber="51" columnNumber="62" moduleId="0" traceableId="1"/>
    <hit lineNumber="55" columnNumber="79" moduleId="0" traceableId="1"/>
    <hit lineNumber="57" columnNumber="61" moduleId="0" traceableId="1"/>
-   <hit lineNumber="58" columnNumber="11" moduleId="0" traceableId="1"/>
-   <traceable traceableId="2" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="58" columnNumber="11" moduleId="0" traceableId="2"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="2"/>
+   <traceable traceableId="2" class="net.sf.saxon.expr.instruct.Block"/>
+   <hit lineNumber="59" columnNumber="17" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
+              class="net.sf.saxon.expr.instruct.Choose"
+              uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
+   <hit lineNumber="59" columnNumber="17" moduleId="0" traceableId="3"/>
+   <traceable traceableId="4" class="net.sf.saxon.expr.instruct.FixedElement"/>
+   <hit lineNumber="106" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="108" columnNumber="38" moduleId="0" traceableId="4"/>
+   <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="60" columnNumber="38" moduleId="0" traceableId="3"/>
-   <traceable traceableId="4"
+   <hit lineNumber="108" columnNumber="38" moduleId="0" traceableId="5"/>
+   <traceable traceableId="6"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="61" columnNumber="58" moduleId="0" traceableId="4"/>
-   <traceable traceableId="5"
+   <hit lineNumber="109" columnNumber="58" moduleId="0" traceableId="6"/>
+   <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.GlobalVariable"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}variable"/>
-   <hit lineNumber="7" columnNumber="70" moduleId="0" traceableId="5"/>
-   <hit lineNumber="64" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="64" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="65" columnNumber="59" moduleId="0" traceableId="4"/>
-   <hit lineNumber="8" columnNumber="48" moduleId="0" traceableId="5"/>
+   <hit lineNumber="7" columnNumber="70" moduleId="0" traceableId="7"/>
+   <hit lineNumber="112" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="112" columnNumber="38" moduleId="0" traceableId="5"/>
+   <hit lineNumber="113" columnNumber="59" moduleId="0" traceableId="6"/>
+   <hit lineNumber="8" columnNumber="48" moduleId="0" traceableId="7"/>
    <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="1"/>
-   <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="4"/>
-   <hit lineNumber="10" columnNumber="14" moduleId="0" traceableId="2"/>
+   <hit lineNumber="9" columnNumber="15" moduleId="0" traceableId="6"/>
    <hit lineNumber="10" columnNumber="14" moduleId="0" traceableId="4"/>
-   <hit lineNumber="68" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="68" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="69" columnNumber="54" moduleId="0" traceableId="4"/>
-   <hit lineNumber="12" columnNumber="55" moduleId="0" traceableId="5"/>
+   <hit lineNumber="10" columnNumber="14" moduleId="0" traceableId="6"/>
+   <hit lineNumber="116" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="116" columnNumber="38" moduleId="0" traceableId="5"/>
+   <hit lineNumber="117" columnNumber="54" moduleId="0" traceableId="6"/>
+   <hit lineNumber="12" columnNumber="55" moduleId="0" traceableId="7"/>
    <hit lineNumber="13" columnNumber="15" moduleId="0" traceableId="1"/>
-   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="72" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="73" columnNumber="72" moduleId="0" traceableId="4"/>
-   <hit lineNumber="15" columnNumber="72" moduleId="0" traceableId="5"/>
-   <hit lineNumber="76" columnNumber="38" moduleId="0" traceableId="2"/>
-   <hit lineNumber="76" columnNumber="38" moduleId="0" traceableId="3"/>
-   <hit lineNumber="77" columnNumber="70" moduleId="0" traceableId="4"/>
-   <hit lineNumber="16" columnNumber="54" moduleId="0" traceableId="5"/>
-   <hit lineNumber="80" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="80" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="81" columnNumber="57" moduleId="0" traceableId="4"/>
-   <hit lineNumber="84" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="84" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="85" columnNumber="58" moduleId="0" traceableId="4"/>
+   <hit lineNumber="120" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="120" columnNumber="38" moduleId="0" traceableId="5"/>
+   <hit lineNumber="121" columnNumber="72" moduleId="0" traceableId="6"/>
+   <hit lineNumber="15" columnNumber="72" moduleId="0" traceableId="7"/>
+   <hit lineNumber="124" columnNumber="38" moduleId="0" traceableId="4"/>
+   <hit lineNumber="124" columnNumber="38" moduleId="0" traceableId="5"/>
+   <hit lineNumber="125" columnNumber="70" moduleId="0" traceableId="6"/>
+   <hit lineNumber="16" columnNumber="54" moduleId="0" traceableId="7"/>
+   <hit lineNumber="128" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="128" columnNumber="37" moduleId="0" traceableId="5"/>
+   <hit lineNumber="129" columnNumber="57" moduleId="0" traceableId="6"/>
+   <hit lineNumber="132" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="132" columnNumber="37" moduleId="0" traceableId="5"/>
+   <hit lineNumber="133" columnNumber="58" moduleId="0" traceableId="6"/>
    <hit lineNumber="35" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="35" columnNumber="17" moduleId="0" traceableId="4"/>
-   <hit lineNumber="36" columnNumber="16" moduleId="0" traceableId="2"/>
+   <hit lineNumber="35" columnNumber="17" moduleId="0" traceableId="6"/>
    <hit lineNumber="36" columnNumber="16" moduleId="0" traceableId="4"/>
-   <hit lineNumber="88" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="88" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="89" columnNumber="53" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="16" moduleId="0" traceableId="6"/>
+   <hit lineNumber="136" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="136" columnNumber="37" moduleId="0" traceableId="5"/>
+   <hit lineNumber="137" columnNumber="53" moduleId="0" traceableId="6"/>
    <hit lineNumber="39" columnNumber="17" moduleId="0" traceableId="1"/>
-   <hit lineNumber="92" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="92" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="93" columnNumber="71" moduleId="0" traceableId="4"/>
-   <hit lineNumber="96" columnNumber="37" moduleId="0" traceableId="2"/>
-   <hit lineNumber="96" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="97" columnNumber="69" moduleId="0" traceableId="4"/>
+   <hit lineNumber="140" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="140" columnNumber="37" moduleId="0" traceableId="5"/>
+   <hit lineNumber="141" columnNumber="71" moduleId="0" traceableId="6"/>
+   <hit lineNumber="144" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="144" columnNumber="37" moduleId="0" traceableId="5"/>
+   <hit lineNumber="145" columnNumber="69" moduleId="0" traceableId="6"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-variable-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-variable-01.xsl
@@ -55,6 +55,54 @@
     <xsl:variable name="variableLocalEmptySequenceUnused01" as="element()?" /> <!-- Expected miss -->
     <!-- Not used -->
     <xsl:variable name="variableLocalEmptyStringUnused01" />                   <!-- Expected miss -->
+
+    <xsl:choose>
+      <xsl:when test="1 eq 2">                                                 <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalSelectNoEffect01" select="string(1600)" /><!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalDocNodeNoEffect01">                   <!-- Expected miss -->
+          <xsl:text>170</xsl:text>                                             <!-- Expected miss -->
+          <element>0</element>                                                 <!-- Expected miss -->
+        </xsl:variable>                                                        <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalasNoEffect01" as="text()">            <!-- Expected miss -->
+          <xsl:text>1700</xsl:text>                                            <!-- Expected miss -->
+        </xsl:variable>                                                        <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalEmptySequenceNoEffect01" as="element()?" /><!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalEmptyStringNoEffect01" />             <!-- Expected miss -->
+        <!-- No relevant following siblings; warning from Saxon -->
+        <xsl:variable name="variableLocalSeq" as="item()+"
+          select="($variableLocalSelectNoEffect01, $variableLocalDocNodeNoEffect01,
+          $variableLocalasNoEffect01, $variableLocalEmptySequenceNoEffect01,
+          $variableLocalEmptyStringNoEffect01)"/>                              <!-- Expected miss -->
+      </xsl:when>                                                              <!-- Expected miss -->
+      <xsl:otherwise>                                                          <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalSelectNoEffect02" select="string(1600)" /><!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalDocNodeNoEffect02">                   <!-- Expected miss -->
+          <xsl:text>170</xsl:text>                                             <!-- Expected miss -->
+          <element>0</element>                                                 <!-- Expected miss -->
+        </xsl:variable>                                                        <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalasNoEffect02" as="text()">            <!-- Expected miss -->
+          <xsl:text>1700</xsl:text>                                            <!-- Expected miss -->
+        </xsl:variable>                                                        <!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalEmptySequenceNoEffect02" as="element()?" /><!-- Expected miss -->
+        <!-- No relevant following siblings -->
+        <xsl:variable name="variableLocalEmptyStringNoEffect02" />             <!-- Expected miss -->
+        <!-- No relevant following siblings; warning from Saxon -->
+        <xsl:variable name="variableLocalSeq" as="item()+"
+          select="($variableLocalSelectNoEffect02, $variableLocalDocNodeNoEffect02,
+          $variableLocalasNoEffect02, $variableLocalEmptySequenceNoEffect02,
+          $variableLocalEmptyStringNoEffect02)"/>                              <!-- Expected miss -->
+      </xsl:otherwise>                                                         <!-- Expected miss -->
+    </xsl:choose>
+
     <root>
       <!-- Global variable used -->
       <node type="variable - global">


### PR DESCRIPTION
This pull request prevents a fatal error during generation of the XSLT coverage report in the case where a local variable has no following siblings (not counting other `xsl:variable` elements). In that case, the `xsl:variable` element has no effect, Saxon does not report it as a hit, and the coverage report now marks it as 'missed'.

In the coverage test for this case, I used `xsl:choose` for two reasons:

- Make it easier to add content to the template, if needed in the future, without having to remember that certain `xsl:variable` elements must not have any following siblings. The `xsl:choose` block makes the set of variables related to this PR self-contained.
- Illustrate the somewhat odd behavior that the coverage report doesn't show which branch of `xsl:choose` was hit. In this test, the `xsl:when` branch is 'missed' because `test` evaluates to false, whereas the `xsl:otherwise` branch is 'missed' because the Use Descendant Data rule finds that all executable descendants are traceable but not 'hit'.

Fixes #2019.
