### PR TITLE
ci(deps): bump Saxon from 12.5 to 12.7 (except coverage)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>12.5</version>
+      <version>12.7</version>
     </dependency>
   </dependencies>
 

--- a/test/ci/env/saxon-12.env
+++ b/test/ci/env/saxon-12.env
@@ -2,5 +2,5 @@
 # Latest Saxon 12
 #
 SAXON_URL=https://github.com/Saxonica/Saxon-HE/raw/main/12/Java
-SAXON_VERSION=12.5
+SAXON_VERSION=12.7
 XMLCALABASH_VERSION=1.5.7-120


### PR DESCRIPTION
* Skip Saxon 12.6 because it does not support Java 8.
* Retain 12.4 for code coverage testing with Ant, until the discussion in #2112 is complete. If the conclusion there is to use 12.7 for code coverage testing, that will be a separate pull request involving the `test/ci/env/codecoverage.env` file. (#1991 created the split between testing of code coverage and everything else.)

Cc: @birdya22 as an FYI