### PR TITLE
Issue #2026 : set xml:base to an absolute URI

### DIFF
--- a/src/schematron/preprocessor.xsl
+++ b/src/schematron/preprocessor.xsl
@@ -1,24 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
-	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:variable as="map(xs:string, item())" name="x:schematron-preprocessor" select="
+<xsl:stylesheet
+        exclude-result-prefixes="#all"
+        version="3.0"
+        xmlns:x="http://www.jenitennison.com/xslt/xspec"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:variable name="sbu" select="resolve-uri('../../lib/', static-base-uri())" static="yes"/>
+    <xsl:variable as="map(xs:string, item())" name="x:schematron-preprocessor"
+	        select="
 			(
 			map {
 				'name': 'skeleton',
 				'stylesheets': [
-					resolve-uri('iso-schematron/iso_dsdl_include.xsl'),
-					resolve-uri('iso-schematron/iso_abstract_expand.xsl'),
-					resolve-uri('iso-schematron/iso_svrl_for_xslt2.xsl')
+					resolve-uri('iso-schematron/iso_dsdl_include.xsl', $sbu),
+					resolve-uri('iso-schematron/iso_abstract_expand.xsl', $sbu),
+					resolve-uri('iso-schematron/iso_svrl_for_xslt2.xsl', $sbu)
 				]
 			},
 			map {
 				'name': 'schxslt',
 				'stylesheets': [
-					resolve-uri('schxslt/2.0/include.xsl'),
-					resolve-uri('schxslt/2.0/expand.xsl'),
-					resolve-uri('schxslt/2.0/compile-for-svrl.xsl')
+					resolve-uri('schxslt/2.0/include.xsl', $sbu),
+					resolve-uri('schxslt/2.0/expand.xsl', $sbu),
+					resolve-uri('schxslt/2.0/compile-for-svrl.xsl', $sbu)
 				]
 			}
-			)[doc-available(?stylesheets?1)]" static="yes" xml:base="../../lib/" />
+			)[doc-available(?stylesheets?1)]" static="yes"/>
 </xsl:stylesheet>


### PR DESCRIPTION
According to issue #2026 , this PR proposes to set `xml:base` URI of `src/schematron/preprocessor.xsl` to an absolute URI.

This PR is made to start all tests in all environments.