### PR TITLE
ci(deps): bump BaseX from 11.6 to 11.7

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.6
+BASEX_VERSION=11.7
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 11.7 (January 31, 2025) ----------------------------------------

 - [ADD] XQuery: Ordered maps, preserving the insertion order
 - [ADD] New Pipeline operator "->"
 - [ADD] XQuery 3.1 function (finally) fn:load-xquery-module
 - [ADD] New functions: fn:siblings, fn:type-of, fn:elements-to-maps
 - [ADD] New parse functions: fn:parse-csv, fn:parse-html
 - [ADD] HTML parsing: Support for both TagSoup and Validate.nu
 - [MOD] Better readable serialization of doubles, maps and arrays
 - [MOD] Store functions: only read if contents have changed
 - [MOD] RESTXQERRORS option: if disabled, write error to logs
 - [FIX] RESTXQ: Correct handling of query and form parameters
 