### PR TITLE
refactor: change master to main or top-level

### DIFF
--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -4,7 +4,7 @@ on:
     paths:
       - src/common/VERSION
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -3,7 +3,7 @@ name: Maven Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   maven-deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@
 ## How to contribute
 
 - [Report an issue](https://github.com/xspec/xspec/issues/new): whether you find a bug in XSpec or have a feature request, raise an issue to let us know. Please submit code examples to reproduce a bug and read the [wiki](https://github.com/xspec/xspec/wiki) to check how XSpec is supposed to work.
-- [Raise a pull request](https://github.com/xspec/xspec/pulls): all code changes in XSpec are initiated via pull requests towards the `master` branch and are usually reviewed by a maintainer or another contributor before merging. Your pull request will be automatically scanned by our CI systems so you may want to [run the test suite locally](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to avoid surprises. If possible, add a test when submitting a bug fix or a new feature and consider writing some documentation in the pull request which could be later added to the wiki. Before implementing a large feature or fix, consider discussing it first with the maintainers via an issue, this usually speeds up the review process and avoids disappointment.
+- [Raise a pull request](https://github.com/xspec/xspec/pulls): all code changes in XSpec are initiated via pull requests towards the `main` branch and are usually reviewed by a maintainer or another contributor before merging. Your pull request will be automatically scanned by our CI systems so you may want to [run the test suite locally](https://github.com/xspec/xspec/wiki/How-to-Run-the-Test-Suite-Locally) to avoid surprises. If possible, add a test when submitting a bug fix or a new feature and consider writing some documentation in the pull request which could be later added to the wiki. Before implementing a large feature or fix, consider discussing it first with the maintainers via an issue, this usually speeds up the review process and avoids disappointment.
 - [Improve the documentation](https://github.com/xspec/xspec/wiki): if you notice a gap in the documentation on the [wiki](https://github.com/xspec/xspec/wiki), raise an issue or discuss it within an existing issue or pull request. Changes in the wiki can only be made by maintainers and contributors with write permissions.
 
-All code contributions are submitted under the [MIT License](https://github.com/xspec/xspec/blob/master/LICENSE).
+All code contributions are submitted under the [MIT License](https://github.com/xspec/xspec/blob/main/LICENSE).
 
 All wiki contributions are submitted under the [Creative Commons 3.0 BY](https://creativecommons.org/licenses/by/3.0/) license.
 
@@ -36,7 +36,7 @@ This convention is enforced only in the pull request title. Each commit message 
 
 #### Type
 
-These are the valid prefixes for type (see also [the Angular documentation](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type)):
+These are the valid prefixes for type (see also [the Angular documentation](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type)):
 
 | Type       | Description                                         |
 | ---------- | --------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=master&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/xspec/xspec/branch/master)
-[![Azure Pipelines Build Status](https://dev.azure.com/xspec/xspec/_apis/build/status/xspec.xspec?branchName=master)](https://dev.azure.com/xspec/xspec/_build/latest?definitionId=1&branchName=master)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/xspec/xspec?branch=main&svg=true "AppVeyor Build Status")](https://ci.appveyor.com/project/xspec/xspec/branch/main)
+[![Azure Pipelines Build Status](https://dev.azure.com/xspec/xspec/_apis/build/status/xspec.xspec?branchName=main)](https://dev.azure.com/xspec/xspec/_build/latest?definitionId=1&branchName=main)
 [![Test](https://github.com/xspec/xspec/actions/workflows/test.yml/badge.svg?event=push)](https://github.com/xspec/xspec/actions/workflows/test.yml)
 [![Lint](https://github.com/xspec/xspec/actions/workflows/lint.yml/badge.svg?event=push)](https://github.com/xspec/xspec/actions/workflows/lint.yml)
 
@@ -21,14 +21,14 @@ Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/w
 
 XSpec is an open source project originally written by [Jeni Tennison](https://github.com/JeniT). It was maintained in the past years by [Florent Georges](https://github.com/fgeorges). Active development of XSpec restarted in 2016 and the project is currently maintained by [AirQuick](https://github.com/AirQuick), [Amanda Galtman](https://github.com/galtm) (technical development) and [Sandro Cirulli](https://github.com/cirulls) (management and community) with the help of the XSpec community.
 
-If you wish to contribute to XSpec, please read the [contributing guidelines](https://github.com/xspec/xspec/blob/master/CONTRIBUTING.md) and then [raise or pick up an issue](https://github.com/xspec/xspec/issues) and [send us your pull requests](https://github.com/xspec/xspec/pulls). Please document any issue with examples of your XSpec code.
+If you wish to contribute to XSpec, please read the [contributing guidelines](https://github.com/xspec/xspec/blob/main/CONTRIBUTING.md) and then [raise or pick up an issue](https://github.com/xspec/xspec/issues) and [send us your pull requests](https://github.com/xspec/xspec/pulls). Please document any issue with examples of your XSpec code.
 
 ## License
 
 XSpec code is released under the [MIT License](LICENSE), except:
 
 - The `lib/` directory consists of third-party code in subdirectories that each contain their own `LICENSE` files.
-- [A few parts of the codebase](https://github.com/xspec/xspec/blob/master/java/com/jenitennison/xslt/tests/XSLTCoverageTraceListener.java) are released under the [Mozilla Public License](https://www.mozilla.org/en-US/MPL/).
+- [A few parts of the codebase](https://github.com/xspec/xspec/blob/main/java/com/jenitennison/xslt/tests/XSLTCoverageTraceListener.java) are released under the [Mozilla Public License](https://www.mozilla.org/en-US/MPL/).
 - Some files are derived from code examples that are licensed under the [W3C Software License](https://www.w3.org/copyright/software-license-2023/). Such files indicate their license in a code comment that includes "W3C Software License" text.
 
 The content of the XSpec wiki is released under the [Creative Commons 3.0 BY](https://creativecommons.org/licenses/by/3.0/) license.

--- a/src/cli/terminate-on-test-failure.xsl
+++ b/src/cli/terminate-on-test-failure.xsl
@@ -4,7 +4,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet searches the test result XML and raises an error on any test failure.
+		This top-level stylesheet searches the test result XML and raises an error on any test failure.
 	-->
 
 	<xsl:include href="../common/parse-report.xsl" />

--- a/src/common/runtime-utils.xsl
+++ b/src/common/runtime-utils.xsl
@@ -3,8 +3,8 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This stylesheet is included in the compiled test runner and also serves as a master file on
-		Oxygen.
+		This stylesheet is included in the compiled test runner and also serves as a "master file"
+		in Oxygen.
 	-->
 
 	<xsl:include href="common-utils.xsl" />

--- a/src/compiler/xquery/main.xsl
+++ b/src/compiler/xquery/main.xsl
@@ -94,7 +94,7 @@
       <!-- Serialization parameters for the test result report XML -->
       <xsl:text expand-text="yes">declare option {x:known-UQName('output:parameter-document')} "{resolve-uri('../../common/xml-report-serialization-parameters.xml')}";&#x0A;</xsl:text>
 
-      <!-- Absolute URI of the master .xspec file -->
+      <!-- Absolute URI of the top-level .xspec file -->
       <xsl:call-template name="x:declare-or-let-variable">
          <xsl:with-param name="as-global" select="true()" />
          <xsl:with-param name="uqname" select="x:known-UQName('x:xspec-uri')" />

--- a/src/compiler/xslt/main.xsl
+++ b/src/compiler/xslt/main.xsl
@@ -73,11 +73,11 @@
             </variable>
          </xsl:if>
 
-         <!-- Absolute URI of the master .xspec file (Original one if specified i.e. Schematron) -->
-         <xsl:variable name="xspec-master-uri" as="xs:anyURI"
+         <!-- Absolute URI of the top-level .xspec file (Original one if specified i.e. Schematron) -->
+         <xsl:variable name="xspec-top-level-uri" as="xs:anyURI"
             select="(@original-xspec, $initial-document-actual-uri)[1] cast as xs:anyURI" />
          <variable name="{x:known-UQName('x:xspec-uri')}" as="{x:known-UQName('xs:anyURI')}">
-            <xsl:value-of select="$xspec-master-uri" />
+            <xsl:value-of select="$xspec-top-level-uri" />
          </variable>
 
          <!-- Let the compiled stylesheet know whether external or not -->
@@ -145,7 +145,7 @@
                   <xsl:attribute name="namespace" select="$x:xspec-namespace" />
 
                   <xsl:variable name="attributes" as="attribute()+">
-                     <xsl:attribute name="xspec" select="$xspec-master-uri" />
+                     <xsl:attribute name="xspec" select="$xspec-top-level-uri" />
 
                      <!-- This @stylesheet is used by ../../reporter/coverage-report.xsl -->
                      <xsl:sequence select="@stylesheet" />

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -23,7 +23,7 @@ description =
 		[ a:defaultValue = "3.1" ]
 		attribute xquery-version { text }?,
 
-		## XSLT version which will be declared in the compiled master stylesheet.
+		## XSLT version which will be declared in the compiled top-level stylesheet.
 		## This version may also activate a certain compatibility mode when
 		## evaluating expressions and comparing sequences.
 		[ a:defaultValue = "3.0" ]

--- a/test/ant/README.md
+++ b/test/ant/README.md
@@ -2,7 +2,7 @@
 
 <!-- "?v=" in the src parameter value is to invalidate cache -->
 
-![diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.github.com/xspec/xspec/master/test/ant/diagram.txt?v=1)
+![diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.github.com/xspec/xspec/main/test/ant/diagram.txt?v=1)
 
 1. Put `.xspec` files in a directory.
    - The default directory is `../` defined by `xspecfiles.dir` Ant property.

--- a/test/ci/build_test-maven-jar.xml
+++ b/test/ci/build_test-maven-jar.xml
@@ -16,7 +16,7 @@
 		<fileset refid="test-maven-jar.builtin.class.files" />
 	</delete>
 
-	<!-- Delete some master stylesheet files -->
+	<!-- Delete some top-level stylesheet files -->
 	<condition property="test-maven-jar.builtin.src.files.count.ok">
 		<resourcecount count="4">
 			<fileset dir="../../src/" id="test-maven-jar.builtin.src.files">

--- a/test/ci/run-commitlint.sh
+++ b/test/ci/run-commitlint.sh
@@ -3,4 +3,4 @@
 echo "Run commitlint"
 
 # Check PR title
-echo "${PR_TITLE}" | commitlint --help-url 'https://github.com/xspec/xspec/blob/master/CONTRIBUTING.md#code-conventions' --verbose
+echo "${PR_TITLE}" | commitlint --help-url 'https://github.com/xspec/xspec/blob/main/CONTRIBUTING.md#code-conventions' --verbose

--- a/test/end-to-end/processor/base/compare.xsl
+++ b/test/end-to-end/processor/base/compare.xsl
@@ -9,7 +9,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet is a basis for comparing the input document with the expected file.
+		This top-level stylesheet is a basis for comparing the input document with the expected file.
 			* Before comparing, the input document is normalized.
 		
 		Each processor must import this stylesheet and provide its own deserializer, normalizer and serializer.

--- a/test/end-to-end/processor/base/normalize.xsl
+++ b/test/end-to-end/processor/base/normalize.xsl
@@ -6,7 +6,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet is a basis for normalizing various reports.
+		This top-level stylesheet is a basis for normalizing various reports.
 		
 		The processor must import this stylesheet and provide its own deserializer, normalizer and serializer.
 	-->

--- a/test/end-to-end/processor/coverage/compare.xsl
+++ b/test/end-to-end/processor/coverage/compare.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet compares the coverage report HTML with the expected one.
+		This top-level stylesheet compares the coverage report HTML with the expected one.
 	-->
 
 	<xsl:import href="../base/compare.xsl" />

--- a/test/end-to-end/processor/coverage/normalize.xsl
+++ b/test/end-to-end/processor/coverage/normalize.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet normalizes the coverage report HTML.
+		This top-level stylesheet normalizes the coverage report HTML.
 	-->
 
 	<xsl:import href="../base/normalize.xsl" />

--- a/test/end-to-end/processor/coveragedata/compare.xsl
+++ b/test/end-to-end/processor/coveragedata/compare.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet compares the test result XML with the expected one.
+		This top-level stylesheet compares the test result XML with the expected one.
 	-->
 
 	<xsl:import href="../base/compare.xsl" />

--- a/test/end-to-end/processor/coveragedata/normalize.xsl
+++ b/test/end-to-end/processor/coveragedata/normalize.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet normalizes the test result XML.
+		This top-level stylesheet normalizes the test result XML.
 	-->
 
 	<xsl:import href="../base/normalize.xsl" />

--- a/test/end-to-end/processor/html/compare.xsl
+++ b/test/end-to-end/processor/html/compare.xsl
@@ -3,7 +3,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet compares the test result HTML with the expected one.
+		This top-level stylesheet compares the test result HTML with the expected one.
 	-->
 
 	<xsl:import href="../base/compare.xsl" />

--- a/test/end-to-end/processor/html/normalize.xsl
+++ b/test/end-to-end/processor/html/normalize.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet normalizes the test result HTML.
+		This top-level stylesheet normalizes the test result HTML.
 	-->
 
 	<xsl:import href="../base/normalize.xsl" />

--- a/test/end-to-end/processor/junit/compare.xsl
+++ b/test/end-to-end/processor/junit/compare.xsl
@@ -3,7 +3,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet compares the JUnit report with the expected one.
+		This top-level stylesheet compares the JUnit report with the expected one.
 	-->
 
 	<xsl:import href="../base/compare.xsl" />

--- a/test/end-to-end/processor/junit/normalize.xsl
+++ b/test/end-to-end/processor/junit/normalize.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet normalizes the JUnit report.
+		This top-level stylesheet normalizes the JUnit report.
 	-->
 
 	<xsl:import href="../base/normalize.xsl" />

--- a/test/end-to-end/processor/xml/compare.xsl
+++ b/test/end-to-end/processor/xml/compare.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet compares the test result XML with the expected one.
+		This top-level stylesheet compares the test result XML with the expected one.
 	-->
 
 	<xsl:import href="../base/compare.xsl" />

--- a/test/end-to-end/processor/xml/normalize.xsl
+++ b/test/end-to-end/processor/xml/normalize.xsl
@@ -3,7 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!--
-		This master stylesheet normalizes the test result XML.
+		This top-level stylesheet normalizes the test result XML.
 	-->
 
 	<xsl:import href="../base/normalize.xsl" />

--- a/tutorial/under-the-hood/Compilation.md
+++ b/tutorial/under-the-hood/Compilation.md
@@ -13,7 +13,7 @@
 
 ## Introduction
 
-This page is an overview of how XSpec test suites are compiled into XSLT and XQuery. It shows examples of simple test suites along with their XSpec-generated stylesheets and queries. Some of these examples are in the [test directory](https://github.com/xspec/xspec/tree/master/test).
+This page is an overview of how XSpec test suites are compiled into XSLT and XQuery. It shows examples of simple test suites along with their XSpec-generated stylesheets and queries. Some of these examples are in the [test directory](https://github.com/xspec/xspec/tree/main/test).
 
 The generated stylesheets and queries are not shown in their entirety. In particular, the code generating parts of the final report has been removed, except in examples specifically intended to show how this is done. The root elements of test suites are omitted, and indentation and comments have been added where appropriate.
 


### PR DESCRIPTION
This pull request adapts some code files to the change in default branch name, from `master` to `main`. The adaptations fall into the following categories.

| Meaning | Outcome |
|--------|--------|
| Default branch of this repo | Change to `main` |
| Primary, as in a stylesheet | Change to top-level |
| Another repo's default branch | Use current default branch name of the other repo (`master` or `main`) |
| "master file" feature in Oxygen | No change | 

Fixes #2289.