### PR TITLE
build(oxygen): add-on v3.1.3

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,14 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.1.3</h3>
+				<ul>
+					<li>Fix for <a href="https://github.com/xspec/xspec-maven-plugin-1/">xspec/xspec-maven-plugin-1</a> and other uses
+						of XSpec from a .zip or .jar file</li>
+					<li>SchXslt 1.10.1 replaces 1.10 as the built-in Schematron implementation</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.1.2</h3>
 				<ul>
 					<li>Official release of v3.1</li>
@@ -73,22 +81,6 @@
 				<h3>v2.3.2</h3>
 				<ul>
 					<li>Official release of v2.3</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.3.1</h3>
-				<ul>
-					<li>Release Candidate of the stable release</li>
-					<li>fix(cli): properly detect <code>XSPEC_HOME</code> (<a
-							href="https://github.com/xspec/xspec/issues/1568">#1568</a>)</li>
-					<li>Saxon 9.9 is no longer recommended, though the <a
-							href="https://github.com/xspec/xspec/wiki/Code-Coverage">Code
-							Coverage</a> feature still <a
-							href="https://github.com/xspec/xspec/issues/852">requires 9.9</a>.</li>
-					<li>Tested with Saxon 10.9, 11.6 and 12.3</li>
-					<li>Tested with SchXslt 1.9.5</li>
-					<li>Tested with Oxygen 25.1</li>
-					<li>Tested with BaseX 10.7</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/c0f362f81c23ea5a9a8440457cb430dc68cfb2c5.zip" />
+			href="https://github.com/xspec/xspec/archive/38920bd0a7c1fbbb397acd689c00979dc79a59a2.zip" />
 
-		<xt:version>3.1.2</xt:version>
+		<xt:version>3.1.3</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.1.3-SNAPSHOT</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-c0f362f81c23ea5a9a8440457cb430dc68cfb2c5/xspec.framework/XSpec</String>
+                                    <String>4/xspec-38920bd0a7c1fbbb397acd689c00979dc79a59a2/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This v3.1.3 add-on has the bug fix in #2027, which motivated this release. The v3.1.3 add-on also has several changes that were merged onto the `master` branch since the start of v3.2 development. The only one I think is worth mentioning is the SchXslt upgrade.

I tested this change in Oxygen 26.1 build 2024031806 using https://github.com/galtm/xspec/raw/v3.1.3/oxygen-addon.xml . I checked the subbullets under "Test the add-on 3.1.3 with latest Oxygen" in #2031 and noticed no problems.

### Branch Notes

**This PR is seeking to merge to the `v3.1.3-release` branch, not the `master` branch.**

In a separate pull request, I will push the Oxygen commit to the `master` branch as well. I'll wait until after this PR is merged, just in case anything changes between now and then.

