### PR TITLE
fix(report): xsl:evaluate coverage is known

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -336,14 +336,8 @@ Although it seems more like a declaration than an instruction, it isn't a direct
 | PARENT   |                              |
 | CHILDREN | xsl:fallback, xsl:with-param |
 | CONTENT  |                              |
-| TRACE    | Column number 0              |
-| RULE     | Use Descendant Data          |
-
-#### Comment
-
-Column 0 in XSpec trace and Saxon trace.
-
-There is an alternate option of accepting the trace output for now and saying if the node is xsl:evaluate then check column number 0 (the chance of 2 xsl:evaluate elements on the same line is low).
+| TRACE    | Yes                          |
+| RULE     | Use Trace Data               |
 
 ## xsl:expose
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -138,8 +138,7 @@
     <!-- Use Descendant Data -->
     <xsl:template
         match="
-        XSLT:evaluate
-        | XSLT:fallback
+        XSLT:fallback
         | XSLT:map
         | XSLT:map-entry
         | XSLT:matching-substring
@@ -360,7 +359,6 @@
     <xsl:template match="
         XSLT:assert
         | XSLT:catch
-        | XSLT:evaluate (: Not sure if this should be listed here :)
         | XSLT:fallback
         | XSLT:iterate/XSLT:param
         | XSLT:map

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-evaluate-01-coverage.html
@@ -31,9 +31,9 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />37</th>
-               <th class="totals emphasis">missed<br />0</th>
-               <th class="totals">unknown<br />4</th>
+               <th class="totals">hit<br />39</th>
+               <th class="totals emphasis">missed<br />1</th>
+               <th class="totals">unknown<br />1</th>
                <th class="totals">lines<br />69</th>
             </tr>
          </thead>
@@ -41,15 +41,15 @@
             <tr class="successful">
                <th><a href="#module1">xsl-evaluate-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">37</th>
-               <th class="totals">0</th>
-               <th class="totals">4</th>
+               <th class="totals">39</th>
+               <th class="totals">1</th>
+               <th class="totals">1</th>
                <th class="totals">69</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-evaluate-01.xsl<span class="scenario-totals">hit: 37 / missed: 0 / unknown: 4</span></h2>
+         <h2 class="successful">module: xsl-evaluate-01.xsl<span class="scenario-totals">hit: 39 / missed: 1 / unknown: 1</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -79,11 +79,11 @@
 27: <span class="whitespace">        </span><span class="hit">&lt;xsl:for-each select="$data/data"&gt;</span>
 28: <span class="whitespace">          </span><span class="hit">&lt;node type="evaluate"&gt;</span>
 29: <span class="whitespace">            </span><span class="hit">&lt;xsl:value-of&gt;</span>
-30: <span class="whitespace">              </span><span class="unknown">&lt;xsl:evaluate xpath="$sortKey" context-item="."  /&gt;</span><span class="whitespace">                </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+30: <span class="whitespace">              </span><span class="hit">&lt;xsl:evaluate xpath="$sortKey" context-item="."  /&gt;</span>
 31: <span class="whitespace">            </span><span class="hit">&lt;/xsl:value-of&gt;</span>
 32: <span class="whitespace">          </span><span class="hit">&lt;/node&gt;</span>
 33: <span class="whitespace">        </span><span class="hit">&lt;/xsl:for-each&gt;</span>
-34: <span class="whitespace">        </span>
+34: 
 35: <span class="whitespace">        </span><span class="comment">&lt;!-- Circuitous ways to get $data/data[2] content --&gt;</span>
 36: <span class="whitespace">        </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
 37: <span class="whitespace">        </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
@@ -102,12 +102,12 @@
 50: <span class="whitespace">        </span><span class="hit">&lt;/node&gt;</span>
 51: 
 52: <span class="whitespace">        </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamAttr"&gt;</span>
-53: <span class="whitespace">          </span><span class="unknown">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"</span>
-54: <span class="unknown">            with-params="map{QName('','index'): $index }" /&gt;</span><span class="whitespace">                   </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+53: <span class="whitespace">          </span><span class="hit">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"</span>
+54: <span class="hit">            with-params="map{QName('','index'): $index }" /&gt;</span>
 55: <span class="whitespace">        </span><span class="hit">&lt;/xsl:variable&gt;</span>
 56: <span class="whitespace">        </span><span class="hit">&lt;xsl:if test="exists(nonexistent)"&gt;</span>
-57: <span class="whitespace">          </span><span class="unknown">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"</span>
-58: <span class="unknown">            with-params="map{QName('','index'): $index }" /&gt;</span><span class="whitespace">                   </span><span class="comment">&lt;!-- Expected unknown --&gt;</span><span class="whitespace">          </span>
+57: <span class="whitespace">          </span><span class="missed">&lt;xsl:evaluate xpath="'string(data[$index])'" context-item="$data"</span>
+58: <span class="missed">            with-params="map{QName('','index'): $index }" /&gt;</span><span class="whitespace">                   </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 59: <span class="whitespace">        </span><span class="hit">&lt;/xsl:if&gt;</span>
 60: <span class="whitespace">        </span><span class="hit">&lt;node type="evaluate/with-param executed unknown"&gt;</span>
 61: <span class="whitespace">          </span><span class="hit">&lt;xsl:value-of select="$evaluatedExpressionParamAttr" /&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-with-param-01-coverage.html
@@ -31,9 +31,9 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />53</th>
-               <th class="totals emphasis">missed<br />13</th>
-               <th class="totals">unknown<br />6</th>
+               <th class="totals">hit<br />57</th>
+               <th class="totals emphasis">missed<br />15</th>
+               <th class="totals">unknown<br />0</th>
                <th class="totals">lines<br />130</th>
             </tr>
          </thead>
@@ -41,9 +41,9 @@
             <tr class="successful">
                <th><a href="#module1">xsl-with-param-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">45</th>
-               <th class="totals">13</th>
-               <th class="totals">6</th>
+               <th class="totals">49</th>
+               <th class="totals">15</th>
+               <th class="totals">0</th>
                <th class="totals">111</th>
             </tr>
             <tr class="successful">
@@ -57,7 +57,7 @@
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-with-param-01.xsl<span class="scenario-totals">hit: 45 / missed: 13 / unknown: 6</span></h2>
+         <h2 class="successful">module: xsl-with-param-01.xsl<span class="scenario-totals">hit: 49 / missed: 15 / unknown: 0</span></h2>
          <pre class="xspecCoverage">001: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 002: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 003: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -103,10 +103,10 @@
 043: <span class="whitespace">      </span><span class="comment">&lt;!-- Evaluate with-param (200) --&gt;</span>
 044: <span class="whitespace">      </span><span class="hit">&lt;xsl:variable name="index" select="2" /&gt;</span>
 045: <span class="whitespace">      </span><span class="hit">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span>
-046: <span class="whitespace">        </span><span class="unknown">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span><span class="whitespace">         </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-047: <span class="whitespace">          </span><span class="unknown">&lt;xsl:with-param name="index" select="$index" /&gt;</span><span class="whitespace">                      </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-048: <span class="whitespace">          </span><span class="unknown">&lt;xsl:with-param name="nonexistent"&gt;</span><span class="unknown">unused parameter</span><span class="unknown">&lt;/xsl:with-param&gt;</span><span class="whitespace"> </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-049: <span class="whitespace">        </span><span class="unknown">&lt;/xsl:evaluate&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+046: <span class="whitespace">        </span><span class="hit">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span>
+047: <span class="whitespace">          </span><span class="hit">&lt;xsl:with-param name="index" select="$index" /&gt;</span>
+048: <span class="whitespace">          </span><span class="hit">&lt;xsl:with-param name="nonexistent"&gt;</span><span class="hit">unused parameter</span><span class="hit">&lt;/xsl:with-param&gt;</span>
+049: <span class="whitespace">        </span><span class="hit">&lt;/xsl:evaluate&gt;</span>
 050: <span class="whitespace">      </span><span class="hit">&lt;/xsl:variable&gt;</span>
 051: <span class="whitespace">      </span><span class="hit">&lt;node type="with-param - evaluate"&gt;</span>
 052: <span class="whitespace">        </span><span class="hit">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span>
@@ -126,9 +126,9 @@
 066: <span class="whitespace">          </span><span class="missed">&lt;xsl:with-param name="withParam-NM-Param01" select="0" /&gt;</span><span class="whitespace">            </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 067: <span class="whitespace">        </span><span class="missed">&lt;/xsl:next-match&gt;</span><span class="whitespace">                                                      </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 068: <span class="whitespace">        </span><span class="missed">&lt;xsl:variable name="evaluatedExpressionParamChild"&gt;</span><span class="whitespace">                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-069: <span class="whitespace">          </span><span class="unknown">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span><span class="whitespace">       </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-070: <span class="whitespace">            </span><span class="unknown">&lt;xsl:with-param name="index" select="$index" /&gt;</span><span class="whitespace">                    </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-071: <span class="whitespace">          </span><span class="unknown">&lt;/xsl:evaluate&gt;</span><span class="whitespace">                                                      </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+069: <span class="whitespace">          </span><span class="missed">&lt;xsl:evaluate xpath="'string(node[$index])'" context-item="."&gt;</span><span class="whitespace">       </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+070: <span class="whitespace">            </span><span class="missed">&lt;xsl:with-param name="index" select="$index" /&gt;</span><span class="whitespace">                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+071: <span class="whitespace">          </span><span class="missed">&lt;/xsl:evaluate&gt;</span><span class="whitespace">                                                      </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 072: <span class="whitespace">        </span><span class="missed">&lt;/xsl:variable&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 073: <span class="whitespace">        </span><span class="missed">&lt;xsl:value-of select="$evaluatedExpressionParamChild" /&gt;</span><span class="whitespace">               </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 074: <span class="whitespace">      </span><span class="hit">&lt;/xsl:if&gt;</span>

--- a/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-evaluate-01.xsl
@@ -27,11 +27,11 @@
         <xsl:for-each select="$data/data">
           <node type="evaluate">
             <xsl:value-of>
-              <xsl:evaluate xpath="$sortKey" context-item="."  />                <!-- Expected unknown -->
+              <xsl:evaluate xpath="$sortKey" context-item="."  />
             </xsl:value-of>
           </node>
         </xsl:for-each>
-        
+
         <!-- Circuitous ways to get $data/data[2] content -->
         <xsl:variable name="index" select="2" />
         <xsl:variable name="evaluatedExpressionParamChild">
@@ -51,11 +51,11 @@
 
         <xsl:variable name="evaluatedExpressionParamAttr">
           <xsl:evaluate xpath="'string(data[$index])'" context-item="$data"
-            with-params="map{QName('','index'): $index }" />                   <!-- Expected unknown -->
+            with-params="map{QName('','index'): $index }" />
         </xsl:variable>
         <xsl:if test="exists(nonexistent)">
           <xsl:evaluate xpath="'string(data[$index])'" context-item="$data"
-            with-params="map{QName('','index'): $index }" />                   <!-- Expected unknown -->          
+            with-params="map{QName('','index'): $index }" />                   <!-- Expected miss -->
         </xsl:if>
         <node type="evaluate/with-param executed unknown">
           <xsl:value-of select="$evaluatedExpressionParamAttr" />

--- a/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-with-param-01.xsl
@@ -43,10 +43,10 @@
       <!-- Evaluate with-param (200) -->
       <xsl:variable name="index" select="2" />
       <xsl:variable name="evaluatedExpressionParamChild">
-        <xsl:evaluate xpath="'string(node[$index])'" context-item=".">         <!-- Expected unknown -->
-          <xsl:with-param name="index" select="$index" />                      <!-- Expected unknown -->
-          <xsl:with-param name="nonexistent">unused parameter</xsl:with-param> <!-- Expected unknown -->
-        </xsl:evaluate>                                                        <!-- Expected unknown -->
+        <xsl:evaluate xpath="'string(node[$index])'" context-item=".">
+          <xsl:with-param name="index" select="$index" />
+          <xsl:with-param name="nonexistent">unused parameter</xsl:with-param>
+        </xsl:evaluate>
       </xsl:variable>
       <node type="with-param - evaluate">
         <xsl:value-of select="$evaluatedExpressionParamChild" />
@@ -66,9 +66,9 @@
           <xsl:with-param name="withParam-NM-Param01" select="0" />            <!-- Expected miss -->
         </xsl:next-match>                                                      <!-- Expected miss -->
         <xsl:variable name="evaluatedExpressionParamChild">                    <!-- Expected miss -->
-          <xsl:evaluate xpath="'string(node[$index])'" context-item=".">       <!-- Expected unknown -->
-            <xsl:with-param name="index" select="$index" />                    <!-- Expected unknown -->
-          </xsl:evaluate>                                                      <!-- Expected unknown -->
+          <xsl:evaluate xpath="'string(node[$index])'" context-item=".">       <!-- Expected miss -->
+            <xsl:with-param name="index" select="$index" />                    <!-- Expected miss -->
+          </xsl:evaluate>                                                      <!-- Expected miss -->
         </xsl:variable>                                                        <!-- Expected miss -->
         <xsl:value-of select="$evaluatedExpressionParamChild" />               <!-- Expected miss -->
       </xsl:if>


### PR DESCRIPTION
This pull request contains the XSLT change, test comment updates, and documentation update by @birdya22 from the ZIP-file linked from #2113. The XSLT change makes the coverage status of `xsl:evaluate` follow from the trace data instead of using the status 'unknown'.

I reviewed the files, which all look good to me. Thanks, @birdya22 !

Fixes #2113.