### PR TITLE
fix(xproc): handle private XProc steps correctly

### DIFF
--- a/src/compiler/xproc/compile/get-step-declaration.xsl
+++ b/src/compiler/xproc/compile/get-step-declaration.xsl
@@ -69,6 +69,9 @@
     <xsl:template match="/p:library" mode="local:gather-steps">
         <xsl:apply-templates select="(p:option, p:declare-step[@type], p:import)" mode="#current"/>
     </xsl:template>
+    <xsl:template match="p:declare-step[@visibility eq 'private']" mode="local:gather-steps">
+        <!-- Skip private steps -->
+    </xsl:template>
     <xsl:template match="p:declare-step[not(@visibility eq 'private')]" mode="local:gather-steps">
         <xsl:copy>
             <xsl:attribute name="type" select="x:UQName-of-step(./@type)"/>

--- a/test/get-step-declaration.xspec
+++ b/test/get-step-declaration.xspec
@@ -36,7 +36,11 @@
                         <p:output port="result"/>
                         <p:identity/>
                     </p:declare-step>
-                    <p:declare-step type="loc-p:step3" visibility="private"/>
+                    <p:declare-step type="loc-p:step3" visibility="private">
+                        <p:input port="source" sequence="true"/>
+                        <p:output port="result"/>
+                        <p:identity/>
+                    </p:declare-step>
                 </p:library>
             </x:context>
             <x:expect>

--- a/test/xproc/cases/library-with-private-step.xpl
+++ b/test/xproc/cases/library-with-private-step.xpl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:library xmlns:s="x-urn:test:xproc:steplibrary" xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+
+    <p:declare-step type="s:public-step-that-calls-private-step">
+        <p:documentation>This step calls a private step.</p:documentation>
+        <p:input port="source"/>
+        <p:option name="some-option"/>
+        <p:output port="xproc-result"/>
+        <s:private-step some-option="{$some-option}"/>
+        <p:add-attribute attribute-name="public-step" attribute-value="{$some-option}"/>
+    </p:declare-step>
+
+    <p:declare-step type="s:private-step" visibility="private">
+        <p:input port="source"/>
+        <p:option name="some-option"/>
+        <p:output port="xproc-result"/>
+        <p:add-attribute attribute-name="private-step" attribute-value="{$some-option}"/>
+    </p:declare-step>
+
+    <p:declare-step type="s:unused-private-step" visibility="private">
+        <p:input port="source"/>
+        <p:option name="some-option"/>
+        <p:output port="xproc-result"/>
+        <p:identity/>
+    </p:declare-step>
+
+    <p:declare-step type="s:self-contained-public-step" visibility="public">
+        <p:input port="source"/>
+        <p:option name="some-option"/>
+        <p:output port="xproc-result"/>
+        <p:identity/>
+    </p:declare-step>
+
+</p:library>

--- a/test/xproc/cases/private-step-in-same-library.xspec
+++ b/test/xproc/cases/private-step-in-same-library.xspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:s="x-urn:test:xproc:steplibrary"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" version="4.0"
+    xproc="library-with-private-step.xpl">
+    <x:scenario label="Specifying an option that also exists in a private step">
+        <x:scenario label="where the public step calls the private one">
+            <x:call step="s:public-step-that-calls-private-step">
+                <x:input port="source">
+                    <root/>
+                </x:input>
+                <x:option name="some-option" select="'executed'"/>
+            </x:call>
+            <x:expect label="should work" port="xproc-result">
+                <root public-step="executed" private-step="executed"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="where the public step is self-contained">
+            <x:call step="s:self-contained-public-step">
+                <x:input port="source">
+                    <root/>
+                </x:input>
+                <x:option name="some-option"><some-value/></x:option>
+            </x:call>
+            <x:expect label="should work" port="xproc-result">
+                <root/>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+</x:description>


### PR DESCRIPTION
The `local:gather-steps` mode shouldn't put any content of private steps in the library it is building, especially not at the top level where it confuses downstream error checking.

Fixes #2296.