### PR TITLE
fix(xproc): correct xml:base on p:document in generated test-case step

### DIFF
--- a/src/compiler/base/resolve-import/gather/gather-specs.xsl
+++ b/src/compiler/base/resolve-import/gather/gather-specs.xsl
@@ -87,6 +87,24 @@
          select="resolve-uri(., x:base-uri(.))" />
    </xsl:template>
 
+   <!-- Evaluation of p:document/@href in XProc might require base URI, so record it in xml:base
+      in addition to copying @href. -->
+   <xsl:template
+      match="p:document/@href"
+      as="attribute()+"
+      mode="x:gather-specs">
+      <xsl:attribute name="base" namespace="http://www.w3.org/XML/1998/namespace"
+         select="x:base-uri(..)" />
+      <xsl:copy/>
+   </xsl:template>
+
+   <!-- If original p:document has xml:base attribute, it was already accounted for in
+      template rule for p:document/@href. Use empty template rule to avoid copying
+      @xml:base value based on xsl:mode/@on-no-match. -->
+   <xsl:template match="p:document/@xml:base"
+      as="empty-sequence()"
+      mode="x:gather-specs"/>
+
    <xsl:template match="@as | @function | @mode | @name | @port | @template" as="attribute()"
       mode="x:gather-specs">
       <xsl:attribute name="{local-name()}" namespace="{namespace-uri()}" select="x:trim(.)" />

--- a/src/compiler/xproc/in-scope-steps/generate-test-case-step.xsl
+++ b/src/compiler/xproc/in-scope-steps/generate-test-case-step.xsl
@@ -75,8 +75,7 @@
                         </xsl:message>
                     </xsl:when>
                     <xsl:when test="exists(p:document)">
-                        <!-- Pass x:input/p:document, except @xml:base, for evaluation
-                                in XProc. -->
+                        <!-- Pass x:input/p:document for evaluation in XProc. -->
                         <p:with-input port="{@port}">
                             <xsl:sequence select="local:create-p-document(p:document)"/>
                         </p:with-input>
@@ -119,8 +118,7 @@
                         </xsl:message>
                     </xsl:when>
                     <xsl:when test="exists(p:document)">
-                        <!-- Pass x:option/p:document, except @xml:base, for evaluation
-                                in XProc. -->
+                        <!-- Pass x:option/p:document for evaluation in XProc. -->
                         <p:with-option name="{$option-name-escaped}" select=".">
                             <xsl:if test="count(p:document) eq 1">
                                 <!-- <p:with-option name="..." select="."> would raise error
@@ -209,16 +207,8 @@
     <xsl:function name="local:create-p-document" as="element(p:document)+">
         <xsl:param name="p-document" as="element(p:document)+"/>
         <xsl:for-each select="$p-document">
-            <xsl:variable name="new-xml-base" as="xs:anyURI" select="
-                if (exists(@xml:base))
-                then
-                resolve-uri(@xml:base, $initial-document-actual-uri)
-                else
-                $initial-document-actual-uri"
-            />
             <xsl:copy copy-namespaces="yes">
-                <xsl:attribute name="xml:base" select="$new-xml-base"/>
-                <xsl:apply-templates select="@* except (@xml:base, @port, @name, @as)"
+                <xsl:apply-templates select="@* except (@port, @name, @as)"
                     mode="in-p-document"/>
                 <xsl:apply-templates mode="in-p-document"/>
             </xsl:copy>

--- a/test/generate-test-case-step.xspec
+++ b/test/generate-test-case-step.xspec
@@ -31,9 +31,9 @@
             <x:expect label="This step invokes the test target step,"
                 test="/p:declare-step/s:inputs-options-outputs"
                 select="$expected/s:inputs-options-outputs"/>
-            <x:expect label="setting/adjusting xml:base to $x:xspec-uri on p:document elements."
-                test="//p:document/@xml:base => distinct-values()
-                => ends-with('/inputs-options-outputs.xspec')"/>
+            <x:expect label="preserving @xml:base that x:gather-specs mode put on p:document."
+                test="//p:document/@xml:base/string()"
+                select="('.../inputs-options-outputs.xspec', '.../some-dir/')"/>
             <x:expect label="Curly braces in p:document/@document-properties are doubled."
                 test="//p:document/@document-properties/string()"
                 as="xs:string">map{{'a': '}}}}{{false()}}{{{{'}}</x:expect>

--- a/test/xproc/cases/import-in-subdir/p-document-href-avt.xspec
+++ b/test/xproc/cases/import-in-subdir/p-document-href-avt.xspec
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:items="x-urn:test:xspec-items" xmlns:mirror="x-urn:test:mirror"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    version="4.0" xproc="../library-mirror.xpl">
+
+    <x:scenario label="Imported scenario in subdirectory, p:document/@href AVT expression,">
+        <x:scenario label="and directory adjustment in x:scenario/@xml:base" xml:base="../">
+            <x:call step="mirror:identity">
+                <x:input port="source">
+                    <p:document href="{ concat('document','.xml') }"/>
+                </x:input>
+            </x:call>
+            <x:expect label="works" port="xproc-result">
+                <document/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="and directory adjustment in p:document/@xml:base">
+            <x:call step="mirror:identity">
+                <x:input port="source">
+                    <p:document href="{ concat('document','.xml') }" xml:base="../"/>
+                </x:input>
+            </x:call>
+            <x:expect label="works" port="xproc-result">
+                <document/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="and directory adjustment in AVT expression">
+            <x:call step="mirror:identity">
+                <x:input port="source">
+                    <p:document href="{ concat('../','document','.xml') }"/>
+                </x:input>
+            </x:call>
+            <x:expect label="works" port="xproc-result">
+                <document/>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+    <x:scenario label="xml:base attribute">
+        <x:call step="mirror:identity">
+            <x:input port="source">
+                <p:document href="cases/document.xml" xml:base="../../"/>
+                <p:document href="../document.xml" xml:base="subdir/../"/>
+            </x:input>
+        </x:call>
+        <x:expect label="is resolved with respect to p:document element's base URI" port="xproc-result">
+            <document/>
+            <document/>
+        </x:expect>
+    </x:scenario>
+
+</x:description>

--- a/test/xproc/cases/p-document-within-x-input.xspec
+++ b/test/xproc/cases/p-document-within-x-input.xspec
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:items="x-urn:test:xspec-items" xmlns:mirror="x-urn:test:mirror"
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    xproc="library-mirror.xpl">
+    version="4.0" xproc="library-mirror.xpl">
+
+    <x:import href="import-in-subdir/p-document-href-avt.xspec"/>
 
     <x:scenario label="x:input with child p:document elements">
         <x:call step="mirror:identity">
@@ -118,7 +120,7 @@
                     <p:document href="../document.xml" xml:base="subdir/"/>
                 </x:input>
             </x:call>
-            <x:expect label="is resolved with respect to $x:xspec-uri" port="xproc-result">
+            <x:expect label="is resolved with respect to p:document element's base URI" port="xproc-result">
                 <document/>
                 <document/>
             </x:expect>

--- a/test/xproc/unit-test-supporting-files/inputs-options-outputs.xspec
+++ b/test/xproc/unit-test-supporting-files/inputs-options-outputs.xspec
@@ -7,8 +7,9 @@
             <x:input port="in1">in1 document</x:input>
             <x:input port="in2" xmlns:cx="http://xmlcalabash.com/ns/extensions">
                 <p:document href="path/to/data.json" parameters="map{'cx:extension': true()}"
-                    cx:another-extension="{'x'}"/>
-                <p:document href="path/to/text.txt" document-properties="map{'a': '}}{false()}{{'}">
+                    cx:another-extension="{'x'}" xml:base=".../inputs-options-outputs.xspec"/>
+                <p:document href="path/to/text.txt" document-properties="map{'a': '}}{false()}{{'}"
+                    xml:base=".../some-dir/">
                     <p:pipeinfo><element attr="{'arbitrary'}">Text</element></p:pipeinfo>
                     <p:documentation><element attr="arbitrary">Text</element></p:documentation>
                 </p:document>


### PR DESCRIPTION
If a test for XProc has `<p:document>` located in an imported file in a location other than the directory of the test suite being executed, then the `href` value that gets evaluated in XProc doesn't have the correct base URI to work with. 2db113062480d6b9a43e2c50fbe52b29aaf61e00 reproduces some instances of the problem.

The fix is to add `@xml:base` to each `<p:document>` element during early processing (`mode="x:gather-specs"`), with a value local to that `<p:document>` element. Computing the value early is important because later processing no longer retains data about where each `<p:document>` element came from.

