### PR TITLE
fix(report): consistent indentation in code coverage repor

### DIFF
--- a/src/reporter/test-report-base.css
+++ b/src/reporter/test-report-base.css
@@ -50,7 +50,6 @@ img {
 }
 
 pre {
-	padding-left: 5%;
 	margin-left: 5%;
 }
 

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -8,7 +8,7 @@
    <body>
       <h1>Test Coverage Report</h1>
       <p>Stylesheet:  <a href="../../xsl-include-01.xsl">xsl-include-01.xsl</a></p>
-      <h2>module: xsl-include-01.xsl; 14 lines</h2>
+      <h2>module: xsl-include-01.xsl; 15 lines</h2>
       <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -16,13 +16,14 @@
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:include --&gt;</span>
 07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01A.xsl" /&gt;</span>
-08: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
-09: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-include"&gt;</span>
-10: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
-11: <span class="whitespace">      </span><span class="hit">&lt;xsl:call-template name="includeTemplate01" /&gt;</span>
-12: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
-13: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-14: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01B.xsl" /&gt;</span>
+09: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
+10: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-include"&gt;</span>
+11: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
+12: <span class="whitespace">      </span><span class="hit">&lt;xsl:call-template name="includeTemplate01" /&gt;</span>
+13: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
+14: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+15: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       <h2>module: xsl-include-01A.xsl; 9 lines</h2>
       <pre class="xspecCoverage">1: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 2: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
@@ -33,5 +34,7 @@
 7: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
 8: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 9: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+      <h2>module: xsl-include-01B.xsl; 5 lines</h2>
+      <p><span class="missed">not used</span></p>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.xml
@@ -5,13 +5,13 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="9" columnNumber="37" moduleId="0" traceableId="0"/>
+   <hit lineNumber="10" columnNumber="37" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="10" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="11" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.CallTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}call-template"/>
-   <hit lineNumber="11" columnNumber="53" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="53" moduleId="0" traceableId="2"/>
    <module moduleId="1" uri="../../xsl-include-01A.xsl"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.NamedTemplate"

--- a/test/end-to-end/cases-coverage/xsl-include-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01.xsl
@@ -5,6 +5,7 @@
   -->
   <!-- xsl:include -->
   <xsl:include href="xsl-include-01A.xsl" />
+  <xsl:include href="xsl-include-01B.xsl" />
   <!-- Main template -->
   <xsl:template match="xsl-include">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-include-01B.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01B.xsl
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <!-- This file is here only so that the code coverage report
+    includes both code blocks and a "not used" paragraph. -->
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes #2062. Thanks to @birdya22 for noticing the inconsistency and proposing a solution.

I'm not sure whether to classify this change as a bug fix or a feature. The classification affects how it will show up in release notes. I'm going to pick "fix" for the pull request title here. I don't think users would interpret this change as an enticement to upgrade to the latest XSpec version the way something labeled "feature" might.
