### PR TITLE
test(xslt): end-to-end coverage test for issue 2071

### DIFF
--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -252,6 +252,10 @@
 							)">
 						<xsl:text>Requires xspec/xspec#1156 to have been fixed</xsl:text>
 					</xsl:when>
+					
+					<xsl:when test="$pis = 'require-xspec-issue-2071-fixed'">
+						<xsl:text>Requires xspec/xspec#2071 to have been fixed</xsl:text>
+					</xsl:when>
 				</xsl:choose>
 			</xsl:variable>
 

--- a/test/ant/worker/generate.xsl
+++ b/test/ant/worker/generate.xsl
@@ -242,13 +242,9 @@
 							($pis = 'require-xspec-issue-1156-fixed')
 							and
 							(
-							(environment-variable('TRAVIS_OS_NAME') eq 'linux')
-							or
-							(
 							(environment-variable('GITHUB_ACTIONS') eq 'true')
 							and
 							(environment-variable('RUNNER_OS') eq 'macOS')
-							)
 							)">
 						<xsl:text>Requires xspec/xspec#1156 to have been fixed</xsl:text>
 					</xsl:when>

--- a/test/end-to-end/cases-coverage/external_issue-2071-call-function.xsl
+++ b/test/end-to-end/cases-coverage/external_issue-2071-call-function.xsl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xsl:stylesheet version="3.0" xmlns:local="http://local/xslt" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output method="text" />
 
   <xsl:function name="local:func-choose" visibility="public">
     <xsl:param name="text" />

--- a/test/end-to-end/cases-coverage/external_issue-2071-call-function.xsl
+++ b/test/end-to-end/cases-coverage/external_issue-2071-call-function.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="3.0" xmlns:local="http://local/xslt" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text" />
+
+  <xsl:function name="local:func-choose" visibility="public">
+    <xsl:param name="text" />
+    <xsl:choose>
+      <xsl:when test="$text = 'one'">
+        <xsl:text>1</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>                                                          <!-- Expected miss -->
+        <xsl:text>0</xsl:text>                                                 <!-- Expected miss -->
+      </xsl:otherwise>                                                         <!-- Expected miss -->
+    </xsl:choose>
+  </xsl:function>
+</xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/external_issue-2071-call-function.xspec
+++ b/test/end-to-end/cases-coverage/external_issue-2071-call-function.xspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xspec-test enable-coverage?>
+
+<!-- Calling a xsl:function when run-as="external" set. 
+     Related to https://saxonica.plan.io/issues/6688 as well as XSpec issue 2071. --> 
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               xmlns:local="http://local/xslt"
+               stylesheet="external_issue-2071-call-function.xsl"
+               run-as="external">
+
+  <x:scenario label="func-choose">
+    <x:call function="local:func-choose">
+      <x:param>one</x:param>
+    </x:call>
+    <x:expect label="1 returned">1</x:expect>
+  </x:scenario>
+</x:description>

--- a/test/end-to-end/cases-coverage/external_issue-2071-call-function.xspec
+++ b/test/end-to-end/cases-coverage/external_issue-2071-call-function.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xspec-test enable-coverage?>
+<?xspec-test require-xspec-issue-2071-fixed?>
 
 <!-- Calling a xsl:function when run-as="external" set. 
      Related to https://saxonica.plan.io/issues/6688 as well as XSpec issue 2071. --> 


### PR DESCRIPTION
This pull request has a new end-to-end coverage test, developed by @birdya22 and provided in a ZIP-file linked from
https://github.com/xspec/xspec/issues/2071#issuecomment-2669271632

I have configured the test not to run at the moment, because of the problem documented in #2071. After that issue is completed, the changes in 9d49aa0e5d5ee1d69ecb8184e98ae9b3d5ca0f6e should be reverted to make this test operational.