### PR TITLE
ci: bump Java from 8 to 11 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ trigger:
 jobs:
   - template: test/ci/azure-pipelines_windows.yml
     parameters:
-      jobName: Win_Java8
-      javaVersion: 8
+      jobName: Win_Java11
+      javaVersion: 11
       testOxygen: false
 
   - template: test/ci/azure-pipelines_windows.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - task: JavaToolInstaller@0
         inputs:
-          versionSpec: '8'
+          versionSpec: '11'
           jdkArchitectureOption: 'x64'
           jdkSourceOption: 'PreInstalled'
       - script: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,5 @@ jobs:
           && test/ci/print-env.sh
           && test/ci/run-core-tests.sh
           && test/ci/maven-package.sh -q
-          && test/ci/compile-java.sh -silent
-          && test/ci/last-git-status.sh
           && test/ci/test-maven-jar.sh -silent
         displayName: Test

--- a/test/ci/azure-pipelines_windows.yml
+++ b/test/ci/azure-pipelines_windows.yml
@@ -67,11 +67,5 @@ jobs:
       - script: call test\ci\maven-package.cmd --no-transfer-progress
         displayName: Maven package
 
-      - script: call test\ci\compile-java.cmd -verbose
-        displayName: Compile Java
-
-      - script: call test\ci\last-git-status.cmd
-        displayName: Check git status
-
       - script: call test\ci\test-maven-jar.cmd
         displayName: Test Maven jar

--- a/test/ci/set-env.cmd
+++ b/test/ci/set-env.cmd
@@ -103,8 +103,11 @@ rem
 rem BaseX
 rem
 
-rem BaseX 10 requires Java 11
+rem BaseX 12 requires Java 17
 java -version 2>&1 | "%SYSTEMROOT%\system32\find" " 1.8." > NUL
+if not errorlevel 1 set BASEX_VERSION=
+
+java -version 2>&1 | "%SYSTEMROOT%\system32\find" " 11." > NUL
 if not errorlevel 1 set BASEX_VERSION=
 
 if defined BASEX_VERSION (

--- a/test/ci/set-env.sh
+++ b/test/ci/set-env.sh
@@ -124,8 +124,12 @@ fi
 # BaseX
 #
 
-# BaseX 10 requires Java 11
+# BaseX 12 requires Java 17
 if java -version 2>&1 | grep -F " 1.8." > /dev/null; then
+    unset BASEX_VERSION
+fi
+
+if java -version 2>&1 | grep -F " 11." > /dev/null; then
     unset BASEX_VERSION
 fi
 


### PR DESCRIPTION
Part of #2108; see https://github.com/xspec/xspec/issues/2108#issuecomment-3233020765.