### PR TITLE
refactor(xslt): change 2 global parameters to variables in compiler

### DIFF
--- a/src/compiler/base/main.xsl
+++ b/src/compiler/base/main.xsl
@@ -20,10 +20,6 @@
    -->
 
    <xsl:param name="force-focus" as="xs:string?" />
-   <xsl:param name="is-external" as="xs:boolean"
-      select="$initial-document/x:description/@run-as = 'external'" />
-   <xsl:param name="measure-time" as="xs:boolean"
-      select="$initial-document/x:description/@measure-time => x:yes-no-synonym(false())" />
 
    <!--
       Global variables
@@ -38,6 +34,11 @@
 
    <xsl:variable name="initial-document-actual-uri" as="xs:anyURI"
       select="x:document-actual-uri($initial-document)" />
+
+   <xsl:variable name="is-external" as="xs:boolean"
+      select="$initial-document/x:description/@run-as = 'external'" />
+   <xsl:variable name="measure-time" as="xs:boolean"
+      select="$initial-document/x:description/@measure-time => x:yes-no-synonym(false())" />
 
    <!--
       Accumulators for scenario-level variable declarations (x:param and x:variable)


### PR DESCRIPTION
The `x:description/@run-as` and `x:description/@measure-time` attributes enable end users to access certain XSpec features, namely, external transformations and time measurement, respectively. As far as I know, these attributes are the only intended ways for users to access to these features.

I don't know why the XSpec compiler has global parameters that appear to access the same features but bypassing the attributes.

@cmarchand or anyone on the @xspec/xspec list : Can you think of any reason why these would be global parameters (i.e., allowing override) instead of global variables? FYI, the parameters were introduced in #892 and #1397.

If there's no reason for it, I think it would be better to make them global variables. That's what this pull request does.