### PR TITLE
test(xslt): scenario-level static parameters

### DIFF
--- a/test/external_scenario-param-static-use-when.xsl
+++ b/test/external_scenario-param-static-use-when.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:param name="A" static="yes" as="xs:integer" select="0"/>
+	<xsl:param name="B" static="yes" as="xs:integer" select="0"/>
+
+	<xsl:template name="process-A-and-B">
+		<xsl:context-item use="absent"/>
+		<xsl:call-template name="template-based-on-A"/>
+		<xsl:call-template name="template-based-on-B"/>
+	</xsl:template>
+
+	<xsl:template name="template-based-on-A" use-when="$A ge 0" as="xs:integer">
+		<xsl:context-item use="absent"/>
+		<xsl:sequence select="$A"/>
+	</xsl:template>
+
+	<xsl:template name="template-based-on-A" use-when="$A lt 0" as="xs:string">
+		<xsl:context-item use="absent"/>
+		<xsl:sequence select="'$A is negative'"/>
+	</xsl:template>
+
+	<xsl:template name="template-based-on-B" use-when="$B ge 0" as="xs:integer">
+		<xsl:context-item use="absent"/>
+		<xsl:sequence select="$B"/>
+	</xsl:template>
+
+	<xsl:template name="template-based-on-B" use-when="$B lt 0" as="xs:string">
+		<xsl:context-item use="absent"/>
+		<xsl:sequence select="'$B is negative'"/>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/test/external_scenario-param-static-use-when.xsl
+++ b/test/external_scenario-param-static-use-when.xsl
@@ -5,6 +5,8 @@
 
 	<xsl:param name="A" static="yes" as="xs:integer" select="0"/>
 	<xsl:param name="B" static="yes" as="xs:integer" select="0"/>
+	<xsl:param name="myp:default" static="no"
+		xmlns:myp="http://example.org/ns/my/param"/>
 
 	<xsl:template name="process-A-and-B">
 		<xsl:context-item use="absent"/>

--- a/test/external_scenario-param-static-use-when.xspec
+++ b/test/external_scenario-param-static-use-when.xspec
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description run-as="external" stylesheet="external_scenario-param-static-use-when.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<x:param name="A" static="yes" as="xs:integer" select="-1"/>
+
+	<x:scenario label="Destination templates have @use-when depending on static parameter values">
+		<x:call template="process-A-and-B"/>
+		<x:scenario label="Description-level static param $A and">
+			<x:scenario label="non-overridden static param $B">
+				<x:expect label="String about negative $A and 0 for $B"
+					select="('$A is negative', 0)"/>
+			</x:scenario>
+			<x:scenario label="independent scenario-level static param $B">
+				<x:param name="B" static="yes" as="xs:integer" select="-2"/>
+				<x:expect label="Strings about negative $A and $B"
+					select="('$A is negative', '$B is negative')"/>
+			</x:scenario>
+			<x:scenario label="dependent scenario-level static param $B">
+				<x:param name="B" static="yes" as="xs:integer" select="2 + $A"/>
+				<x:expect label="String about negative $A and 1 for $B"
+					select="('$A is negative', 1)"/>
+			</x:scenario>
+		</x:scenario>
+		<x:scenario label="Scenario-level static param $A and">
+			<x:param name="A" static="yes" as="xs:integer" select="10"/>
+			<x:scenario label="non-overridden static param $B">
+				<x:expect label="10 for $A and 0 for $B"
+					select="(10, 0)"/>
+			</x:scenario>
+			<x:scenario label="independent scenario-level static param $B">
+				<x:param name="B" static="yes" as="xs:integer" select="-2"/>
+				<x:expect label="10 for $A and string about negative $B"
+					select="(10, '$B is negative')"/>
+			</x:scenario>
+			<x:scenario label="dependent scenario-level static param $B">
+				<x:param name="B" static="yes" as="xs:integer" select="1 + $A"/>
+				<x:expect label="10 for $A and 11 for $B"
+					select="(10, 11)"/>
+			</x:scenario>
+		</x:scenario>		
+	</x:scenario>
+</x:description>

--- a/test/external_scenario-param-static-use-when.xspec
+++ b/test/external_scenario-param-static-use-when.xspec
@@ -3,6 +3,8 @@
 	xmlns:x="http://www.jenitennison.com/xslt/xspec"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
+	<!-- This file runs as a test and is also referenced in transform-options.xspec -->
+
 	<x:param name="A" static="yes" as="xs:integer" select="-1"/>
 
 	<x:scenario label="Destination templates have @use-when depending on static parameter values">
@@ -12,8 +14,11 @@
 				<x:expect label="String about negative $A and 0 for $B"
 					select="('$A is negative', 0)"/>
 			</x:scenario>
-			<x:scenario label="independent scenario-level static param $B">
-				<x:param name="B" static="yes" as="xs:integer" select="-2"/>
+			<x:scenario label="independent scenario-level static param $B" xml:id="inh-A-local-B">
+				<!-- xml:id and myp:default are for use in transform-options.xspec -->
+				<x:param name="B" static="true" as="xs:integer" select="-2"/>
+				<x:param name="myp:default" static="0" select="()"
+					xmlns:myp="http://example.org/ns/my/param"/>
 				<x:expect label="Strings about negative $A and $B"
 					select="('$A is negative', '$B is negative')"/>
 			</x:scenario>

--- a/test/transform-options.xspec
+++ b/test/transform-options.xspec
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../src/compiler/compile-xslt-tests.xsl"
+	xmlns:x="http://www.jenitennison.com/xslt/xspec"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:XSLT="http://www.w3.org/1999/XSL/Transform">
+
+	<!-- This test file doesn't verify all aspects of x:transform-options but
+		aims to sanity-check the assignment of static and non-static parameters
+		to the correct map entries in the map of transform options. -->
+
+	<x:scenario>
+		<x:label>Scenario with global static param, scenario-level static param,
+			and scenario-level non-static param</x:label>
+		<x:context href="external_scenario-param-static-use-when.xspec"
+			select="exactly-one(/x:description//x:scenario[@xml:id = 'inh-A-local-B'])"/>
+		<x:call template="x:transform-options">
+			<x:param name="invocation-type" as="xs:string" select="'call-template'"/>
+			<x:param name="call" as="element(x:call)?" tunnel="yes"
+				href="external_scenario-param-static-use-when.xspec"
+				select="/x:description/x:scenario[1]/x:call" />
+			<x:param name="context" as="element(x:context)?" tunnel="yes" select="()" />
+		</x:call>
+		<x:expect label="Map of transform options includes A and B as static parameters"
+			test="XSLT:variable/XSLT:map/XSLT:map-entry[@key='''static-params''']">
+			<XSLT:map-entry key="'static-params'">
+				<XSLT:map>
+					<XSLT:map-entry key="QName('', 'A')" select="$Q{{}}A" />
+					<XSLT:map-entry key="QName('', 'B')" select="$Q{{}}B" />
+				</XSLT:map>
+			</XSLT:map-entry>
+		</x:expect>
+		<x:expect label="and myp:default as non-static stylesheet parameter"
+			test="XSLT:variable/XSLT:map/XSLT:map-entry[@key='''stylesheet-params''']">
+			<XSLT:map-entry key="'stylesheet-params'">
+				<XSLT:map>
+					<XSLT:map-entry key="QName('http://example.org/ns/my/param', 'myp:default')"
+						select="$Q{{http://example.org/ns/my/param}}default" />
+				</XSLT:map>
+			</XSLT:map-entry>			
+		</x:expect>
+	</x:scenario>
+</x:description>


### PR DESCRIPTION
https://github.com/xspec/xspec/pull/1120#issue-668016916 says, "Hopefully #991 will try supporting `@static` in `//x:scenario/x:param` in the future."

I believe that scenario-level static parameters in tests for XSLT work fine. I don't see any tests for that capability, so this pull request adds some.

For reference: https://github.com/xspec/xspec/pull/1354

### Further work:

- [ ] On the External Transformation page in the wiki, update "- test with a static parameter (`/x:description/x:param/@static`)"

### Extra test not in this PR

At first, I was going to modify the existing `external_scenario-param.xspec` test and its XSLT test target, to add `static="yes"` everywhere. That worked (after I modified some `as` attributes from `item()+` to `item()* in the test target`), but I decided not to include it in this PR. (A) It seemed like overkill to check things like different ways of selecting nodes when that's far afield from how static parameters are actually implemented in the XSpec compiler; and (B) I wanted a less generic test, one that does a better job of convincing you that _static_ parameters in XSpec are doing what they're supposed to do. In case I change my mind or a future maintainer wants to revive the test that I didn't include in this PR, I'm attaching the files here. I appended `.txt` to the file name extensions just to make the files acceptable to GitHub.

[external_scenario-param-static.xsl.txt](https://github.com/user-attachments/files/17801238/external_scenario-param-static.xsl.txt)
[external_scenario-param-static.xspec.txt](https://github.com/user-attachments/files/17801239/external_scenario-param-static.xspec.txt)
[external_scenario-param.xml.txt](https://github.com/user-attachments/files/17801240/external_scenario-param.xml.txt)
