### PR TITLE
refactor(report): new CSS files, isolating report colors

### DIFF
--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -35,6 +35,7 @@
    <xsl:param name="inline-css" as="xs:string" select="false() cast as xs:string" />
 
    <xsl:param name="report-css-uri" as="xs:string?" />
+   <!-- See also report-theme parameter, which is defined in format-utils.xsl -->
 
    <!-- @use-character-maps for inline CSS -->
    <xsl:output method="xhtml" use-character-maps="fmt:disable-escaping" />

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -19,6 +19,8 @@
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/format-utils.xsl</pkg:import-uri>
 
+   <xsl:param name="report-theme" as="xs:string" select="'classic'" />
+
    <!-- @character specifies intermediate characters for mimicking @disable-output-escaping.
       For the test result report HTML, these Private Use Area characters should be considered
       as reserved by fmt:disable-escaping. -->
@@ -420,28 +422,37 @@
 
    <!-- Generates <style> or <link> for CSS.
       If you enable $inline, you must use fmt:disable-escaping character map in serialization. -->
-   <xsl:template name="fmt:load-css" as="element()">
+   <xsl:template name="fmt:load-css" as="element()+">
       <xsl:context-item use="absent" />
 
       <xsl:param name="inline" as="xs:boolean" required="yes" />
-      <xsl:param name="uri" as="xs:string?" required="yes" />
+      <xsl:param name="uri" as="xs:string*" required="yes" />
 
-      <xsl:variable as="xs:string" name="uri" select="($uri, resolve-uri('test-report.css'))[1]" />
+      <xsl:variable as="xs:string+" name="uri-or-default" select="
+            if (empty($uri)) then
+            (resolve-uri(concat('test-report-colors-', $report-theme, '.css')), resolve-uri('test-report-base.css'))
+            else
+               $uri" />
 
       <xsl:choose>
          <xsl:when test="$inline">
-            <xsl:variable name="css-string" as="xs:string" select="unparsed-text($uri)" />
-
-            <!-- Replace CR LF with LF -->
-            <xsl:variable name="css-string" as="xs:string" select="replace($css-string, '&#x0D;(&#x0A;)', '$1')" />
-
             <style type="text/css">
-               <xsl:value-of select="fmt:disable-escaping($css-string)" />
+               <xsl:for-each select="$uri-or-default">
+                  <xsl:variable name="css-string" as="xs:string" select="unparsed-text(.)" />
+   
+                  <!-- Replace CR LF with LF -->
+                  <xsl:variable name="css-string" as="xs:string" select="replace($css-string, '&#x0D;(&#x0A;)', '$1')" />
+   
+                  <xsl:text>&#xA;</xsl:text>
+                  <xsl:value-of select="fmt:disable-escaping($css-string)" />
+               </xsl:for-each>
             </style>
          </xsl:when>
 
          <xsl:otherwise>
-            <link rel="stylesheet" type="text/css" href="{$uri}"/>
+            <xsl:for-each select="$uri-or-default">
+               <link rel="stylesheet" type="text/css" href="{.}"/>   
+            </xsl:for-each>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:template>

--- a/src/reporter/format-xspec-report.xsl
+++ b/src/reporter/format-xspec-report.xsl
@@ -31,6 +31,7 @@
    <xsl:param name="force-focus" as="xs:string?" />
    <xsl:param name="inline-css" as="xs:string" select="false() cast as xs:string" />
    <xsl:param name="report-css-uri" as="xs:string?" />
+   <!-- See also report-theme parameter, which is defined in format-utils.xsl -->
 
    <!-- @use-character-maps for inline CSS -->
    <xsl:output method="xhtml" use-character-maps="fmt:disable-escaping" />

--- a/src/reporter/test-report-base.css
+++ b/src/reporter/test-report-base.css
@@ -1,0 +1,493 @@
+/****************************************************************************/
+/*  File:       test-report-base.css                                        */
+/*  Author:     Jeni Tennison                                               */
+/*  Tags:                                                                   */
+/*    Copyright (c) 2008, 2010 Jeni Tennison (see end of file.)             */
+/* ------------------------------------------------------------------------ */
+
+/* test */
+
+/* box model */
+
+body {
+	margin-right: 5%;
+	margin-left: 5%;
+}
+
+h1 {
+	padding: 0.3em 0.5em 0.3em 0.5em;
+	position: relative;
+}
+
+h2 {
+	padding: 0.1em 0.5em 0.2em 0.5em;
+}
+
+h3 {
+	padding-left: 0.6em;
+}
+
+h4 {
+	padding-left: 0.8em;
+}
+
+p,
+table {
+	margin-left: 5%;
+}
+
+dd ul,
+dd ol {
+	margin-left: 0%;
+}
+
+li ul,
+li ol {
+	margin-left: 5%;
+}
+
+dl,
+ul,
+ol,
+blockquote {
+	margin-left: 10%;
+}
+
+dt {
+	padding-top: 3px;
+	padding-bottom: 3px;
+	clear: both;
+}
+
+dd p {
+	margin-left: -5px;
+	margin-top: 5px;
+	clear: both;
+}
+
+p.link {
+	margin-top: 4px;
+	margin-bottom: 0px;
+	clear: both;
+}
+
+tr td,
+td p,
+li,
+li p {
+	margin-left: 0%;
+}
+
+td {
+	padding-right: 5%;
+}
+
+.link img,
+dt img {
+	vertical-align: middle;
+	position: relative;
+	top: -5px;
+}
+
+img {
+	position: relative;
+}
+
+#xml-link {
+	position: absolute;
+	left: 5px;
+	top: 5px;
+	width: 10%;
+	margin-left: 0%;
+}
+
+#link-up {
+	position: absolute;
+	left: 93%;
+	right: 2em;
+	top: 0.3em;
+}
+
+#link-top {
+	position: absolute;
+	left: 89%;
+	right: 4em;
+	top: 0.3em;
+}
+
+.popup {
+	display: block;
+	visibility: hidden;
+	float: right;
+	position: absolute;
+	top: 5px;
+	left: -200px;
+	z-index: 1;
+	padding: 0.3em;
+	width: 220px;
+}
+
+.note {
+	position: relative;
+}
+
+.post {
+	margin-left: 5%;
+	padding-top: 1em;
+}
+
+.example,
+.sidebar {
+	margin-left: 5%;
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
+pre {
+	padding-left: 5%;
+	margin-left: 5%;
+}
+
+dd pre,
+li pre {
+	padding-left: 5%;
+}
+
+/* fonts */
+body,
+table {
+	font-family: sans-serif;
+	font-size: 12px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-family: sans-serif;
+}
+
+h1 {
+	font-size: 1.7em;
+	font-weight: bold;
+}
+
+h2 {
+	font-size: 1.4em;
+	font-weight: bold;
+}
+
+h3 {
+	font-size: 120%;
+	font-weight: normal;
+}
+
+h4 {
+	font-size: 100%;
+	font-weight: bold;
+}
+
+dt {
+	font-weight: bold;
+}
+
+a:link,
+a:visited,
+a:active,
+a:hover {
+	font-weight: bold;
+}
+
+a.offsite:link,
+a.offsite:visited,
+a.offsite:active,
+a.offsite:hover {
+	font-weight: normal;
+}
+
+/* suppress the normal italics */
+address {
+	font-style: normal;
+}
+
+div.example,
+.sidebar {
+	font-family: sans-serif;
+	font-size: 100%;
+}
+
+.note,
+.link {
+	font-family: sans-serif;
+	/*font-size: 83%;*/
+}
+
+.example,
+.string,
+.rtf,
+.code,
+pre,
+code {
+	font-family: monospace;
+	/*font-size: 83%;*/
+}
+
+.boolean {
+	font-style: italic;
+}
+
+#colophon,
+#xml-link {
+	font-size: 69%;
+}
+
+.question,
+.title {
+	font-weight: bold;
+}
+
+/* this is to make Navigator fill the entire line */
+h1,
+h2 {
+	border: 1px solid white;
+	width: auto;
+}
+
+body {
+	border: 0px none black;
+}
+
+img,
+a:link img,
+a:visited img,
+a:hover img,
+a:active img,
+#link-up img,
+#link-top img {
+	border: 0px none white;
+	background: transparent;
+}
+
+a:link {
+	border: 0px none white;
+}
+
+a:visited {
+	border: 0px none white;
+}
+
+a:active {
+	border: 0px none white;
+}
+
+a:hover {
+	border: 0px none white;
+}
+
+a.img:hover,
+a.img:active {
+	background: transparent;
+}
+
+.popup {
+	border: 1px solid #606;
+}
+
+.post {
+	border-top: 2px solid #606;
+}
+
+.example {
+	border-top: 2px solid #606;
+	border-bottom: 2px solid #606;
+}
+
+.sidebar {
+	border-top: 2px solid #090;
+	border-bottom: 2px solid #090;
+}
+
+.rng {
+	border-left: 2px solid #666;
+}
+
+/* code coverage report styles */
+.ignored,
+.comment,
+pre.xspecCoverage > .whitespace {
+	font-style: italic;
+}
+
+.unknown {
+	font-style: italic;
+	font-weight: bold;
+}
+
+.hit {
+}
+
+.missed {
+}
+
+/* text */
+ol ol li {
+	list-style: lower-alpha;
+}
+
+td {
+	vertical-align: top;
+}
+
+h1 {
+	text-transform: uppercase;
+}
+
+.question {
+	text-indent: -33px;
+}
+
+.byline {
+	text-align: right;
+}
+
+#link-top,
+#link-up {
+	text-align: right;
+}
+
+a {
+	text-decoration: none;
+}
+
+body > h2:first-of-type {
+	background: inherit;
+	font-size: 1.7em;
+	margin-bottom: 0;
+}
+
+table {
+	width: 95%;
+	/* border: collapse; */
+}
+
+th {
+	text-align: left;
+}
+
+th.totals {
+	text-align: center;
+	font-weight: normal;
+}
+
+div > table > tbody > tr > th:first-child {
+	font-weight: bold;
+}
+
+.xspec tbody th {
+	font-weight: normal; /*font-size: 0.8em;*/
+	border-top: 1px #666 solid;
+}
+
+.xspec tbody th .elapsed {
+	float: right;
+	font-weight: initial;
+}
+
+.successful td:first-child:before,
+body > table:first-of-type tr.successful th:first-child:before {
+	margin-right: 5px;
+
+	/* optimized version of ../../graphics/success12.png */
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAABcUlEQVR42m1SPUsDQRB9661BIoEQDBqJnRhE1BD8CP4AgwhWEbQIKIhi6Q/QwspCtBBs/CBG1Fb9AWK0iBosLCQgYmGQEFARRUguezfuLeZygsWbmZ037zEMyxZ2W0IgHBIoIjPoF6q2QQYIWVlPcxmS3mYt4vFpjmEpd4pNaJ9vRvS9ILa57Aw2ejUYBtVcTdsZPnc7Qk0juNQ3QC/o55JkhnAO19wDnjAmIkkcZBMwBVmci1uEoR5Od4K73o94eAuZpx3kX+9U35TgVjAqVWdmZUWOhldQrnwhnduEELD7dVYhdMJY9zom+/ZAgqOnNY7OQAynt0sol3TFSyiRWklUCKXyN8Jt40gM7SPo68VDIY1c/ly5KlBtJaU+vlmEpyGArmBMkiZOrpdV3yFQ4PJBkmBkCqTO5jE3fITixyOei/dy0L5aVSjY7Jo/w10sqnFmn9VU+e+ZhW7BvGAzq/4O2UiBMCBJRv9/DyHDFQFTPwI/IlPYPLYnAAAAAElFTkSuQmCC");
+}
+
+.failed td:first-child:before,
+body > table:first-of-type tr.failed th:first-child:before {
+	margin-right: 5px;
+
+	/* optimized version of ../../graphics/fail12.png */
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAMAAABhq6zVAAAAjVBMVEWDKBSQLBadMBidMBiSLBWSLRaLKhWCKBOZLheHKRT//////v3ivLPgt67dsafhraLfqJvcopXQl4vNkoTKjH3RbljKaVO8aVaxYlCsUDylUDusOh+wNxu0OBu4ORy7OhzAOx3EPB2rNRqnNBqjMhifMRidMBeaLxeXLhaULRaRLBaOKxWLKhWIKRSFKBRkN75PAAAACnRSTlP7+c3Hx8TIwicknixbQAAAAIZJREFUeNoNwsEKgkAUBdD77jzSXKhDuEpyURBE//8h0SratQuKRK3QsdccjqTjDgLEV9VpPSEyYHPjVtFb9LYQKNYPrVk7fOyAfdMUWRnX9VHFLO9GJB4ClR8wxyIQYmGveZmGu1BUJFjm5fHtShDM8xVZFZ4nXtQVjDxd4hbPytGRPLf8A/K/MGOep8atAAAAAElFTkSuQmCC");
+}
+
+.pending td:first-child:before,
+body > table:first-of-type tr.pending th:first-child:before {
+	margin-right: 5px;
+
+	/* optimized version of ../../graphics/pending12.png */
+	content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAMAAABhq6zVAAAAt1BMVEVgYGBZWVldXV1gYGBjY2NmZmZnZ2dnZ2diYmJfX19dXV1hYWFZWVlYWFhiYmJeXl5YWFhoaGj6+vr39/fz8/Py8vLv7+/p6enk5OR9fX18fHx7e3t6enp5eXl4eHh3d3d2dnZ1dXV0dHRzc3NycnJxcXFwcHBvb29ubm5tbW1sbGxra2tqamppaWloaGhnZ2dmZmZlZWVkZGRjY2NiYmJhYWFfX19eXl5dXV1cXFxbW1taWlpZWVl0CTiLAAAAEnRSTlP++/75/P7Nx8fHyMTBwygmIycZZx20AAAAdElEQVR42jWKvQ4BURSEzzdzED+NQiFRaCWi4f1rhcor2EZl2RDdcq+YyUzyZYb5c0MUn3PIaPUKKk4aBgsqfHPRVpLl0nuFbbkKoe7te5ftw0jue4OJFIeOn4KZsNN26SB28Z9OHi+RJUTePL0263LMY5sfIzMU3HCY7dEAAAAASUVORK5CYII=");
+}
+
+.xspecResult {
+	width: 95%;
+	table-layout: fixed;
+}
+
+.xspecResult td,
+.xspecResult th {
+	width: 50%;
+}
+
+.xspecResult pre {
+	margin-left: 0;
+	padding: 0.5em;
+	overflow: auto;
+	border: 1px #999 dotted;
+}
+
+span.scenario-totals {
+	float: right;
+	text-align: right;
+}
+
+/* highlight the link target */
+*:target {
+	box-shadow: -0.5rem 0 0 0 #fc511d;
+}
+
+/* hint button */
+.xTestReport {
+	display: grid;
+	grid-template-areas:
+		"title title"
+		"table hint";
+	grid-template-columns: 1fr 1em;
+}
+.xTestReportTitle {
+	grid-area: title;
+}
+.xTestReportHint {
+	grid-area: hint;
+}
+.xspecResult {
+	grid-area: table;
+}
+
+/* ------------------------------------------------------------------------ */
+/*  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS COMMENT.               */
+/*                                                                          */
+/*  Copyright (c) 2008, 2010 Jeni Tennison                                  */
+/*                                                                          */
+/*  The contents of this file are subject to the MIT License (see the URI   */
+/*  http://www.opensource.org/licenses/mit-license.php for details).        */
+/*                                                                          */
+/*  Permission is hereby granted, free of charge, to any person obtaining   */
+/*  a copy of this software and associated documentation files (the         */
+/*  "Software"), to deal in the Software without restriction, including     */
+/*  without limitation the rights to use, copy, modify, merge, publish,     */
+/*  distribute, sublicense, and/or sell copies of the Software, and to      */
+/*  permit persons to whom the Software is furnished to do so, subject to   */
+/*  the following conditions:                                               */
+/*                                                                          */
+/*  The above copyright notice and this permission notice shall be          */
+/*  included in all copies or substantial portions of the Software.         */
+/*                                                                          */
+/*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,         */
+/*  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF      */
+/*  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  */
+/*  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY    */
+/*  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,    */
+/*  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE       */
+/*  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                  */
+/* ------------------------------------------------------------------------ */

--- a/src/reporter/test-report-colors-classic.css
+++ b/src/reporter/test-report-colors-classic.css
@@ -1,0 +1,142 @@
+/****************************************************************************/
+/*  File:       test-report-colors-classic.css                              */
+/* ------------------------------------------------------------------------ */
+
+/* text and background colours */
+body {
+	background-color: white;
+	color: black;
+}
+
+h1 {
+	background: #606;
+	color: #6f6;
+}
+
+h2 {
+	color: #606;
+	background: #cfc;
+}
+
+hr {
+	color: #606;
+	background: white;
+}
+
+a:link {
+	color: #636;
+	background: transparent;
+}
+
+a:visited {
+	color: #606;
+	background: transparent;
+}
+
+a:active {
+	color: #6f6;
+	background: #606;
+}
+
+a:hover {
+	color: #636;
+	background: #9f9;
+}
+
+#colophon,
+#xml-link,
+.note {
+	color: #666;
+}
+
+#colophon a:link,
+#colophon a:visited,
+#colophon a:hover,
+#xml-link a:link,
+#xml-link a:visited,
+#xml-link a:hover,
+.note a:link,
+.note a:visited,
+.note a:hover {
+	color: #969;
+	background: transparent;
+}
+
+#colophon a:hover,
+#xml-link a:hover,
+.note a:hover {
+	background: #cfc;
+	color: #969;
+}
+
+.popup {
+	background: white;
+}
+
+.same {
+	background-color: rgb(206, 239, 174);
+}
+
+.inner-diff {
+	background-color: rgba(255, 204, 204, 0.4);
+}
+
+.diff {
+	background-color: #fcc;
+}
+
+/*
+ * Whitespace notation in diffs in test result report,
+ * not literal whitespace characters in code coverage report.
+ */
+td > pre > .whitespace {
+	color: #999;
+}
+
+.ellipsis {
+	color: #999;
+}
+
+.xmlns.trivial {
+	color: #c0c0c0;
+}
+
+div > table > tbody > tr > th:first-child {
+	color: #474747;
+}
+
+.xspec tbody td {
+	color: #262626;
+}
+
+.successful {
+	background-color: #cfc;
+}
+.pending {
+	background-color: #eee;
+	color: #666;
+}
+.failed {
+	background-color: #fcc;
+}
+
+/* code coverage report styles */
+.ignored,
+.comment,
+pre.xspecCoverage > .whitespace {
+	color: #999;
+	background: white;
+}
+
+.unknown {
+	color: #999;
+	background: white;
+}
+
+.hit {
+}
+
+.missed {
+	color: white;
+	background-color: #a33;
+}

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_by-child-nodes.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-hit.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-leading-string.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-global-context-item-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-result-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-1.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-2.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity_single-line.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_no-entity.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for non-xsl-top-level-element-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for text-node-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-accumulator-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-analyze-string-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-imports-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-templates-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-assert-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-set-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-call-template-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-character-map-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-choose-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-comment-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-context-item-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-of-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-decimal-format-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-element-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-evaluate-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-fallback-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-group-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-function-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-if-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-import-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-include-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-iterate-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-key-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-map-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-merge-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-02.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-mode-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-alias-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-next-match-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-number-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-empty-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-non-empty-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-output-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-02.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-perform-sort-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-preserve-space-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-processing-instruction-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sequence-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sort-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-source-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-strip-space-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-stylesheet-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-template-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-text-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-transform-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-try-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-value-of-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-variable-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-where-populated-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-with-param-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/query/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/query/empty-scenario-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/query/expect-empty-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/function-result.html
+++ b/test/end-to-end/cases/expected/query/function-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/import-result.html
+++ b/test/end-to-end/cases/expected/query/import-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/imported-result.html
+++ b/test/end-to-end/cases/expected/query/imported-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-151-result.html
+++ b/test/end-to-end/cases/expected/query/issue-151-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test-mix (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-153-result.html
+++ b/test/end-to-end/cases/expected/query/issue-153-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-177-result.html
+++ b/test/end-to-end/cases/expected/query/issue-177-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-346-result.html
+++ b/test/end-to-end/cases/expected/query/issue-346-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_3-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_4-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_5-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_3-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-448-result.html
+++ b/test/end-to-end/cases/expected/query/issue-448-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-449-result.html
+++ b/test/end-to-end/cases/expected/query/issue-449-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-452-result.html
+++ b/test/end-to-end/cases/expected/query/issue-452-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-467-result.html
+++ b/test/end-to-end/cases/expected/query/issue-467-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-50-result.html
+++ b/test/end-to-end/cases/expected/query/issue-50-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-528-result.html
+++ b/test/end-to-end/cases/expected/query/issue-528-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-55-result.html
+++ b/test/end-to-end/cases/expected/query/issue-55-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/issue-67-result.html
+++ b/test/end-to-end/cases/expected/query/issue-67-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:xspec-items (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/measure-time-result.html
+++ b/test/end-to-end/cases/expected/query/measure-time-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 3 / pending: 2 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/pending-result.html
+++ b/test/end-to-end/cases/expected/query/pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/report-result.html
+++ b/test/end-to-end/cases/expected/query/report-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/report_java-object-result.html
+++ b/test/end-to-end/cases/expected/query/report_java-object-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/query/report_schema-aware-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:notation (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
+++ b/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/serialize-result.html
+++ b/test/end-to-end/cases/expected/query/serialize-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/shared-like-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/three-dots-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:three-dots (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 12 / total: 24)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-693.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/measure-time-result.html
+++ b/test/end-to-end/cases/expected/schematron/measure-time-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 3 / pending: 2 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 6 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for schematron-023.sch (passed: 1 / pending: 0 / failed: 2 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo-02.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for tvt_label.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xml-1-1.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_function-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_import-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for escape-for-regex.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" /><script language="javascript" type="text/javascript">
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" /><script language="javascript" type="text/javascript">
 function toggle(scenarioID) {
    table = document.getElementById("table_"+scenarioID);
    icon = document.getElementById("icon_"+scenarioID)

--- a/test/end-to-end/cases/expected/stylesheet/function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-151-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-151-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-151.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-214.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-214.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-23_2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-23_2.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 7 / pending: 0 / failed: 0 / total: 7)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for items.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-778_ws.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-cr.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-cr.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-crlf.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-crlf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-lf.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-lf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/measure-time-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/measure-time-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 3 / pending: 2 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mode-all.xsl (passed: 3 / pending: 0 / failed: 3 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/report_java-object-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report_java-object-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report_schema-aware-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for notation.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for three-dots.xsl (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Coverage Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
@@ -2,7 +2,8 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xslt1.xsl (passed: 6 / pending: 0 / failed: 1 / total: 7)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
       <h1>Test Report</h1>

--- a/test/end-to-end/processor/coverage/_normalizer.xsl
+++ b/test/end-to-end/processor/coverage/_normalizer.xsl
@@ -31,17 +31,19 @@
 		Replaces the embedded CSS with the link to its source
 			For brevity. The details of style are not critical anyway.
 	-->
-	<xsl:template as="element(link)" match="/html/head/style" mode="normalizer:normalize">
+	<xsl:template as="element(link)+" match="/html/head/style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<!-- Absolute URI of CSS -->
-		<xsl:variable as="xs:anyURI" name="css-uri"
-			select="resolve-uri('../../../../src/reporter/test-report.css')" />
-
-		<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
-			<xsl:attribute name="href"
-				select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
-		</link>
+		<xsl:for-each select="('test-report-colors-classic.css', 'test-report-base.css')">
+			<!-- Absolute URI of CSS -->
+			<xsl:variable as="xs:anyURI" name="css-uri"
+				select="resolve-uri(concat('../../../../src/reporter/', .))" />
+			
+			<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
+				<xsl:attribute name="href"
+					select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
+			</link>			
+		</xsl:for-each>
 	</xsl:template>
 
 	<!--

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -39,24 +39,26 @@
 		Replaces the embedded CSS with the link to its source
 			For brevity. The details of style are not critical anyway.
 	-->
-	<xsl:template as="element(link)" match="style" mode="normalizer:normalize">
+	<xsl:template as="element(link)+" match="style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<!-- Absolute URI of CSS -->
-		<xsl:variable as="xs:anyURI" name="css-uri"
-			select="resolve-uri('../../../../src/reporter/test-report.css')" />
-
-		<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
-			<xsl:attribute name="href"
-				select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
-		</link>
+		<xsl:for-each select="('test-report-colors-classic.css', 'test-report-base.css')">
+			<!-- Absolute URI of CSS -->
+			<xsl:variable as="xs:anyURI" name="css-uri"
+				select="resolve-uri(concat('../../../../src/reporter/', .))" />
+			
+			<link rel="stylesheet" type="text/css" xmlns="http://www.w3.org/1999/xhtml">
+				<xsl:attribute name="href"
+					select="normalizer:relative-uri($css-uri, $tunnel_document-uri)" />
+			</link>			
+		</xsl:for-each>
 	</xsl:template>
 
 	<!--
 		Normalizes the link to the external CSS file
 			Example:
-				in:  href="file:/path/to/test-report.css"
-				out: href="../path/to/test-report.css"
+				in:  href="file:/path/to/test-report-base.css"
+				out: href="../path/to/test-report-base.css"
 	-->
 	<xsl:template as="attribute(href)" match="link[@rel eq 'stylesheet']/@href"
 		mode="normalizer:normalize">


### PR DESCRIPTION
This pull request introduces two new CSS files for use in test result reports and code coverage reports. Jointly, the two CSS files have the same styles as the existing `test-report.css` file, so there should be no change in functionality or appearance of test reports.

The motivation for this change is to make it easier to work on #2047. The two files divide the styles so that:

- `test-report-colors-classic.css` has color properties
- `test-report-base.css` has all other properties

### Compatibility

For backward compatibility of related repos (https://github.com/xspec/xspec-maven-plugin-1 and https://github.com/xspec/oXygen-XML-editor-xspec-support), I am not changing `test-report.css` (though maybe a comment at the top is warranted, to explain the file's role). If it makes sense for those repos to adapt to the new arrangement, the maintainers and I can collaborate toward a smooth transition.

Cc: @cmarchand , @AlexJitianu

### More about the change

When a report includes CSS styles inline, it now copies the content from the base CSS file and the color-specific one. When a report has links to external CSS, it now has two `<link>` elements instead of one (as illustrated in the end-to-end expected results in 5b25939d6d5211fd1dc9e44c0c4e4979b2750bd4).

I named the color-specific file `test-report-colors-classic.css`. I was at first going to use "pinkgreen" in the filename, but the code coverage report doesn't use pink or green.

This change introduces an XSLT global parameter named `report-theme`. As of this PR, the interface for end users does not provide access to let users pick a different theme; so far, there is only one theme for the pair of report types. I have in mind that the work for #2047 will introduce one or more additional themes and provide a way for end users to choose.
