### PR TITLE
refactor(report): remove obsolete CSS styles

### DIFF
--- a/src/reporter/test-report-base.css
+++ b/src/reporter/test-report-base.css
@@ -36,45 +36,8 @@ table {
 	margin-left: 5%;
 }
 
-dd ul,
-dd ol {
-	margin-left: 0%;
-}
-
-li ul,
-li ol {
-	margin-left: 5%;
-}
-
-dl,
-ul,
-ol,
-blockquote {
-	margin-left: 10%;
-}
-
-dt {
-	padding-top: 3px;
-	padding-bottom: 3px;
-	clear: both;
-}
-
-dd p {
-	margin-left: -5px;
-	margin-top: 5px;
-	clear: both;
-}
-
-p.link {
-	margin-top: 4px;
-	margin-bottom: 0px;
-	clear: both;
-}
-
 tr td,
-td p,
-li,
-li p {
+td p {
 	margin-left: 0%;
 }
 
@@ -82,75 +45,13 @@ td {
 	padding-right: 5%;
 }
 
-.link img,
-dt img {
-	vertical-align: middle;
-	position: relative;
-	top: -5px;
-}
-
 img {
 	position: relative;
-}
-
-#xml-link {
-	position: absolute;
-	left: 5px;
-	top: 5px;
-	width: 10%;
-	margin-left: 0%;
-}
-
-#link-up {
-	position: absolute;
-	left: 93%;
-	right: 2em;
-	top: 0.3em;
-}
-
-#link-top {
-	position: absolute;
-	left: 89%;
-	right: 4em;
-	top: 0.3em;
-}
-
-.popup {
-	display: block;
-	visibility: hidden;
-	float: right;
-	position: absolute;
-	top: 5px;
-	left: -200px;
-	z-index: 1;
-	padding: 0.3em;
-	width: 220px;
-}
-
-.note {
-	position: relative;
-}
-
-.post {
-	margin-left: 5%;
-	padding-top: 1em;
-}
-
-.example,
-.sidebar {
-	margin-left: 5%;
-	margin-top: 1em;
-	margin-bottom: 1em;
 }
 
 pre {
 	padding-left: 5%;
 	margin-left: 5%;
-}
-
-dd pre,
-li pre {
-	padding-left: 5%;
 }
 
 /* fonts */
@@ -163,9 +64,7 @@ table {
 h1,
 h2,
 h3,
-h4,
-h5,
-h6 {
+h4 {
 	font-family: sans-serif;
 }
 
@@ -189,10 +88,6 @@ h4 {
 	font-weight: bold;
 }
 
-dt {
-	font-weight: bold;
-}
-
 a:link,
 a:visited,
 a:active,
@@ -200,52 +95,9 @@ a:hover {
 	font-weight: bold;
 }
 
-a.offsite:link,
-a.offsite:visited,
-a.offsite:active,
-a.offsite:hover {
-	font-weight: normal;
-}
-
-/* suppress the normal italics */
-address {
-	font-style: normal;
-}
-
-div.example,
-.sidebar {
-	font-family: sans-serif;
-	font-size: 100%;
-}
-
-.note,
-.link {
-	font-family: sans-serif;
-	/*font-size: 83%;*/
-}
-
-.example,
-.string,
-.rtf,
-.code,
 pre,
 code {
 	font-family: monospace;
-	/*font-size: 83%;*/
-}
-
-.boolean {
-	font-style: italic;
-}
-
-#colophon,
-#xml-link {
-	font-size: 69%;
-}
-
-.question,
-.title {
-	font-weight: bold;
 }
 
 /* this is to make Navigator fill the entire line */
@@ -263,9 +115,7 @@ img,
 a:link img,
 a:visited img,
 a:hover img,
-a:active img,
-#link-up img,
-#link-top img {
+a:active img {
 	border: 0px none white;
 	background: transparent;
 }
@@ -284,33 +134,6 @@ a:active {
 
 a:hover {
 	border: 0px none white;
-}
-
-a.img:hover,
-a.img:active {
-	background: transparent;
-}
-
-.popup {
-	border: 1px solid #606;
-}
-
-.post {
-	border-top: 2px solid #606;
-}
-
-.example {
-	border-top: 2px solid #606;
-	border-bottom: 2px solid #606;
-}
-
-.sidebar {
-	border-top: 2px solid #090;
-	border-bottom: 2px solid #090;
-}
-
-.rng {
-	border-left: 2px solid #666;
 }
 
 /* code coverage report styles */
@@ -332,29 +155,12 @@ pre.xspecCoverage > .whitespace {
 }
 
 /* text */
-ol ol li {
-	list-style: lower-alpha;
-}
-
 td {
 	vertical-align: top;
 }
 
 h1 {
 	text-transform: uppercase;
-}
-
-.question {
-	text-indent: -33px;
-}
-
-.byline {
-	text-align: right;
-}
-
-#link-top,
-#link-up {
-	text-align: right;
 }
 
 a {
@@ -369,7 +175,6 @@ body > h2:first-of-type {
 
 table {
 	width: 95%;
-	/* border: collapse; */
 }
 
 th {
@@ -386,7 +191,7 @@ div > table > tbody > tr > th:first-child {
 }
 
 .xspec tbody th {
-	font-weight: normal; /*font-size: 0.8em;*/
+	font-weight: normal;
 	border-top: 1px #666 solid;
 }
 

--- a/src/reporter/test-report-colors-blackwhite.css
+++ b/src/reporter/test-report-colors-blackwhite.css
@@ -23,9 +23,6 @@ h1 {
 h2 {
 }
 
-hr {
-}
-
 a:link {
 	color: #171717;
 	background: transparent;
@@ -43,36 +40,6 @@ a:hover {
 
 a:active {
 	color: #171717;
-	background: white;
-}
-
-#colophon,
-#xml-link,
-.note {
-	color: #454545;
-}
-
-#colophon a:link,
-#colophon a:visited,
-#colophon a:hover,
-#xml-link a:link,
-#xml-link a:visited,
-#xml-link a:hover,
-.note a:link,
-.note a:visited,
-.note a:hover {
-	color: #171717;
-	background: transparent;
-}
-
-#colophon a:hover,
-#xml-link a:hover,
-.note a:hover {
-	background: #f0f0f0;
-	color: #171717;
-}
-
-.popup {
 	background: white;
 }
 

--- a/src/reporter/test-report-colors-classic.css
+++ b/src/reporter/test-report-colors-classic.css
@@ -18,11 +18,6 @@ h2 {
 	background: #cfc;
 }
 
-hr {
-	color: #606;
-	background: white;
-}
-
 a:link {
 	color: #636;
 	background: transparent;
@@ -41,36 +36,6 @@ a:hover {
 a:active {
 	color: #6f6;
 	background: #606;
-}
-
-#colophon,
-#xml-link,
-.note {
-	color: #666;
-}
-
-#colophon a:link,
-#colophon a:visited,
-#colophon a:hover,
-#xml-link a:link,
-#xml-link a:visited,
-#xml-link a:hover,
-.note a:link,
-.note a:visited,
-.note a:hover {
-	color: #969;
-	background: transparent;
-}
-
-#colophon a:hover,
-#xml-link a:hover,
-.note a:hover {
-	background: #cfc;
-	color: #969;
-}
-
-.popup {
-	background: white;
 }
 
 .same {

--- a/src/reporter/test-report-colors-whiteblack.css
+++ b/src/reporter/test-report-colors-whiteblack.css
@@ -23,9 +23,6 @@ h1 {
 h2 {
 }
 
-hr {
-}
-
 a:link {
 	color: white;
 	background: transparent;
@@ -43,36 +40,6 @@ a:hover {
 
 a:active {
 	color: white;
-	background: #171717;
-}
-
-#colophon,
-#xml-link,
-.note {
-	color: #e6e6e6;
-}
-
-#colophon a:link,
-#colophon a:visited,
-#colophon a:hover,
-#xml-link a:link,
-#xml-link a:visited,
-#xml-link a:hover,
-.note a:link,
-.note a:visited,
-.note a:hover {
-	color: white;
-	background: transparent;
-}
-
-#colophon a:hover,
-#xml-link a:hover,
-.note a:hover {
-	background: #262626;
-	color: white;
-}
-
-.popup {
 	background: #171717;
 }
 


### PR DESCRIPTION
Fixes #2050.

In addition to relying on the analysis by @birdya22 (thanks!) and some of my own, I sanity-checked two representative reports:

- Viewed the test result report for `test/end-to-end/cases/serialize.xspec` and the coverage report for `test/end-to-end/cases-coverage/xsl-with-param-01.xspec` in a browser. Scanned the page and hovered and clicked on a few links. Looks normal.
- Modified the `test-report-base.css` file by adding a style (see below) that displays some text for each of the elements, classes, and IDs that were removed -- and also displays that text for h1. I see the text in the browser next to the h1, but that is the only instance on the page. ("Find in page" doesn't find that text, but printing to PDF and doing "find in page" there successfully finds the 1 expected instance and no others.)

```
h1::before,
hr::before,
#colophon::before,
#xml-link::before,
.note::before,
.popup::before,
dd::before,
li::before,
dl::before,
ul::before,
ol::before,
blockquote::before,
dt::before,
.link::before,
#link-up::before,
#link-top::before,
.post::before,
.example::before,
.sidebar::before,
h5::before,
h6::before,
.offsite::before,
address::before,
.string::before,
.rtf::before,
.code::before,
.boolean::before,
.question::before,
.title::before,
.img::before,
.rng::before,
.byline::before {
content:"** hello ** ";
}
```

