### PR TITLE
test: user content includes comment or PI

### DIFF
--- a/test/user-content-utils.xspec
+++ b/test/user-content-utils.xspec
@@ -205,14 +205,14 @@
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
-				<x:scenario label="comment as preceding sibling of x:expect/x:label">
+				<x:scenario label="comment as sibling of x:expect/x:label">
 					<x:call>
 						<x:param href="user-content-utils/is-user-content.xspec" select="(//x:expect/x:label/preceding-sibling::comment())[1]" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
-				<x:scenario label="PI as preceding sibling of x:expect/x:label">
+				<x:scenario label="PI as sibling of x:expect/x:label">
 					<x:call>
 						<x:param href="user-content-utils/is-user-content.xspec" select="(//x:expect/x:label/preceding-sibling::processing-instruction())[1]" />
 					</x:call>
@@ -255,14 +255,14 @@
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 
-				<x:scenario label="comment as preceding sibling of x:context/x:param">
+				<x:scenario label="comment as sibling of x:context/x:param">
 					<x:call>
 						<x:param href="user-content-utils/is-user-content.xspec" select="//x:context/x:param/preceding-sibling::comment()" />
 					</x:call>
 					<x:expect label="True" select="true()" />
 				</x:scenario>
 				
-				<x:scenario label="PI as preceding sibling of x:context/x:param">
+				<x:scenario label="PI as sibling of x:context/x:param">
 					<x:call>
 						<x:param href="user-content-utils/is-user-content.xspec" select="//x:context/x:param/preceding-sibling::processing-instruction()" />
 					</x:call>

--- a/test/user-content-utils/is-user-content.xspec
+++ b/test/user-content-utils/is-user-content.xspec
@@ -8,28 +8,28 @@
 				<local:foo/>
 			</param>
 		</call>
-		<scenario label="preceded by comment sibling not in actual result">
+		<scenario label="having comment sibling not in actual result">
 			<expect>
 				<!--comment is part of user content-->
 				<label>Fails because comment is part of expected result</label>
 				<local:foo/>
 			</expect>
 		</scenario>
-		<scenario label="preceded by PI sibling not in actual result">
+		<scenario label="having PI sibling not in actual result">
 			<expect>
 				<?pi node is part of user content?>
 				<label>Fails because PI is part of expected result</label>
 				<local:foo/>
 			</expect>
 		</scenario>
-		<scenario label="preceded by comment sibling, with boolean @test"
+		<scenario label="having comment sibling, with boolean @test"
 			pending="Boolean @test must not be accompanied by @as, @href, @select, or child node.">
 			<expect test="true()">
 				<!--comment is part of user content-->
 				<label>Would raise error because comment is part of expected result</label>
 			</expect>
 		</scenario>
-		<scenario label="preceded by PI sibling, with boolean @test"
+		<scenario label="having PI sibling, with boolean @test"
 			pending="Boolean @test must not be accompanied by @as, @href, @select, or child node.">
 			<expect test="true()">
 				<?pi node is part of user content?>
@@ -38,7 +38,7 @@
 		</scenario>
 	</scenario>
 	<scenario label="x:context/x:param">
-		<scenario label="preceded by comment sibling">
+		<scenario label="having comment sibling">
 			<context mode="mirror:context-mirror">
 				<!--comment is part of user content-->
 				<param name="irrelevant-param"/>
@@ -49,7 +49,7 @@
 				<local:foo/>
 			</expect>
 		</scenario>
-		<scenario label="preceded by PI sibling">
+		<scenario label="having PI sibling">
 			<context mode="mirror:context-mirror">
 				<?pi node is part of user content?>
 				<param name="irrelevant-param"/>


### PR DESCRIPTION
A comment or PI node that occurs as a preceding sibling of `x:expect/x:label` or `x:context/x:param` is taken to be part of the user content inside `x:expect` or `x:context`, respectively. This pull request adds test cases for those situations.

### A long history

I found this behavior surprising because in `x:expect[x:label]` or `x:context[x:param]`, I think of the user content as what occurs _after_ `x:label` or `x:param`. But that's not true; in reality, the user content is what _isn't_ `x:label` or `x:param`.

This behavior has been in XSpec for a long time, so I'm not looking to change it now.

I actually reproduced these cases based on the [earliest commit](https://github.com/expath/xspec/commit/54f6e15de57cf90d8180cf1896f159d9948d61ed) from 2008 in the https://github.com/expath/xspec/ repository from which this repo was forked. Here's a snapshot of part of the test report:

<img width="844" height="880" alt="image" src="https://github.com/user-attachments/assets/e9549486-c853-4f17-a543-c3cd8630039b" />

(In this experiment, the command script that I ran to execute the test suite is from the old XSpec, and the test suite is from this PR branch of the current-day XSpec.)