### PR TITLE
test: reduce instances of fixed date/time

### DIFF
--- a/test/end-to-end/ant/base/build.xml
+++ b/test/end-to-end/ant/base/build.xml
@@ -9,9 +9,6 @@
 	<!-- Absolute path of directory where *.xspec files are located -->
 	<property location="${e2e-base.basedir}/../../${cases.dir}/" name="xspecfiles.dir" />
 
-	<!-- Use fixed date time stamp -->
-	<property name="run-xspec-tests.now" value="2000-01-01T00:00:00Z" />
-
 	<!-- Import "run-xspec-tests" build file to override its target -->
 	<import file="../../../ant/build.xml" />
 

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -472,8 +472,7 @@
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html"
     call :verify_retval 0
 	</case>
 
@@ -495,8 +494,7 @@
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html"
     call :verify_retval 0
 
     rem Run again (ndw/xmlcalabash1#322)
@@ -542,8 +540,7 @@
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html"
     call :verify_retval 0
 
     rem Verify that inline CSS uses > instead of &gt;
@@ -570,8 +567,7 @@
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html"
     call :verify_retval 0
 
     rem Verify that inline CSS uses > instead of &gt;
@@ -649,8 +645,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html"
         call :verify_retval 0
 
         rem Verify JUnit report
@@ -684,8 +679,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/stylesheet/serialize-result.html"
         call :verify_retval 0
 
         rem Verify JUnit report
@@ -738,8 +732,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html"
         call :verify_retval 0
 
         rem Verify JUnit report
@@ -794,8 +787,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/query/serialize-result.html"
         call :verify_retval 0
 
         rem Verify that inline CSS uses > instead of &gt;
@@ -888,8 +880,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/schematron/schematron-xqs-demo-01-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/schematron/schematron-xqs-demo-01-result.html"
         call :verify_retval 0
 
         rem Verify that inline CSS uses > instead of &gt;
@@ -972,8 +963,7 @@
         call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^
         -s:"%ACTUAL_REPORT%" ^
         -xsl:end-to-end\processor\html\compare.xsl ^
-        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/xproc/tutorial_xproc-testing-demo-result.html" ^
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:///%ACTUAL_REPORT_DIR:\=/%/../../expected/xproc/tutorial_xproc-testing-demo-result.html"
         call :verify_retval 0
 
         rem Verify that inline CSS uses > instead of &gt;

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -539,8 +539,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html"
 }
 
 @test "XProc 1 harness for Saxon (XQuery)" {
@@ -564,8 +563,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html"
 
     # Run again (ndw/xmlcalabash1#322)
     java -cp "${XMLCALABASH_CP}:${SAXON_JAR}" com.xmlcalabash.drivers.Main \
@@ -616,8 +614,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html"
 
     # Verify that inline CSS uses > instead of &gt;
     myrun grep -F "> h2:first-of-type" "${actual_report}"
@@ -646,8 +643,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html"
 
     # Verify that inline CSS uses > instead of &gt;
     myrun grep -F "> h2:first-of-type" "${actual_report}"
@@ -742,8 +738,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html"
 
     # Verify JUnit report
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
@@ -779,8 +774,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/stylesheet/serialize-result.html"
 
     # Verify JUnit report
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
@@ -843,8 +837,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html"
 
     # Verify JUnit report
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
@@ -912,8 +905,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/query/serialize-result.html"
 
     # Verify that inline CSS uses > instead of &gt;
     myrun grep -F "> h2:first-of-type" "${actual_report}"
@@ -1047,8 +1039,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/schematron/schematron-xqs-demo-01-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/schematron/schematron-xqs-demo-01-result.html"
 
     # Verify that inline CSS uses > instead of &gt;
     myrun grep -F "> h2:first-of-type" "${actual_report}"
@@ -1151,8 +1142,7 @@ load bats-helper
     java -cp "${SAXON_CP}" net.sf.saxon.Transform \
         -s:"${actual_report}" \
         -xsl:end-to-end/processor/html/compare.xsl \
-        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/xproc/tutorial_xproc-testing-demo-result.html" \
-        NORMALIZE-HTML-DATETIME="2000-01-01T00:00:00Z"
+        EXPECTED-DOC-URI="file:${actual_report_dir}/../../expected/xproc/tutorial_xproc-testing-demo-result.html"
 
     # Verify that inline CSS uses > instead of &gt;
     myrun grep -F "> h2:first-of-type" "${actual_report}"


### PR DESCRIPTION
Closes #2307.

> In #2306, I set the same fixed date/time stamp in the end-to-end normalizer stylesheets (for HTML and XML test results). That should make it unnecessary to pass in `$NORMALIZE-HTML-DATETIME` from Bats tests. Maybe we should stop having so many places where the fixed value `2000-01-01T00:00:00Z` appears.
