### PR TITLE
docs: fix badges for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=master&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/xspec/xspec/branch/master)
 [![Azure Pipelines Build Status](https://dev.azure.com/xspec/xspec/_apis/build/status/xspec.xspec?branchName=master)](https://dev.azure.com/xspec/xspec/_build/latest?definitionId=1&branchName=master)
-[![GitHub Actions Test Workflow Status](https://github.com/xspec/xspec/workflows/Test/badge.svg?branch=master&event=push)](https://github.com/xspec/xspec/actions?query=branch%3Amaster+event%3Apush+workflow%3ATest)
-[![GitHub Actions Lint Workflow Status](https://github.com/xspec/xspec/workflows/Lint/badge.svg?branch=master&event=push)](https://github.com/xspec/xspec/actions?query=branch%3Amaster+event%3Apush+workflow%3ALint)
+[![Test](https://github.com/xspec/xspec/actions/workflows/test.yml/badge.svg?event=push)](https://github.com/xspec/xspec/actions/workflows/test.yml)
+[![Lint](https://github.com/xspec/xspec/actions/workflows/lint.yml/badge.svg?event=push)](https://github.com/xspec/xspec/actions/workflows/lint.yml)
 
 ## XSpec [![Release](https://img.shields.io/github/v/release/xspec/xspec.svg)](https://github.com/xspec/xspec/releases/latest)
 


### PR DESCRIPTION
The main README in this repo has badges to reflect status of testing workflows. The GitHub Actions badges don't seem to work; they say "no status."

![image](https://github.com/user-attachments/assets/ca44d8ef-f932-40e9-8481-d39934cd0fb6)

This PR fixes them. The original badges were for the 'push' event, so I kept that setting. I obtained the markup by following instructions about badges in the GitHub doc.

I pasted the new URLs into a browser, and they look right.

![image](https://github.com/user-attachments/assets/85ca7033-4526-446c-97d3-91e4daa6a66f)

![image](https://github.com/user-attachments/assets/2ee8dfbc-1c7f-4031-9907-377ab6e18488)