### PR TITLE
fix(maven): use 3.3-snapshot between pre-release and release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>3.3.1</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery and Schematron</description>


### PR DESCRIPTION
#2165 shouldn't have changed the version number in `pom.xml` because 3.3.1 is only a release candidate. This PR switches it back to `3.3-SNAPSHOT`.

Will we have any updates to make between 3.3.1 and the final release of v3.3.x?

- If so, this pull request should be merged **first**. That way, we'll get a proper snapshot and we won't have errors from Maven attempting to recreate the v3.3.1 artifacts.
- If not, this PR won't be needed and can be closed without merging.