### PR TITLE
fix(report): avoid visible borders on headings

### DIFF
--- a/src/reporter/test-report-base.css
+++ b/src/reporter/test-report-base.css
@@ -102,7 +102,7 @@ code {
 /* this is to make Navigator fill the entire line */
 h1,
 h2 {
-	border: 1px solid white;
+	border: 0px solid white;
 	width: auto;
 }
 


### PR DESCRIPTION
Fixes #2077 by making the border `0px` instead of `1px`. I considered removing that style, but I thought this approach would be safer. I'm not sure how to reproduce the original problem to which the comment alludes or why the workaround worked.

With this change, I viewed a sample test result report and a sample code coverage report in Brave version 1.75.181 (uses Chromium 133.0.6943.141), Firefox version 135.0.1, and Edge version 133.0.3065.92. I made the browser narrow and wide, and I didn't see anything that looks like a line not being filled.

With the `'whiteblack'` theme, I no longer see the boxes, so #2077 is fixed. Here's a sample screen capture.

![image](https://github.com/user-attachments/assets/ffa65c8b-9191-4685-a05b-05a8549d8692)


