### PR TITLE
fix: reject x:call that doesn't say what to call

### DIFF
--- a/src/compiler/xslt/compile/compile-scenario.xsl
+++ b/src/compiler/xslt/compile/compile-scenario.xsl
@@ -45,6 +45,15 @@
             </xsl:call-template>
          </xsl:message>
       </xsl:if>
+      <xsl:if test="$call[$run-sut-now][not(@template) and not(@function)]">
+         <xsl:message terminate="yes">
+            <xsl:call-template name="x:prefix-diag-message">
+               <xsl:with-param name="message" as="xs:string">
+                  <xsl:text expand-text="yes">{name($call)} must specify a function or template to call</xsl:text>
+               </xsl:with-param>
+            </xsl:call-template>
+         </xsl:message>
+      </xsl:if>
       <xsl:if test="$context and $call/@function and not($is-external)">
          <xsl:message terminate="yes">
             <xsl:call-template name="x:prefix-diag-message">

--- a/test/error-compiling-scenario/call-both-function-and-template.xspec
+++ b/test/error-compiling-scenario/call-both-function-and-template.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="x:call both with @function and @template">
+	<x:scenario label="x:call with both @function and @template">
 		<x:call function="my-function" template="my-template" />
 		<x:expect label="should be error" test="true()" />
 	</x:scenario>

--- a/test/error-compiling-scenario/call-neither-function-nor-template.xspec
+++ b/test/error-compiling-scenario/call-neither-function-nor-template.xspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
+	<x:scenario label="x:call with neither @function nor @template">
+		<x:call function="true"/>
+		<x:scenario label="but inheriting one of those attributes from ancestor scenario">
+			<x:call />
+			<x:expect label="should compile successfully" test="true()" />
+		</x:scenario>
+	</x:scenario>
+	<x:scenario label="x:call with neither @function nor @template">
+		<x:call />
+		<x:scenario label="but inheriting one of those attributes from descendant scenario">
+			<x:call function="true" />
+			<x:expect label="should compile successfully" test="true()" />
+		</x:scenario>
+	</x:scenario>
+	<x:scenario label="x:call with neither @function nor @template, not even through inheritance">
+		<x:call />
+		<x:expect label="should be error" test="true()" />
+	</x:scenario>
+</x:description>

--- a/test/error-compiling-scenario/context-both-href-and-content.xspec
+++ b/test/error-compiling-scenario/context-both-href-and-content.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="../do-nothing.xsl" xmlns:x="http://www.jenitennison.com/xslt/xspec">
-	<x:scenario label="x:context both with @href and content">
+	<x:scenario label="x:context with both @href and content">
 		<x:context href="context-doc.href">
 			<context-child />
 		</x:context>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2448,6 +2448,13 @@
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
+	<case name="x:call with neither @function nor @template">
+    call :run ..\bin\xspec.bat error-compiling-scenario\call-neither-function-nor-template.xspec
+    call :verify_retval 2
+    call :verify_line  6 x "ERROR in x:scenario ('x:call with neither @function nor @template, not even through inheritance'): x:call must specify a function or template to call"
+    call :verify_line -1 x "*** Error compiling the test suite"
+	</case>
+    
 	<case name="x:call[@function] with x:context">
     call :run ..\bin\xspec.bat error-compiling-scenario\function-with-context.xspec
     call :verify_retval 2

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -2437,14 +2437,14 @@
 	<case name="x:context with both @href and content">
     call :run ..\bin\xspec.bat error-compiling-scenario\context-both-href-and-content.xspec
     call :verify_retval 2
-    call :verify_line  6 x "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element"
+    call :verify_line  6 x "ERROR in x:scenario ('x:context with both @href and content'): Can't set the context document using both the href attribute and the content of the x:context element"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 
 	<case name="x:call with both @function and @template">
     call :run ..\bin\xspec.bat error-compiling-scenario\call-both-function-and-template.xspec
     call :verify_retval 2
-    call :verify_line  6 x "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time"
+    call :verify_line  6 x "ERROR in x:scenario ('x:call with both @function and @template'): Can't call a function and a template at the same time"
     call :verify_line -1 x "*** Error compiling the test suite"
 	</case>
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2598,6 +2598,13 @@ load bats-helper
     [ "${lines[${#lines[@]} - 1]}" = "*** Error compiling the test suite" ]
 }
 
+@test "x:call with neither @function nor @template" {
+    myrun ../bin/xspec.sh error-compiling-scenario/call-neither-function-nor-template.xspec
+    [ "$status" -eq 1 ]
+    [ "${lines[5]}" = "ERROR in x:scenario ('x:call with neither @function nor @template, not even through inheritance'): x:call must specify a function or template to call" ]
+    [ "${lines[${#lines[@]} - 1]}" = "*** Error compiling the test suite" ]
+}
+
 @test "x:call[@function] with x:context" {
     myrun ../bin/xspec.sh error-compiling-scenario/function-with-context.xspec
     [ "$status" -eq 1 ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2587,14 +2587,14 @@ load bats-helper
 @test "x:context with both @href and content" {
     myrun ../bin/xspec.sh error-compiling-scenario/context-both-href-and-content.xspec
     [ "$status" -eq 1 ]
-    [ "${lines[5]}" = "ERROR in x:scenario ('x:context both with @href and content'): Can't set the context document using both the href attribute and the content of the x:context element" ]
+    [ "${lines[5]}" = "ERROR in x:scenario ('x:context with both @href and content'): Can't set the context document using both the href attribute and the content of the x:context element" ]
     [ "${lines[${#lines[@]} - 1]}" = "*** Error compiling the test suite" ]
 }
 
 @test "x:call with both @function and @template" {
     myrun ../bin/xspec.sh error-compiling-scenario/call-both-function-and-template.xspec
     [ "$status" -eq 1 ]
-    [ "${lines[5]}" = "ERROR in x:scenario ('x:call both with @function and @template'): Can't call a function and a template at the same time" ]
+    [ "${lines[5]}" = "ERROR in x:scenario ('x:call with both @function and @template'): Can't call a function and a template at the same time" ]
     [ "${lines[${#lines[@]} - 1]}" = "*** Error compiling the test suite" ]
 }
 


### PR DESCRIPTION
If `x:call` is ready to run the SUT but does not have either a `function` or `template` attribute on that element or through inheritance, then there is nothing to call. This commit adds a user-facing error message for that situation.

Without this change, the situation leads to a user-unfriendly error from the compiler:
```
src\compiler\xslt\compile\compile-scenario.xsl:198:34: Fatal Error!
Conditional expression: None of the conditions is satisfied, so an empty sequence is returned,
but this is not allowed as the value of variable $invocation-type
```