### PR TITLE
ci(deps): bump BaseX from 11.7 to 11.8

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.7
+BASEX_VERSION=11.8
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 11.8 (March 20, 2025) ------------------------------------------

 - [MOD] Lightning fast construction of ordered maps of all types
 - [MOD] fn:distinct-values, fn:duplicate-values: faster comparisons
 - [MOD] Faster map comparison (ordered and unordered)
 - [ADD] New function util:values-except
 - [ADD] XQuery 4.0 functionality (functions, %method annotation)
 - [MOD] XQuery fold functions: more early exits
 - [MOD] XQuery, fn:parse-xml: options added
 - [MOD] prof:variables: Better capture of in-scope variables
 - [FIX] Stricter permission checks when calling built-in functions