### PR TITLE
fix(cli): make saxon script the fallback, not first try

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -55,28 +55,16 @@ die() {
     exit 1
 }
 
+# SAXON_CP and SAXON_HOME are the documented ways to point to Saxon.
+#
+# Fallback:
 # If there is a script called "saxon" and returning ok (status code 0)
 # when called with "--help", we assume this is the EXPath Packaging
 # script for Saxon [1].  If it is present, that means the user already
 # configured it, so there is no point to duplicate the logic here.
 # Just use it.
 # [1]http://code.google.com/p/expath-pkg/source/browse/trunk/saxon/pkg-saxon/src/shell/saxon
-
-if command -v saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev/null 2>&1; then
-    echo Saxon script found, use it.
-    echo
-    xslt() {
-        saxon \
-            --java -Dxspec.coverage.ignore="${TEST_DIR}" \
-            --java -Dxspec.coverage.xml="${COVERAGE_XML}" \
-            --java -Dxspec.home="${XSPEC_HOME}" \
-            --java -Dxspec.xspecfile="${XSPEC}" \
-            --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xsl "$@"
-    }
-    xquery() {
-        saxon --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xq "$@"
-    }
-else
+if [ -n "${SAXON_CP}" ] || [ -n "${SAXON_HOME}" ]; then
     xslt() {
         java \
             -Dxspec.coverage.ignore="${TEST_DIR}" \
@@ -88,6 +76,24 @@ else
     xquery() {
         java -cp "$CP" net.sf.saxon.Query ${CATALOG:+"$CATALOG"} "$@"
     }
+else
+    if command -v saxon > /dev/null 2>&1 && saxon --help | grep "EXPath Packaging" > /dev/null 2>&1; then
+        echo Saxon script found, use it.
+        echo
+        xslt() {
+            saxon \
+                --java -Dxspec.coverage.ignore="${TEST_DIR}" \
+                --java -Dxspec.coverage.xml="${COVERAGE_XML}" \
+                --java -Dxspec.home="${XSPEC_HOME}" \
+                --java -Dxspec.xspecfile="${XSPEC}" \
+                --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xsl "$@"
+        }
+        xquery() {
+            saxon --add-cp "${XSPEC_HOME}/java/" ${CATALOG:+"$CATALOG"} --xq "$@"
+        }
+    else
+        echo "Cannot find SAXON_CP, SAXON_HOME, or saxon!"
+    fi
 fi
 
 ##
@@ -129,10 +135,7 @@ fi
 unset USE_SAXON_HOME
 
 if test -z "$SAXON_CP"; then
-    if test -z "$SAXON_HOME"; then
-        echo "SAXON_CP and SAXON_HOME both not set!"
-        # die "SAXON_CP and SAXON_HOME both not set!"
-    else
+    if test -n "$SAXON_HOME"; then
         USE_SAXON_HOME=1
         for f in \
             "${SAXON_HOME}"/saxon9?e.jar \

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -522,9 +522,11 @@
 	-->
 
 	<!-- bin\xspec.bat does not support saxon script -->
-	<case ifdef="NEVER" name="invoking xspec with saxon script uses the saxon script #121 #122">
+	<case ifdef="NEVER" name="invoking xspec with saxon script uses the saxon script (as a fallback if SAXON_CP and SAXON_HOME are not set) #121 #122">
     (echo @echo Saxon script with EXPath Packaging System) > "%WORK_DIR%\saxon.bat"
     set "PATH=%PATH%;%WORK_DIR%"
+    set SAXON_CP=
+    set SAXON_HOME=
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 1 x "Saxon script found, use it."

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -522,7 +522,7 @@
 	-->
 
 	<!-- bin\xspec.bat does not support saxon script -->
-	<case ifdef="NEVER" name="invoking xspec with saxon script uses the saxon script (as a fallback if SAXON_CP and SAXON_HOME are not set) #121 #122">
+	<case ifdef="NEVER" name="invoking xspec with saxon script uses the saxon script, as a fallback if SAXON_CP and SAXON_HOME are not set #121 #122">
     (echo @echo Saxon script with EXPath Packaging System) > "%WORK_DIR%\saxon.bat"
     set "PATH=%PATH%;%WORK_DIR%"
     set SAXON_CP=
@@ -530,6 +530,14 @@
     call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
     call :verify_retval 0
     call :verify_line 1 x "Saxon script found, use it."
+	</case>
+
+	<case ifdef="NEVER" name="invoking xspec with saxon script and SAXON_CP uses SAXON_CP #2072">
+    (echo @echo Some Saxon script) > "%WORK_DIR%\saxon.bat"
+    set "PATH=%PATH%;%WORK_DIR%"
+    call :run ..\bin\xspec.bat ..\tutorial\escape-for-regex.xspec
+    call :verify_retval 0
+    call :verify_line 1 r "Creating XSpec Directory "
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -63,7 +63,7 @@ load bats-helper
     unset SAXON_CP
     myrun ../bin/xspec.sh
     [ "$status" -eq 1 ]
-    [ "${lines[0]}" = "SAXON_CP and SAXON_HOME both not set!" ]
+    [ "${lines[0]}" = "Cannot find SAXON_CP, SAXON_HOME, or saxon!" ]
     assert_regex "${lines[3]}" '^Usage: xspec '
 }
 
@@ -588,10 +588,12 @@ load bats-helper
 # saxon script
 #
 
-@test "invoking xspec with saxon script uses the saxon script #121 #122" {
+@test "invoking xspec with saxon script uses the saxon script (as a fallback if SAXON_CP and SAXON_HOME are not set) #121 #122" {
     echo "echo 'Saxon script with EXPath Packaging System'" > "${work_dir}/saxon"
     chmod +x "${work_dir}/saxon"
     export PATH="$PATH:${work_dir}"
+    unset SAXON_CP
+    unset SAXON_HOME
     myrun ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "Saxon script found, use it." ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -588,7 +588,7 @@ load bats-helper
 # saxon script
 #
 
-@test "invoking xspec with saxon script uses the saxon script (as a fallback if SAXON_CP and SAXON_HOME are not set) #121 #122" {
+@test "invoking xspec with saxon script uses the saxon script, as a fallback if SAXON_CP and SAXON_HOME are not set #121 #122" {
     echo "echo 'Saxon script with EXPath Packaging System'" > "${work_dir}/saxon"
     chmod +x "${work_dir}/saxon"
     export PATH="$PATH:${work_dir}"
@@ -597,6 +597,15 @@ load bats-helper
     myrun ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "Saxon script found, use it." ]
+}
+
+@test "invoking xspec with saxon script and SAXON_CP uses SAXON_CP #2072" {
+    echo "echo 'Some Saxon script'" > "${work_dir}/saxon"
+    chmod +x "${work_dir}/saxon"
+    export PATH="$PATH:${work_dir}"
+    myrun ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+    [ "$status" -eq 0 ]
+    assert_regex "${lines[0]}" '^Creating XSpec Directory '
 }
 
 #


### PR DESCRIPTION
The SAXON_CP and SAXON_HOME environment variables are the [documented](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux#installation) ways to indicate where to find Saxon. The "saxon" script from the EXPath Packaging System is a tested but undocumented alternative that has been implemented only on Linux and macOS. The implementation interferes with other "saxon" scripts a user might have on the path, so this pull request gives SAXON_CP and SAXON_HOME higher precedence in the logic.

Fixes #2072.

Other notes:

- It looks like #112 was trying to solve essentially the same problem that showed up in #2072: a "saxon" script on the path isn't the EXPath Packaging System's saxon script. After some discussion, the accepted fix was #124, which assumed that any other "saxon" script would accept a --help option. But it turns out that the homebrew Saxon errors out on a --help option, which led to issue 2072.
- I don't know who might be using the EXPath Packaging System, so I don't want to remove the functionality.
- This pull request leads to different behavior for users who have the EXPath Packaging System saxon script on their path and _also_ one of the environment variables (SAXON_CP, SAXON_HOME). If they want to use the saxon script, they should unset SAXON_CP and SAXON_HOME.
- @djbpitt , with this change, if you install Saxon via homebrew again and set either SAXON_CP or SAXON_HOME as documented in the wiki, you should be able to run `xspec.sh`.
