### PR TITLE
fix(cli): forward slash for use with Saxon -p

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -417,7 +417,8 @@ if not exist "%TEST_DIR%" (
 
 if defined SCHEMATRON call :classify_and_process_schematron || goto :win_main_error_exit
 
-set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%-compiled"
+rem Forward slash in COMPILED is deliberate; see https://github.com/xspec/xspec/issues/2246#issuecomment-3783402532
+set "COMPILED=%TEST_DIR%/%TARGET_FILE_NAME%-compiled"
 if defined XSLT (
     set "COMPILED=%COMPILED%.xsl"
 ) else (


### PR DESCRIPTION
This pull request takes the suggestion that @birdya22 made in #2246 in the following comment:

>With my Saxon options I wanted to use `?strip-space=yes` and set `-p:on` in Saxon custom options, but got an exception (See Saxon issue [6992](https://saxonica.plan.io/issues/6992) for what caused it). While nothing to do with this XSpec issue I found that `-p:on` doesn't work with XSpec because the option causes paths to be treated as URIs and the command script uses '\\' to reference the compiled stylesheet (I know the [Controlling whitespace-only text nodes in external XML](https://github.com/xspec/xspec/wiki/Whitespace-only-Text-Nodes#controlling-whitespace-only-text-nodes-in-external-xml) recommends using `--recognize-uri-query-parameters:true` and doesn't mention `-p:on`). For the command script case on Windows a change in this line: `set "COMPILED=%TEST_DIR%\%TARGET_FILE_NAME%-compiled"` from '\\' to '/' would enable it to work.

The `COMPILED` environment variable is used in various places for all the languages that XSpec supports. Interactively on Windows 11, I set `TEST_DIR` to a value that has a mix of forward slashes and backslashes, and then I ran a sample test suite for XSLT, XSLT with coverage reporting, XQuery, Schematron via SchXslt, and Schematron via XQS. The results look normal. If either type of slash works within `TEST_DIR` then it should be fine for `COMPILED`, which is an extension of `TEST_DIR`.

That said, I'm not going so far (at the moment) to make further backslash-to-forward-slash changes in the script, unless I find out that further changes would fix something that's currently broken.