### PR TITLE
ci(deps): bump BaseX from 12.0 to 12.1

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=12.0
+BASEX_VERSION=12.1
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

VERSION 12.1 (December 23, 2025) ---------------------------------------

 RESTXQ
 - improved local locking for resources supplied via arguments

 Storage
 - PUT operations: replace or ignore existing resources

 XQuery
 - Cache Functions: Store transient data in main-memory LRU caches
 - Key/Value Store: All opened stores are now kept in main memory
 - faster generation and conversion of sequences and arrays
 - fn:load-xquery-module: retrieve module only once at runtime

 XQuery 4.0
 - Function declarations: The 'local' prefix can now be omitted
 - Destructuring: let $($head, $tail) := ...
 - Map construction generalized: { 1: 2, $map-entries }
 - Pseudo path function: $xml/get($node-name)
 - New node comparators (is-not, precedes, follows, ...)
 - %method annotation replace by =?> operator