### PR TITLE
ci(deps): bump BaseX from 11.9 to 12.0

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=11.9
+BASEX_VERSION=12.0
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 12.0 (June 26, 2025) -------------------------------------------

  🔧 Core Upgrades
  - Java 17: better performance, long-term support
  - Jetty 12: better compatibility, future-proofing

  ✨ XQuery features, 4.0
  - Order-Preserving Maps: more intuitive & predictable data structures
  - Map performance: significantly leaner & faster, close to native Java
  - Arrays & sequences: Wrapping as arrays in constant time & vice versa
  - Pipeline Operator: clean, expressive queries with the -> operator
  - Typed constructs: structured data with item and record constructors
  - Stack Traces, finally block: better debugging, robust error-handling
  - While Clauses: better control flow in functional logic
  - Standardized CSV, JSON, and HTML Parsing, support for Validator.nu
  - Scripting: launch XQuery expressions as independent jobs
  - Profiler Optimizations: aggregation of profiled results

  🔐 Security & Admin Enhancements
  - Automatic Admin Password Generation (first startup)
  - Log Filtering, Masking & Truncation: better control over logging