### PR TITLE
docs(xproc): clean up tutorial files

### DIFF
--- a/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-library-result.html
+++ b/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-library-result.html
@@ -93,14 +93,13 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">doc</span> <span class="xmlns">xmlns:eg="x-urn:tutorial:xproc:xproc-demo"</span>
-     <span class="xmlns">xmlns:map="http://www.w3.org/2005/xpath-functions/map"</span>
-     <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">Sample document</span>&lt;/doc&gt;</pre>
+                           <pre>&lt;<span class="inner-diff">doc</span>&gt;<span class="diff">Sample document</span>&lt;/doc&gt;</pre>
                         </td>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">doc</span> <span class="xmlns">xmlns:eg="x-urn:tutorial:xproc:xproc-demo"</span>
      <span class="xmlns">xmlns:map="http://www.w3.org/2005/xpath-functions/map"</span>
+     <span class="xmlns">xmlns:p="http://www.w3.org/ns/xproc"</span>
      <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">Other document</span>&lt;/doc&gt;</pre>
                         </td>
                      </tr>

--- a/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-library-result.xml
+++ b/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-library-result.xml
@@ -10,10 +10,12 @@
       <input-wrap xmlns="">
          <x:call xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                  xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                 xmlns:p="http://www.w3.org/ns/xproc"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
                  step="eg:demo">
             <x:input port="source">
-               <doc>Sample document</doc>
+               <p:document xml:base="../../../../../tutorial/xproc/xproc-testing-demo.xspec"
+                           href="document.xml"/>
             </x:input>
             <x:input port="id-data">
                <element-with-id xml:id="a123"/>
@@ -23,13 +25,9 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{"ports":map{"original":map{"document-properties":map{Q{}base-uri:"wrap.xsl",Q{}content-type:"application/xml"},"document":&lt;doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-     xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;Sample document&lt;/doc&gt;
+            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{"ports":map{"original":map{"document-properties":map{Q{}base-uri:"document.xml",Q{}content-type:"application/xml"},"document":&lt;doc&gt;Sample document&lt;/doc&gt;
 },"result":map{"document-properties":map{Q{}base-uri:"demo-library.xpl",Q{}content-type:"application/xml"},"document":&lt;outermost xml:id="a123"&gt;
-   &lt;doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-        xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-        xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;Sample document&lt;/doc&gt;
+   &lt;doc&gt;Sample document&lt;/doc&gt;
 &lt;/outermost&gt;
 }}}</pseudo-map>
          </content-wrap>
@@ -40,9 +38,7 @@
             <result select="/self::document-node()">
                <content-wrap xmlns="">
                   <outermost xml:id="a123">
-                     <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                          xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                          xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                     <doc>Sample document</doc>
                   </outermost>
                </content-wrap>
             </result>
@@ -51,6 +47,7 @@
             <content-wrap xmlns="">
                <outermost xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                           xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                          xmlns:p="http://www.w3.org/ns/xproc"
                           xmlns:x="http://www.jenitennison.com/xslt/xspec"
                           xml:id="a123">
                   <doc>Sample document</doc>
@@ -63,9 +60,7 @@
          <port-specific>
             <result select="/self::document-node()">
                <content-wrap xmlns="">
-                  <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                  <doc>Sample document</doc>
                </content-wrap>
             </result>
          </port-specific>
@@ -73,6 +68,7 @@
             <content-wrap xmlns="">
                <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                    xmlns:p="http://www.w3.org/ns/xproc"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
             </content-wrap>
          </expect>
@@ -82,9 +78,7 @@
          <port-specific>
             <result select="/self::document-node()">
                <content-wrap xmlns="">
-                  <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                  <doc>Sample document</doc>
                </content-wrap>
             </result>
          </port-specific>
@@ -92,6 +86,7 @@
             <content-wrap xmlns="">
                <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                    xmlns:p="http://www.w3.org/ns/xproc"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">Other document</doc>
             </content-wrap>
          </expect>
@@ -102,9 +97,7 @@
             <result select="/self::document-node()">
                <content-wrap xmlns="">
                   <outermost xml:id="a123">
-                     <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                          xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                          xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                     <doc>Sample document</doc>
                   </outermost>
                </content-wrap>
             </result>
@@ -113,6 +106,7 @@
             <content-wrap xmlns="">
                <outermost xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                           xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                          xmlns:p="http://www.w3.org/ns/xproc"
                           xmlns:x="http://www.jenitennison.com/xslt/xspec"
                           xml:id="a123">
                   <doc>Sample document</doc>
@@ -125,6 +119,7 @@
          <expect-test-wrap xmlns="">
             <x:expect xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                      xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:x="http://www.jenitennison.com/xslt/xspec"
                       test="$x:result?ports =&gt; map:keys() =&gt; count()"/>
          </expect-test-wrap>

--- a/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-result.html
+++ b/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-result.html
@@ -93,14 +93,13 @@
                      <tr>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
-                           <pre>&lt;<span class="inner-diff">doc</span> <span class="xmlns">xmlns:eg="x-urn:tutorial:xproc:xproc-demo"</span>
-     <span class="xmlns">xmlns:map="http://www.w3.org/2005/xpath-functions/map"</span>
-     <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">Sample document</span>&lt;/doc&gt;</pre>
+                           <pre>&lt;<span class="inner-diff">doc</span>&gt;<span class="diff">Sample document</span>&lt;/doc&gt;</pre>
                         </td>
                         <td>
                            <p>XPath <code class="same">/self::document-node()</code> from:</p>
                            <pre>&lt;<span class="inner-diff">doc</span> <span class="xmlns">xmlns:eg="x-urn:tutorial:xproc:xproc-demo"</span>
      <span class="xmlns">xmlns:map="http://www.w3.org/2005/xpath-functions/map"</span>
+     <span class="xmlns">xmlns:p="http://www.w3.org/ns/xproc"</span>
      <span class="xmlns trivial">xmlns:x="http://www.jenitennison.com/xslt/xspec"</span>&gt;<span class="diff">Other document</span>&lt;/doc&gt;</pre>
                         </td>
                      </tr>

--- a/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-result.xml
+++ b/test/end-to-end/cases/expected/xproc/tutorial_xproc-testing-demo-result.xml
@@ -10,10 +10,12 @@
       <input-wrap xmlns="">
          <x:call xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                  xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                 xmlns:p="http://www.w3.org/ns/xproc"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
                  step="eg:demo">
             <x:input port="source">
-               <doc>Sample document</doc>
+               <p:document xml:base="../../../../../tutorial/xproc/xproc-testing-demo.xspec"
+                           href="document.xml"/>
             </x:input>
             <x:input port="id-data">
                <element-with-id xml:id="a123"/>
@@ -23,13 +25,9 @@
       </input-wrap>
       <result select="/*">
          <content-wrap xmlns="">
-            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{"ports":map{"original":map{"document-properties":map{Q{}base-uri:"wrap.xsl",Q{}content-type:"application/xml"},"document":&lt;doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-     xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;Sample document&lt;/doc&gt;
+            <pseudo-map xmlns="http://www.jenitennison.com/xslt/xspec">map{"ports":map{"original":map{"document-properties":map{Q{}base-uri:"document.xml",Q{}content-type:"application/xml"},"document":&lt;doc&gt;Sample document&lt;/doc&gt;
 },"result":map{"document-properties":map{Q{}base-uri:"demo.xpl",Q{}content-type:"application/xml"},"document":&lt;outermost xml:id="a123"&gt;
-   &lt;doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-        xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-        xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;Sample document&lt;/doc&gt;
+   &lt;doc&gt;Sample document&lt;/doc&gt;
 &lt;/outermost&gt;
 }}}</pseudo-map>
          </content-wrap>
@@ -40,9 +38,7 @@
             <result select="/self::document-node()">
                <content-wrap xmlns="">
                   <outermost xml:id="a123">
-                     <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                          xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                          xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                     <doc>Sample document</doc>
                   </outermost>
                </content-wrap>
             </result>
@@ -51,6 +47,7 @@
             <content-wrap xmlns="">
                <outermost xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                           xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                          xmlns:p="http://www.w3.org/ns/xproc"
                           xmlns:x="http://www.jenitennison.com/xslt/xspec"
                           xml:id="a123">
                   <doc>Sample document</doc>
@@ -63,9 +60,7 @@
          <port-specific>
             <result select="/self::document-node()">
                <content-wrap xmlns="">
-                  <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                  <doc>Sample document</doc>
                </content-wrap>
             </result>
          </port-specific>
@@ -73,6 +68,7 @@
             <content-wrap xmlns="">
                <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                    xmlns:p="http://www.w3.org/ns/xproc"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
             </content-wrap>
          </expect>
@@ -82,9 +78,7 @@
          <port-specific>
             <result select="/self::document-node()">
                <content-wrap xmlns="">
-                  <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                       xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                  <doc>Sample document</doc>
                </content-wrap>
             </result>
          </port-specific>
@@ -92,6 +86,7 @@
             <content-wrap xmlns="">
                <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                    xmlns:p="http://www.w3.org/ns/xproc"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">Other document</doc>
             </content-wrap>
          </expect>
@@ -102,9 +97,7 @@
             <result select="/self::document-node()">
                <content-wrap xmlns="">
                   <outermost xml:id="a123">
-                     <doc xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-                          xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-                          xmlns:x="http://www.jenitennison.com/xslt/xspec">Sample document</doc>
+                     <doc>Sample document</doc>
                   </outermost>
                </content-wrap>
             </result>
@@ -113,6 +106,7 @@
             <content-wrap xmlns="">
                <outermost xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                           xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                          xmlns:p="http://www.w3.org/ns/xproc"
                           xmlns:x="http://www.jenitennison.com/xslt/xspec"
                           xml:id="a123">
                   <doc>Sample document</doc>
@@ -125,6 +119,7 @@
          <expect-test-wrap xmlns="">
             <x:expect xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
                       xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                      xmlns:p="http://www.w3.org/ns/xproc"
                       xmlns:x="http://www.jenitennison.com/xslt/xspec"
                       test="$x:result?ports =&gt; map:keys() =&gt; count()"/>
          </expect-test-wrap>

--- a/test/end-to-end/processor/xml/_normalizer.xsl
+++ b/test/end-to-end/processor/xml/_normalizer.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0" xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:local="x-urn:xspec:test:end-to-end:processor:xml:normalizer:local"
 	xmlns:normalizer="x-urn:xspec:test:end-to-end:processor:normalizer"
+	xmlns:p="http://www.w3.org/ns/xproc"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -29,6 +30,8 @@
 			| x:scenario/input-wrap/x:call/x:input/@href
 			| x:scenario/input-wrap/x:call/x:option/@href
 			| x:scenario/input-wrap/x:context/@href
+			| x:scenario/input-wrap/x:call/x:input/p:document/@xml:base
+			| x:scenario/input-wrap/x:call/x:option/p:document/@xml:base
 			|
 			/x:report[local:svrl-creator(.) eq 'skeleton']//x:scenario/x:result/content-wrap
 			/svrl:schematron-output/svrl:active-pattern/@document[string()]" mode="normalizer:normalize">

--- a/tutorial/xproc/demo-library.xpl
+++ b/tutorial/xproc/demo-library.xpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:library xmlns:p="http://www.w3.org/ns/xproc" xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0" exclude-inline-prefixes="eg xs">
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.1">
 
     <p:declare-step name="demo" type="eg:demo">
 

--- a/tutorial/xproc/demo.xpl
+++ b/tutorial/xproc/demo.xpl
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" name="demo" type="eg:demo" version="3.0"
-    exclude-inline-prefixes="eg xs">
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" name="demo" type="eg:demo" version="3.1">
 
     <!-- Ports -->
     <p:input port="source" primary="true" content-types="application/xml"/>

--- a/tutorial/xproc/document.xml
+++ b/tutorial/xproc/document.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document/>
+<doc>Sample document</doc>

--- a/tutorial/xproc/xproc-testing-demo-library.xspec
+++ b/tutorial/xproc/xproc-testing-demo-library.xspec
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-  xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-  xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" version="4.0"
   xproc="demo-library.xpl">
 
   <!-- The same scenarios work for a library containing the step in demo.xpl -->

--- a/tutorial/xproc/xproc-testing-demo.xspec
+++ b/tutorial/xproc/xproc-testing-demo.xspec
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:eg="x-urn:tutorial:xproc:xproc-demo"
-  xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-  xmlns:x="http://www.jenitennison.com/xslt/xspec"
-  xproc="demo.xpl">
+  xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:p="http://www.w3.org/ns/xproc"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec" version="4.0" xproc="demo.xpl">
 
   <x:scenario>
     <x:label>Executing eg:demo with a source document, a document having @xml:id, and a wrapper
       element name</x:label>
     <x:call step="eg:demo">
       <x:input port="source">
-        <doc>Sample document</doc>
+        <p:document href="document.xml"/>
       </x:input>
       <x:input port="id-data">
         <element-with-id xml:id="a123"/>


### PR DESCRIPTION
Fixes #2329.

I'm also adding `version="4.0"` to the XSpec files because the test suites require XSpec version 4. (When I get a chance, I might also add `version="4.0"` to XSpec files under `test/`.)
