### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver from 5.2.5 to 5.3.0

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -24,4 +24,4 @@ XMLCALABASH_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=5.2.5
+XMLRESOLVERORG_XMLRESOLVER_VERSION=5.3.0


### PR DESCRIPTION
Release notes:
https://github.com/xmlresolver/xmlresolver/releases/tag/5.3.0

I also tried version 6.0.13, but there are some issues to address before we can upgrade to v6.