### PR TITLE
ci(deps): bump BaseX from 11.3 to 11.6

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.3
+BASEX_VERSION=11.6
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 11.6 (November 28, 2024) ---------------------------------------

 - [ADD] New XQuery 4 features (sibling axes, civil-timezone, etc)
 - [ADD] job:execute: Run XQuery scripts
 - [ADD] Permissions: Access to request headers and query parameters
 - [ADD] New options: LOGEXCLUDE, LOGCUT
 - [ADD] JSON serialization: Improved double representation
 - [ADD] JSON serialization: json-lines support
 - [FIX] Tomcat: improved job handling

VERSION 11.5 (October 29, 2024) ----------------------------------------

 - [ADD] New XQuery 4 features (support for named record type, etc)
 - [MOD] XQuery: tweaked rules for swapping comparison operands
 - [FIX] Logging: Whitespace normalized
 - [FIX] XQuery: transitive module imports

VERSION 11.4 (October 2, 2024) -----------------------------------------

 - [ADD] New XQuery 4 features (fn:element-number, others)
 - [FIX] XQuery: Inlining of sequences
 - [FIX] XQuery: better support for JSON payloads in HTTP requests
 - [FIX] XQuery: improved processing of serialization parameters
 - [FIX] Core: concurrent string caching