### PR TITLE
test: test catalog with RECOGNIZE_URI_QUERY_PARAMETERS

### DIFF
--- a/test/saxon-custom-options/catalog-rewriteURI.xml
+++ b/test/saxon-custom-options/catalog-rewriteURI.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+	<rewriteURI rewritePrefix="./" uriStartString="catalog-01:/" />
+</catalog>

--- a/test/saxon-custom-options/test.xspec
+++ b/test/saxon-custom-options/test.xspec
@@ -15,7 +15,9 @@
 				<!-- ws-only-text-copy.xml is identical to ws-only-text.xml. In Saxon 11,
 				the test fails if the same XML file is read with and without the URI
 				query parameter in the same test session.-->
-				<x:param href="ws-only-text-copy.xml?strip-space=yes;xinclude=yes" />
+				<!-- Use of XML catalog demonstrates compatibility with
+					RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later -->
+				<x:param href="catalog-01:/ws-only-text-copy.xml?strip-space=yes;xinclude=yes" />
 			</x:call>
 			<x:expect label="Whitespace-only text nodes are stripped" select="'AB'"
 				test="string($x:result)" />

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1599,9 +1599,11 @@
     set "SAXON_CONFIG=%WORK_DIR%\saxon config %RANDOM%.xml"
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
+    rem Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_ANT_LIB%" ^
+        -Dcatalog="%CD%\saxon-custom-options\catalog-rewriteURI.xml" ^
         -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" ^
         -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
     call :verify_retval 0
@@ -1617,9 +1619,11 @@
     set "SAXON_CONFIG=%WORK_DIR%\saxon config %RANDOM%.xml"
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
+    rem Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
     call :run ant ^
         -buildfile ..\build.xml ^
         -lib "%SAXON_ANT_LIB%" ^
+        -Dcatalog="%CD%\saxon-custom-options\catalog-rewriteURI.xml" ^
         -Dsaxon.custom.options="-config:""%SAXON_CONFIG%"" -t" ^
         -Dtest.type=q ^
         -Dxspec.xml="%CD%\saxon-custom-options\test.xspec"
@@ -1641,7 +1645,8 @@
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
     set "SAXON_CUSTOM_OPTIONS=-config:"%SAXON_CONFIG%" -t"
-    call :run ..\bin\xspec.bat saxon-custom-options\test.xspec
+    rem Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
+    call :run ..\bin\xspec.bat -catalog saxon-custom-options\catalog-rewriteURI.xml saxon-custom-options\test.xspec
     call :verify_retval 0
     call :verify_line -3 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
 
@@ -1655,7 +1660,8 @@
     call :copy saxon-custom-options\config.xml "%SAXON_CONFIG%"
 
     set "SAXON_CUSTOM_OPTIONS=-config:"%SAXON_CONFIG%" -t"
-    call :run ..\bin\xspec.bat -q saxon-custom-options\test.xspec
+    rem Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
+    call :run ..\bin\xspec.bat -catalog saxon-custom-options\catalog-rewriteURI.xml -q saxon-custom-options\test.xspec
     call :verify_retval 0
     call :verify_line -3 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1780,9 +1780,11 @@ load bats-helper
     xspec_properties="${work_dir}/xspec.properties"
     echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
 
+    # Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_ANT_LIB}" \
+        -Dcatalog="${PWD}/saxon-custom-options/catalog-rewriteURI.xml" \
         -Dxspec.properties="${xspec_properties}" \
         -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
     [ "$status" -eq 0 ]
@@ -1802,9 +1804,11 @@ load bats-helper
     xspec_properties="${work_dir}/xspec.properties"
     echo "saxon.custom.options=-config:\"${saxon_config}\" -t" > "${xspec_properties}"
 
+    # Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
     myrun ant \
         -buildfile ../build.xml \
         -lib "${SAXON_ANT_LIB}" \
+        -Dcatalog="${PWD}/saxon-custom-options/catalog-rewriteURI.xml" \
         -Dtest.type=q \
         -Dxspec.properties="${xspec_properties}" \
         -Dxspec.xml="${PWD}/saxon-custom-options/test.xspec"
@@ -1826,7 +1830,8 @@ load bats-helper
     cp saxon-custom-options/config.xml "${saxon_config}"
 
     export SAXON_CUSTOM_OPTIONS="\"-config:${saxon_config}\" -t"
-    myrun ../bin/xspec.sh saxon-custom-options/test.xspec
+    # Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
+    myrun ../bin/xspec.sh -catalog saxon-custom-options/catalog-rewriteURI.xml saxon-custom-options/test.xspec
     [ "$status" -eq 0 ]
     [ "${lines[${#lines[@]} - 3]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
 
@@ -1840,7 +1845,8 @@ load bats-helper
     cp saxon-custom-options/config.xml "${saxon_config}"
 
     export SAXON_CUSTOM_OPTIONS="\"-config:${saxon_config}\" -t"
-    myrun ../bin/xspec.sh -q saxon-custom-options/test.xspec
+    # Use of XML catalog demonstrates compatibility with RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later
+    myrun ../bin/xspec.sh -catalog saxon-custom-options/catalog-rewriteURI.xml -q saxon-custom-options/test.xspec
     [ "$status" -eq 0 ]
     [ "${lines[${#lines[@]} - 3]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
 


### PR DESCRIPTION
In Saxon 11, XML catalog usage is compatible with the `RECOGNIZE_URI_QUERY_PARAMETERS` option (`recognizeUriQueryParameters` in configuration file and `--recognize-uri-query-parameters` in command).

The clue was in the [Saxon doc](https://www.saxonica.com/documentation12/index.html#!changes/s9api/11-11.1), where it says
>The configuration property RECOGNIZE_URI_QUERY_PARAMETERS now applies to all calls on the doc() and document() functions, even if a user-defined URI resolver is in use.

This pull request adds catalog usage to the existing bats test case involving `RECOGNIZE_URI_QUERY_PARAMETERS`, now that we're not testing with Saxon 10 anymore.

