### PR TITLE
test: typo: change oridinary to ordinary

### DIFF
--- a/test/end-to-end/cases/expected/query/serialize-result.html
+++ b/test/end-to-end/cases/expected/query/serialize-result.html
@@ -591,10 +591,10 @@
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
+   &lt;<span class="inner-diff">ordinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">actual</span>&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;<span class="inner-diff">significant-whitespace-only-text-node</span>&gt;
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">\t\n\r␣</span>&lt;/diff&gt;
@@ -604,10 +604,10 @@
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
+   &lt;<span class="inner-diff">ordinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">expect</span>&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;<span class="inner-diff">significant-whitespace-only-text-node</span>&gt;
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">␣\t\n\r</span>&lt;/diff&gt;
@@ -633,10 +633,10 @@
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
                            <pre>&lt;test <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;oridinary-text-node&gt;
+   &lt;ordinary-text-node&gt;
       &lt;same&gt;same&lt;/same&gt;
       &lt;diff&gt;actual&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;significant-whitespace-only-text-node&gt;
       &lt;same xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;diff xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/diff&gt;

--- a/test/end-to-end/cases/expected/query/serialize-result.xml
+++ b/test/end-to-end/cases/expected/query/serialize-result.xml
@@ -293,10 +293,10 @@
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element(test)">
                <test>
-                  <oridinary-text-node>
+                  <ordinary-text-node>
                      <same>same</same>
                      <diff>actual</diff>
-                  </oridinary-text-node>
+                  </ordinary-text-node>
                   <significant-whitespace-only-text-node>
                      <same xml:space="preserve">	
 &#xD; </same>
@@ -310,10 +310,10 @@
       <result select="/element()">
          <content-wrap xmlns="">
             <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
-               <oridinary-text-node>
+               <ordinary-text-node>
                   <same>same</same>
                   <diff>actual</diff>
-               </oridinary-text-node>
+               </ordinary-text-node>
                <significant-whitespace-only-text-node>
                   <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/xspec">	
 &#xD; </ws></same>
@@ -329,10 +329,10 @@
          <expect select="/element()">
             <content-wrap xmlns="">
                <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                  <oridinary-text-node>
+                  <ordinary-text-node>
                      <same>same</same>
                      <diff>expect</diff>
-                  </oridinary-text-node>
+                  </ordinary-text-node>
                   <significant-whitespace-only-text-node>
                      <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/xspec">	
 &#xD; </ws></same>

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.html
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.html
@@ -590,10 +590,10 @@
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
+   &lt;<span class="inner-diff">ordinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">actual</span>&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;<span class="inner-diff">significant-whitespace-only-text-node</span>&gt;
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">\t\n\r␣</span>&lt;/diff&gt;
@@ -603,10 +603,10 @@
                         <td>
                            <p>XPath <code class="same">/element()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">test</span> <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;<span class="inner-diff">oridinary-text-node</span>&gt;
+   &lt;<span class="inner-diff">ordinary-text-node</span>&gt;
       &lt;<span class="same">same</span>&gt;<span class="same">same</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span>&gt;<span class="diff">expect</span>&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;<span class="inner-diff">significant-whitespace-only-text-node</span>&gt;
       &lt;<span class="same">same</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="same whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;<span class="inner-diff">diff</span> <span class="same">xml:space</span>=<span class="same">"preserve"</span>&gt;<span class="diff whitespace">␣\t\n\r</span>&lt;/diff&gt;
@@ -632,10 +632,10 @@
                         <td>
                            <p>XPath <code>/element()</code> from:</p>
                            <pre>&lt;test <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;
-   &lt;oridinary-text-node&gt;
+   &lt;ordinary-text-node&gt;
       &lt;same&gt;same&lt;/same&gt;
       &lt;diff&gt;actual&lt;/diff&gt;
-   &lt;/oridinary-text-node&gt;
+   &lt;/ordinary-text-node&gt;
    &lt;significant-whitespace-only-text-node&gt;
       &lt;same xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/same&gt;
       &lt;diff xml:space="preserve"&gt;<span class="whitespace">\t\n\r␣</span>&lt;/diff&gt;

--- a/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/serialize-result.xml
@@ -292,10 +292,10 @@
                  function="Q{x-urn:test:mirror}param-mirror">
             <x:param as="element(test)">
                <test>
-                  <oridinary-text-node>
+                  <ordinary-text-node>
                      <same>same</same>
                      <diff>actual</diff>
-                  </oridinary-text-node>
+                  </ordinary-text-node>
                   <significant-whitespace-only-text-node>
                      <same xml:space="preserve">	
 &#xD; </same>
@@ -309,10 +309,10 @@
       <result select="/element()">
          <content-wrap xmlns="">
             <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
-               <oridinary-text-node>
+               <ordinary-text-node>
                   <same>same</same>
                   <diff>actual</diff>
-               </oridinary-text-node>
+               </ordinary-text-node>
                <significant-whitespace-only-text-node>
                   <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/xspec">	
 &#xD; </ws></same>
@@ -328,10 +328,10 @@
          <expect select="/element()">
             <content-wrap xmlns="">
                <test xmlns:x="http://www.jenitennison.com/xslt/xspec">
-                  <oridinary-text-node>
+                  <ordinary-text-node>
                      <same>same</same>
                      <diff>expect</diff>
-                  </oridinary-text-node>
+                  </ordinary-text-node>
                   <significant-whitespace-only-text-node>
                      <same xml:space="preserve"><ws xmlns="http://www.jenitennison.com/xslt/xspec">	
 &#xD; </ws></same>

--- a/test/end-to-end/cases/serialize.xspec
+++ b/test/end-to-end/cases/serialize.xspec
@@ -178,10 +178,10 @@
 		<x:call function="Q{x-urn:test:mirror}param-mirror">
 			<x:param as="element(test)">
 				<test>
-					<oridinary-text-node>
+					<ordinary-text-node>
 						<same>same</same>
 						<diff>actual</diff>
-					</oridinary-text-node>
+					</ordinary-text-node>
 					<significant-whitespace-only-text-node>
 						<same xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</same>
 						<diff xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</diff>
@@ -193,10 +193,10 @@
 			<x:label>both in [Result] and [Expected Result] with diff, the significant text nodes
 				must be serialized with color. (xspec/xspec#386)</x:label>
 			<test>
-				<oridinary-text-node>
+				<ordinary-text-node>
 					<same>same</same>
 					<diff>expect</diff>
-				</oridinary-text-node>
+				</ordinary-text-node>
 				<significant-whitespace-only-text-node>
 					<same xml:space="preserve">&#x09;&#x0A;&#x0D;&#x20;</same>
 					<diff xml:space="preserve">&#x20;&#x09;&#x0A;&#x0D;</diff>


### PR DESCRIPTION
I noticed a typo in a word that's used as an element name in a test file. There is no effect on the functionality of the test, but I prefer to have the word "ordinary" spelled correctly. This PR fixes the test file and the generated expected result files.