### PR TITLE
ci(deps): bump BaseX from 12.1 to 12.2

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=12.1
+BASEX_VERSION=12.2
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

```
VERSION 12.2 (January 20, 2025) ----------------------------------------

 XQUERY 4.0
 - support for private variables and functions without namespace

 PERFORMANCE
 - offset-based access to records with fixed entries
 - improved propagation/modification of static record types
 - union/intersect/except: more compile-time rewritings
 - fold functions: improved short-circuiting
 - faster general comparisons
 - JDK 17+ Optimization tweaks

 DEBUGGING
 - better error messages
 - unlimited trace output on command line

 BUG FIXES
 - RESTXQ, %input annotation: map/array construction
 - HTML serialization, script elements
```