### PR TITLE
fix(report): make active link coloring take effect

### DIFF
--- a/src/reporter/test-report.css
+++ b/src/reporter/test-report.css
@@ -300,15 +300,15 @@ a:visited {
 	border: 0px none white;
 }
 
-a:active {
-	color: #6f6;
-	background: #606;
-	border: 0px none white;
-}
-
 a:hover {
 	color: #636;
 	background: #9f9;
+	border: 0px none white;
+}
+
+a:active {
+	color: #6f6;
+	background: #606;
 	border: 0px none white;
 }
 


### PR DESCRIPTION
Moving the a:active style below the a:hover style in the CSS file enables the a:active style to take effect.

How to reproduce the problem:

1. Run `tutorial/escape-for-regex.xspec` to generate the HTML report
2. Scroll down to the bottom of the report, so that step 3 won't cause any further scrolling
3. Click the link on the failure label, "Strings should be escaped and status attributes should be added" (or click and hold down the mouse button, to see the effect longer)

As you do step 3, you should see the link text change its text color and background color. The bug is that without this code change, the colors stay the same because the a:active style has no effect.

Reference: Look for LVHA in this document: https://developer.mozilla.org/en-US/docs/Web/CSS/:active