### PR TITLE
feat(schema): allow mixing x:variable and x:like

### DIFF
--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -198,8 +198,8 @@ like =
 ## Child scenarios can override the parameters in the context, and can provide
 ## any missing values in the <context> (for example, if the context on the parent
 ## scenario doesn't provide a mode, that could be provided by the child scenario).
-matching-scenario = (global-param | variable)*, context?, variable*,
-                    like*,
+matching-scenario = (global-param | variable)*, context?,
+                    (variable | like)*,
                     (pending-element | assertion | variable)*,
                     (pending-element | 
                      element scenario { common-scenario-attributes, 
@@ -209,8 +209,8 @@ matching-scenario = (global-param | variable)*, context?, variable*,
 ## <call> element defines the function call and the parameters passed to it
 ## and the <expect> elements test the result of the function. Child scenarios
 ## can override the parameters in the function call.
-function-scenario = (global-param | variable)*, context?, variable*, function-call?, variable*,
-                    like*,
+function-scenario = (global-param | variable)*, context?, variable*, function-call?,
+                    (variable | like)*,
                     (pending-element | assertion | variable)*,
                     (pending-element | 
                      element scenario { common-scenario-attributes,
@@ -220,8 +220,8 @@ function-scenario = (global-param | variable)*, context?, variable*, function-ca
 ## element defines the template call and the parameters passed to it and the
 ## <expect> elements test the result of the template call. Child scenarios
 ## can override the parameters in the template call.
-named-scenario = (global-param | variable)*, context?, variable*, template-call?, variable*,
-                 like*,
+named-scenario = (global-param | variable)*, context?, variable*, template-call?,
+                 (variable | like)*,
                  (pending-element | assertion | variable)*,
                  (pending-element | 
                   element scenario { common-scenario-attributes,
@@ -331,8 +331,8 @@ text-element =
 	## Text in this element is not ignored even when it's whitespace-only.
 	element text { common-attributes, text }
 
-schematron-scenario = (global-param | variable)*, context?, variable*,
-                    like*,
+schematron-scenario = (global-param | variable)*, context?,
+                    (variable | like)*,
                     (pending-element | schematron-expect | assertion | variable)*,
                     (pending-element | 
                      element scenario { common-scenario-attributes, 

--- a/test/variable-like.xspec
+++ b/test/variable-like.xspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" query="x-urn:test:do-nothing"
+    query-at="do-nothing.xqm" schematron="do-nothing.sch">
+    <x:scenario>
+        <x:label>Interspersing x:variable and x:like in a function call scenario</x:label>
+        <x:call function="one-or-more">
+            <x:param>
+                <section>
+                    <link/>
+                    <xref/>
+                </section>
+            </x:param>
+        </x:call>
+        <x:variable name="parent-name" select="'section'"/>
+        <x:like label="verify-parent"/>
+        <x:variable name="child-name" select="'link'"/>
+        <x:like label="verify-child1"/>
+        <x:variable name="child-name" select="'xref'"/>
+        <x:like label="verify-child2"/>
+    </x:scenario>
+    <x:scenario label="verify-parent" shared="yes">
+        <x:expect label="should work" test="$x:result/name()" select="$parent-name"/>
+    </x:scenario>
+    <x:scenario label="verify-child1" shared="yes">
+        <x:expect label="should work" test="$x:result/*[1]/name()" select="$child-name"/>
+    </x:scenario>
+    <x:scenario label="verify-child2" shared="yes">
+        <x:expect label="and should preserve order of elements" test="$x:result/*[2]/name()"
+            select="$child-name"/>
+    </x:scenario>
+</x:description>

--- a/test/variable-like_schematron.xspec
+++ b/test/variable-like_schematron.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="variable.sch">
+    <x:scenario>
+        <x:label>Interspersing x:variable and x:like in a Schematron scenario</x:label>
+        <x:context>
+            <mycontext role="after_context"/>
+        </x:context>
+        <x:variable name="data" select="'mycontext'"/>
+        <x:like label="verify-location-using-name"/>
+        <x:variable name="data" select="'after_context'"/>
+        <x:like label="verify-location-using-role"/>
+    </x:scenario>
+    <x:scenario label="verify-location-using-name" shared="yes">
+        <x:expect-report location="/*[name()=$data]"/>
+    </x:scenario>
+    <x:scenario label="verify-location-using-role" shared="yes">
+        <x:expect-report location="/*[@role=$data]"/>
+    </x:scenario>
+</x:description>

--- a/test/variable-like_stylesheet.xspec
+++ b/test/variable-like_stylesheet.xspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:mirror="x-urn:test:mirror" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="mirror.xsl">
+    <x:scenario>
+        <x:label>Interspersing x:variable and x:like</x:label>
+        <x:context>
+            <section>
+                <link/>
+                <xref/>
+            </section>
+        </x:context>
+        <x:scenario label="in a named template scenario">
+            <x:call template="mirror:context-mirror"/>
+            <x:like label="interspersed x:variable and x:like"/>
+        </x:scenario>
+        <x:scenario label="in a matching template rule scenario">
+            <x:context mode="mirror:context-mirror"/>
+            <x:like label="interspersed x:variable and x:like"/>
+        </x:scenario>
+    </x:scenario>
+    <x:scenario label="interspersed x:variable and x:like" shared="yes">
+        <x:variable name="parent-name" select="'section'"/>
+        <x:like label="verify-parent"/>
+        <x:variable name="child-name" select="'link'"/>
+        <x:like label="verify-child1"/>
+        <x:variable name="child-name" select="'xref'"/>
+        <x:like label="verify-child2"/>
+    </x:scenario>
+    <x:import href="variable-like.xspec"/>
+</x:description>


### PR DESCRIPTION
I can't think of a reason to forbid mixtures of `x:variable` and `x:like` elements between the part of the scenario that executes the code you're testing and the part of the scenario that verifies results. Even after looking at the schema file history in this repo and its predecessor, I suspect that the restriction wasn't specifically intended.

This pull request removes the restriction. I don't think any compiler changes are needed to support interspersing `x:variable` and `x:like` elements.