### PR TITLE
fix(schematron): handle Schematron context with href and select

### DIFF
--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -86,7 +86,7 @@
     -->
 
     <!-- The "skeleton" Schematron implementation requires a document node -->
-    <xsl:template match="x:context[not(@href)][
+    <xsl:template match="x:context[
         parent::*/x:expect-assert | parent::*/x:expect-not-assert |
         parent::*/x:expect-report | parent::*/x:expect-not-report |
         parent::*/x:expect-valid | ancestor::x:description[@schematron] ]"
@@ -94,22 +94,27 @@
         mode="x:gather-specs">
         <xsl:copy>
             <xsl:apply-templates select="attribute()" mode="#current" />
-            <xsl:attribute name="select">
-                <xsl:choose>
-                    <xsl:when test="@select">
-                        <xsl:text expand-text="yes">if (({@select}) => {x:known-UQName('x:wrappable-sequence')}())</xsl:text>
-                        <xsl:text expand-text="yes"> then {x:known-UQName('x:wrap-nodes')}(({@select}))</xsl:text>
+            <xsl:where-populated>
+                <xsl:attribute name="select">
+                    <xsl:choose>
+                        <xsl:when test="@select">
+                            <xsl:text expand-text="yes">if (({@select}) => {x:known-UQName('x:wrappable-sequence')}())</xsl:text>
+                            <xsl:text expand-text="yes"> then {x:known-UQName('x:wrap-nodes')}(({@select}))</xsl:text>
 
-                        <!-- Some Schematron implementations might possibly be able to handle
-                            non-document nodes. Just generate a warning and pass @select as is. -->
-                        <xsl:text expand-text="yes"> else trace(({@select}), 'WARNING: Failed to wrap {name()}/@select')</xsl:text>
-                    </xsl:when>
+                            <!-- Some Schematron implementations might possibly be able to handle
+                                non-document nodes. Just generate a warning and pass @select as is. -->
+                            <xsl:text expand-text="yes"> else trace(({@select}), 'WARNING: Failed to wrap {name()}/@select')</xsl:text>
+                        </xsl:when>
 
-                    <xsl:otherwise>
-                        <xsl:text>self::document-node()</xsl:text>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:attribute>
+                        <xsl:when test="not(@href)">
+                            <xsl:text>self::document-node()</xsl:text>
+                        </xsl:when>
+
+                        <!-- If x:context has @href but no @select, no need to construct @select in output,
+                            so xsl:otherwise is omitted and xsl:where-populated produces nothing. -->
+                    </xsl:choose>
+                </xsl:attribute>
+            </xsl:where-populated>
 
             <xsl:apply-templates select="node()" mode="#current" />
         </xsl:copy>

--- a/test/issue-547.xml
+++ b/test/issue-547.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<context-child>
+  <context-grandchild />
+</context-child>

--- a/test/issue-547.xspec
+++ b/test/issue-547.xspec
@@ -17,6 +17,20 @@
 		<x:expect-report id="context-grandchild-fired" />
 	</x:scenario>
 
+	<x:scenario label="//x:context[@href][@select]">
+		<x:context href="issue-547.xml"
+			select="
+				context-child/context-grandchild,
+
+			(: Additional (but effectively empty) expression for testing @select with a bit complex expression :)
+			bogus"/>
+		<x:expect-not-report id="context-child-fired" />
+		<x:expect-report id="context-grandchild-fired" />
+		<x:expect label="Base URI of the context is populated" test="base-uri($x:context) ne ''"/>
+		<x:expect label="but is not the original href (consider it undefined as in embedded case)"
+			test="not(contains(base-uri($x:context), 'issue-547.xml'))"/>
+	</x:scenario>
+
 	<x:scenario label="//x:context[not(@href)][not(@select)]">
 		<x:context>
 			<context-child>

--- a/test/schema/build.xml
+++ b/test/schema/build.xml
@@ -16,6 +16,8 @@
 			<!-- Contains invalid /x:description/@original-xspec deliberately
 				https://github.com/xspec/xspec/issues/176 -->
 			<exclude name="test/schematron/schut-to-xspec-0??-out.xspec" />
+			<exclude name="test/schematron/schut-to-xspec-007-select-out.xspec" />
+			<exclude name="test/schematron/schut-to-xspec-008-select-out.xspec" />
 
 			<!-- Tests x:* which is not allowed in user-content -->
 			<exclude name="test/obsolete-space/test.xspec" />

--- a/test/schematron/schut-to-xspec-007-select-in.xspec
+++ b/test/schematron/schut-to-xspec-007-select-in.xspec
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="schut-to-xspec-test.sch">
+    <x:scenario label="Schematron test scenario">
+        <x:context href="schut-to-xspec-007.xml" select="child"/>
+    </x:scenario>
+</x:description>

--- a/test/schematron/schut-to-xspec-007-select-out.xspec
+++ b/test/schematron/schut-to-xspec-007-select-out.xspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.jenitennison.com/xslt/xspec"
+             schematron="%TEST_BASE%/schematron/schut-to-xspec-test.sch"
+             original-xspec="%TEST_BASE%/schematron/schut-to-xspec-007-select-in.xspec"
+             stylesheet="schut-to-xspec-test.sch.xsl">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns=""
+               xslt-version="3"
+               xspec="%TEST_BASE%/schematron/schut-to-xspec-007-select-in.xspec"
+               label="Schematron test scenario">
+      <x:context href="%TEST_BASE%/schematron/schut-to-xspec-007.xml"
+         select="if ((child) => Q{http://www.jenitennison.com/xslt/xspec}wrappable-sequence()) then Q{http://www.jenitennison.com/xslt/xspec}wrap-nodes((child)) else trace((child), 'WARNING: Failed to wrap x:context/@select')"/>
+   </x:scenario>
+</description>

--- a/test/schematron/schut-to-xspec-007.xml
+++ b/test/schematron/schut-to-xspec-007.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document/>
+<document>
+  <child/>
+</document>

--- a/test/schematron/schut-to-xspec-008-select-in.xspec
+++ b/test/schematron/schut-to-xspec-008-select-in.xspec
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="schut-to-xspec-test.sch">
+    <x:scenario label="Schematron test scenario">
+        <x:context select="child">
+            <snippet>
+                <child/>
+            </snippet>
+        </x:context>
+    </x:scenario>
+</x:description>

--- a/test/schematron/schut-to-xspec-008-select-out.xspec
+++ b/test/schematron/schut-to-xspec-008-select-out.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.jenitennison.com/xslt/xspec"
+             schematron="%TEST_BASE%/schematron/schut-to-xspec-test.sch"
+             original-xspec="%TEST_BASE%/schematron/schut-to-xspec-008-select-in.xspec"
+             stylesheet="schut-to-xspec-test.sch.xsl">
+   <x:scenario xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns=""
+               xslt-version="3"
+               xspec="%TEST_BASE%/schematron/schut-to-xspec-008-select-in.xspec"
+               label="Schematron test scenario">
+      <x:context select="if ((child) => Q{http://www.jenitennison.com/xslt/xspec}wrappable-sequence()) then Q{http://www.jenitennison.com/xslt/xspec}wrap-nodes((child)) else trace((child), 'WARNING: Failed to wrap x:context/@select')">
+         <snippet>
+            <child/>
+         </snippet>
+      </x:context>
+   </x:scenario>
+</description>

--- a/test/schut-to-xspec.xspec
+++ b/test/schut-to-xspec.xspec
@@ -80,9 +80,23 @@
                 select="helper:expect(.)" />
         </x:scenario>
 
+        <x:scenario label="file with select">
+            <x:context href="schematron/schut-to-xspec-007-select-in.xspec"/>
+            <x:expect label="wrapper document node via x:wrap-nodes"
+                href="schematron/schut-to-xspec-007-select-out.xspec"
+                select="helper:expect(.)" />
+        </x:scenario>
+
         <x:scenario label="inline">
             <x:context href="schematron/schut-to-xspec-008-in.xspec"/>
             <x:expect label="wrapper document node" href="schematron/schut-to-xspec-008-out.xspec"
+                select="helper:expect(.)" />
+        </x:scenario>
+
+        <x:scenario label="inline with select">
+            <x:context href="schematron/schut-to-xspec-008-select-in.xspec"/>
+            <x:expect label="wrapper document node via x:wrap-nodes"
+                href="schematron/schut-to-xspec-008-select-out.xspec"
                 select="helper:expect(.)" />
         </x:scenario>
     </x:scenario>


### PR DESCRIPTION
Issue #547 is about a Schematron validation context that uses the `select` attribute with embedded XML content. The problem was fixed in #549 by wrapping the selection in a document node, if possible.

An analogous problem occurs when the context uses the `select` attribute with `href`. You get an error, `XPDY0002  The context item is absent`, pointing to the compiled XSLT file.

This pull request adds a scenario in `issue-547.xspec` to reproduce that problem, and then provides an analogous fix.

Note: In tests for Schematron, the node selection operation of `x:context[@href][@select]` should consider the base URI to be undefined, which is like the embedded case but unlike other node selection operations that use `@href`.