### PR TITLE
build(oxygen): add-on v3.2.0

### DIFF
--- a/editors/oxygen/add-on/description/latest.xhtml
+++ b/editors/oxygen/add-on/description/latest.xhtml
@@ -16,6 +16,18 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.2.0</h3>
+				<ul>
+					<li>Test reports use black text on white background by default, improving accessibility.
+						Themes 'whiteblack' (white on black) and 'classic' (earlier green/pink design) are
+						also available. (<a href="https://github.com/xspec/xspec/pull/1822">#2055</a>)</li>
+					<li>Tests for Schematron can verify string values of Schematron properties
+						(<a href="https://github.com/xspec/xspec/pull/1822">#2045</a>).</li>
+					<li>Tested with BaseX 11.6</li>
+					<li>Tested with Oxygen 27.0.</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.1.3</h3>
 				<ul>
 					<li>Fix for <a href="https://github.com/xspec/xspec-maven-plugin-1/">xspec/xspec-maven-plugin-1</a> and other uses
@@ -75,12 +87,6 @@
 				<ul>
 					<li>Initial development version of v3.0</li>
 					<li>Tested with Oxygen 26.0</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v2.3.2</h3>
-				<ul>
-					<li>Official release of v2.3</li>
 				</ul>
 			</div>
 		</div>

--- a/oxygen-addon.xml
+++ b/oxygen-addon.xml
@@ -16,9 +16,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/38920bd0a7c1fbbb397acd689c00979dc79a59a2.zip" />
+			href="https://github.com/xspec/xspec/archive/fee92fd453ac9e55e3c889df168ebc918fdc8485.zip" />
 
-		<xt:version>3.1.3</xt:version>
+		<xt:version>3.2.0</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.

--- a/xspec.xpr
+++ b/xspec.xpr
@@ -20,7 +20,7 @@
                         <documentTypeEntry-array>
                             <documentTypeEntry>
                                 <field name="documentTypeID">
-                                    <String>4/xspec-38920bd0a7c1fbbb397acd689c00979dc79a59a2/xspec.framework/XSpec</String>
+                                    <String>4/xspec-fee92fd453ac9e55e3c889df168ebc918fdc8485/xspec.framework/XSpec</String>
                                 </field>
                                 <field name="enable">
                                     <Boolean>false</Boolean>


### PR DESCRIPTION
This pull request publishes the latest `master` via Oxygen add-on channel.

This v3.2.0 add-on is not the v3.2 release but instead has a portion of the changes we expect to be in XSpec v3.2. I wanted to make #2045 and #2055 more easily available to users who want to try out these changes.

I tested this change in Oxygen 27.0 build 2024112212 using https://github.com/galtm/xspec/raw/oxygen-addon-3-2-0/oxygen-addon.xml . I checked the subbullets under "Test the add-on 3.2.num with latest Oxygen" in #2017 and noticed no problems.