### PR TITLE
docs: w3c licenses and citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ If you wish to contribute to XSpec, please read the [contributing guidelines](ht
 
 XSpec code is released under the [MIT License](LICENSE). [Few parts of the codebase](https://github.com/xspec/xspec/blob/master/java/com/jenitennison/xslt/tests/XSLTCoverageTraceListener.java) are released under the [Mozilla Public License](https://www.mozilla.org/en-US/MPL/).
 
+Some files are derived from code examples that are licensed under the [W3C Software License](https://www.w3.org/copyright/software-license-2023/). Such files indicate their license in a code comment that includes "W3C Software License" text.
+
 The content of the XSpec wiki is released under the [Creative Commons 3.0 BY](https://creativecommons.org/licenses/by/3.0/) license.

--- a/src/common/common-utils.xqm
+++ b/src/common/common-utils.xqm
@@ -15,7 +15,7 @@ declare variable $x:xspec-namespace as xs:anyURI := xs:anyURI('http://www.jenite
 declare variable $x:apos as xs:string := "'";
 
 (:
-	Returns numeric literal of xs:decimal
+	Returns numeric literal of xs:decimal. For more information, see
 		https://www.w3.org/TR/xpath-31/#id-literals
 
 		Example:

--- a/src/common/common-utils.xsl
+++ b/src/common/common-utils.xsl
@@ -18,7 +18,7 @@
 	<xsl:variable as="xs:string" name="x:apos">'</xsl:variable>
 
 	<!--
-		Returns numeric literal of xs:decimal
+		Returns numeric literal of xs:decimal. For more information, see
 			https://www.w3.org/TR/xpath-31/#id-literals
 
 			Example:

--- a/src/common/report-sequence.xqm
+++ b/src/common/report-sequence.xqm
@@ -196,7 +196,7 @@ declare function rep:report-atomic-value(
     case xs:long               return rep:report-atomic-value-as-constructor($value)
     case xs:nonNegativeInteger return rep:report-atomic-value-as-constructor($value)
 
-    (: Numeric types which can be expressed as numeric literals:
+    (: Numeric types which can be expressed as numeric literals, based on
       https://www.w3.org/TR/xpath-31/#id-literals :)
     case xs:integer return string($value)
     case xs:decimal return x:decimal-string($value)
@@ -238,7 +238,7 @@ declare %private function rep:report-atomic-value-as-constructor(
 };
 
 (:
-  Returns URIQualifiedName of atomic value type
+  Returns URIQualifiedName of atomic value type, based on
      https://www.w3.org/TR/xquery-31/#id-types
 
   This function should be %private. But ../../test/report-sequence.xspec requires this to be exposed.

--- a/src/common/wrap.xsl
+++ b/src/common/wrap.xsl
@@ -18,7 +18,7 @@
    <xsl:function name="local:wrappable-node" as="xs:boolean">
       <xsl:param name="item" as="item()" />
 
-      <!-- Document node cannot wrap attribute node or namespace node:
+      <!-- Document node cannot wrap attribute node or namespace node, according to
          https://www.w3.org/TR/xslt-30/#err-XTDE0420 -->
       <xsl:sequence
          select="

--- a/src/compiler/base/resolve-import/gather/distinct-nodes-stable.xsl
+++ b/src/compiler/base/resolve-import/gather/distinct-nodes-stable.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:local="urn:x-xspec:compiler:base:resolve-import:gather:gather-descriptions:local"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all"
+                version="3.0">
+
+   <!-- Removes duplicate nodes from a sequence of nodes. (Removes a node if it appears
+      in a prior position of the sequence.)
+      This function does not sort nodes in document order.
+      
+      The xsl:function/xsl:sequence/@select attribute is based on the XPath expression in
+      "XPath and XQuery Functions and Operators 3.1" (W3C Recommendation 21 March 2017)
+      > "D Other Functions (Non-Normative)" > "D.4 Illustrative user-written functions"
+      > "D.4.5 eg:distinct-nodes-stable"
+      http://www.w3.org/TR/xpath-functions-31/#func-distinct-nodes-stable
+      (Modifications: Parameter name)
+   -->
+   <xsl:function name="local:distinct-nodes-stable" as="node()*">
+      <xsl:param name="nodes" as="node()*"/>
+
+      <xsl:sequence select="$nodes[empty(subsequence($nodes, 1, position() - 1) intersect .)]"/>
+   </xsl:function>
+
+</xsl:stylesheet>
+<!--
+  LICENSE NOTICE
+
+  [Copyright](https://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2017 [W3C](https://www.w3.org/)® ([MIT](https://www.csail.mit.edu/), [ERCIM](https://www.ercim.eu/), [Keio](https://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)), All Rights Reserved.
+  W3C [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), [document use](https://www.w3.org/Consortium/Legal/copyright-documents), and [software licensing](http://www.w3.org/Consortium/Legal/copyright-software) rules apply.
+
+  This software or document includes material copied from or derived from "XPath and XQuery Functions and Operators 3.1", W3C Recommendation 21 March 2017. https://www.w3.org/TR/xpath-functions-31/
+  https://www.w3.org/copyright/software-license-2023/
+  
+  Text of W3C Document License: ../../../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../../../third-party-licenses/W3C-software-license-2023.txt
+-->

--- a/src/compiler/base/resolve-import/gather/gather-descriptions.xsl
+++ b/src/compiler/base/resolve-import/gather/gather-descriptions.xsl
@@ -52,14 +52,6 @@
       Local functions
    -->
 
-   <!-- Removes duplicate nodes from a sequence of nodes. (Removes a node if it appears
-      in a prior position of the sequence.)
-      This function does not sort nodes in document order.
-      Based on http://www.w3.org/TR/xpath-functions-31/#func-distinct-nodes-stable -->
-   <xsl:function name="local:distinct-nodes-stable" as="node()*">
-      <xsl:param name="nodes" as="node()*"/>
-
-      <xsl:sequence select="$nodes[empty(subsequence($nodes, 1, position() - 1) intersect .)]"/>
-   </xsl:function>
+   <xsl:include href="distinct-nodes-stable.xsl"/>
 
 </xsl:stylesheet>

--- a/src/compiler/base/util/compiler-misc-utils.xsl
+++ b/src/compiler/base/util/compiler-misc-utils.xsl
@@ -16,9 +16,16 @@
    </xsl:function>
 
    <!-- Removes duplicate strings from a sequence of strings. (Removes a string if it appears
-     in a prior position of the sequence.)
-     Unlike fn:distinct-values(), the order of the returned sequence is stable.
-     Based on http://www.w3.org/TR/xpath-functions-31/#func-distinct-nodes-stable -->
+      in a prior position of the sequence.)
+      Unlike fn:distinct-values(), the order of the returned sequence is stable.
+
+      The xsl:function/xsl:sequence/@select attribute is similar to the XPath expression in
+      "XPath and XQuery Functions and Operators 3.1" (W3C Recommendation 21 March 2017)
+      > "D Other Functions (Non-Normative)" > "D.4 Illustrative user-written functions"
+      > "D.4.5 eg:distinct-nodes-stable"
+      http://www.w3.org/TR/xpath-functions-31/#func-distinct-nodes-stable
+      except that this function processes strings, not nodes. 
+   -->
    <xsl:function name="x:distinct-strings-stable" as="xs:string*">
       <xsl:param name="strings" as="xs:string*" />
 

--- a/src/compiler/xslt/declare-variable/declare-variable.xsl
+++ b/src/compiler/xslt/declare-variable/declare-variable.xsl
@@ -68,11 +68,8 @@
             <xsl:when test="empty(@as) and empty(@select)">
                <!--
                   Prevent the variable from being an unexpected zero-length string.
-
-                  https://www.w3.org/TR/xslt-30/#variable-values
-                        <xsl:variable name="x"/>
-                     is equivalent to
-                        <xsl:variable name="x" select="''"/>
+                  See https://www.w3.org/TR/xslt-30/#variable-values for mention of
+                  zero-length string under these attribute conditions.
                -->
                <xsl:attribute name="select" select="'()'" />
             </xsl:when>

--- a/test/xslt-package/arith/package/complex-arithmetic.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic.xsl
@@ -56,15 +56,10 @@
 <!--
   LICENSE NOTICE
   
-  This file is derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017.
-  https://www.w3.org/TR/xslt-30/
+  Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang).
+  This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
+  https://www.w3.org/copyright/software-license-2023/
   
-  That document is licensed under the W3C Document License - 2023 version.
-  Copyright © 2017 World Wide Web Consortium <https://www.w3.org/> . <https://www.w3.org/copyright/document-license-2023/>
-
-  The code examples in the document are licensed under the W3C Software License. Copyright notice:
-  Copyright © 2023 W3C®. This software or document includes material copied from or derived from XSL Transformations (XSLT) Version 3.0 (https://www.w3.org/TR/xslt-30).
-  
-  Text of W3C Document license: ../../../third-party-licenses/W3C-document-license-2023.txt
-  Text of W3C Software license: ../../../third-party-licenses/W3C-software-license-2023.txt
+  Text of W3C Document License: ../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../third-party-licenses/W3C-software-license-2023.txt
 -->

--- a/test/xslt-package/arith/package/complex-arithmetic.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic.xsl
@@ -53,3 +53,18 @@
   <!-- etc. -->
   
 </xsl:package>
+<!--
+  LICENSE NOTICE
+  
+  This file is derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017.
+  https://www.w3.org/TR/xslt-30/
+  
+  That document is licensed under the W3C Document License - 2023 version.
+  Copyright © 2017 World Wide Web Consortium <https://www.w3.org/> . <https://www.w3.org/copyright/document-license-2023/>
+
+  The code examples in the document are licensed under the W3C Software License. Copyright notice:
+  Copyright © 2023 W3C®. This software or document includes material copied from or derived from XSL Transformations (XSLT) Version 3.0 (https://www.w3.org/TR/xslt-30).
+  
+  Text of W3C Document license: ../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software license: ../../../third-party-licenses/W3C-software-license-2023.txt
+-->

--- a/test/xslt-package/arith/package/complex-arithmetic.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic.xsl
@@ -55,8 +55,10 @@
 </xsl:package>
 <!--
   LICENSE NOTICE
-  
-  Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang).
+
+  [Copyright](https://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2017 [W3C](https://www.w3.org/)® ([MIT](https://www.csail.mit.edu/), [ERCIM](https://www.ercim.eu/), [Keio](https://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)), All Rights Reserved.
+  W3C [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), [document use](https://www.w3.org/Consortium/Legal/copyright-documents), and [software licensing](http://www.w3.org/Consortium/Legal/copyright-software) rules apply.
+
   This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
   https://www.w3.org/copyright/software-license-2023/
   

--- a/test/xslt-package/arith/package/complex-arithmetic.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic.xsl
@@ -60,6 +60,6 @@
   This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
   https://www.w3.org/copyright/software-license-2023/
   
-  Text of W3C Document License: ../../../third-party-licenses/W3C-document-license-2023.txt
-  Text of W3C Software License: ../../../third-party-licenses/W3C-software-license-2023.txt
+  Text of W3C Document License: ../../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../../third-party-licenses/W3C-software-license-2023.txt
 -->

--- a/test/xslt-package/arith/package/complex-arithmetic_private.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic_private.xsl
@@ -60,8 +60,10 @@
 </xsl:package>
 <!--
   LICENSE NOTICE
-  
-  Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang).
+
+  [Copyright](https://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2017 [W3C](https://www.w3.org/)® ([MIT](https://www.csail.mit.edu/), [ERCIM](https://www.ercim.eu/), [Keio](https://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)), All Rights Reserved.
+  W3C [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), [document use](https://www.w3.org/Consortium/Legal/copyright-documents), and [software licensing](http://www.w3.org/Consortium/Legal/copyright-software) rules apply.
+
   This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
   https://www.w3.org/copyright/software-license-2023/
   

--- a/test/xslt-package/arith/package/complex-arithmetic_private.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic_private.xsl
@@ -65,6 +65,6 @@
   This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
   https://www.w3.org/copyright/software-license-2023/
   
-  Text of W3C Document License: ../../../third-party-licenses/W3C-document-license-2023.txt
-  Text of W3C Software License: ../../../third-party-licenses/W3C-software-license-2023.txt
+  Text of W3C Document License: ../../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../../third-party-licenses/W3C-software-license-2023.txt
 -->

--- a/test/xslt-package/arith/package/complex-arithmetic_private.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic_private.xsl
@@ -61,15 +61,10 @@
 <!--
   LICENSE NOTICE
   
-  This file is derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017.
-  https://www.w3.org/TR/xslt-30/
+  Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang).
+  This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
+  https://www.w3.org/copyright/software-license-2023/
   
-  That document is licensed under the W3C Document License - 2023 version.
-  Copyright © 2017 World Wide Web Consortium <https://www.w3.org/> . <https://www.w3.org/copyright/document-license-2023/>
-
-  The code examples in the document are licensed under the W3C Software License. Copyright notice:
-  Copyright © 2023 W3C®. This software or document includes material copied from or derived from XSL Transformations (XSLT) Version 3.0 (https://www.w3.org/TR/xslt-30).
-  
-  Text of W3C Document license: ../../../third-party-licenses/W3C-document-license-2023.txt
-  Text of W3C Software license: ../../../third-party-licenses/W3C-software-license-2023.txt
+  Text of W3C Document License: ../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../third-party-licenses/W3C-software-license-2023.txt
 -->

--- a/test/xslt-package/arith/package/complex-arithmetic_private.xsl
+++ b/test/xslt-package/arith/package/complex-arithmetic_private.xsl
@@ -3,7 +3,7 @@
 	Example: An example package
 		https://www.w3.org/TR/xslt-30/#packages
 	
-	@visibility is set as a shadow attribute controlled by a static param ('private' by default).
+	Modifications: @visibility is set as a shadow attribute controlled by a static param ('private' by default).
 -->
 <xsl:package
   name="http://example.org/complex-arithmetic.xsl"
@@ -58,3 +58,18 @@
   <!-- etc. -->
   
 </xsl:package>
+<!--
+  LICENSE NOTICE
+  
+  This file is derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017.
+  https://www.w3.org/TR/xslt-30/
+  
+  That document is licensed under the W3C Document License - 2023 version.
+  Copyright © 2017 World Wide Web Consortium <https://www.w3.org/> . <https://www.w3.org/copyright/document-license-2023/>
+
+  The code examples in the document are licensed under the W3C Software License. Copyright notice:
+  Copyright © 2023 W3C®. This software or document includes material copied from or derived from XSL Transformations (XSLT) Version 3.0 (https://www.w3.org/TR/xslt-30).
+  
+  Text of W3C Document license: ../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software license: ../../../third-party-licenses/W3C-software-license-2023.txt
+-->

--- a/test/xslt-package/filter/package/filter.xsl
+++ b/test/xslt-package/filter/package/filter.xsl
@@ -3,6 +3,7 @@
 	Based on
 		3.13.2 Shadow Attributes
 			https://www.w3.org/TR/xslt-30/#shadow-attributes
+	Modifications: visibility="public", namespace URI of filter function, order of writing attributes		
 -->
 <xsl:package name="http://example.org/filter.xsl" package-version="1.0" version="3.0"
 	xmlns:f="http://example.org/filter.xsl" xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -17,3 +18,15 @@
 	</xsl:function>
 
 </xsl:package>
+<!--
+  LICENSE NOTICE
+
+  [Copyright](https://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2017 [W3C](https://www.w3.org/)® ([MIT](https://www.csail.mit.edu/), [ERCIM](https://www.ercim.eu/), [Keio](https://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)), All Rights Reserved.
+  W3C [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), [document use](https://www.w3.org/Consortium/Legal/copyright-documents), and [software licensing](http://www.w3.org/Consortium/Legal/copyright-software) rules apply.
+
+  This software or document includes material copied from or derived from "XSL Transformations (XSLT) Version 3.0", W3C Recommendation 8 June 2017. https://www.w3.org/TR/xslt-30/
+  https://www.w3.org/copyright/software-license-2023/
+  
+  Text of W3C Document License: ../../../../third-party-licenses/W3C-document-license-2023.txt
+  Text of W3C Software License: ../../../../third-party-licenses/W3C-software-license-2023.txt
+-->

--- a/third-party-licenses/W3C-document-license-2023.txt
+++ b/third-party-licenses/W3C-document-license-2023.txt
@@ -1,0 +1,35 @@
+W3C DOCUMENT LICENSE
+
+License
+
+By using and/or copying this document, or the W3C document from which this statement is linked, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C document from which this statement is linked, in any medium for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the document, or portions thereof, that you use:
+
+- A link or URL to the original W3C document.
+- The pre-existing copyright notice of the original author, or if it doesn't exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright © [$date-of-document] World Wide Web Consortium. https://www.w3.org/copyright/document-license-2023/"
+- If it exists, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this NOTICE should be provided. We request that authorship attribution be provided in any software, documents, or other items or products that you create pursuant to the implementation of the contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted pursuant to this license, except as follows: To facilitate implementation of the technical specifications set forth in this document, anyone may prepare and distribute derivative works and portions of this document in software, in supporting materials accompanying software, and in documentation of software, PROVIDED that all such works include the notice below. HOWEVER, the publication of derivative works of this document for use as a technical specification is expressly prohibited.
+
+In addition, "Code Components" —Web IDL in sections clearly marked as Web IDL; and W3C-defined markup (HTML, CSS, etc.) and computer programming language code clearly marked as code examples— are licensed under the W3C Software License.
+
+The notice is:
+
+"Copyright © 2023 W3C®. This software or document includes material copied from or derived from [title and URI of the W3C document]."
+
+Disclaimers
+
+THIS DOCUMENT IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission. Title to copyright in this document will at all times remain with copyright holders.
+
+Versions
+
+This version: https://www.w3.org/copyright/document-license-2023/
+Latest version: https://www.w3.org/copyright/document-license/
+Previous version: https://www.w3.org/copyright/document-license-2015/

--- a/third-party-licenses/W3C-software-license-2023.txt
+++ b/third-party-licenses/W3C-software-license-2023.txt
@@ -1,0 +1,25 @@
+W3C SOFTWARE LICENSE
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
+
+- The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+- Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C software and document short notice should be included.
+- Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [$year-of-document] World Wide Web Consortium. https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.
+
+Versions
+
+This version: https://www.w3.org/copyright/software-license-2023/
+Latest version: https://www.w3.org/copyright/software-license/
+Previous version: https://www.w3.org/copyright/software-license-2015/


### PR DESCRIPTION
The XSpec repo has some test files and other code that is copied or derived from W3C specification documents. This pull request attempts to carry out the requirements of the W3C licenses, as a good-faith effort by a layperson without a legal background. I followed the XSLT 3 spec to its GitHub source's license file, https://github.com/w3c/qtspecs/blob/master/LICENSE.md, which points to https://www.w3.org/copyright/document-license-2023/ which in turn points to https://www.w3.org/copyright/software-license-2023/ in a paragraph that mentions code examples.

The license notice in the two .xsl files here will also be needed in new test files for #2082.