### PR TITLE
feat(xproc): error checking for xspec-home option

### DIFF
--- a/src/xproc3/harness-lib.xpl
+++ b/src/xproc3/harness-lib.xpl
@@ -60,6 +60,28 @@
    </p:declare-step>
 
    <!--
+       Error checking for $xspec-home or catalog
+   -->
+   <p:declare-step type="x:check-xspec-home">
+      <p:input port="source"/>
+      <p:output port="result"/>
+      <p:option name="xspec-home" as="xs:string?"/>
+      <p:variable name="report-stylesheet" as="xs:anyURI"
+         select="xs:anyURI('http://www.jenitennison.com/xslt/xspec/format-xspec-report.xsl')"/>
+      <p:if test="not($xspec-home != '') and
+         ($report-stylesheet eq p:lookup-uri($report-stylesheet))">
+         <p:error code="x:ERR003">
+            <p:with-input port="source">
+               <p:inline>
+                  <message>Provide either an 'xspec-home' option value or an XML catalog containing XSpec system identifiers.</message>
+               </p:inline>
+            </p:with-input>
+         </p:error>
+      </p:if>
+      <p:identity/>
+   </p:declare-step>
+
+   <!--
        Compile the suite on source into a stylesheet on result.
    -->
    <p:declare-step type="x:compile-test-for-xslt-or-xproc" name="compile-xsl-xproc"

--- a/src/xproc3/run-xquery.xpl
+++ b/src/xproc3/run-xquery.xpl
@@ -56,6 +56,9 @@
 
    <p:option name="parameters" as="map(xs:QName,item()*)" select="map{}"/>
 
+   <t:check-xspec-home>
+      <p:with-option name="xspec-home" select="$xspec-home"/>
+   </t:check-xspec-home>
 
    <!-- compile the suite into a query -->
    <t:compile-xquery name="compile" p:message="Creating Test Runner...">

--- a/src/xproc3/run-xslt.xpl
+++ b/src/xproc3/run-xslt.xpl
@@ -57,6 +57,10 @@
 
    <p:option name="parameters" as="map(xs:QName,item()*)" select="map{}"/>
 
+   <t:check-xspec-home>
+      <p:with-option name="xspec-home" select="$xspec-home"/>
+   </t:check-xspec-home>
+
    <!-- compile the suite into a stylesheet -->
    <t:compile-xslt name="compile" p:message="Creating Test Runner...">
       <p:with-option name="xspec-home" select="$xspec-home"/>

--- a/src/xproc3/schematron-xqs/run-schematron-xqs.xpl
+++ b/src/xproc3/schematron-xqs/run-schematron-xqs.xpl
@@ -23,6 +23,7 @@
 
    <p:import href="preprocess-schematron-xqs.xpl"/>
    <p:import href="../run-xquery.xpl"/>
+   <p:import href="../harness-lib.xpl"/>
 
    <p:input port="source" primary="true" sequence="false" content-types="application/xml"/>
    <p:output port="result"
@@ -44,6 +45,10 @@
    <!-- TODO: Decide whether to support report-css-uri for t:format-report. -->
    
    <p:option name="parameters" as="map(xs:QName,item()*)" select="map{}"/>
+
+   <x:check-xspec-home>
+      <p:with-option name="xspec-home" select="$xspec-home"/>
+   </x:check-xspec-home>
 
    <!-- preprocess -->
    <x:preprocess-schematron-xqs p:message="Converting Schematron XSpec into XQuery XSpec...">

--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -31,17 +31,11 @@
             resolve-uri('src/xproc3/harness-lib.xpl', $xspec-home)
             else
             'http://www.jenitennison.com/xslt/xspec/xproc/lib'"/>
-        <xsl:variable name="run-xslt-step"
-            select="if ($xspec-home != '') then
-            resolve-uri('src/xproc3/run-xslt.xpl', $xspec-home)
-            else
-            'http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xslt'"/>
 
         <p:declare-step name="xproc-compile-run-format" type="x:xproc-compile-run-format">
             <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
 
             <p:import href="{$harness-library}"/>
-            <p:import href="{$run-xslt-step}"/>
 
             <p:input port="source" primary="true" sequence="false" content-types="application/xml"/>
             <p:output port="result" serialization="map{{

--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet version="3.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-    <xsl:param name="xspec-home" as="xs:string" select="resolve-uri('../../../')"/>
+    <xsl:param name="xspec-home" as="xs:string?"/>
     <xsl:param name="force-focus" as="xs:string?"/>
     <xsl:param name="html-report-theme" as="xs:string" select="'default'"/>
     <xsl:include href="../../compiler/xproc/in-scope-steps/generate-xproc-imports.xsl"/>
@@ -26,12 +26,22 @@
 
     <xsl:template name="declare-harness-step" as="node()+">
         <xsl:comment>substep to run a test suite whose XProc step functions are in scope</xsl:comment>
-        <xsl:variable name="xproc3-uri" as="xs:anyURI" select="resolve-uri('src/xproc3/', $xspec-home)"/>
+        <xsl:variable name="harness-library"
+            select="if ($xspec-home != '') then
+            resolve-uri('src/xproc3/harness-lib.xpl', $xspec-home)
+            else
+            'http://www.jenitennison.com/xslt/xspec/xproc/lib'"/>
+        <xsl:variable name="run-xslt-step"
+            select="if ($xspec-home != '') then
+            resolve-uri('src/xproc3/run-xslt.xpl', $xspec-home)
+            else
+            'http://www.jenitennison.com/xslt/xspec/xproc/steps/run-xslt'"/>
+
         <p:declare-step name="xproc-compile-run-format" type="x:xproc-compile-run-format">
             <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
 
-            <p:import href="{$xproc3-uri}harness-lib.xpl"/>
-            <p:import href="{$xproc3-uri}run-xslt.xpl"/>
+            <p:import href="{$harness-library}"/>
+            <p:import href="{$run-xslt-step}"/>
 
             <p:input port="source" primary="true" sequence="false" content-types="application/xml"/>
             <p:output port="result" serialization="map{{
@@ -78,6 +88,11 @@
 
     <xsl:template name="execute-harness-step" as="node()+">
         <xsl:comment>run the test suite</xsl:comment>
-        <x:xproc-compile-run-format xspec-home="{$xspec-home}"/>
+        <x:xproc-compile-run-format>
+            <p:with-option name="xspec-home">
+                <xsl:attribute name="select"
+                    select="if (exists($xspec-home)) then x:quote-with-apos($xspec-home) else '()'"/>
+            </p:with-option>
+        </x:xproc-compile-run-format>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/xproc3/xproc-testing/run-xproc.xpl
+++ b/src/xproc3/xproc-testing/run-xproc.xpl
@@ -24,7 +24,7 @@
         }"
         primary="true"/>
 
-    <p:option name="xspec-home" as="xs:string" select="resolve-uri('../../../')"/>
+    <p:option name="xspec-home" as="xs:string?"/>
     <p:option name="force-focus" as="xs:string?"/>
     <p:option name="html-report-theme" as="xs:string" select="'default'"/>
     <!-- TODO: Declare inline-css option, when we can support it. -->

--- a/src/xproc3/xproc-testing/run-xproc.xpl
+++ b/src/xproc3/xproc-testing/run-xproc.xpl
@@ -13,6 +13,8 @@
             `whiteblack` (white on black), or `classic` (earlier green/pink design). Defaults to `blackwhite`.</p>
     </p:documentation>
 
+    <p:import href="../harness-lib.xpl"/>
+
     <p:input port="source" primary="true" sequence="false"/>
     <p:output port="result"
         serialization="map{
@@ -30,6 +32,10 @@
     <!-- TODO: Declare inline-css option, when we can support it. -->
     <!-- TODO: Decide whether to support is-external or measure-time for t:compile-xslt. -->
     <!-- TODO: Decide whether to support report-css-uri for t:format-report. -->
+
+    <x:check-xspec-home>
+        <p:with-option name="xspec-home" select="$xspec-home"/>
+    </x:check-xspec-home>
 
     <!-- Generate the pipeline we want to run. -->
     <p:xslt name="generate-pipeline">

--- a/test/generate-pipeline.xspec
+++ b/test/generate-pipeline.xspec
@@ -27,10 +27,9 @@
         <x:expect label="and then executes the substep for testing step functions."
             test="p:declare-step/p:declare-step[last()]/following-sibling::*/local-name()"
             select="'xproc-compile-run-format'"/>
-        <x:expect label="A substantive xspec-home value helps locate imported pipelines"
+        <x:expect label="A substantive xspec-home value helps locate the imported harness library"
             test="p:declare-step/p:declare-step[@name='xproc-compile-run-format']/p:import">
             <p:import href="file:/C:/my-xspec-home/src/xproc3/harness-lib.xpl" />
-            <p:import href="file:/C:/my-xspec-home/src/xproc3/run-xslt.xpl" />
         </x:expect>
         <x:expect label="and gets passed to the substep."
             test="//x:xproc-compile-run-format/p:with-option">

--- a/test/generate-pipeline.xspec
+++ b/test/generate-pipeline.xspec
@@ -3,6 +3,7 @@
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
     stylesheet="../src/xproc3/xproc-testing/generate-pipeline.xsl">
 
+    <x:param name="xspec-home" select="'file:/C:/my-xspec-home/'"/>
     <x:scenario label="At a high level, the generate-pipeline template">
         <x:context href="xproc/unit-test-supporting-files/top-level.xspec"/>
         <x:call template="generate-pipeline"/>
@@ -26,5 +27,14 @@
         <x:expect label="and then executes the substep for testing step functions."
             test="p:declare-step/p:declare-step[last()]/following-sibling::*/local-name()"
             select="'xproc-compile-run-format'"/>
+        <x:expect label="A substantive xspec-home value helps locate imported pipelines"
+            test="p:declare-step/p:declare-step[@name='xproc-compile-run-format']/p:import">
+            <p:import href="file:/C:/my-xspec-home/src/xproc3/harness-lib.xpl" />
+            <p:import href="file:/C:/my-xspec-home/src/xproc3/run-xslt.xpl" />
+        </x:expect>
+        <x:expect label="and gets passed to the substep."
+            test="//x:xproc-compile-run-format/p:with-option">
+            <p:with-option name="xspec-home" select="'file:/C:/my-xspec-home/'" />
+        </x:expect>
     </x:scenario>
 </x:description>

--- a/test/xproc/cases/library-xspec-home-error-check.xpl
+++ b/test/xproc/cases/library-xspec-home-error-check.xpl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:library xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:s="x-urn:test:xproc:steplibrary"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.1">
+
+    <p:declare-step type="s:xslt-varying-xspec-home">
+        <p:import href="../../../src/xproc3/run-xslt.xpl"/>
+        <p:option name="xspec-home" as="xs:string?"/>
+        <p:output port="result" sequence="true"/>
+        <x:run-xslt>
+            <p:with-input href="../../../tutorial/escape-for-regex.xspec"/>
+            <p:with-option name="xspec-home" select="$xspec-home"/>
+        </x:run-xslt>
+    </p:declare-step>
+
+    <p:declare-step type="s:xquery-varying-xspec-home">
+        <p:import href="../../../src/xproc3/run-xquery.xpl"/>
+        <p:option name="xspec-home" as="xs:string?"/>
+        <x:run-xquery>
+            <p:with-input href="../../../tutorial/xquery-tutorial.xspec"/>
+            <p:with-option name="xspec-home" select="$xspec-home"/>
+        </x:run-xquery>
+    </p:declare-step>
+
+    <p:declare-step type="s:xproc-varying-xspec-home">
+        <p:import href="../../../src/xproc3/xproc-testing/run-xproc.xpl"/>
+        <p:option name="xspec-home" as="xs:string?"/>
+        <x:run-xproc>
+            <p:with-input href="../../../tutorial/xproc/xproc-testing-demo.xspec"/>
+            <p:with-option name="xspec-home" select="$xspec-home"/>
+        </x:run-xproc>
+    </p:declare-step>
+
+    <!-- Schematron via XQS requires BaseX, so s:schematron-xqs-varying-xspec-home
+        is used in test/xqs/xspec-home-error-check.xspec, not in
+        test/xproc/xspec-home-error-check.xspec -->
+    <p:declare-step type="s:schematron-xqs-varying-xspec-home">
+        <p:import href="../../../src/xproc3/schematron-xqs/run-schematron-xqs.xpl"/>
+        <p:option name="xspec-home" as="xs:string?"/>
+        <x:run-schematron-xqs>
+            <p:with-input href="../../../tutorial/schematron-xqs/demo-01.xspec"/>
+            <p:with-option name="xspec-home" select="$xspec-home"/>
+        </x:run-schematron-xqs>
+    </p:declare-step>
+
+</p:library>

--- a/test/xproc/cases/xspec-home-error-check.xspec
+++ b/test/xproc/cases/xspec-home-error-check.xspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:s="x-urn:test:xproc:steplibrary"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xproc="library-xspec-home-error-check.xpl">
+
+    <!--
+        These scenarios test xspec-home error checking in the absence of an XML Catalog
+        containing XSpec system identifiers. See also test/xqs/xspec-home-error-check.xspec.
+        
+        When running this test suite, make sure the XSpec catalog.xml file is not in use.
+
+        Note: XML Calabash picks up catalog.xml in the same directory as build.xml,
+        which causes failures when the test runs with either the main XSpec build.xml
+        file or Oxygen's Ant-based "Run XSpec Test" transformation scenario.
+    -->
+
+    <x:import href="xspec-home-error-check_import.xspec"/>
+    <x:scenario label="Running XSpec test for XSLT" catch="yes">
+        <x:call step="s:xslt-varying-xspec-home"/>
+        <x:like label="Check xspec-home empty and zero-length string"/>
+    </x:scenario>
+    <x:scenario label="Running XSpec test for XQuery" catch="yes">
+        <x:call step="s:xquery-varying-xspec-home"/>
+        <x:like label="Check xspec-home empty and zero-length string"/>
+    </x:scenario>
+    <x:scenario label="Running XSpec test for XProc" catch="yes">
+        <x:call step="s:xproc-varying-xspec-home"/>
+        <x:like label="Check xspec-home empty and zero-length string"/>
+    </x:scenario>
+
+</x:description>

--- a/test/xproc/cases/xspec-home-error-check_import.xspec
+++ b/test/xproc/cases/xspec-home-error-check_import.xspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:c="http://www.w3.org/ns/xproc-step"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xproc="library-xspec-home-error-check.xpl">
+
+    <!-- This file is imported by the xspec-home-error-check.xspec files in
+        this directory and the test/xqs/ directory. -->
+
+    <x:scenario shared="yes" label="Check xspec-home empty and zero-length string">
+        <!-- x:call/@step must be inherited from an ancestor scenario. -->
+        <x:scenario label="with xspec-home empty">
+            <x:call>
+                <x:option name="xspec-home" select="()"/>
+            </x:call>
+            <x:like label="Verify error"/>
+        </x:scenario>
+        <x:scenario label="with xspec-home=''">
+            <x:call>
+                <x:option name="xspec-home" select="''"/>
+            </x:call>
+            <x:like label="Verify error"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario shared="yes" label="Verify error">
+        <x:expect label="raises error x:ERR003" test="$x:result?err?code"
+            select="xs:QName('x:ERR003')"/>
+        <x:expect label="with expected message" test="$x:result?err?value//c:error/message">
+            <message>Provide either an 'xspec-home' option value or an XML catalog containing XSpec system identifiers.</message>
+        </x:expect>
+    </x:scenario>
+
+</x:description>

--- a/test/xqs/run-tests-with-basex.xpl
+++ b/test/xqs/run-tests-with-basex.xpl
@@ -21,6 +21,7 @@
 
    <p:import href="../../src/xproc3/schematron-xqs/run-schematron-xqs.xpl"/>
    <p:import href="../../src/xproc3/run-xquery.xpl"/>
+   <p:import href="../../src/xproc3/xproc-testing/run-xproc.xpl"/>
 
    <p:option name="xspec-home" as="xs:string?"/>
    <p:option name="xqs-home" as="xs:string?"/>
@@ -39,7 +40,7 @@
       <p:variable name="idx" select="p:iteration-position()"/>
       <p:load href="{$test-dir}{$test-filename}" name="test-file"/>
       <p:for-each>
-         <p:with-input select="/x:description/(@schematron | @query)/name()"/>
+         <p:with-input select="/x:description/(@schematron | @query | @xproc)/name()"/>
          <p:variable name="test-type" select="."/>
          <p:choose>
             <p:when test="$test-type eq 'schematron'">
@@ -51,6 +52,14 @@
                   <p:with-option name="xqs-home" select="$xqs-home"/>
                   <p:with-option name="parameters" select="$parameters"/>
                </x:run-schematron-xqs>
+            </p:when>
+            <p:when test="$test-type eq 'xproc'">
+               <!-- Test for XProc -->
+               <p:identity message="&#10;--- Case #{ $idx }: { $test-filename } (test for XProc) ---"/>
+               <x:run-xproc>
+                  <p:with-input pipe="result@test-file"/>
+                  <p:with-option name="xspec-home" select="$xspec-home-to-use"/>
+               </x:run-xproc>
             </p:when>
             <p:otherwise>
                <!-- Test for XQuery -->

--- a/test/xqs/xspec-home-error-check.xspec
+++ b/test/xqs/xspec-home-error-check.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:s="x-urn:test:xproc:steplibrary"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xproc="library-xspec-home-error-check.xpl"
+    xml:base="../xproc/cases/">
+
+    <!--
+        This scenario tests xspec-home error checking in the absence of an XML Catalog containing
+        XSpec system identifiers. See also test/xproc/cases/xspec-home-error-check.xspec.
+        
+        When running this test suite, make sure the XSpec catalog.xml file is not in use.
+
+        Note: XML Calabash picks up catalog.xml in the same directory as build.xml,
+        which causes failures when the test runs with either the main XSpec build.xml
+        file or Oxygen's Ant-based "Run XSpec Test" transformation scenario.
+    -->
+
+    <x:import href="xspec-home-error-check_import.xspec"/>
+    <x:scenario label="Running XSpec test for Schematron via XQS" catch="yes">
+        <x:call step="s:schematron-xqs-varying-xspec-home"/>
+        <x:like label="Check xspec-home empty and zero-length string"/>
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Fixes #2303 by producing the following error message if the user provides neither a substantive `xspec-home` value nor a way (typically, a suitable XML catalog) to resolve the "symbolic" URIs like `http://www.jenitennison.com/xslt/xspec/compile-xslt-tests.xsl`.

```
Provide either an 'xspec-home' option value or an XML catalog containing XSpec system identifiers.
```

The first two commits are from #2318, making the treatment of `xspec-home` consistent across this repo's XProc harness pipelines. The 3rd and 4th commits are specific to this PR.

When testing this change, I found it handy that XSpec is able to test XProc code. :) Compared to adding new Bats test cases, the XSpec test approach was simpler and works across platforms.