### PR TITLE
refactor(report): move report colors to dedicated CSS file

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -35,6 +35,7 @@
    <xsl:param name="inline-css" as="xs:string" select="false() cast as xs:string" />
 
    <xsl:param name="report-css-uri" as="xs:string?" />
+   <!-- See also report-theme parameter, which is defined in format-utils.xsl -->
 
    <!-- @use-character-maps for inline CSS -->
    <xsl:output method="xhtml" use-character-maps="fmt:disable-escaping" />

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -420,28 +420,37 @@
 
    <!-- Generates <style> or <link> for CSS.
       If you enable $inline, you must use fmt:disable-escaping character map in serialization. -->
-   <xsl:template name="fmt:load-css" as="element()">
+   <xsl:template name="fmt:load-css" as="element()+">
       <xsl:context-item use="absent" />
 
       <xsl:param name="inline" as="xs:boolean" required="yes" />
-      <xsl:param name="uri" as="xs:string?" required="yes" />
+      <xsl:param name="uri" as="xs:string*" required="yes" />
 
-      <xsl:variable as="xs:string" name="uri" select="($uri, resolve-uri('test-report.css'))[1]" />
+      <xsl:variable as="xs:string+" name="uri-or-default" select="
+            if (empty($uri)) then
+            (resolve-uri('test-report-colors-classic.css'), resolve-uri('test-report.css'))
+            else
+               $uri" />
 
       <xsl:choose>
          <xsl:when test="$inline">
-            <xsl:variable name="css-string" as="xs:string" select="unparsed-text($uri)" />
-
-            <!-- Replace CR LF with LF -->
-            <xsl:variable name="css-string" as="xs:string" select="replace($css-string, '&#x0D;(&#x0A;)', '$1')" />
-
             <style type="text/css">
-               <xsl:value-of select="fmt:disable-escaping($css-string)" />
+               <xsl:for-each select="$uri-or-default">
+                  <xsl:variable name="css-string" as="xs:string" select="unparsed-text(.)" />
+   
+                  <!-- Replace CR LF with LF -->
+                  <xsl:variable name="css-string" as="xs:string" select="replace($css-string, '&#x0D;(&#x0A;)', '$1')" />
+   
+                  <xsl:text>&#xA;</xsl:text>
+                  <xsl:value-of select="fmt:disable-escaping($css-string)" />
+               </xsl:for-each>
             </style>
          </xsl:when>
 
          <xsl:otherwise>
-            <link rel="stylesheet" type="text/css" href="{$uri}"/>
+            <xsl:for-each select="$uri-or-default">
+               <link rel="stylesheet" type="text/css" href="{.}"/>   
+            </xsl:for-each>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:template>

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -19,6 +19,8 @@
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/format-utils.xsl</pkg:import-uri>
 
+   <xsl:param name="report-theme" as="xs:string" select="'classic'" />
+
    <!-- @character specifies intermediate characters for mimicking @disable-output-escaping.
       For the test result report HTML, these Private Use Area characters should be considered
       as reserved by fmt:disable-escaping. -->
@@ -428,7 +430,7 @@
 
       <xsl:variable as="xs:string+" name="uri-or-default" select="
             if (empty($uri)) then
-            (resolve-uri('test-report-colors-classic.css'), resolve-uri('test-report.css'))
+            (resolve-uri(concat('test-report-colors-', $report-theme, '.css')), resolve-uri('test-report.css'))
             else
                $uri" />
 

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -31,6 +31,7 @@
    <xsl:param name="force-focus" as="xs:string?" />
    <xsl:param name="inline-css" as="xs:string" select="false() cast as xs:string" />
    <xsl:param name="report-css-uri" as="xs:string?" />
+   <!-- See also report-theme parameter, which is defined in format-utils.xsl -->
 
    <!-- @use-character-maps for inline CSS -->
    <xsl:output method="xhtml" use-character-maps="fmt:disable-escaping" />

--- a/src/reporter/test-report-colors-classic.css
+++ b/src/reporter/test-report-colors-classic.css
@@ -119,3 +119,24 @@ div > table > tbody > tr > th:first-child {
 .failed {
 	background-color: #fcc;
 }
+
+/* code coverage report styles */
+.ignored,
+.comment,
+pre.xspecCoverage > .whitespace {
+	color: #999;
+	background: white;
+}
+
+.unknown {
+	color: #999;
+	background: white;
+}
+
+.hit {
+}
+
+.missed {
+	color: white;
+	background-color: #a33;
+}

--- a/src/reporter/test-report-colors-classic.css
+++ b/src/reporter/test-report-colors-classic.css
@@ -1,0 +1,121 @@
+/****************************************************************************/
+/*  File:       test-report-colors-classic.css                              */
+/* ------------------------------------------------------------------------ */
+
+/* text and background colours */
+body {
+	background-color: white;
+	color: black;
+}
+
+h1 {
+	background: #606;
+	color: #6f6;
+}
+
+h2 {
+	color: #606;
+	background: #cfc;
+}
+
+hr {
+	color: #606;
+	background: white;
+}
+
+a:link {
+	color: #636;
+	background: transparent;
+}
+
+a:visited {
+	color: #606;
+	background: transparent;
+}
+
+a:active {
+	color: #6f6;
+	background: #606;
+}
+
+a:hover {
+	color: #636;
+	background: #9f9;
+}
+
+#colophon,
+#xml-link,
+.note {
+	color: #666;
+}
+
+#colophon a:link,
+#colophon a:visited,
+#colophon a:hover,
+#xml-link a:link,
+#xml-link a:visited,
+#xml-link a:hover,
+.note a:link,
+.note a:visited,
+.note a:hover {
+	color: #969;
+	background: transparent;
+}
+
+#colophon a:hover,
+#xml-link a:hover,
+.note a:hover {
+	background: #cfc;
+	color: #969;
+}
+
+.popup {
+	background: white;
+}
+
+.same {
+	background-color: rgb(206, 239, 174);
+}
+
+.inner-diff {
+	background-color: rgba(255, 204, 204, 0.4);
+}
+
+.diff {
+	background-color: #fcc;
+}
+
+/*
+ * Whitespace notation in diffs in test result report,
+ * not literal whitespace characters in code coverage report.
+ */
+td > pre > .whitespace {
+	color: #999;
+}
+
+.ellipsis {
+	color: #999;
+}
+
+.xmlns.trivial {
+	color: #c0c0c0;
+}
+
+div > table > tbody > tr > th:first-child {
+	color: #474747;
+}
+
+.xspec tbody td {
+	color: #262626;
+}
+
+.successful {
+	background-color: #cfc;
+}
+.pending {
+	background-color: #eee;
+	color: #666;
+}
+.failed {
+	background-color: #fcc;
+}

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -256,8 +256,6 @@ h2 {
 }
 
 body {
-	background-color: white;
-	color: black;
 	border: 0px none black;
 }
 
@@ -313,120 +311,6 @@ a.img:active {
 
 .rng {
 	border-left: 2px solid #666;
-}
-
-/* interior text and background colours */
-h1 {
-	background: #606;
-	color: #6f6;
-}
-
-h2 {
-	color: #606;
-	background: #cfc;
-}
-
-hr {
-	color: #606;
-	background: white;
-}
-
-a:link {
-	color: #636;
-	background: transparent;
-}
-
-a:visited {
-	color: #606;
-	background: transparent;
-}
-
-a:active {
-	color: #6f6;
-	background: #606;
-}
-
-a:hover {
-	color: #636;
-	background: #9f9;
-}
-
-#colophon,
-#xml-link,
-.note {
-	color: #666;
-}
-
-#colophon a:link,
-#colophon a:visited,
-#colophon a:hover,
-#xml-link a:link,
-#xml-link a:visited,
-#xml-link a:hover,
-.note a:link,
-.note a:visited,
-.note a:hover {
-	color: #969;
-	background: transparent;
-}
-
-#colophon a:hover,
-#xml-link a:hover,
-.note a:hover {
-	background: #cfc;
-	color: #969;
-}
-
-.popup {
-	background: white;
-}
-
-.same {
-	background-color: rgb(206, 239, 174);
-}
-
-.inner-diff {
-	background-color: rgba(255, 204, 204, 0.4);
-}
-
-.diff {
-	background-color: #fcc;
-}
-
-/*
- * Whitespace notation in diffs in test result report,
- * not literal whitespace characters in code coverage report.
- */
-td > pre > .whitespace {
-	/*font-style: italic;*/
-	color: #999;
-}
-
-.ellipsis {
-	color: #999;
-}
-
-.xmlns.trivial {
-	color: #c0c0c0;
-}
-
-div > table > tbody > tr > th:first-child {
-	color: #474747;
-}
-
-.xspec tbody td {
-	color: #262626;
-}
-
-.successful {
-	background-color: #cfc;
-}
-.pending {
-	background-color: #eee;
-	color: #666;
-}
-.failed {
-	background-color: #fcc;
 }
 
 /* code coverage report styles */

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -248,13 +248,6 @@ code {
 	font-weight: bold;
 }
 
-/* colours */
-body {
-	background-color: white;
-	color: black;
-	border: 0px none black;
-}
-
 /* this is to make Navigator fill the entire line */
 h1,
 h2 {
@@ -262,6 +255,67 @@ h2 {
 	width: auto;
 }
 
+body {
+	background-color: white;
+	color: black;
+	border: 0px none black;
+}
+
+img,
+a:link img,
+a:visited img,
+a:hover img,
+a:active img,
+#link-up img,
+#link-top img {
+	border: 0px none white;
+	background: transparent;
+}
+
+a:link {
+	border: 0px none white;
+}
+
+a:visited {
+	border: 0px none white;
+}
+
+a:active {
+	border: 0px none white;
+}
+
+a:hover {
+	border: 0px none white;
+}
+
+a.img:hover,
+a.img:active {
+	background: transparent;
+}
+
+.popup {
+	border: 1px solid #606;
+}
+
+.post {
+	border-top: 2px solid #606;
+}
+
+.example {
+	border-top: 2px solid #606;
+	border-bottom: 2px solid #606;
+}
+
+.sidebar {
+	border-top: 2px solid #090;
+	border-bottom: 2px solid #090;
+}
+
+.rng {
+	border-left: 2px solid #666;
+}
+
+/* interior text and background colours */
 h1 {
 	background: #606;
 	color: #6f6;
@@ -277,44 +331,24 @@ hr {
 	background: white;
 }
 
-img,
-a:link img,
-a:visited img,
-a:hover img,
-a:active img,
-#link-up img,
-#link-top img {
-	border: 0px none white;
-	background: transparent;
-}
-
 a:link {
 	color: #636;
 	background: transparent;
-	border: 0px none white;
 }
 
 a:visited {
 	color: #606;
 	background: transparent;
-	border: 0px none white;
 }
 
 a:active {
 	color: #6f6;
 	background: #606;
-	border: 0px none white;
 }
 
 a:hover {
 	color: #636;
 	background: #9f9;
-	border: 0px none white;
-}
-
-a.img:hover,
-a.img:active {
-	background: transparent;
 }
 
 #colophon,
@@ -345,25 +379,6 @@ a.img:active {
 
 .popup {
 	background: white;
-	border: 1px solid #606;
-}
-
-.post {
-	border-top: 2px solid #606;
-}
-
-.example {
-	border-top: 2px solid #606;
-	border-bottom: 2px solid #606;
-}
-
-.sidebar {
-	border-top: 2px solid #090;
-	border-bottom: 2px solid #090;
-}
-
-.rng {
-	border-left: 2px solid #666;
 }
 
 .same {
@@ -385,7 +400,6 @@ a.img:active {
 td > pre > .whitespace {
 	/*font-style: italic;*/
 	color: #999;
-	/*background: white;*/
 }
 
 .ellipsis {
@@ -396,6 +410,26 @@ td > pre > .whitespace {
 	color: #c0c0c0;
 }
 
+div > table > tbody > tr > th:first-child {
+	color: #474747;
+}
+
+.xspec tbody td {
+	color: #262626;
+}
+
+.successful {
+	background-color: #cfc;
+}
+.pending {
+	background-color: #eee;
+	color: #666;
+}
+.failed {
+	background-color: #fcc;
+}
+
+/* code coverage report styles */
 .ignored,
 .comment,
 pre.xspecCoverage > .whitespace {
@@ -471,32 +505,16 @@ th.totals {
 
 div > table > tbody > tr > th:first-child {
 	font-weight: bold;
-	color: #474747;
 }
 
 .xspec tbody th {
 	font-weight: normal; /*font-size: 0.8em;*/
 	border-top: 1px #666 solid;
 }
-.xspec tbody td {
-	/*font-size: 0.8em;*/
-	color: #262626;
-}
 
 .xspec tbody th .elapsed {
 	float: right;
 	font-weight: initial;
-}
-
-.successful {
-	background-color: #cfc;
-}
-.pending {
-	background-color: #eee;
-	color: #666;
-}
-.failed {
-	background-color: #fcc;
 }
 
 .successful td:first-child:before,

--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -318,23 +318,17 @@ a.img:active {
 .comment,
 pre.xspecCoverage > .whitespace {
 	font-style: italic;
-	color: #999;
-	background: white;
 }
 
 .unknown {
 	font-style: italic;
 	font-weight: bold;
-	color: #999;
-	background: white;
 }
 
 .hit {
 }
 
 .missed {
-	background-color: #a33;
-	color: white;
 }
 
 /* text */

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_by-child-nodes.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-hit.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-leading-string.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-global-context-item-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-result-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-1.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-2.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity_single-line.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_no-entity.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for non-xsl-top-level-element-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for text-node-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-accumulator-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-analyze-string-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-imports-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-templates-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-assert-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-set-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-call-template-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-character-map-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-choose-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-comment-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-context-item-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-of-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-decimal-format-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-element-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-evaluate-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-fallback-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-group-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-function-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-if-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-import-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-include-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-iterate-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-key-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-map-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-merge-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-02.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-mode-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-alias-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-next-match-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-number-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-empty-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-non-empty-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-output-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-02.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-perform-sort-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-preserve-space-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-processing-instruction-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sequence-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sort-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-source-document-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-strip-space-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-stylesheet-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-template-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-text-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-transform-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-try-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-value-of-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-variable-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-where-populated-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-with-param-01.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/query/empty-scenario-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (total: 0)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/query/expect-empty-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/function-result.html
+++ b/test/end-to-end/cases/expected/query/function-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/import-result.html
+++ b/test/end-to-end/cases/expected/query/import-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/imported-result.html
+++ b/test/end-to-end/cases/expected/query/imported-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-153-result.html
+++ b/test/end-to-end/cases/expected/query/issue-153-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-177-result.html
+++ b/test/end-to-end/cases/expected/query/issue-177-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-346-result.html
+++ b/test/end-to-end/cases/expected/query/issue-346-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_2-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_3-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_4-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_5-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_2-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_3-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-448-result.html
+++ b/test/end-to-end/cases/expected/query/issue-448-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-449-result.html
+++ b/test/end-to-end/cases/expected/query/issue-449-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-452-result.html
+++ b/test/end-to-end/cases/expected/query/issue-452-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-467-result.html
+++ b/test/end-to-end/cases/expected/query/issue-467-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-50-result.html
+++ b/test/end-to-end/cases/expected/query/issue-50-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-528-result.html
+++ b/test/end-to-end/cases/expected/query/issue-528-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-55-result.html
+++ b/test/end-to-end/cases/expected/query/issue-55-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-67-result.html
+++ b/test/end-to-end/cases/expected/query/issue-67-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:xspec-items (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/pending-result.html
+++ b/test/end-to-end/cases/expected/query/pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/report-result.html
+++ b/test/end-to-end/cases/expected/query/report-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
+++ b/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/serialize-result.html
+++ b/test/end-to-end/cases/expected/query/serialize-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/shared-like-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/three-dots-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:three-dots (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (total: 0)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 12 / total: 24)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-693.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 6 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for schematron-023.sch (passed: 1 / pending: 0 / failed: 2 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo-02.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for tvt_label.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xml-1-1.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (total: 0)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_function-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_import-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for escape-for-regex.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" /><script language="javascript" type="text/javascript">
 function toggle(scenarioID) {
    table = document.getElementById("table_"+scenarioID);

--- a/test/end-to-end/cases/expected/stylesheet/function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-214.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-214.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 7 / pending: 0 / failed: 0 / total: 7)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for items.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-778_ws.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-cr.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-cr.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-crlf.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-crlf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-lf.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-lf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mode-all.xsl (passed: 3 / pending: 0 / failed: 3 / total: 6)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for three-dots.xsl (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
@@ -2,6 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xslt1.xsl (passed: 6 / pending: 0 / failed: 1 / total: 7)</title>
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
    </head>
    <body>

--- a/test/end-to-end/processor/coverage/_normalizer.xsl
+++ b/test/end-to-end/processor/coverage/_normalizer.xsl
@@ -31,17 +31,19 @@
 		Replaces the embedded CSS with the link to its source
 			For brevity. The details of style are not critical anyway.
 	-->
-	<xsl:template as="element(link)" match="/html/head/style" mode="normalizer:normalize">
+	<xsl:template as="element(link)+" match="/html/head/style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<!-- Absolute URI of CSS -->
-		<xsl:variable as="xs:anyURI" name="css-uri"
-			select="resolve-uri('../../../../src/reporter/test-report.css')" />
-
-		<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
-			<xsl:attribute name="href"
-				select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
-		</link>
+		<xsl:for-each select="('test-report-colors-classic.css', 'test-report.css')">
+			<!-- Absolute URI of CSS -->
+			<xsl:variable as="xs:anyURI" name="css-uri"
+				select="resolve-uri(concat('../../../../src/reporter/', .))" />
+			
+			<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
+				<xsl:attribute name="href"
+					select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
+			</link>			
+		</xsl:for-each>
 	</xsl:template>
 
 	<!--

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -39,17 +39,19 @@
 		Replaces the embedded CSS with the link to its source
 			For brevity. The details of style are not critical anyway.
 	-->
-	<xsl:template as="element(link)" match="style" mode="normalizer:normalize">
+	<xsl:template as="element(link)+" match="style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<!-- Absolute URI of CSS -->
-		<xsl:variable as="xs:anyURI" name="css-uri"
-			select="resolve-uri('../../../../src/reporter/test-report.css')" />
-
-		<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
-			<xsl:attribute name="href"
-				select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
-		</link>
+		<xsl:for-each select="('test-report-colors-classic.css', 'test-report.css')">
+			<!-- Absolute URI of CSS -->
+			<xsl:variable as="xs:anyURI" name="css-uri"
+				select="resolve-uri(concat('../../../../src/reporter/', .))" />
+			
+			<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
+				<xsl:attribute name="href"
+					select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
+			</link>			
+		</xsl:for-each>
 	</xsl:template>
 
 	<!--


### PR DESCRIPTION
This pull request moves the CSS color choices to a separate CSS file for use in test result reports and code coverage reports. There should be no change in functionality or appearance of test reports.

The motivation for this change is to make it easier to work on #2047.

### More about the change

When a report includes CSS styles inline, it now copies the content from the main CSS file and the new, color-specific one. When a report has links to external CSS, it now has two `<link>` elements instead of one (as illustrated in the end-to-end expected results in b165b259fe6cef6a8b71e65526d02e2dd245cc33).

I named the new, color-specific file `test-report-colors-classic.css`. I was at first going to use "pinkgreen" in the filename, but the code coverage report doesn't use pink or green.

This change introduces an XSLT global parameter named `report-theme`. As of this PR, the interface for end users does not provide access to let users pick a different theme; so far, there is only one theme for the pair of report types. I have in mind that the work for #2047 will introduce one or more additional themes and provide a way for end users to choose.

### Interactive testing

I interactively viewed some test reports to check that I don't see any changes. The [serialize.xspec result report](https://html-preview.github.io/?url=https://github.com/xspec/xspec/blob/master/test/end-to-end/cases/expected/stylesheet/serialize-result.html) and [xsl:with-param code coverage report](https://html-preview.github.io/?url=https://github.com/xspec/xspec/blob/master/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html) exercise a lot of styles.

### Possibly obsolete styles

While working on this PR, I came across some selectors that I suspect are obsolete:

- `#colophon`
- `#xml-link`
- `.note`
- `.popup` 

I left the corresponding styles in place for now. If anyone can confirm that they're obsolete, I can remove them now; otherwise, maybe I'll come back to them in a different PR.
