### PR TITLE
feature: Adding XML catalogs

### DIFF
--- a/catalog.xml
+++ b/catalog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+	
+	<nextCatalog catalog="src/catalog.xml" />
+	
+</catalog>

--- a/src/catalog.xml
+++ b/src/catalog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+	
+	<nextCatalog catalog="compiler/catalog.xml" />
+	<nextCatalog catalog="reporter/catalog.xml" />
+	<nextCatalog catalog="schemas/catalog.xml" />
+	<nextCatalog catalog="xproc3/catalog.xml" />
+	
+</catalog>

--- a/src/compiler/catalog.xml
+++ b/src/compiler/catalog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+		
+	<system systemId="http://www.jenitennison.com/xslt/xspec/compile-xslt-tests.xsl"
+		uri="compile-xslt-tests.xsl" />
+	
+	<system systemId="http://www.jenitennison.com/xslt/xspec/compile-xquery-tests.xsl"
+		uri="compile-xquery-tests.xsl" />
+	
+</catalog>

--- a/src/reporter/catalog.xml
+++ b/src/reporter/catalog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+	
+	<system systemId="http://www.jenitennison.com/xslt/xspec/format-xspec-report.xsl"
+		uri="format-xspec-report.xsl" />
+	
+</catalog>

--- a/src/schemas/catalog.xml
+++ b/src/schemas/catalog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+				
+	<system systemId="http://www.jenitennison.com/xslt/xspec.rnc"
+		uri="xspec.rnc" />
+	
+	<system systemId="http://www.jenitennison.com/xslt/xspec.sch"
+		uri="xspec.sch" />
+			
+</catalog>

--- a/src/xproc3/catalog.xml
+++ b/src/xproc3/catalog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+				
+	<system systemId="http://www.jenitennison.com/xslt/xspec/xproc/lib"
+		uri="harness-lib.xpl" />
+	
+	<system systemId="http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xslt"
+		uri="xslt-harness.xproc" />
+	
+	<system systemId="http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xquery"
+		uri="xquery-harness.xproc" />
+			
+</catalog>


### PR DESCRIPTION
Addresses the original reason for opening  issue #1832.  The XProc harness defaults to using a system ID in several places.  This PR seeks to add a modular XML catalog so that:

- XSpec users have the option of using this one; they don't have to write their own from scratch
- the intended resolution target for each system ID is explicitly documented 

It should have no backwards impact as it didn't exist before and won't be used at run-time unless a user explicitly specifies that it should be.

I've made it modular/broken the catalog down into multiple files because, from a development perspective:

- it's often easier to remember to update a catalog if it's in the same directory as the files it relates to (aims to address object impermanence)
- there are fewer URLs to make sense of/check per file

However, for ease of use, a user just needs to reference a single `catalog.xml` which is easy to find, at the top of the project.