### PR TITLE
fix(xproc): remove default value for xspec-home

### DIFF
--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -31,17 +31,11 @@
             resolve-uri('src/xproc3/harness-lib.xpl', $xspec-home)
             else
             'http://www.jenitennison.com/xslt/xspec/xproc/lib'"/>
-        <xsl:variable name="run-xslt-step"
-            select="if ($xspec-home != '') then
-            resolve-uri('src/xproc3/run-xslt.xpl', $xspec-home)
-            else
-            'http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xslt'"/>
 
         <p:declare-step name="xproc-compile-run-format" type="x:xproc-compile-run-format">
             <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
 
             <p:import href="{$harness-library}"/>
-            <p:import href="{$run-xslt-step}"/>
 
             <p:input port="source" primary="true" sequence="false" content-types="application/xml"/>
             <p:output port="result" serialization="map{{

--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet version="3.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-    <xsl:param name="xspec-home" as="xs:string" select="resolve-uri('../../../')"/>
+    <xsl:param name="xspec-home" as="xs:string?"/>
     <xsl:param name="force-focus" as="xs:string?"/>
     <xsl:param name="html-report-theme" as="xs:string" select="'default'"/>
     <xsl:include href="../../compiler/xproc/in-scope-steps/generate-xproc-imports.xsl"/>
@@ -26,12 +26,22 @@
 
     <xsl:template name="declare-harness-step" as="node()+">
         <xsl:comment>substep to run a test suite whose XProc step functions are in scope</xsl:comment>
-        <xsl:variable name="xproc3-uri" as="xs:anyURI" select="resolve-uri('src/xproc3/', $xspec-home)"/>
+        <xsl:variable name="harness-library"
+            select="if ($xspec-home != '') then
+            resolve-uri('src/xproc3/harness-lib.xpl', $xspec-home)
+            else
+            'http://www.jenitennison.com/xslt/xspec/xproc/lib'"/>
+        <xsl:variable name="run-xslt-step"
+            select="if ($xspec-home != '') then
+            resolve-uri('src/xproc3/run-xslt.xpl', $xspec-home)
+            else
+            'http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xslt'"/>
+
         <p:declare-step name="xproc-compile-run-format" type="x:xproc-compile-run-format">
             <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
 
-            <p:import href="{$xproc3-uri}harness-lib.xpl"/>
-            <p:import href="{$xproc3-uri}run-xslt.xpl"/>
+            <p:import href="{$harness-library}"/>
+            <p:import href="{$run-xslt-step}"/>
 
             <p:input port="source" primary="true" sequence="false" content-types="application/xml"/>
             <p:output port="result" serialization="map{{
@@ -78,6 +88,11 @@
 
     <xsl:template name="execute-harness-step" as="node()+">
         <xsl:comment>run the test suite</xsl:comment>
-        <x:xproc-compile-run-format xspec-home="{$xspec-home}"/>
+        <x:xproc-compile-run-format>
+            <p:with-option name="xspec-home">
+                <xsl:attribute name="select"
+                    select="if (exists($xspec-home)) then x:quote-with-apos($xspec-home) else '()'"/>
+            </p:with-option>
+        </x:xproc-compile-run-format>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/xproc3/xproc-testing/run-xproc.xpl
+++ b/src/xproc3/xproc-testing/run-xproc.xpl
@@ -24,7 +24,7 @@
         }"
         primary="true"/>
 
-    <p:option name="xspec-home" as="xs:string" select="resolve-uri('../../../')"/>
+    <p:option name="xspec-home" as="xs:string?"/>
     <p:option name="force-focus" as="xs:string?"/>
     <p:option name="html-report-theme" as="xs:string" select="'default'"/>
     <!-- TODO: Declare inline-css option, when we can support it. -->

--- a/test/generate-pipeline.xspec
+++ b/test/generate-pipeline.xspec
@@ -27,10 +27,9 @@
         <x:expect label="and then executes the substep for testing step functions."
             test="p:declare-step/p:declare-step[last()]/following-sibling::*/local-name()"
             select="'xproc-compile-run-format'"/>
-        <x:expect label="A substantive xspec-home value helps locate imported pipelines"
+        <x:expect label="A substantive xspec-home value helps locate the imported harness library"
             test="p:declare-step/p:declare-step[@name='xproc-compile-run-format']/p:import">
             <p:import href="file:/C:/my-xspec-home/src/xproc3/harness-lib.xpl" />
-            <p:import href="file:/C:/my-xspec-home/src/xproc3/run-xslt.xpl" />
         </x:expect>
         <x:expect label="and gets passed to the substep."
             test="//x:xproc-compile-run-format/p:with-option">

--- a/test/generate-pipeline.xspec
+++ b/test/generate-pipeline.xspec
@@ -3,6 +3,7 @@
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
     stylesheet="../src/xproc3/xproc-testing/generate-pipeline.xsl">
 
+    <x:param name="xspec-home" select="'file:/C:/my-xspec-home/'"/>
     <x:scenario label="At a high level, the generate-pipeline template">
         <x:context href="xproc/unit-test-supporting-files/top-level.xspec"/>
         <x:call template="generate-pipeline"/>
@@ -26,5 +27,14 @@
         <x:expect label="and then executes the substep for testing step functions."
             test="p:declare-step/p:declare-step[last()]/following-sibling::*/local-name()"
             select="'xproc-compile-run-format'"/>
+        <x:expect label="A substantive xspec-home value helps locate imported pipelines"
+            test="p:declare-step/p:declare-step[@name='xproc-compile-run-format']/p:import">
+            <p:import href="file:/C:/my-xspec-home/src/xproc3/harness-lib.xpl" />
+            <p:import href="file:/C:/my-xspec-home/src/xproc3/run-xslt.xpl" />
+        </x:expect>
+        <x:expect label="and gets passed to the substep."
+            test="//x:xproc-compile-run-format/p:with-option">
+            <p:with-option name="xspec-home" select="'file:/C:/my-xspec-home/'" />
+        </x:expect>
     </x:scenario>
 </x:description>


### PR DESCRIPTION
### Background

While working on tests for #2303, I started having doubts about a way in which #2227 made `run-xproc.xpl` different from the other languages' XProc harnesses: `run-xproc.xpl` established a default value for `xspec-home`. I had done that on purpose, thinking that (a) a sensible default value would be helpful for users and (b) mixing different XSpec installations would provide more flexibility than we really need. (For instance, you can't use an XML catalog to point to an XSpec v3.0 installation and expect it to successfully run your test for XProc. As another example, if use a catalog to swap in a custom compiler stylesheet, you are on your own. I'm not sure if users are doing that.)

But the default value takes precedence over an XML catalog. Users who are accustomed to pointing to XSpec using an XML catalog when running their tests for XSLT or XQuery might be confused by the catalog not taking effect or might consider it a bug.

I'm now thinking that `run-xproc.xpl` should really be consistent with the other XProc 3 harnesses in this repo. That is, we should support XML catalog usage for locating compiler/reporter files in **all** or **none** of the XProc 3 harnesses in this repo. I am not completely sure whether the ability to find compiler/reporter files using a user-provided catalog instead of a sensible default is a worthwhile extensibility hook for advanced users or a bell/whistle that no one needs. In making this PR, I am sympathizing with the "worthwhile extensibility hook" perspective and enabling catalog support to work in `run-xproc.xpl` the way it does for `run-xslt.xpl`, etc.

### What this PR does

This PR removes the default for `xspec-home`. The user must either specify a substantive value for `xspec-home` (a zero-length string doesn't count as "substantive") or provide another way to resolve URIs, typically an XML catalog.

A substantive value of `xspec-home` takes precedence over catalog entries.

### Interactive testing

I successfully ran the `tutorial/xproc/xproc-testing-demo.xspec` test with XML Calabash 3.0.44 from the Windows command line, from the `test` directory, with

- A zero-length string for `xspec-home`, and pointing to a modification of this repo's catalog file that helped me confirm that the catalog took effect.
- An empty sequence for `xspec-home`, and pointing to the modified catalog file.
- No value provided for `xspec-home` on the command line, and pointing to the modified catalog file.
- A substantive value for `xspec-home` (even containing an apostrophe), and pointing to the modified catalog file. The `xspec-home` value took precedence over the catalog file.
- A substantive value for `xspec-home`, and no catalog file.

The upcoming PR for #2303 will have automated tests for the no-catalog case with `xspec-home` equal to `()` or `''`.

Cc: @birdya22 