### PR TITLE
fix(schematron): use UQName in phase variable 'as'

### DIFF
--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -6,7 +6,7 @@
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 exclude-result-prefixes="#all">
 
-    <xsl:param name="sch-impl-name" as="xs:string" select="'schxslt'" static="yes"/>
+    <xsl:param name="sch-impl-name" as="xs:string" select="'schxslt2'" static="yes"/>
     <xsl:param name="xqs-home" as="xs:string" select="'../../lib/XQS/'"/>
 
     <!--
@@ -58,7 +58,9 @@
     <xsl:include href="../common/uri-utils.xsl" />
     <xsl:include href="../common/user-content-utils.xsl" />
     <xsl:include href="../common/yes-no-utils.xsl" />
+    <xsl:include href="../compiler/base/declare-variable/sequencetype-with-uqnames.xsl" />
     <xsl:include href="../compiler/base/resolve-import/resolve-import.xsl" />
+    <xsl:include href="../compiler/base/util/compiler-eqname-utils.xsl" />
     <xsl:include href="../compiler/base/util/compiler-misc-utils.xsl" />
 
     <xsl:output indent="yes" />
@@ -143,7 +145,11 @@
                             <!-- Define $impl:phase variable for use in xqs:validate calling syntax. -->
                             <xsl:element name="{x:xspec-name('variable',.)}" namespace="{namespace-uri()}">
                                 <xsl:attribute name="name" select="x:known-UQName('impl:phase')"/>
-                                <xsl:copy-of select="(@* except @name) | node()"/>
+                                <xsl:if test="exists(@as)">
+                                    <xsl:attribute name="as"
+                                        select="x:lexical-to-UQName-in-sequence-type(., 'as')"/>
+                                </xsl:if>
+                                <xsl:copy-of select="(@* except (@name | @as)) | node()"/>
                             </xsl:element>
                         </xsl:for-each>
                         <xsl:sequence select="$specs[not(self::x:param[@name='phase'])]"/>

--- a/test/external_schut-to-xspec-for-xqs.xspec
+++ b/test/external_schut-to-xspec-for-xqs.xspec
@@ -42,6 +42,14 @@
                 href="schematron/schut-to-xspec-for-xqs-phase-string-out.xspec"
                 select="helper:expect(.)" />
         </x:scenario>
+
+        <x:scenario label="with prefixed type in @as">
+            <!-- Modeled on schut-to-xspec-for-xqs-phase-text-in.xspec but adds x:param/@as -->
+            <x:context href="schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"/>
+            <x:expect label="defines x:variable for phase, converting @as to use UQNames"
+                href="schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec"
+                select="helper:expect(.)" />
+        </x:scenario>
     </x:scenario>
 
     <x:scenario label="namespaces defined in Schematron">

--- a/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec
+++ b/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="schut-to-xspec-test.sch"
+    xquery-version="3.1">
+    <x:param name="phase" as="xs:string">P1</x:param>
+    <x:scenario label="Schematron test scenario">
+        <x:context>
+            <element/>
+        </x:context>
+    </x:scenario>
+</x:description>

--- a/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec
+++ b/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.jenitennison.com/xslt/xspec"
+             xmlns:x="http://www.jenitennison.com/xslt/xspec"
+             schematron="%TEST_BASE%/schematron/schut-to-xspec-test.sch"
+             original-xspec="%TEST_BASE%/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"
+             query="http://www.andrewsales.com/ns/xqs" query-at="%TEST_BASE%/../lib/XQS/xqs.xqm"
+             xquery-version="3.1">
+   <x:variable xmlns=""
+               name="Q{urn:x-xspec:compile:impl}schema-uri"
+               as="Q{http://www.w3.org/2001/XMLSchema}anyURI"
+               select="'%TEST_BASE%/schematron/schut-to-xspec-test.sch'" />
+   <x:variable xmlns="" name="Q{urn:x-xspec:compile:impl}phase"
+      as="Q{http://www.w3.org/2001/XMLSchema}string">
+      <x:text>P1</x:text>
+   </x:variable>
+   <x:scenario xmlns=""
+               xslt-version="3"
+               xspec="%TEST_BASE%/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"
+               label="Schematron test scenario">
+      <x:variable name="Q{http://www.jenitennison.com/xslt/xspec}context" select="self::document-node()">
+         <element/>
+      </x:variable>
+      <x:call function="Q{http://www.andrewsales.com/ns/xqs}validate">
+         <x:param name="instance" as="node()" select="$Q{http://www.jenitennison.com/xslt/xspec}context" />
+         <x:param name="schema" as="element()" select="doc($Q{urn:x-xspec:compile:impl}schema-uri)/*" />
+         <x:param name="options" as="map(*)" select="map{'phase': string($Q{urn:x-xspec:compile:impl}phase)}"/>
+      </x:call>
+   </x:scenario>
+</description>

--- a/test/xqs/phases-xqs.xspec
+++ b/test/xqs/phases-xqs.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="phases-xqs.sch">
-    <x:param name="phase">P1</x:param>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="phases-xqs.sch">
+    <x:param name="phase" as="xs:string">P1</x:param>
     <x:scenario label="Phase P1 includes title check but not subtitle check">
         <x:context>
             <section/>


### PR DESCRIPTION
In a test for Schematron via XQS, you would use a global `x:param` to indicate the Schematron phase to use during validation. If `x:param` uses `@as`, the sequence type value might use a namespace prefix. When XSpec transforms the test suite for Schematron into a test suite for XQuery, it generates a global `x:variable` corresponding to your original `x:param`. When generating this `x:variable`, XSpec should resolve any prefixes in `@as` to use URI-qualified names instead of prefixed ones.

For instance,

- Original test suite for Schematron: `<x:param name="phase" as="xs:string">...</x:param>`
- Generated test suite for XQuery: `<x:variable name="Q{urn:x-xspec:compile:impl}phase" as="Q{http://www.w3.org/2001/XMLSchema}string">...</x:variable>`
