### PR TITLE
fix(schematron): use original xspec in XQS result

### DIFF
--- a/src/compiler/xquery/main.xsl
+++ b/src/compiler/xquery/main.xsl
@@ -123,18 +123,19 @@
 
       <xsl:call-template name="x:zero-or-more-node-constructors">
          <xsl:with-param name="nodes" as="attribute()+">
-            <xsl:attribute name="xspec" select="$initial-document-actual-uri" />
             <xsl:choose>
                <xsl:when test="exists($this/@schematron) and exists($this/@original-xspec)">
                   <!-- If this file is derived from a test for Schematron, record @schematron.
                      That way, the HTML report indicates the schema, not the XQS module. -->
-                  <xsl:attribute name="schematron" select="$this/@schematron" />                  
+                  <xsl:attribute name="xspec" select="$this/@original-xspec" />
+                  <xsl:attribute name="schematron" select="$this/@schematron" />
                </xsl:when>
                <xsl:otherwise>
+                  <xsl:attribute name="xspec" select="$initial-document-actual-uri" />
                   <xsl:attribute name="query" select="$this/@query" />
                   <xsl:if test="exists($query-at)">
                      <xsl:attribute name="query-at" select="$query-at" />
-                  </xsl:if>                  
+                  </xsl:if>
                </xsl:otherwise>
             </xsl:choose>
          </xsl:with-param>


### PR DESCRIPTION
While working on the end-to-end testing for #2291, I noticed that the result XML file from a test for Schematron via XQS has the `/x:report/@xspec` attribute pointing to the preprocessed XSpec file. To be consistent with behavior for tests for Schematron via SchXslt or SchXslt2 (and also make more sense for users), the attribute should point to the original XSpec file.

Attributes of `<report>` for a test for XQuery are unchanged. The before/after comparison below is for a sample Schematron/XQS test.

### Before
```
<report xmlns="http://www.jenitennison.com/xslt/xspec"
  xspec="file:/C:/.../tutorial/schematron-xqs/xspec/demo-01-sch-preprocessed.xspec"
  schematron="file:/C:/.../tutorial/schematron-xqs/demo-01.sch"
  date="2026-04-15T13:28:23.011-04:00">
```

### After
```
<report xmlns="http://www.jenitennison.com/xslt/xspec"
  xspec="file:/C:/.../tutorial/schematron-xqs/demo-01.xspec"
  schematron="file:/C:/.../tutorial/schematron-xqs/demo-01.sch"
  date="2026-04-15T13:27:43.343-04:00">
```