### PR TITLE
feat(report): black/white themes for XSpec reports

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -93,6 +93,7 @@ rem ##
     set WIN_EXTRA_OPTION=
     set XSPEC=
     set CATALOG=
+    set REPORT_THEME=default
     set ERROR_ON_TEST_FAILURE=
     goto :EOF
 
@@ -441,6 +442,7 @@ rem
 
 if not defined HTML_REPORTER_XSL set "HTML_REPORTER_XSL=%XSPEC_HOME%\src\reporter\format-xspec-report.xsl"
 if not defined COVERAGE_REPORTER_XSL set "COVERAGE_REPORTER_XSL=%XSPEC_HOME%\src\reporter\coverage-report.xsl"
+if defined XSPEC_HTML_REPORT_THEME set "REPORT_THEME=%XSPEC_HTML_REPORT_THEME%"
 
 echo:
 echo Formatting Report...
@@ -448,6 +450,7 @@ call :xslt -o:"%HTML%" ^
     -s:"%RESULT%" ^
     -xsl:"%HTML_REPORTER_XSL%" ^
     inline-css=true ^
+    report-theme=%REPORT_THEME% ^
     || ( call :die "Error formatting the report" & goto :win_main_error_exit )
 
 if defined COVERAGE (
@@ -458,6 +461,7 @@ if defined COVERAGE (
         -s:"%COVERAGE_XML%" ^
         -xsl:"%COVERAGE_REPORTER_XSL%" ^
         inline-css=true ^
+        report-theme=%REPORT_THEME% ^
         || ( call :die "Error formatting the coverage report" & goto :win_main_error_exit )
     call :win_echo "Report available at %COVERAGE_HTML%"
     rem %OPEN% "%COVERAGE_HTML%"

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -393,6 +393,11 @@ fi
 if [ -z "${COVERAGE_REPORTER_XSL}" ]; then
     COVERAGE_REPORTER_XSL="$XSPEC_HOME/src/reporter/coverage-report.xsl"
 fi
+if test -n "$XSPEC_HTML_REPORT_THEME"; then
+    REPORT_THEME="$XSPEC_HTML_REPORT_THEME"
+else
+    REPORT_THEME="default"
+fi
 
 echo
 echo "Formatting Report..."
@@ -400,6 +405,7 @@ xslt -o:"$HTML" \
     -s:"$RESULT" \
     -xsl:"${HTML_REPORTER_XSL}" \
     inline-css=true \
+    report-theme="$REPORT_THEME" \
     || die "Error formatting the report"
 if test -n "$COVERAGE"; then
     echo
@@ -409,6 +415,7 @@ if test -n "$COVERAGE"; then
         -s:"$COVERAGE_XML" \
         -xsl:"${COVERAGE_REPORTER_XSL}" \
         inline-css=true \
+        report-theme="$REPORT_THEME" \
         || die "Error formatting the coverage report"
     echo "Report available at $COVERAGE_HTML"
     #$OPEN "$COVERAGE_HTML"

--- a/build.xml
+++ b/build.xml
@@ -487,6 +487,8 @@
         <param name="force-focus" expression="${xspec.force.focus}"
                if="xspec.force.focus" />
         <param name="inline-css" expression="true" />
+        <param name="report-theme" expression="${xspec.html.report.theme}"
+          if="xspec.html.report.theme" />
         <param name="report-css-uri" expression="${xspec.result.html.css.url}"
                if="xspec.result.html.css.url" />
       </xslt-elements>
@@ -515,6 +517,8 @@
           <pathelement location="${xspec.project.dir}/java" />
         </classpath>
         <param name="inline-css" expression="true" />
+        <param name="report-theme" expression="${xspec.html.report.theme}"
+          if="xspec.html.report.theme" />
         <param name="report-css-uri" expression="${xspec.coverage.html.css.url}"
                if="xspec.coverage.html.css.url" />
       </xslt-elements>

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -30,7 +30,7 @@
    -->
    <xsl:param name="report-theme" as="xs:string" select="'default'" />
    <xsl:variable name="report-theme-to-use" as="xs:string"
-      select="if ($report-theme ne 'default') then $report-theme else 'classic'"/>
+      select="if ($report-theme ne 'default') then $report-theme else 'blackwhite'"/>
 
    <!-- @character specifies intermediate characters for mimicking @disable-output-escaping.
       For the test result report HTML, these Private Use Area characters should be considered

--- a/src/reporter/format-utils.xsl
+++ b/src/reporter/format-utils.xsl
@@ -19,7 +19,18 @@
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/format-utils.xsl</pkg:import-uri>
 
-   <xsl:param name="report-theme" as="xs:string" select="'classic'" />
+   <!--
+      Use $report-theme to select a color palette CSS file in this directory:
+      * test-report-colors-blackwhite.css  (black text on white background)
+      * test-report-colors-whiteblack.css  (white text on black background)
+      * test-report-colors-classic.css     (green for successes, pink for failures)
+      
+      The $report-theme value is expected to be the part of the filename
+      between 'test-report-colors-' and '.css'.
+   -->
+   <xsl:param name="report-theme" as="xs:string" select="'default'" />
+   <xsl:variable name="report-theme-to-use" as="xs:string"
+      select="if ($report-theme ne 'default') then $report-theme else 'classic'"/>
 
    <!-- @character specifies intermediate characters for mimicking @disable-output-escaping.
       For the test result report HTML, these Private Use Area characters should be considered
@@ -430,7 +441,7 @@
 
       <xsl:variable as="xs:string+" name="uri-or-default" select="
             if (empty($uri)) then
-            (resolve-uri(concat('test-report-colors-', $report-theme, '.css')), resolve-uri('test-report-base.css'))
+            (resolve-uri(concat('test-report-colors-', $report-theme-to-use, '.css')), resolve-uri('test-report-base.css'))
             else
                $uri" />
 

--- a/src/reporter/test-report-colors-blackwhite.css
+++ b/src/reporter/test-report-colors-blackwhite.css
@@ -1,0 +1,179 @@
+/****************************************************************************/
+/*  File:       test-report-colors-blackwhite.css                           */
+/* ------------------------------------------------------------------------ */
+
+/*
+Colors used, other than white:
+	#171717 gray 90%
+	#262626 gray 85%
+	#454545 gray 70%
+	#e6e6e6 gray 10%
+	#f0f0f0 gray  5%
+*/
+
+/* text and background colours */
+body {
+	background-color: white;
+	color: #171717;
+}
+
+h1 {
+}
+
+h2 {
+}
+
+hr {
+}
+
+a:link {
+	color: #171717;
+	background: transparent;
+}
+
+a:visited {
+	color: #454545;
+	background: transparent;
+}
+
+a:hover {
+	color: #f0f0f0;
+	background: #171717;
+}
+
+a:active {
+	color: #171717;
+	background: white;
+}
+
+#colophon,
+#xml-link,
+.note {
+	color: #454545;
+}
+
+#colophon a:link,
+#colophon a:visited,
+#colophon a:hover,
+#xml-link a:link,
+#xml-link a:visited,
+#xml-link a:hover,
+.note a:link,
+.note a:visited,
+.note a:hover {
+	color: #171717;
+	background: transparent;
+}
+
+#colophon a:hover,
+#xml-link a:hover,
+.note a:hover {
+	background: #f0f0f0;
+	color: #171717;
+}
+
+.popup {
+	background: white;
+}
+
+.same {
+}
+
+.inner-diff {
+	/* No change in color */
+	font-weight: bold;
+}
+
+.diff {
+	color: white;
+	background-color: #171717;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the white-on-black effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: #171717;
+}
+
+/*
+ * Whitespace notation in diffs in test result report,
+ * not literal whitespace characters in code coverage report.
+ * There are two possibilities:
+ *
+ * 1. Not in relevant part of diff: dark against light background */
+td > pre > .whitespace {
+	font-style: italic;
+	color: #171717;
+}
+
+/* 2. In relevant part of diff: override color
+ * and instead use light against dark background */
+.diff.whitespace {
+	color: #e6e6e6;
+}
+
+.ellipsis {
+	color: #454545;
+}
+
+.xmlns.trivial {
+	color: #454545;
+	font-style: italic;
+}
+
+div > table > tbody > tr > th:first-child {
+	color: #454545;
+}
+
+/* 'failed: n' part of Contents */
+table > thead > tr > th:nth-child(4) {
+	color: white;
+	background-color: #171717;
+	padding: 2px;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the white-on-black effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: #171717;
+}
+
+.xspec tbody td {
+	color: #262626;
+}
+
+.successful {
+}
+
+.pending {
+	color: #454545;
+}
+
+/* body makes this selector more specific than the one in test-report.css  */
+body *:target {
+	box-shadow: -0.5rem 0 0 0 #e6e6e6;
+}
+
+/* code coverage report styles */
+.ignored,
+.comment,
+pre.xspecCoverage > .whitespace {
+	color: #454545;
+	background: white;
+}
+
+.unknown {
+	color: #454545;
+	background: white;
+}
+
+.hit {
+}
+
+.missed {
+	color: white;
+	background-color: #171717;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the white-on-black effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: #171717;
+}

--- a/src/reporter/test-report-colors-whiteblack.css
+++ b/src/reporter/test-report-colors-whiteblack.css
@@ -1,0 +1,179 @@
+/****************************************************************************/
+/*  File:       test-report-colors-whiteblack.css                           */
+/* ------------------------------------------------------------------------ */
+
+/*
+Colors used, other than white:
+	#171717 gray 90%
+	#262626 gray 85%
+	#454545 gray 70%
+	#e6e6e6 gray 10%
+	#f0f0f0 gray  5%
+*/
+
+/* text and background colours */
+body {
+	background-color: #171717;
+	color: white;
+}
+
+h1 {
+}
+
+h2 {
+}
+
+hr {
+}
+
+a:link {
+	color: white;
+	background: transparent;
+}
+
+a:visited {
+	color: #e6e6e6;
+	background: transparent;
+}
+
+a:hover {
+	color: #262626;
+	background: white;
+}
+
+a:active {
+	color: white;
+	background: #171717;
+}
+
+#colophon,
+#xml-link,
+.note {
+	color: #e6e6e6;
+}
+
+#colophon a:link,
+#colophon a:visited,
+#colophon a:hover,
+#xml-link a:link,
+#xml-link a:visited,
+#xml-link a:hover,
+.note a:link,
+.note a:visited,
+.note a:hover {
+	color: white;
+	background: transparent;
+}
+
+#colophon a:hover,
+#xml-link a:hover,
+.note a:hover {
+	background: #262626;
+	color: white;
+}
+
+.popup {
+	background: #171717;
+}
+
+.same {
+}
+
+.inner-diff {
+	/* No change in color */
+	font-weight: bold;
+}
+
+.diff {
+	color: #171717;
+	background-color: white;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the black-on-white effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: white;
+}
+
+/*
+ * Whitespace notation in diffs in test result report,
+ * not literal whitespace characters in code coverage report.
+ * There are two possibilities:
+ *
+ * 1. Not in relevant part of diff: light against dark background */
+td > pre > .whitespace {
+	font-style: italic;
+	color: white;
+}
+
+/* 2. In relevant part of diff: override color
+ * and instead use dark against light background */
+.diff.whitespace {
+	color: #454545;
+}
+
+.ellipsis {
+	color: #e6e6e6;
+}
+
+.xmlns.trivial {
+	color: #e6e6e6;
+	font-style: italic;
+}
+
+div > table > tbody > tr > th:first-child {
+	color: #e6e6e6;
+}
+
+/* 'failed: n' part of Contents */
+table > thead > tr > th:nth-child(4) {
+	color: #171717;
+	background-color: white;
+	padding: 2px;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the black-on-white effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: white;
+}
+
+.xspec tbody td {
+	color: #f0f0f0;
+}
+
+.successful {
+}
+
+.pending {
+	color: #e6e6e6;
+}
+
+/* body makes this selector more specific than the one in test-report.css  */
+body *:target {
+	box-shadow: -0.5rem 0 0 0 #454545;
+}
+
+/* code coverage report styles */
+.ignored,
+.comment,
+pre.xspecCoverage > .whitespace {
+	color: #e6e6e6;
+	background: #171717;
+}
+
+.unknown {
+	color: #e6e6e6;
+	background: #171717;
+}
+
+.hit {
+}
+
+.missed {
+	color: #171717;
+	background-color: white;
+	/* Underline is visible in Windows high-contrast mode,
+	 * where the black-on-white effect here is no different
+	 * from the surrounding text. */
+	text-decoration: underline;
+	text-decoration-color: white;
+}

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_by-child-nodes.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-hit-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-hit.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_no-leading-string-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for coverage_no-leading-string.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-empty-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_issue-1410_invoke-not-empty-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_issue-1410.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-global-context-item-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-result-document-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for external_xsl-result-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-1-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-1.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_complex-2-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_complex-2.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_entity_single-line-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_entity_single-line.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1411_no-entity-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1411_no-entity.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-choose-first-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/issue-1917-variable-first-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-1917.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/non-xsl-top-level-element-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for non-xsl-top-level-element-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/text-node-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for text-node-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-accumulator-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-analyze-string-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-imports-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-apply-templates-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-assert-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-assert-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-attribute-set-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-call-template-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-call-template-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-character-map-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-choose-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-choose-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-comment-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-comment-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-context-item-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-context-item-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-copy-of-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-copy-of-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-decimal-format-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-document-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-element-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-element-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-evaluate-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-fallback-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-fallback-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-for-each-group-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-for-each-group-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-function-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-function-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-if-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-if-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-import-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-include-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-iterate-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-key-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-map-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-map-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-merge-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-merge-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-message-02-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-message-02.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-mode-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-namespace-alias-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-next-match-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-number-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-number-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-empty-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-on-non-empty-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-output-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-02-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-param-02.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-perform-sort-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-perform-sort-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-preserve-space-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-processing-instruction-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-processing-instruction-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sequence-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-sort-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-source-document-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-source-document-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-strip-space-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-stylesheet-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-stylesheet-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-template-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-template-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-text-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-text-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-transform-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-transform-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-try-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-try-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-value-of-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-value-of-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-variable-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-variable-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-where-populated-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-where-populated-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for xsl-with-param-01.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/query/empty-scenario-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/query/expect-empty-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-vs-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/query/force-focus_none-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/function-result.html
+++ b/test/end-to-end/cases/expected/query/function-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/import-result.html
+++ b/test/end-to-end/cases/expected/query/import-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/imported-result.html
+++ b/test/end-to-end/cases/expected/query/imported-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/query/issue-1340-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-153-result.html
+++ b/test/end-to-end/cases/expected/query/issue-153-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-177-result.html
+++ b/test/end-to-end/cases/expected/query/issue-177-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-346-result.html
+++ b/test/end-to-end/cases/expected/query/issue-346-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-355-result.html
+++ b/test/end-to-end/cases/expected/query/issue-355-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_2-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_3-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_4-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for http://example.org/ns/my (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/query/issue-446_5-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_2-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/query/issue-447_3-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-448-result.html
+++ b/test/end-to-end/cases/expected/query/issue-448-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-449-result.html
+++ b/test/end-to-end/cases/expected/query/issue-449-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/query/issue-450-451-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-452-result.html
+++ b/test/end-to-end/cases/expected/query/issue-452-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-467-result.html
+++ b/test/end-to-end/cases/expected/query/issue-467-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-50-result.html
+++ b/test/end-to-end/cases/expected/query/issue-50-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-528-result.html
+++ b/test/end-to-end/cases/expected/query/issue-528-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-55-result.html
+++ b/test/end-to-end/cases/expected/query/issue-55-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/issue-67-result.html
+++ b/test/end-to-end/cases/expected/query/issue-67-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:xspec-items (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/label-element-result.html
+++ b/test/end-to-end/cases/expected/query/label-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/pending-result.html
+++ b/test/end-to-end/cases/expected/query/pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:do-nothing (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/report-result.html
+++ b/test/end-to-end/cases/expected/query/report-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
+++ b/test/end-to-end/cases/expected/query/result-file-threshold_query-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/serialize-junit.xml
+++ b/test/end-to-end/cases/expected/query/serialize-junit.xml
@@ -31,15 +31,15 @@
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:result of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:result of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(green in 'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:expect of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:expect of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(green in 'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a child node of an element is indented, the diff of the element must&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;not be affected. So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;and x:expect of the report XML file with different indentation&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;length, &lt;foo&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a child node of an element is indented, the diff of the element must&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;not be affected. So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;and x:expect of the report XML file with different indentation&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;length, &lt;foo&gt; must be serialized as a match (green in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -47,7 +47,7 @@
    <testsuite name="When x:expect has an element of '...',"
               tests="1"
               failures="1">
-      <testcase name="the corresponding nodes in [Result] with diff must be serialized in green.&#xA;&#x9;&#x9;&#x9;&#x9;(xspec/xspec#379)"
+      <testcase name="the corresponding nodes in [Result] with diff must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;(green in 'classic'). (xspec/xspec#379)"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -93,7 +93,7 @@
       </testcase>
    </testsuite>
    <testsuite name="When the result contains attribute," tests="2" failures="2">
-      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) attributes must be serialized&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;as green=&#34;green&#34;. The name-match attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;palePink=&#34;solidPink&#34;. The orphan attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;solidPink=&#34;solidPink&#34; regardless of their values."
+      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) attributes must be serialized&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;as green=&#34;green&#34; ('classic'). The name-match attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;bold=&#34;whiteOnBlack&#34; ('blackwhite') or palePink=&#34;solidPink&#34; ('classic'). The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;orphan attributes must be serialized as whiteOnBlack=&#34;whiteOnBlack&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or solidPink=&#34;solidPink&#34; ('classic') regardless of their&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;values."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -105,7 +105,7 @@
    <testsuite name="When the result contains processing instructions,"
               tests="2"
               failures="2">
-      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?green green?&gt;. The name-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?palePink solidPink?&gt;. The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;value-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?solidPink green?&gt;. The no-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?solidPink solidPink?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;regardless of their values."
+      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?green green?&gt; ('classic'). The name-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?bold whiteOnBlack?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;value-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?solidPink green?&gt; ('classic'). The no-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or &lt;?solidPink solidPink?&gt; ('classic') regardless of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;their values."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>

--- a/test/end-to-end/cases/expected/query/serialize-result.html
+++ b/test/end-to-end/cases/expected/query/serialize-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
@@ -255,7 +255,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario1-scenario1-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario1-scenario1-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -265,7 +265,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario1-scenario2-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario1-scenario2-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -276,7 +276,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario2-scenario1-expect1">&lt;foo&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario2-scenario1-expect1">&lt;foo&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -385,7 +385,7 @@
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -425,7 +425,7 @@
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -465,7 +465,7 @@
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
                XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">&lt;foo&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">&lt;foo&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -513,7 +513,8 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario3-expect1">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
+                  <td><a href="#scenario3-expect1">the corresponding nodes in [Result] with diff must be serialized as a match (green
+                        in 'classic'). (xspec/xspec#379)</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -521,7 +522,8 @@
          <div id="scenario3">
             <h3>When x:expect has an element of '...',</h3>
             <div id="scenario3-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
+               <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized as a match (green
+                  in 'classic'). (xspec/xspec#379)</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -920,9 +922,10 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario6-scenario1-expect1">The exact-match (taking '...' into account) attributes must be serialized as green="green".
-                        The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                        must be serialized as solidPink="solidPink" regardless of their values.</a></td>
+                  <td><a href="#scenario6-scenario1-expect1">The exact-match (taking '...' into account) attributes must be serialized as green="green"
+                        ('classic'). The name-match attributes must be serialized as bold="whiteOnBlack" ('blackwhite')
+                        or palePink="solidPink" ('classic'). The orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+                        ('blackwhite') or solidPink="solidPink" ('classic') regardless of their values.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -938,9 +941,10 @@
          <div id="scenario6-scenario1">
             <h3>When the result contains attribute, both in [Result] and [Expected Result] with diff,</h3>
             <div id="scenario6-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green".
-                  The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                  must be serialized as solidPink="solidPink" regardless of their values.</h4>
+               <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green"
+                  ('classic'). The name-match attributes must be serialized as bold="whiteOnBlack" ('blackwhite')
+                  or palePink="solidPink" ('classic'). The orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+                  ('blackwhite') or solidPink="solidPink" ('classic') regardless of their values.</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1048,10 +1052,12 @@
                </tr>
                <tr class="failed">
                   <td><a href="#scenario7-scenario1-expect1">The exact-match (taking '...' into account) processing instructions must be serialized
-                        as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
-                        solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
-                        be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                        serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</a></td>
+                        as &lt;?green green?&gt; ('classic'). The name-match processing instructions must be serialized
+                        as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
+                        value-match (taking '...' into account) processing instructions must be serialized
+                        as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?solidPink green?&gt; ('classic'). The no-match
+                        processing instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt; ('blackwhite')
+                        or &lt;?solidPink solidPink?&gt; ('classic') regardless of their values.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -1069,10 +1075,12 @@
                with diff,</h3>
             <div id="scenario7-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">The exact-match (taking '...' into account) processing instructions must be serialized
-                  as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
-                  solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
-                  be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
+                  as &lt;?green green?&gt; ('classic'). The name-match processing instructions must be serialized
+                  as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
+                  value-match (taking '...' into account) processing instructions must be serialized
+                  as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?solidPink green?&gt; ('classic'). The no-match
+                  processing instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt; ('blackwhite')
+                  or &lt;?solidPink solidPink?&gt; ('classic') regardless of their values.</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -151,7 +151,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario1-scenario1-expect1" successful="false">
-                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</label>
+                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match
+							(green in 'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -189,7 +190,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario1-scenario2-expect1" successful="false">
-                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</label>
+                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match
+							(green in 'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -235,7 +237,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario2-scenario1-expect1" successful="false">
-                  <label>&lt;foo&gt; must be green.</label>
+                  <label>&lt;foo&gt; must be serialized as a match (green in
+							'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -273,8 +276,8 @@
          </content-wrap>
       </result>
       <test id="scenario3-expect1" successful="false">
-         <label>the corresponding nodes in [Result] with diff must be serialized in green.
-				(xspec/xspec#379)</label>
+         <label>the corresponding nodes in [Result] with diff must be serialized as a match
+				(green in 'classic'). (xspec/xspec#379)</label>
          <expect select="/element()">
             <content-wrap xmlns="">
                <foo xmlns:x="http://www.jenitennison.com/xslt/xspec">...</foo>
@@ -497,9 +500,11 @@
          </result>
          <test id="scenario6-scenario1-expect1" successful="false">
             <label>The exact-match (taking '...' into account) attributes must be serialized
-					as green="green". The name-match attributes must be serialized as
-					palePink="solidPink". The orphan attributes must be serialized as
-					solidPink="solidPink" regardless of their values.</label>
+					as green="green" ('classic'). The name-match attributes must be serialized as
+					bold="whiteOnBlack" ('blackwhite') or palePink="solidPink" ('classic'). The
+					orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+					('blackwhite') or solidPink="solidPink" ('classic') regardless of their
+					values.</label>
             <expect select="/element()">
                <content-wrap xmlns="">
                   <exact-match xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -596,12 +601,15 @@
          </result>
          <test id="scenario7-scenario1-expect1" successful="false">
             <label>The exact-match (taking '...' into account) processing instructions must be
-					serialized as &lt;?green green?&gt;. The name-match processing
-					instructions must be serialized as &lt;?palePink solidPink?&gt;. The
+					serialized as &lt;?green green?&gt; ('classic'). The name-match processing
+					instructions must be serialized as &lt;?bold whiteOnBlack?&gt;
+					('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
 					value-match (taking '...' into account) processing instructions must be
-					serialized as &lt;?solidPink green?&gt;. The no-match processing
-					instructions must be serialized as &lt;?solidPink solidPink?&gt;
-					regardless of their values.</label>
+					serialized as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or
+					&lt;?solidPink green?&gt; ('classic'). The no-match processing
+					instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt;
+					('blackwhite') or &lt;?solidPink solidPink?&gt; ('classic') regardless of
+					their values.</label>
             <expect select="/element()">
                <content-wrap xmlns="">
                   <exact-match xmlns:x="http://www.jenitennison.com/xslt/xspec"><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>

--- a/test/end-to-end/cases/expected/query/shared-like-result.html
+++ b/test/end-to-end/cases/expected/query/shared-like-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/three-dots-result.html
+++ b/test/end-to-end/cases/expected/query/three-dots-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:three-dots (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/query/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/query/xml-1-1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for x-urn:test:mirror (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/schematron/empty-scenario-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-vs-pending_schematron-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 12 / total: 24)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/schematron/force-focus_none-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/issue-693-result.html
+++ b/test/end-to-end/cases/expected/schematron/issue-693-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-693.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/label-element-result.html
+++ b/test/end-to-end/cases/expected/schematron/label-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/pending-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/pending_schematron-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.sch (passed: 0 / pending: 12 / failed: 6 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_collision-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_default-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-importing-min-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_inf-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_issue-361-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_large-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/schematron/result-file-threshold_min-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for result-file-threshold.sch (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/schematron-023-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-023-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for schematron-023.sch (passed: 1 / pending: 0 / failed: 2 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo-02.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/tvt_label_schematron-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for tvt_label.sch (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
+++ b/test/end-to-end/cases/expected/schematron/xml-1-1_schematron-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xml-1-1.sch (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/custom-coverage-report-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/empty-scenario-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (total: 0)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/expect-empty-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_function-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_import-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for external_mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_issue-450-451_stylesheet-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/external_tutorial_coverage_demo-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 28 / pending: 6 / failed: 0 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-vs-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 4 / pending: 4 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for escape-for-regex.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-attribute-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-vs-pending-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 16 / failed: 0 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_focus-without-pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_none-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/format-xspec-report-folding-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 2 / failed: 1 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" /><script language="javascript" type="text/javascript">
 function toggle(scenarioID) {
    table = document.getElementById("table_"+scenarioID);

--- a/test/end-to-end/cases/expected/stylesheet/function-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/function-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/import-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/import-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 4 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/imported-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/imported-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 2 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-1340-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-153-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 0 / failed: 1 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-177-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-214.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-214-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-214.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-346-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-355-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 2 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_2-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_3-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 2 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_4-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for square.xsl (passed: 1 / pending: 1 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-446_5-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_2-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-447_3-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 1 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-448-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-449-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 6 / pending: 0 / failed: 0 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-450-451_stylesheet-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 7 / pending: 0 / failed: 0 / total: 7)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-452-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 4 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-467-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-50-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-528-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 2 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-55-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-67-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for items.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-778_ws-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-778_ws.xsl (passed: 0 / pending: 0 / failed: 1 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-cr.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-cr-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-cr.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-crlf.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-crlf-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-crlf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for issue-793-lf.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/issue-793-lf-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for issue-793-lf.xsl (passed: 1 / pending: 0 / failed: 3 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/label-element-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/label-element-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/mode-all-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mode-all.xsl (passed: 3 / pending: 0 / failed: 3 / total: 6)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/pending-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/pending-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for do-nothing.xsl (passed: 1 / pending: 16 / failed: 1 / total: 18)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/report-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/report-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 34 / total: 34)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_collision-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 4 / pending: 0 / failed: 0 / total: 4)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_default-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-importing-min-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_inf-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_issue-361-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 3 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_large-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/result-file-threshold_min-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 5 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-junit.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-junit.xml
@@ -31,15 +31,15 @@
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:result of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:result of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(green in 'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:expect of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a node is indented, the diff of the indented node itself must not be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;affected. (xspec/xspec#367) So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;x:expect of the report XML file, both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;(green in 'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
-      <testcase name="But the diff must not be affected by indentation. So... When a child node of an element is indented, the diff of the element must&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;not be affected. So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;and x:expect of the report XML file with different indentation&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;length, &lt;foo&gt; must be green."
+      <testcase name="But the diff must not be affected by indentation. So... When a child node of an element is indented, the diff of the element must&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;not be affected. So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;and x:expect of the report XML file with different indentation&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;length, &lt;foo&gt; must be serialized as a match (green in&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;&#x9;'classic')."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -47,7 +47,7 @@
    <testsuite name="When x:expect has an element of '...',"
               tests="1"
               failures="1">
-      <testcase name="the corresponding nodes in [Result] with diff must be serialized in green.&#xA;&#x9;&#x9;&#x9;&#x9;(xspec/xspec#379)"
+      <testcase name="the corresponding nodes in [Result] with diff must be serialized as a match&#xA;&#x9;&#x9;&#x9;&#x9;(green in 'classic'). (xspec/xspec#379)"
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -93,7 +93,7 @@
       </testcase>
    </testsuite>
    <testsuite name="When the result contains attribute," tests="2" failures="2">
-      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) attributes must be serialized&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;as green=&#34;green&#34;. The name-match attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;palePink=&#34;solidPink&#34;. The orphan attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;solidPink=&#34;solidPink&#34; regardless of their values."
+      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) attributes must be serialized&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;as green=&#34;green&#34; ('classic'). The name-match attributes must be serialized as&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;bold=&#34;whiteOnBlack&#34; ('blackwhite') or palePink=&#34;solidPink&#34; ('classic'). The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;orphan attributes must be serialized as whiteOnBlack=&#34;whiteOnBlack&#34;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or solidPink=&#34;solidPink&#34; ('classic') regardless of their&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;values."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>
@@ -105,7 +105,7 @@
    <testsuite name="When the result contains processing instructions,"
               tests="2"
               failures="2">
-      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?green green?&gt;. The name-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?palePink solidPink?&gt;. The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;value-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?solidPink green?&gt;. The no-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?solidPink solidPink?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;regardless of their values."
+      <testcase name="both in [Result] and [Expected Result] with diff, The exact-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?green green?&gt; ('classic'). The name-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?bold whiteOnBlack?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;value-match (taking '...' into account) processing instructions must be&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;serialized as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;&lt;?solidPink green?&gt; ('classic'). The no-match processing&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt;&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;('blackwhite') or &lt;?solidPink solidPink?&gt; ('classic') regardless of&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;their values."
                 status="failed">
          <failure message="expect assertion failed"/>
       </testcase>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 0 / pending: 0 / failed: 28 / total: 28)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>
@@ -254,7 +254,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario1-scenario1-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario1-scenario1-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -264,7 +264,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario1-scenario2-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario1-scenario2-expect1">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -275,7 +275,7 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario2-scenario2-scenario2-scenario1-expect1">&lt;foo&gt; must be green.</a></td>
+                  <td><a href="#scenario2-scenario2-scenario2-scenario1-expect1">&lt;foo&gt; must be serialized as a match (green in 'classic').</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -384,7 +384,7 @@
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:result of the report
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -424,7 +424,7 @@
                So... When &lt;bar&gt; is indented but &lt;?bar?&gt; is not indented in x:expect of the report
                XML file,</h3>
             <div id="scenario2-scenario2-scenario1-scenario2-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -464,7 +464,7 @@
                So, when the same &lt;bar&gt; in &lt;foo&gt; is indented in x:result and x:expect of the report
                XML file with different indentation length,</h3>
             <div id="scenario2-scenario2-scenario2-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">&lt;foo&gt; must be green.</h4>
+               <h4 class="xTestReportTitle">&lt;foo&gt; must be serialized as a match (green in 'classic').</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -512,7 +512,8 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario3-expect1">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</a></td>
+                  <td><a href="#scenario3-expect1">the corresponding nodes in [Result] with diff must be serialized as a match (green
+                        in 'classic'). (xspec/xspec#379)</a></td>
                   <td>Failure</td>
                </tr>
             </tbody>
@@ -520,7 +521,8 @@
          <div id="scenario3">
             <h3>When x:expect has an element of '...',</h3>
             <div id="scenario3-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized in green. (xspec/xspec#379)</h4>
+               <h4 class="xTestReportTitle">the corresponding nodes in [Result] with diff must be serialized as a match (green
+                  in 'classic'). (xspec/xspec#379)</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -919,9 +921,10 @@
                   <th>passed: 0 / pending: 0 / failed: 1 / total: 1</th>
                </tr>
                <tr class="failed">
-                  <td><a href="#scenario6-scenario1-expect1">The exact-match (taking '...' into account) attributes must be serialized as green="green".
-                        The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                        must be serialized as solidPink="solidPink" regardless of their values.</a></td>
+                  <td><a href="#scenario6-scenario1-expect1">The exact-match (taking '...' into account) attributes must be serialized as green="green"
+                        ('classic'). The name-match attributes must be serialized as bold="whiteOnBlack" ('blackwhite')
+                        or palePink="solidPink" ('classic'). The orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+                        ('blackwhite') or solidPink="solidPink" ('classic') regardless of their values.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -937,9 +940,10 @@
          <div id="scenario6-scenario1">
             <h3>When the result contains attribute, both in [Result] and [Expected Result] with diff,</h3>
             <div id="scenario6-scenario1-expect1" class="xTestReport">
-               <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green".
-                  The name-match attributes must be serialized as palePink="solidPink". The orphan attributes
-                  must be serialized as solidPink="solidPink" regardless of their values.</h4>
+               <h4 class="xTestReportTitle">The exact-match (taking '...' into account) attributes must be serialized as green="green"
+                  ('classic'). The name-match attributes must be serialized as bold="whiteOnBlack" ('blackwhite')
+                  or palePink="solidPink" ('classic'). The orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+                  ('blackwhite') or solidPink="solidPink" ('classic') regardless of their values.</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>
@@ -1047,10 +1051,12 @@
                </tr>
                <tr class="failed">
                   <td><a href="#scenario7-scenario1-expect1">The exact-match (taking '...' into account) processing instructions must be serialized
-                        as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
-                        solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
-                        be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                        serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</a></td>
+                        as &lt;?green green?&gt; ('classic'). The name-match processing instructions must be serialized
+                        as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
+                        value-match (taking '...' into account) processing instructions must be serialized
+                        as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?solidPink green?&gt; ('classic'). The no-match
+                        processing instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt; ('blackwhite')
+                        or &lt;?solidPink solidPink?&gt; ('classic') regardless of their values.</a></td>
                   <td>Failure</td>
                </tr>
                <tr class="failed">
@@ -1068,10 +1074,12 @@
                with diff,</h3>
             <div id="scenario7-scenario1-expect1" class="xTestReport">
                <h4 class="xTestReportTitle">The exact-match (taking '...' into account) processing instructions must be serialized
-                  as &lt;?green green?&gt;. The name-match processing instructions must be serialized as &lt;?palePink
-                  solidPink?&gt;. The value-match (taking '...' into account) processing instructions must
-                  be serialized as &lt;?solidPink green?&gt;. The no-match processing instructions must be
-                  serialized as &lt;?solidPink solidPink?&gt; regardless of their values.</h4>
+                  as &lt;?green green?&gt; ('classic'). The name-match processing instructions must be serialized
+                  as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
+                  value-match (taking '...' into account) processing instructions must be serialized
+                  as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or &lt;?solidPink green?&gt; ('classic'). The no-match
+                  processing instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt; ('blackwhite')
+                  or &lt;?solidPink solidPink?&gt; ('classic') regardless of their values.</h4>
                <div class="xTestReportHint"><a href="https://github.com/xspec/xspec/wiki/Understanding-Test-Results" target="_blank" title="What does this report mean?">[?]</a></div>
                <table class="xspecResult">
                   <thead>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -150,7 +150,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario1-scenario1-expect1" successful="false">
-                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</label>
+                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match
+							(green in 'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -188,7 +189,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario1-scenario2-expect1" successful="false">
-                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be green.</label>
+                  <label>both &lt;bar&gt; and &lt;?bar?&gt; must be serialized as a match
+							(green in 'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -234,7 +236,8 @@
                   </content-wrap>
                </result>
                <test id="scenario2-scenario2-scenario2-scenario1-expect1" successful="false">
-                  <label>&lt;foo&gt; must be green.</label>
+                  <label>&lt;foo&gt; must be serialized as a match (green in
+							'classic').</label>
                   <expect select="/element()">
                      <content-wrap xmlns="">
                         <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
@@ -272,8 +275,8 @@
          </content-wrap>
       </result>
       <test id="scenario3-expect1" successful="false">
-         <label>the corresponding nodes in [Result] with diff must be serialized in green.
-				(xspec/xspec#379)</label>
+         <label>the corresponding nodes in [Result] with diff must be serialized as a match
+				(green in 'classic'). (xspec/xspec#379)</label>
          <expect select="/element()">
             <content-wrap xmlns="">
                <foo xmlns:x="http://www.jenitennison.com/xslt/xspec">...</foo>
@@ -496,9 +499,11 @@
          </result>
          <test id="scenario6-scenario1-expect1" successful="false">
             <label>The exact-match (taking '...' into account) attributes must be serialized
-					as green="green". The name-match attributes must be serialized as
-					palePink="solidPink". The orphan attributes must be serialized as
-					solidPink="solidPink" regardless of their values.</label>
+					as green="green" ('classic'). The name-match attributes must be serialized as
+					bold="whiteOnBlack" ('blackwhite') or palePink="solidPink" ('classic'). The
+					orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+					('blackwhite') or solidPink="solidPink" ('classic') regardless of their
+					values.</label>
             <expect select="/element()">
                <content-wrap xmlns="">
                   <exact-match xmlns:x="http://www.jenitennison.com/xslt/xspec"
@@ -595,12 +600,15 @@
          </result>
          <test id="scenario7-scenario1-expect1" successful="false">
             <label>The exact-match (taking '...' into account) processing instructions must be
-					serialized as &lt;?green green?&gt;. The name-match processing
-					instructions must be serialized as &lt;?palePink solidPink?&gt;. The
+					serialized as &lt;?green green?&gt; ('classic'). The name-match processing
+					instructions must be serialized as &lt;?bold whiteOnBlack?&gt;
+					('blackwhite') or &lt;?palePink solidPink?&gt; ('classic'). The
 					value-match (taking '...' into account) processing instructions must be
-					serialized as &lt;?solidPink green?&gt;. The no-match processing
-					instructions must be serialized as &lt;?solidPink solidPink?&gt;
-					regardless of their values.</label>
+					serialized as &lt;?bold whiteOnBlack?&gt; ('blackwhite') or
+					&lt;?solidPink green?&gt; ('classic'). The no-match processing
+					instructions must be serialized as &lt;?whiteOnBlack whiteOnBlack?&gt;
+					('blackwhite') or &lt;?solidPink solidPink?&gt; ('classic') regardless of
+					their values.</label>
             <expect select="/element()">
                <content-wrap xmlns="">
                   <exact-match xmlns:x="http://www.jenitennison.com/xslt/xspec"><?node1 value1?><?node2 ...?><?node3?><?node4 ...?></exact-match>

--- a/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/shared-like-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 8 / pending: 0 / failed: 0 / total: 8)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/three-dots-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for three-dots.xsl (passed: 48 / pending: 0 / failed: 32 / total: 80)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-coverage.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Coverage Report for demo.xsl</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tutorial_coverage_demo-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for demo.xsl (passed: 1 / pending: 0 / failed: 0 / total: 1)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/tvt_label-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 5 / pending: 0 / failed: 0 / total: 5)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xml-1-1-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for mirror.xsl (passed: 2 / pending: 0 / failed: 1 / total: 3)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/xslt2-result.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       <title>Test Report for xslt1.xsl (passed: 6 / pending: 0 / failed: 1 / total: 7)</title>
-      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-classic.css" />
+      <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-colors-blackwhite.css" />
       <link rel="stylesheet" type="text/css" href="../../../../../src/reporter/test-report-base.css" />
    </head>
    <body>

--- a/test/end-to-end/cases/serialize.xspec
+++ b/test/end-to-end/cases/serialize.xspec
@@ -96,7 +96,8 @@
 						</x:param>
 					</x:call>
 					<x:expect>
-						<x:label>both <![CDATA[<bar> and <?bar?>]]> must be green.</x:label>
+						<x:label>both <![CDATA[<bar> and <?bar?>]]> must be serialized as a match
+							(green in 'classic').</x:label>
 						<test>
 							<elem1>foo<bar /></elem1>
 							<elem2>foo<?bar?></elem2>
@@ -116,7 +117,8 @@
 						</x:param>
 					</x:call>
 					<x:expect>
-						<x:label>both <![CDATA[<bar> and <?bar?>]]> must be green.</x:label>
+						<x:label>both <![CDATA[<bar> and <?bar?>]]> must be serialized as a match
+							(green in 'classic').</x:label>
 						<test>
 							<elem1><!--foo--><bar /></elem1>
 							<elem2><!--foo--><?bar?></elem2>
@@ -141,7 +143,8 @@
 						</x:param>
 					</x:call>
 					<x:expect>
-						<x:label><![CDATA[<foo>]]> must be green.</x:label>
+						<x:label><![CDATA[<foo>]]> must be serialized as a match (green in
+							'classic').</x:label>
 						<test>
 							<foo><bar /></foo>
 							<qux />
@@ -163,8 +166,8 @@
 			</x:param>
 		</x:call>
 		<x:expect>
-			<x:label>the corresponding nodes in [Result] with diff must be serialized in green.
-				(xspec/xspec#379)</x:label>
+			<x:label>the corresponding nodes in [Result] with diff must be serialized as a match
+				(green in 'classic'). (xspec/xspec#379)</x:label>
 			<foo>...</foo>
 			<qux />
 		</x:expect>
@@ -294,9 +297,11 @@
 			<x:label>both in [Result] and [Expected Result] with diff,</x:label>
 			<x:expect>
 				<x:label>The exact-match (taking '...' into account) attributes must be serialized
-					as green="green". The name-match attributes must be serialized as
-					palePink="solidPink". The orphan attributes must be serialized as
-					solidPink="solidPink" regardless of their values.</x:label>
+					as green="green" ('classic'). The name-match attributes must be serialized as
+					bold="whiteOnBlack" ('blackwhite') or palePink="solidPink" ('classic'). The
+					orphan attributes must be serialized as whiteOnBlack="whiteOnBlack"
+					('blackwhite') or solidPink="solidPink" ('classic') regardless of their
+					values.</x:label>
 				<exact-match attr1="value1" attr2="..." attr3="" attr4="..." />
 				<name-match attr1="VALUE1" attr2="" attr3="value3" attr4="value4" />
 				<orphan attr4="value4" attr5="" attr6="..." />
@@ -357,12 +362,15 @@
 			<x:label>both in [Result] and [Expected Result] with diff,</x:label>
 			<x:expect>
 				<x:label>The exact-match (taking '...' into account) processing instructions must be
-					serialized as <![CDATA[<?green green?>]]>. The name-match processing
-					instructions must be serialized as <![CDATA[<?palePink solidPink?>]]>. The
+					serialized as <![CDATA[<?green green?>]]> ('classic'). The name-match processing
+					instructions must be serialized as <![CDATA[<?bold whiteOnBlack?>]]>
+					('blackwhite') or <![CDATA[<?palePink solidPink?>]]> ('classic'). The
 					value-match (taking '...' into account) processing instructions must be
-					serialized as <![CDATA[<?solidPink green?>]]>. The no-match processing
-					instructions must be serialized as <![CDATA[<?solidPink solidPink?>]]>
-					regardless of their values.</x:label>
+					serialized as <![CDATA[<?bold whiteOnBlack?>]]> ('blackwhite') or
+					<![CDATA[<?solidPink green?>]]> ('classic'). The no-match processing
+					instructions must be serialized as <![CDATA[<?whiteOnBlack whiteOnBlack?>]]>
+					('blackwhite') or <![CDATA[<?solidPink solidPink?>]]> ('classic') regardless of
+					their values.</x:label>
 				<exact-match>
 					<?node1 value1?>
 					<?node2 ...?>

--- a/test/end-to-end/processor/coverage/_normalizer.xsl
+++ b/test/end-to-end/processor/coverage/_normalizer.xsl
@@ -34,7 +34,7 @@
 	<xsl:template as="element(link)+" match="/html/head/style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<xsl:for-each select="('test-report-colors-classic.css', 'test-report-base.css')">
+		<xsl:for-each select="('test-report-colors-blackwhite.css', 'test-report-base.css')">
 			<!-- Absolute URI of CSS -->
 			<xsl:variable as="xs:anyURI" name="css-uri"
 				select="resolve-uri(concat('../../../../src/reporter/', .))" />

--- a/test/end-to-end/processor/html/_normalizer.xsl
+++ b/test/end-to-end/processor/html/_normalizer.xsl
@@ -42,7 +42,7 @@
 	<xsl:template as="element(link)+" match="style" mode="normalizer:normalize">
 		<xsl:param as="xs:anyURI" name="tunnel_document-uri" required="yes" tunnel="yes" />
 
-		<xsl:for-each select="('test-report-colors-classic.css', 'test-report-base.css')">
+		<xsl:for-each select="('test-report-colors-blackwhite.css', 'test-report-base.css')">
 			<!-- Absolute URI of CSS -->
 			<xsl:variable as="xs:anyURI" name="css-uri"
 				select="resolve-uri(concat('../../../../src/reporter/', .))" />

--- a/test/run-bats.cmd
+++ b/test/run-bats.cmd
@@ -56,6 +56,7 @@ set SCHEMATRON_XSLT_INCLUDE=
 set TEST_DIR=
 set XML_CATALOG=
 set XSPEC_HOME=
+set XSPEC_HTML_REPORT_THEME=
 
 rem Saxon path for Ant -lib command line option
 rem  Note: Ant -lib command line option doesn't seem to accept classpath wildcards.

--- a/test/run-bats.sh
+++ b/test/run-bats.sh
@@ -77,6 +77,7 @@ unset SCHEMATRON_XSLT_INCLUDE
 unset TEST_DIR
 unset XML_CATALOG
 unset XSPEC_HOME
+unset XSPEC_HTML_REPORT_THEME
 
 # Saxon path for Ant -lib command line option
 #  Note: Ant -lib command line option doesn't seem to accept classpath wildcards.

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1886,6 +1886,74 @@
 	</case>
 
 	<!--
+		xspec.html.report.theme (Ant)
+	-->
+
+	<case name="Ant with non-default report-theme for result report HTML file">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_ANT_LIB%" ^
+        -Dxspec.fail=false ^
+        -Dxspec.html.report.theme=whiteblack ^
+        -Dxspec.xml="%CD%\..\tutorial\escape-for-regex.xspec"
+    call :verify_retval 0
+        
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
+        -s:"%TEST_DIR%\escape-for-regex-result.html" ^
+        -xsl:check-html-css.xsl ^
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    call :verify_retval 0
+    call :verify_line 1 x "true"
+	</case>
+
+	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="Ant with non-default report-theme for coverage report HTML file">
+    call :run ant ^
+        -buildfile ..\build.xml ^
+        -lib "%SAXON_ANT_LIB%" ^
+        -Dxspec.coverage.enabled=true ^
+        -Dxspec.html.report.theme=whiteblack ^
+        -Dxspec.xml="%CD%\..\tutorial\coverage\demo.xspec"
+    call :verify_retval 0
+    
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
+        -s:"%TEST_DIR%\demo-coverage.html" ^
+        -xsl:check-html-css.xsl ^
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    call :verify_retval 0
+    call :verify_line 1 x "true"
+	</case>
+
+	<!--
+		XSPEC_HTML_REPORT_THEME (CLI)
+	-->
+
+	<case name="invoking xspec with non-default report-theme for result report HTML file">
+    set "XSPEC_HTML_REPORT_THEME=whiteblack"
+    call :run ..\bin\xspec.bat "%CD%\..\tutorial\escape-for-regex.xspec"
+    call :verify_retval 0
+    
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
+        -s:"%TEST_DIR%\escape-for-regex-result.html" ^
+        -xsl:check-html-css.xsl ^
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    call :verify_retval 0
+    call :verify_line 1 x "true"
+	</case>
+
+	<case ifdef="XSLT_SUPPORTS_COVERAGE" name="invoking xspec with non-default report-theme for coverage report HTML file">
+    set "XSPEC_HTML_REPORT_THEME=whiteblack"
+    call :run ..\bin\xspec.bat -c "%CD%\..\tutorial\coverage\demo.xspec"
+    call :verify_retval 0
+    
+    call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
+        -s:"%TEST_DIR%\demo-coverage.html" ^
+        -xsl:check-html-css.xsl ^
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    call :verify_retval 0
+    call :verify_line 1 x "true"
+	</case>
+
+	<!--
 		report-css-uri
 	-->
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2042,6 +2042,80 @@ load bats-helper
 }
 
 #
+# xspec.html.report.theme (Ant)
+#
+
+@test "Ant with non-default report-theme for result report HTML file" {
+    ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_ANT_LIB}" \
+        -Dxspec.fail=false \
+        -Dxspec.html.report.theme=whiteblack \
+        -Dxspec.xml="${PWD}/../tutorial/escape-for-regex.xspec"
+
+    myrun java -cp "${SAXON_CP}" net.sf.saxon.Transform \
+        -s:"${TEST_DIR}/escape-for-regex-result.html" \
+        -xsl:check-html-css.xsl \
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "true" ]
+}
+
+@test "Ant with non-default report-theme for coverage report HTML file" {
+    if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
+        skip "XSLT_SUPPORTS_COVERAGE is not defined"
+    fi
+
+    ant \
+        -buildfile ../build.xml \
+        -lib "${SAXON_ANT_LIB}" \
+        -Dxspec.coverage.enabled=true \
+        -Dxspec.html.report.theme=whiteblack \
+        -Dxspec.xml="${PWD}/../tutorial/coverage/demo.xspec"
+
+    myrun java -cp "${SAXON_CP}" net.sf.saxon.Transform \
+        -s:"${TEST_DIR}/demo-coverage.html" \
+        -xsl:check-html-css.xsl \
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "true" ]
+}
+
+#
+# XSPEC_HTML_REPORT_THEME (CLI)
+#
+
+@test "invoking xspec with non-default report-theme for result report HTML file" {
+    export XSPEC_HTML_REPORT_THEME="whiteblack"
+    myrun ../bin/xspec.sh "${PWD}/../tutorial/escape-for-regex.xspec"
+    [ "$status" -eq 0 ]
+
+    myrun java -cp "${SAXON_CP}" net.sf.saxon.Transform \
+        -s:"${TEST_DIR}/escape-for-regex-result.html" \
+        -xsl:check-html-css.xsl \
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "true" ]
+}
+
+@test "invoking xspec with non-default report-theme for coverage report HTML file" {
+    if [ -z "${XSLT_SUPPORTS_COVERAGE}" ]; then
+        skip "XSLT_SUPPORTS_COVERAGE is not defined"
+    fi
+
+    export XSPEC_HTML_REPORT_THEME="whiteblack"
+    myrun ../bin/xspec.sh -c "${PWD}/../tutorial/coverage/demo.xspec"
+    [ "$status" -eq 0 ]
+
+    myrun java -cp "${SAXON_CP}" net.sf.saxon.Transform \
+        -s:"${TEST_DIR}/demo-coverage.html" \
+        -xsl:check-html-css.xsl \
+        STYLE-CONTAINS="test-report-colors-whiteblack.css"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "true" ]
+}
+
+#
 # report-css-uri
 #
 

--- a/xspec.framework
+++ b/xspec.framework
@@ -590,6 +590,29 @@
 										</antParameter>
 										<antParameter>
 											<field name="name">
+												<String>xspec.html.report.theme</String>
+											</field>
+											<field name="description">
+												<String>Color palette for HTML report, such as blackwhite, whiteblack, or classic</String>
+											</field>
+											<field name="value">
+												<String>default</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
 												<String>xspec.project.dir</String>
 											</field>
 											<field name="description">
@@ -971,6 +994,29 @@
 											</field>
 											<field name="value">
 												<String>false</String>
+											</field>
+											<field name="defaultValue">
+												<null/>
+											</field>
+											<field name="type">
+												<Integer>5</Integer>
+											</field>
+											<field name="possibleValues">
+												<null/>
+											</field>
+											<field name="possibleValuesDescriptions">
+												<null/>
+											</field>
+										</antParameter>
+										<antParameter>
+											<field name="name">
+												<String>xspec.html.report.theme</String>
+											</field>
+											<field name="description">
+												<String>Color palette for HTML report, such as blackwhite, whiteblack, or classic</String>
+											</field>
+											<field name="value">
+												<String>default</String>
 											</field>
 											<field name="defaultValue">
 												<null/>


### PR DESCRIPTION
This pull request introduces two color palettes for XSpec test reports (result report and coverage report) that are alternatives to the existing "classic" palette.

Fixes #2047.

## Review Question: What should the default be?

So far, this PR uses "classic" as the default, but I would like input on whether "blackwhite" would be a better default. The "blackwhite" theme

- Has better accessibility characteristics (see #2047)
- Is closer to an early Oxygen design that several people said they liked (#92)
- Also addresses #919 

Also, the "blackwhite" and "whiteblack" themes play well with the Windows "Use high contrast" feature, whereas the "classic" theme does not.

## How to select a color palette

Use any of the following three ways to specify your preferred palette.

- Before running `xspec.sh` or `xspec.bat`, set an environment variable, `XSPEC_HTML_REPORT_THEME`
- When running Ant, set the `xspec.html.report.theme` property
- Before using the **Run XSpec Test** or **XSLT Code Coverage** transformation scenario in Oxygen: Duplicate the scenario and, on the Parameters tab, modify the `xspec.html.report.theme` value

In all 3 cases, valid values as of this pull request are:

- `blackwhite` for black text on a white background
- `whiteblack` for white text on a black background
- `classic` for the XSpec 3.1 style

### More choices?

If someone in the XSpec community has a good eye for color and wants to contribute one or more additional color-specific CSS files that are swappable with the existing ones, please speak up! You can do so here, in a new issue, or in a new PR.

## Out of scope of this PR

This PR does not intend to solve all accessibility problems at one time; totally redo the report design; or make the XSpec reports arbitrarily customizable by users as a documented feature of XSpec.

## Sample test result reports

![blackwhite-result-report](https://github.com/user-attachments/assets/0dd4b090-dbe9-4104-90fd-ac57c8dfb829)

![whiteblack-result-report](https://github.com/user-attachments/assets/26540695-3a66-459d-a78a-bd57edc831f5)

![classic-result-report](https://github.com/user-attachments/assets/84d14eb5-3754-4d32-9aa3-0017a4586a40)

## Sample XSLT code coverage reports

![blackwhite-coverage-report](https://github.com/user-attachments/assets/7dbd6167-d85f-45cc-9051-124ae23bd0a3)

![whiteblack-coverage-report](https://github.com/user-attachments/assets/940d4549-b64a-463d-bd0d-69d7aa04a05d)

![classic-coverage-report](https://github.com/user-attachments/assets/b285608a-f4ea-4eb7-85db-c4d068901b0b)

## ZIP-files with the sample reports

In case you want to look at the sample reports depicted in the screen captures above, download them here:

[sample-report-files.zip](https://github.com/user-attachments/files/18323368/sample-report-files.zip)

## Further work

- [ ] Update https://github.com/xspec/xspec/wiki/Environment-Variables
- [ ] Update https://github.com/xspec/xspec/wiki/Running-with-Ant
- [ ] Update https://github.com/xspec/xspec/wiki/Running-with-Oxygen#configuring-xspec-transformation-scenario
- [ ] Update other verbiage and screen captures as needed, especially if the default is not "classic"