### PR TITLE
ci(maven): bump setup-maven from 5 to 5.1

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - run: gpg --version
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.9
 


### PR DESCRIPTION
This purpose of this PR is to obtain https://github.com/stCarolas/setup-maven/pull/42 and avoid the following warning from Maven Deploy ([example](https://github.com/xspec/xspec/actions/runs/24605767926)).


> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: stCarolas/setup-maven@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<img width="829" height="540" alt="image" src="https://github.com/user-attachments/assets/aa91c8a7-d328-4e88-bd48-03a6e10820b0" />
