### PR TITLE
test: increase limit on number of Bats test cases

### DIFF
--- a/test/win-bats/stub.cmd
+++ b/test/win-bats/stub.cmd
@@ -350,7 +350,7 @@ rem
     if %CASE_NUM% GTR %NUM_CASES% goto :EOF
 
     rem Failsafe
-    if %CASE_NUM% GEQ 250 (
+    if %CASE_NUM% GEQ 280 (
         call :failed "Too many test cases"
         goto :EOF
     )


### PR DESCRIPTION
With #2227, the number of Bats test cases is 249, just under the upper bound established in `stub.cmd`. The limit is easy to forget, so I'm proactively increasing it in this pull request. Besides, #2228 adds about a dozen new Bats test cases.