### PR TITLE
fix(schematron): bind namespace prefix in tutorial and test files

### DIFF
--- a/test/schematron/schematron-019.sch
+++ b/test/schematron/schematron-019.sch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <sch:ns prefix="e" uri="example" />

--- a/tutorial/schematron/demo-02.sch
+++ b/tutorial/schematron/demo-02.sch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     queryBinding="xslt2">
     


### PR DESCRIPTION
schxslt doesn't mind that certain schemas in this repository use the `xs` prefix without binding it to a namespace URI, but schxslt2 does. This pull request fills in the missing declarations, so that #2287 won't lead to errors ` XPST0081  Namespace prefix 'xs' has not been declared` for tests that use these schemas.