### PR TITLE
ci: restore Maven packaging in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,9 @@ test_script:
       set PATH=%JAVA_HOME%\bin;%PATH%
       test\ci\print-env.cmd
       test\run-bats.cmd
-      rem test\ci\maven-package.cmd -q
+      test\ci\maven-package.cmd -q
       rem test\ci\compile-java.cmd -silent
       rem test\ci\last-git-status.cmd
-      rem test\ci\test-maven-jar.cmd -silent
+      test\ci\test-maven-jar.cmd -silent
 
 deploy: off


### PR DESCRIPTION
By undoing the change mentioned in https://github.com/xspec/xspec/issues/1893#issuecomment-2015639632, we can close #1893.