### PR TITLE
refactor: add 'as' and xsl:context-item

### DIFF
--- a/src/compiler/base/initial-check/perform-initial-check.xsl
+++ b/src/compiler/base/initial-check/perform-initial-check.xsl
@@ -50,6 +50,7 @@
    </xsl:template>
 
    <xsl:template name="x:report-xspec-version" as="empty-sequence()">
+      <xsl:context-item use="absent"/>
       <xsl:message>XSpec v<xsl:value-of select="$x:xspec-version"/></xsl:message>
    </xsl:template>
 </xsl:stylesheet>

--- a/src/compiler/xproc/compile/get-step-declaration.xsl
+++ b/src/compiler/xproc/compile/get-step-declaration.xsl
@@ -13,14 +13,15 @@
             <p:library>
                 <xsl:apply-templates select="$xproc-doc" mode="local:gather-steps">
                     <xsl:with-param name="import-stack" tunnel="yes" select="$xproc-doc-uri"/>
-                </xsl:apply-templates>        
+                </xsl:apply-templates>
             </p:library>
         </xsl:document>
     </xsl:variable>
 
     <!-- Keys -->
     <xsl:key name="step-declarations" match="p:declare-step[@type]" use="string(@type)"/>
-    <xsl:key name="static-library-options" match="p:library/p:option" use="x:UQName-from-EQName-ignoring-default-ns(@name, .)"/>
+    <xsl:key name="static-library-options" match="p:library/p:option"
+        use="x:UQName-from-EQName-ignoring-default-ns(@name, .)"/>
 
     <!-- Functions -->
     <xsl:function name="x:step-declaration" as="element(p:declare-step)">
@@ -66,13 +67,15 @@
             <xsl:with-param name="import-stack" tunnel="yes" select="$import-stack"/>
         </xsl:apply-templates>
     </xsl:template>
-    <xsl:template match="/p:library" mode="local:gather-steps">
+    <xsl:template match="/p:library" mode="local:gather-steps" as="element()*">
         <xsl:apply-templates select="(p:option, p:declare-step[@type], p:import)" mode="#current"/>
     </xsl:template>
-    <xsl:template match="p:declare-step[@visibility eq 'private']" mode="local:gather-steps">
+    <xsl:template match="p:declare-step[@visibility eq 'private']" mode="local:gather-steps"
+        as="empty-sequence()">
         <!-- Skip private steps -->
     </xsl:template>
-    <xsl:template match="p:declare-step[not(@visibility eq 'private')]" mode="local:gather-steps">
+    <xsl:template match="p:declare-step[not(@visibility eq 'private')]" mode="local:gather-steps"
+        as="element()+">
         <xsl:copy>
             <xsl:attribute name="type" select="x:UQName-of-step(./@type)"/>
             <xsl:sequence select="@use-when"/>
@@ -80,20 +83,20 @@
         </xsl:copy>
         <xsl:apply-templates select="p:import" mode="#current"/>
     </xsl:template>
-    <xsl:template match="p:input | p:output" mode="local:gather-steps">
+    <xsl:template match="p:input | p:output" mode="local:gather-steps" as="element()">
         <xsl:copy>
             <xsl:sequence select="@port | @use-when | @sequence"/>
             <xsl:if test="exists(self::p:input/*) or exists(self::p:input/@href)">
-                <xsl:attribute name="x:has-default-input" select="'true'"/>    
+                <xsl:attribute name="x:has-default-input" select="'true'"/>
             </xsl:if>
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="p:option" mode="local:gather-steps">
+    <xsl:template match="p:option" mode="local:gather-steps" as="element()">
         <xsl:copy>
             <xsl:sequence select="@name | @static"/>
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="p:import[@href]" mode="local:gather-steps">
+    <xsl:template match="p:import[@href]" mode="local:gather-steps" as="element()*">
         <xsl:param name="import-stack" tunnel="yes" required="yes" as="xs:anyURI*"/>
         <!-- We might import the same pipeline multiple times, but non-circular duplication doesn't
             matter for later processing. Alternatively, we could remove duplicates by imitating the

--- a/src/compiler/xproc/compile/scoped-result.xsl
+++ b/src/compiler/xproc/compile/scoped-result.xsl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns="http://www.w3.org/1999/XSL/TransformAlias"
-    xmlns:wrap="urn:x-xspec:common:wrap"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="#all" version="3.0">
+    xmlns:wrap="urn:x-xspec:common:wrap" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    exclude-result-prefixes="#all" version="3.0">
 
-    <xsl:template match="x:expect" mode="scope-result-variable">
+    <xsl:template match="x:expect" mode="scope-result-variable" as="element()*">
         <xsl:param name="reason-for-pending" as="xs:string?" required="yes"/>
-        <xsl:variable name="scoped-port" select="@port"/>
+        <xsl:variable name="scoped-port" select="@port" as="attribute(port)?"/>
         <xsl:if test="@port and empty($reason-for-pending)">
             <if test="empty(${x:known-UQName('x:result')}?ports)">
                 <!-- No data from output ports, probably due to caught error. Raising an error
@@ -16,7 +16,7 @@
                         <xsl:with-param
                             name="message">No results to select using @port attribute.</xsl:with-param>
                     </xsl:call-template>
-                </message>                
+                </message>
             </if>
             <if test="not('{$scoped-port}' = map:keys(${x:known-UQName('x:result')}?ports))"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map">
@@ -50,7 +50,7 @@
         <variable name="{x:known-UQName('impl:test-items')}" as="item()*">
             <!-- Don't wrap $x:result. If a port produces multiple document nodes, wrapping them
                 would merge their contents, which would interfere with verifying the documents. -->
-            <sequence select="${x:known-UQName('x:result')}" />
+            <sequence select="${x:known-UQName('x:result')}"/>
         </variable>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/compiler/xproc/compile/scoped-result.xsl
+++ b/src/compiler/xproc/compile/scoped-result.xsl
@@ -47,6 +47,7 @@
     </xsl:function>
 
     <xsl:template name="define-impl-test-items" as="element(xsl:variable)">
+        <xsl:context-item use="absent" />
         <variable name="{x:known-UQName('impl:test-items')}" as="item()*">
             <!-- Don't wrap $x:result. If a port produces multiple document nodes, wrapping them
                 would merge their contents, which would interfere with verifying the documents. -->

--- a/src/compiler/xproc/in-scope-steps/generate-xproc-imports.xsl
+++ b/src/compiler/xproc/in-scope-steps/generate-xproc-imports.xsl
@@ -36,6 +36,7 @@
     </xsl:template>
 
     <xsl:template name="declare-step-runner" as="element(p:declare-step)">
+        <xsl:context-item use="absent"/>
         <xsl:sequence select="doc(resolve-uri('../../../common/step-runner.xpl'))/*"/>
     </xsl:template>
 
@@ -61,6 +62,7 @@
     </xsl:template>
 
     <xsl:template name="import-function-wrappers" as="element(p:import)">
+        <xsl:context-item use="absent"/>
         <xsl:variable name="resolved-uri" select="
                 resolve-uri('../wrap-standard-functions/wrap-standard-functions.xpl')"
             as="xs:anyURI"/>

--- a/src/compiler/xproc/in-scope-steps/generate-xproc-imports.xsl
+++ b/src/compiler/xproc/in-scope-steps/generate-xproc-imports.xsl
@@ -27,11 +27,12 @@
         <xsl:call-template name="import-function-wrappers"/>
         <xsl:sequence>
             <xsl:on-non-empty>
-                <xsl:comment select="'Import pipelines referenced by @xproc in x:helper, ' ||
-                    'recursively across imported XSpec files'"/>
+                <xsl:comment select="
+                        'Import pipelines referenced by @xproc in x:helper, ' ||
+                        'recursively across imported XSpec files'"/>
             </xsl:on-non-empty>
             <xsl:apply-templates select="x:description" mode="generate-imports"/>
-        </xsl:sequence>       
+        </xsl:sequence>
     </xsl:template>
 
     <xsl:template name="declare-step-runner" as="element(p:declare-step)">
@@ -54,14 +55,15 @@
     <xsl:template match="x:description/@xproc | x:helper/@xproc" as="element(p:import)"
         mode="generate-imports">
         <xsl:variable name="resolved-xproc-attribute" as="xs:anyURI">
-            <xsl:apply-templates select="." mode="resolve-xproc-attribute"/>    
+            <xsl:apply-templates select="." mode="resolve-xproc-attribute"/>
         </xsl:variable>
         <p:import href="{$resolved-xproc-attribute}"/>
     </xsl:template>
 
     <xsl:template name="import-function-wrappers" as="element(p:import)">
         <xsl:variable name="resolved-uri" select="
-                resolve-uri('../wrap-standard-functions/wrap-standard-functions.xpl')"/>
+                resolve-uri('../wrap-standard-functions/wrap-standard-functions.xpl')"
+            as="xs:anyURI"/>
         <p:import href="{$resolved-uri}"/>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/compiler/xslt/compile/scoped-result.xsl
+++ b/src/compiler/xslt/compile/scoped-result.xsl
@@ -14,6 +14,7 @@
     </xsl:function>
 
     <xsl:template name="define-impl-test-items" as="node()+">
+        <xsl:context-item use="absent" />
         <xsl:comment> wrap $x:result into a document node if possible </xsl:comment>
         <variable name="{x:known-UQName('impl:test-items')}" as="item()*">
             <choose>

--- a/src/compiler/xslt/report/report-utils.xsl
+++ b/src/compiler/xslt/report/report-utils.xsl
@@ -47,5 +47,5 @@
    </xsl:template>
 
    <!-- Should not reach for XSLT, only for XProc -->
-   <xsl:template name="x:record-port-specific-result"/>
+   <xsl:template name="x:record-port-specific-result" as="empty-sequence()" />
 </xsl:stylesheet>

--- a/src/reporter/coverage-report.xsl
+++ b/src/reporter/coverage-report.xsl
@@ -185,6 +185,7 @@
    <!-- In production, always use the global $coverage-stats variable.
       The template parameter is for unit testing this template. -->
    <xsl:template name="contents-table" as="element(xhtml:table)">
+      <xsl:context-item use="absent"/>
       <xsl:param name="coverage-stats" select="$coverage-stats"
          as="element(module)*"/>
       <table class="xspec">

--- a/src/schematron/get-query-binding-ant.xsl
+++ b/src/schematron/get-query-binding-ant.xsl
@@ -18,8 +18,8 @@
         <xsl:choose>
             <xsl:when test="exists(/*/@schematron)">
                 <xsl:variable name="queryLanguage" select="
-                    doc(resolve-uri(/*/@schematron, base-uri(/*)))/sch:schema/@queryBinding
-                    ! replace(., '[0-9]+', '')"/>
+                        doc(resolve-uri(/*/@schematron, base-uri(/*)))/sch:schema/@queryBinding
+                        ! replace(., '[0-9]+', '')" as="xs:string?"/>
                 <xspec>
                     <schematron>
                         <querylanguage>

--- a/src/schematron/get-query-binding-ant.xsl
+++ b/src/schematron/get-query-binding-ant.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    exclude-result-prefixes="#all" version="3.0">
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="#all" version="3.0">
 
     <!--
         Transform an XSpec test document as follows:
@@ -14,11 +14,11 @@
     -->
     <xsl:template as="element(xspec)?" match="/">
         <xsl:variable name="schema-uri" as="xs:anyURI*"
-            select="/*/@schematron ! resolve-uri(., base-uri(/*))"/>
+            select="/x:description/@schematron ! resolve-uri(., base-uri(/x:description))"/>
         <xsl:choose>
-            <xsl:when test="exists(/*/@schematron)">
+            <xsl:when test="exists(/x:description/@schematron)">
                 <xsl:variable name="queryLanguage" select="
-                        doc(resolve-uri(/*/@schematron, base-uri(/*)))/sch:schema/@queryBinding
+                        doc($schema-uri)/sch:schema/@queryBinding
                         ! replace(., '[0-9]+', '')" as="xs:string?"/>
                 <xspec>
                     <schematron>

--- a/src/schematron/get-query-binding.xsl
+++ b/src/schematron/get-query-binding.xsl
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="#all" version="3.0">
     <xsl:output method="text"/>
     <xsl:template name="xsl:initial-template" as="text()">
+        <xsl:context-item as="document-node(element(x:description))" use="required"/>
         <xsl:value-of select="
-                doc(resolve-uri(/*/@schematron, base-uri(/*)))/sch:schema/@queryBinding
+                doc(resolve-uri(/x:description/@schematron, base-uri(/x:description)))
+                /sch:schema/@queryBinding
                 ! replace(., '[0-9]+', '')"/>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/schematron/preprocessor.xsl
+++ b/src/schematron/preprocessor.xsl
@@ -2,9 +2,9 @@
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:variable name="sbu" select="resolve-uri('../../lib/', static-base-uri())" static="yes"/>
-	<xsl:variable as="map(xs:string, item())" name="x:schematron-preprocessor"
-	        select="
+	<xsl:variable name="sbu" select="resolve-uri('../../lib/', static-base-uri())" static="yes"
+		as="xs:anyURI"/>
+	<xsl:variable as="map(xs:string, item())" name="x:schematron-preprocessor" select="
 			(
 			map {
 				'name': 'skeleton',

--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -6,7 +6,7 @@
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 exclude-result-prefixes="#all">
 
-    <xsl:param name="sch-impl-name" as="xs:string" select="'schxslt'" static="yes"/>
+    <xsl:param name="sch-impl-name" as="xs:string" select="'schxslt2'" static="yes"/>
     <xsl:param name="xqs-home" as="xs:string" select="'../../lib/XQS/'"/>
 
     <!--
@@ -58,7 +58,9 @@
     <xsl:include href="../common/uri-utils.xsl" />
     <xsl:include href="../common/user-content-utils.xsl" />
     <xsl:include href="../common/yes-no-utils.xsl" />
+    <xsl:include href="../compiler/base/declare-variable/sequencetype-with-uqnames.xsl" />
     <xsl:include href="../compiler/base/resolve-import/resolve-import.xsl" />
+    <xsl:include href="../compiler/base/util/compiler-eqname-utils.xsl" />
     <xsl:include href="../compiler/base/util/compiler-misc-utils.xsl" />
 
     <xsl:output indent="yes" />
@@ -143,7 +145,11 @@
                             <!-- Define $impl:phase variable for use in xqs:validate calling syntax. -->
                             <xsl:element name="{x:xspec-name('variable',.)}" namespace="{namespace-uri()}">
                                 <xsl:attribute name="name" select="x:known-UQName('impl:phase')"/>
-                                <xsl:copy-of select="(@* except @name) | node()"/>
+                                <xsl:if test="exists(@as)">
+                                    <xsl:attribute name="as"
+                                        select="x:lexical-to-UQName-in-sequence-type(., 'as')"/>
+                                </xsl:if>
+                                <xsl:copy-of select="(@* except (@name | @as)) | node()"/>
                             </xsl:element>
                         </xsl:for-each>
                         <xsl:sequence select="$specs[not(self::x:param[@name='phase'])]"/>

--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="3.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="3.0" xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <xsl:param name="xspec-home" as="xs:string?"/>
     <xsl:param name="force-focus" as="xs:string?"/>
@@ -29,11 +30,11 @@
 
     <xsl:template name="declare-harness-step" as="node()+">
         <xsl:comment>substep to run a test suite whose XProc step functions are in scope</xsl:comment>
-        <xsl:variable name="harness-library"
-            select="if ($xspec-home != '') then
-            resolve-uri('src/xproc3/harness-lib.xpl', $xspec-home)
-            else
-            'http://www.jenitennison.com/xslt/xspec/xproc/lib'"/>
+        <xsl:variable name="harness-library" select="
+                if ($xspec-home != '') then
+                    'src/xproc3/harness-lib.xpl' => resolve-uri($xspec-home) => string()
+                else
+                    'http://www.jenitennison.com/xslt/xspec/xproc/lib'" as="xs:string"/>
 
         <p:declare-step name="xproc-compile-run-format" type="x:xproc-compile-run-format">
             <xsl:namespace name="x">http://www.jenitennison.com/xslt/xspec</xsl:namespace>
@@ -47,17 +48,10 @@
                 'encoding':'UTF-8',
                 'include-content-type':true(),
                 'omit-xml-declaration':false()
-                }}"
-                primary="true"
-                pipe="result@format-report" />
-            <p:output port="junit"
-                content-types="xml"
-                serialization="map{{
+                }}" primary="true" pipe="result@format-report"/>
+            <p:output port="junit" content-types="xml" serialization="map{{
                 'method':'xml'
-                }}"
-                primary="false"
-                sequence="true"
-                pipe="result@junit-report"/>
+                }}" primary="false" sequence="true" pipe="result@junit-report"/>
 
             <p:option name="xspec-home" as="xs:string?"/>
             <p:option name="force-focus" as="xs:string?" select="'{$force-focus}'"/>
@@ -94,8 +88,8 @@
             <xsl:comment>produce the JUnit report if requested</xsl:comment>
             <x:maybe-format-junit-report name="junit-report" p:depends="format-report">
                 <p:with-input port="source" pipe="result@run"/>
-                <p:with-option name="xspec-home" select="$xspec-home" />
-                <p:with-option name="junit-enabled" select="$junit-enabled" />
+                <p:with-option name="xspec-home" select="$xspec-home"/>
+                <p:with-option name="junit-enabled" select="$junit-enabled"/>
             </x:maybe-format-junit-report>
         </p:declare-step>
     </xsl:template>
@@ -104,8 +98,11 @@
         <xsl:comment>run the test suite</xsl:comment>
         <x:xproc-compile-run-format name="run-test-suite">
             <p:with-option name="xspec-home">
-                <xsl:attribute name="select"
-                    select="if (exists($xspec-home)) then x:quote-with-apos($xspec-home) else '()'"/>
+                <xsl:attribute name="select" select="
+                        if (exists($xspec-home)) then
+                            x:quote-with-apos($xspec-home)
+                        else
+                            '()'"/>
             </p:with-option>
         </x:xproc-compile-run-format>
     </xsl:template>

--- a/src/xproc3/xproc-testing/generate-pipeline.xsl
+++ b/src/xproc3/xproc-testing/generate-pipeline.xsl
@@ -22,6 +22,7 @@
     </xsl:template>
 
     <xsl:template name="declare-ports" as="node()+">
+        <xsl:context-item use="absent"/>
         <xsl:comment>Declare ports</xsl:comment>
         <p:input port="xspec"/>
         <p:output port="result" primary="true"/>
@@ -29,6 +30,7 @@
     </xsl:template>
 
     <xsl:template name="declare-harness-step" as="node()+">
+        <xsl:context-item use="absent"/>
         <xsl:comment>substep to run a test suite whose XProc step functions are in scope</xsl:comment>
         <xsl:variable name="harness-library" select="
                 if ($xspec-home != '') then
@@ -95,6 +97,7 @@
     </xsl:template>
 
     <xsl:template name="execute-harness-step" as="node()+">
+        <xsl:context-item use="absent"/>
         <xsl:comment>run the test suite</xsl:comment>
         <x:xproc-compile-run-format name="run-test-suite">
             <p:with-option name="xspec-home">

--- a/test/check-xproc-harness-options-lib.xpl
+++ b/test/check-xproc-harness-options-lib.xpl
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:library xmlns:p="http://www.w3.org/ns/xproc"
-    xmlns:c="http://www.w3.org/ns/xproc-step"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xspec="http://www.jenitennison.com/xslt/xspec"
-    xmlns:xt="x-urn:test:xproc:check-options"
+<p:library xmlns:p="http://www.w3.org/ns/xproc" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xspec="http://www.jenitennison.com/xslt/xspec" xmlns:xt="x-urn:test:xproc:check-options"
     version="3.0">
     <p:import href="../src/xproc3/run-xquery.xpl"/>
     <p:import href="../src/xproc3/run-xslt.xpl"/>
@@ -21,9 +18,9 @@
                 <p:inline>
                     <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                         xmlns:h="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all">
-                        <xsl:template match="/">
-                            <xsl:if
-                                test="empty(/h:html/h:head/h:link[@rel='stylesheet'][ends-with(@href,'/test-report-colors-whiteblack.css')])">
+                        <xsl:template match="/" as="element(message)?">
+                            <xsl:if test="empty(/h:html/h:head/h:link[@rel='stylesheet']
+                                [ends-with(@href,'/test-report-colors-whiteblack.css')])">
                                 <message>html-report-theme: Did not find test-report-colors-whiteblack.css</message>
                             </xsl:if>
                         </xsl:template>
@@ -46,18 +43,22 @@
         <p:xslt name="verify-force-focus-none">
             <p:with-input port="stylesheet">
                 <p:inline>
-                    <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                        xmlns:h="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all">
-                        <xsl:param name="expected-pending-value"/>
-                        <xsl:template match="/">
-                            <xsl:if test="empty(descendant::h:thead/h:tr/h:th[. = 'pending:&#160;' || $expected-pending-value])">
+                    <xsl:stylesheet xmlns:h="http://www.w3.org/1999/xhtml"
+                        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                        exclude-result-prefixes="#all" version="3.0">
+                        <xsl:param name="expected-pending-value" as="xs:string"/>
+                        <xsl:template match="/" as="element(message)?">
+                            <xsl:if
+                                test="empty(descendant::h:thead/h:tr/h:th[. = 'pending:&#160;' || $expected-pending-value])">
                                 <message>force-focus #none: Did not find 'pending: {$expected-pending-value}'</message>
                             </xsl:if>
                         </xsl:template>
                     </xsl:stylesheet>
                 </p:inline>
             </p:with-input>
-            <p:with-option name="parameters" select="map{'expected-pending-value': $expected-pending-value}"/>
+            <p:with-option name="parameters"
+                select="map{'expected-pending-value': $expected-pending-value}"/>
         </p:xslt>
     </p:declare-step>
 </p:library>

--- a/test/check-xproc-harness-options.xpl
+++ b/test/check-xproc-harness-options.xpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-   xmlns:xt="x-urn:test:xproc:check-options" version="3.1">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:xt="x-urn:test:xproc:check-options"
+   version="3.1">
 
    <p:documentation>
       <p>This pipeline verifies effects of options in the XProc pipelines for XSpec.</p>
@@ -12,12 +12,14 @@
 
    <!-- Run test cases and collect results -->
    <p:xslt name="run-collect">
-      <p:with-input port="source"><dummy/></p:with-input>
+      <p:with-input port="source">
+         <dummy/>
+      </p:with-input>
       <p:with-input port="stylesheet">
          <p:inline>
             <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:xt="x-urn:test:xproc:check-options" exclude-result-prefixes="#all">
-               <xsl:template match="/">
+               <xsl:template match="/" as="element(messages)">
                   <messages>
                      <!-- Each test case is an XProc step. Call each one as an XPath function.
                         https://docs.xmlcalabash.com/userguide/current/pipelineception.html -->

--- a/test/compile-xproc-tests.xspec
+++ b/test/compile-xproc-tests.xspec
@@ -40,8 +40,7 @@
                             namespace="http://www.jenitennison.com/xslt/xspec">
                   <xsl:text>my scenario label</xsl:text>
                </xsl:element>
-               <xsl:element name="input-wrap"
-                  namespace="">...</xsl:element>
+               <xsl:element name="input-wrap" namespace="">...</xsl:element>
             </xsl:element>
          </xsl:template>
       </t:expect>
@@ -60,12 +59,17 @@
          <t:label>The compiler produces the x:result variable. It defines input and option values,
             defines the test-case step for this x:call, and uses the final xsl:sequence to call the
             step runner.</t:label>
-            <xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}result"
-               as="item()*">
-               <xsl:variable name="..." select="(1) => Q{{urn:x-xspec:common:wrap}}wrap-each()"><!--source input--></xsl:variable>
-               <xsl:variable name="..." select="(2) => Q{{urn:x-xspec:common:wrap}}wrap-each()"><!--aux input--></xsl:variable>
-               <xsl:variable name="..." select="1"><!--ex:option1 option--></xsl:variable>
-               <xsl:variable name="..." select="..."><!--ex:option2 option--></xsl:variable>
+            <xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}result" as="item()*">
+               <xsl:variable name="..." select="(1) => Q{{urn:x-xspec:common:wrap}}wrap-each()"
+                  as="xs:integer"><!--source input--></xsl:variable>
+               <xsl:variable name="..." select="(2) => Q{{urn:x-xspec:common:wrap}}wrap-each()"
+                  as="xs:integer"><!--aux input--></xsl:variable>
+               <xsl:variable name="..." select="1" as="xs:integer">
+                  <!--ex:option1 option-->
+               </xsl:variable>
+               <xsl:variable name="..." select="..." as="map(xs:string, xs:integer)">
+                  <!--ex:option2 option-->
+               </xsl:variable>
                <xsl:variable name="Q{{urn:x-xspec:compile:impl}}test-case-step-based-on-x-call"
                   as="element()" expand-text="no">
                   <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"

--- a/test/compile-xproc-tests/compile-scenario.xspec
+++ b/test/compile-xproc-tests/compile-scenario.xspec
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:description xmlns:ex="x-urn:test:compile-xproc-tests" xmlns:t="http://www.jenitennison.com/xslt/xspec"
-	xproc="My-step-type.xpl">
+<t:description xmlns:ex="x-urn:test:compile-xproc-tests" xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:t="http://www.jenitennison.com/xslt/xspec" xproc="My-step-type.xpl">
 	<t:scenario id="dummy-scenario-id" label="my scenario label">
-	    <t:call step="ex:My-step-type">
-	    	<t:input port="source" select="1"/>
-	    	<t:input port="aux" select="2"/>
-	        <t:option name="ex:option1" select="1"/>
-	        <t:option name="ex:option2" select="map{
+		<t:call step="ex:My-step-type">
+			<t:input port="source" select="1" as="xs:integer"/>
+			<t:input port="aux" select="2" as="xs:integer"/>
+			<t:option name="ex:option1" select="1" as="xs:integer"/>
+			<t:option name="ex:option2" select="map{
 	            'a': 1,
 	            'b': 2
-	            }"/>
-	    </t:call>
+	            }" as="map(xs:string, xs:integer)"/>
+		</t:call>
 	</t:scenario>
 </t:description>

--- a/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
+++ b/test/end-to-end/cases/expected/schematron/schematron-import_demo-02-PhaseB-result.xml
@@ -10,6 +10,7 @@
       <input-wrap xmlns="">
          <x:context xmlns:schxslt="http://dmaus.name/ns/2023/schxslt"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
                     href="../../../../../tutorial/schematron/demo-02.xml"/>
       </input-wrap>
       <result select="/element()">
@@ -64,6 +65,7 @@
          <expect-test-wrap xmlns="">
             <x:expect xmlns:schxslt="http://dmaus.name/ns/2023/schxslt"
                       xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="exists(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, @ruleId, @patternId, @groupId)[1] = 't2-1'][(@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}fired-rule[1]/@role, preceding-sibling::Q{http://purl.oclc.org/dsdl/svrl}active-pattern[1]/@role)[1] = 'error'])"/>
          </expect-test-wrap>
          <expect select="()"/>
@@ -73,6 +75,7 @@
          <expect-test-wrap xmlns="">
             <x:expect xmlns:schxslt="http://dmaus.name/ns/2023/schxslt"
                       xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
                       test="Q{http://purl.oclc.org/dsdl/svrl}schematron-output[Q{http://purl.oclc.org/dsdl/svrl}fired-rule] and empty(Q{http://purl.oclc.org/dsdl/svrl}schematron-output/Q{http://purl.oclc.org/dsdl/svrl}failed-assert[(@id, @ruleId, @patternId, @groupId)[1] = 't1-1'])"/>
          </expect-test-wrap>
          <expect select="()"/>

--- a/test/external_scenario-param-static-use-when.xsl
+++ b/test/external_scenario-param-static-use-when.xsl
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<xsl:param name="A" static="yes" as="xs:integer" select="0"/>
 	<xsl:param name="B" static="yes" as="xs:integer" select="0"/>
-	<xsl:param name="myp:default" static="no"
+	<xsl:param name="myp:default" static="no" as="item()?"
 		xmlns:myp="http://example.org/ns/my/param"/>
 
-	<xsl:template name="process-A-and-B">
+	<xsl:template name="process-A-and-B" as="xs:anyAtomicType+">
 		<xsl:context-item use="absent"/>
 		<xsl:call-template name="template-based-on-A"/>
 		<xsl:call-template name="template-based-on-B"/>

--- a/test/external_scenario-param.sch.included.xsl
+++ b/test/external_scenario-param.sch.included.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:param name="user-param" required="yes" />
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:param name="user-param" required="yes" as="xs:string"/>
 </xsl:stylesheet>

--- a/test/external_schut-to-xspec-for-xqs.xspec
+++ b/test/external_schut-to-xspec-for-xqs.xspec
@@ -42,6 +42,14 @@
                 href="schematron/schut-to-xspec-for-xqs-phase-string-out.xspec"
                 select="helper:expect(.)" />
         </x:scenario>
+
+        <x:scenario label="with prefixed type in @as">
+            <!-- Modeled on schut-to-xspec-for-xqs-phase-text-in.xspec but adds x:param/@as -->
+            <x:context href="schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"/>
+            <x:expect label="defines x:variable for phase, converting @as to use UQNames"
+                href="schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec"
+                select="helper:expect(.)" />
+        </x:scenario>
     </x:scenario>
 
     <x:scenario label="namespaces defined in Schematron">

--- a/test/generate-step3-wrapper_custom.xspec
+++ b/test/generate-step3-wrapper_custom.xspec
@@ -13,6 +13,7 @@
 				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+				xmlns:xs="http://www.w3.org/2001/XMLSchema"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 				<xsl:import href="{$ACTUAL-PREPROCESSOR-URI}" />
 				<xsl:variable name="..." as="document-node()">
@@ -21,14 +22,14 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}xspec-uri"
-					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI"
-					select="..." />
+					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI" select="..." />
 				<xsl:variable as="document-node()" name="...">
 					<xsl:document>
 						<xsl:text>PhaseA</xsl:text>
 					</xsl:document>
 				</xsl:variable>
-				<xsl:param name="Q{{http://dmaus.name/ns/2023/schxslt}}phase" select="..." />
+				<xsl:param name="Q{{http://dmaus.name/ns/2023/schxslt}}phase" select="..."
+					as="xs:string"/>
 				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
 					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>

--- a/test/generate-step3-wrapper_default.xspec
+++ b/test/generate-step3-wrapper_default.xspec
@@ -11,6 +11,7 @@
 				- SchXslt metadata generation in SVRL should be disabled.
 			]]></x:label>
 			<xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
+				xmlns:xs="http://www.w3.org/2001/XMLSchema"
 				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 				<xsl:import href="{$x:schematron-preprocessor?stylesheets?3 treat as xs:anyURI}" />
 				<xsl:variable name="..." as="document-node()">
@@ -19,14 +20,14 @@
 					</xsl:document>
 				</xsl:variable>
 				<xsl:variable name="Q{{http://www.jenitennison.com/xslt/xspec}}xspec-uri"
-					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI"
-					select="..." />
+					as="Q{{http://www.w3.org/2001/XMLSchema}}anyURI" select="..." />
 				<xsl:variable name="..." as="document-node()">
 					<xsl:document>
 						<xsl:text>PhaseA</xsl:text>
 					</xsl:document>
 				</xsl:variable>
-				<xsl:param name="Q{{http://dmaus.name/ns/2023/schxslt}}phase" select="..." />
+				<xsl:param name="Q{{http://dmaus.name/ns/2023/schxslt}}phase" select="..."
+				   as="xs:string" />
 				<xsl:param as="Q{{http://www.w3.org/2001/XMLSchema}}boolean"
 					name="Q{{}}schxslt.compile.metadata" select="false()" />
 			</xsl:stylesheet>

--- a/test/schematron-param-001.xspec
+++ b/test/schematron-param-001.xspec
@@ -9,12 +9,13 @@
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                schematron="schematron-param-001.sch"
                xml:base="schematron/">
-    <x:param name="schxslt:phase">P1</x:param>
-    <x:param name="selected" select="codepoints-to-string((80,49))" /><!-- = (U+0050, U+0031) = "P1" -->
-    <x:param name="escape1">AAA BBB CCC</x:param>
-    <x:param name="escape2">a"b</x:param>
-    <x:param name="escape3">a'b</x:param>
-    <x:param name="escape4">A ' " B</x:param>
+    <x:param name="schxslt:phase" as="xs:string">P1</x:param>
+    <x:param name="selected" select="codepoints-to-string((80,49))"
+        as="xs:string"/><!-- = (U+0050, U+0031) = "P1" -->
+    <x:param name="escape1" as="xs:string">AAA BBB CCC</x:param>
+    <x:param name="escape2" as="xs:string">a"b</x:param>
+    <x:param name="escape3" as="xs:string">a'b</x:param>
+    <x:param name="escape4" as="xs:string">A ' " B</x:param>
     <x:param name="foo:selected" select="bar:baz/@qux:quux" as="attribute(qux:quux)">
         <bar:baz qux:quux="corge" />
     </x:param>

--- a/test/schematron/schematron-param-001-step3.xsl
+++ b/test/schematron/schematron-param-001-step3.xsl
@@ -35,6 +35,7 @@
 	</template>
 	
 	<xsl:template name="customize-preprocessed-schema" as="element(xsl:variable)+">
+		<xsl:context-item use="absent"/>
 		<xsl:variable as="map(xs:string, item())" name="vars-map" select="
 				map {
 					'selected': $selected,
@@ -63,6 +64,7 @@
 				'process-prolog'[$x:schematron-preprocessor?name eq 'skeleton'],
 				'schxslt2-does-not-use-this-template'[$x:schematron-preprocessor?name eq 'schxslt2']
 			}" as="element(xsl:variable)+">
+		<xsl:context-item use="absent"/>
 		<xsl:param as="element(sch:schema)" name="schema" required="yes"
 			use-when="$x:schematron-preprocessor?name eq 'schxslt'" />
 

--- a/test/schematron/schematron-param-001-step3.xsl
+++ b/test/schematron/schematron-param-001-step3.xsl
@@ -20,13 +20,13 @@
 	<xsl:include href="../../src/common/namespace-vars.xsl" />
 	<xsl:include href="../../src/common/uqname-utils.xsl" />
 
-	<xsl:param name="selected" required="yes" />
-	<xsl:param name="escape1" required="yes" />
-	<xsl:param name="escape2" required="yes" />
-	<xsl:param name="escape3" required="yes" />
-	<xsl:param name="escape4" required="yes" />
-	<xsl:param name="foo:selected" required="yes" />
-	<xsl:param name="href-selected" required="yes" />
+	<xsl:param name="selected" as="xs:string" required="yes" />
+	<xsl:param name="escape1" as="xs:string" required="yes" />
+	<xsl:param name="escape2" as="xs:string" required="yes" />
+	<xsl:param name="escape3" as="xs:string" required="yes" />
+	<xsl:param name="escape4" as="xs:string" required="yes" />
+	<xsl:param name="foo:selected" as="attribute(Q{qux}quux)" required="yes" />
+	<xsl:param name="href-selected" as="comment()" required="yes" />
 
 
 	<template match="sch:schema/sch:let[@name = 'schxslt2-customization-signal']" as="element()+"
@@ -34,7 +34,7 @@
 		<call-template name="customize-preprocessed-schema"/>
 	</template>
 	
-	<xsl:template name="customize-preprocessed-schema">
+	<xsl:template name="customize-preprocessed-schema" as="element(xsl:variable)+">
 		<xsl:variable as="map(xs:string, item())" name="vars-map" select="
 				map {
 					'selected': $selected,
@@ -56,7 +56,7 @@
 			</xsl:element>
 		</xsl:for-each>
 	</xsl:template>
-	
+
 	<xsl:template _name="
 			{
 				'schxslt-api:validation-stylesheet-body-top-hook'[$x:schematron-preprocessor?name eq 'schxslt'],

--- a/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec
+++ b/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="schut-to-xspec-test.sch"
+    xquery-version="3.1">
+    <x:param name="phase" as="xs:string">P1</x:param>
+    <x:scenario label="Schematron test scenario">
+        <x:context>
+            <element/>
+        </x:context>
+    </x:scenario>
+</x:description>

--- a/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec
+++ b/test/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-out.xspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.jenitennison.com/xslt/xspec"
+             xmlns:x="http://www.jenitennison.com/xslt/xspec"
+             schematron="%TEST_BASE%/schematron/schut-to-xspec-test.sch"
+             original-xspec="%TEST_BASE%/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"
+             query="http://www.andrewsales.com/ns/xqs" query-at="%TEST_BASE%/../lib/XQS/xqs.xqm"
+             xquery-version="3.1">
+   <x:variable xmlns=""
+               name="Q{urn:x-xspec:compile:impl}schema-uri"
+               as="Q{http://www.w3.org/2001/XMLSchema}anyURI"
+               select="'%TEST_BASE%/schematron/schut-to-xspec-test.sch'" />
+   <x:variable xmlns="" name="Q{urn:x-xspec:compile:impl}phase"
+      as="Q{http://www.w3.org/2001/XMLSchema}string">
+      <x:text>P1</x:text>
+   </x:variable>
+   <x:scenario xmlns=""
+               xslt-version="3"
+               xspec="%TEST_BASE%/schematron/schut-to-xspec-for-xqs-phase-prefixed-as-in.xspec"
+               label="Schematron test scenario">
+      <x:variable name="Q{http://www.jenitennison.com/xslt/xspec}context" select="self::document-node()">
+         <element/>
+      </x:variable>
+      <x:call function="Q{http://www.andrewsales.com/ns/xqs}validate">
+         <x:param name="instance" as="node()" select="$Q{http://www.jenitennison.com/xslt/xspec}context" />
+         <x:param name="schema" as="element()" select="doc($Q{urn:x-xspec:compile:impl}schema-uri)/*" />
+         <x:param name="options" as="map(*)" select="map{'phase': string($Q{urn:x-xspec:compile:impl}phase)}"/>
+      </x:call>
+   </x:scenario>
+</description>

--- a/test/xproc/run-xproc-cases.xpl
+++ b/test/xproc/run-xproc-cases.xpl
@@ -67,7 +67,7 @@
                                     xmlns:h="http://www.w3.org/1999/xhtml"
                                     exclude-result-prefixes="#all">
                                     <xsl:mode on-no-match="shallow-skip"/>
-                                    <xsl:template match="/">
+                                    <xsl:template match="/" as="element(message)?">
                                         <!-- $failure-text should be 'failed:&#160;' followed by the number of failures -->
                                         <xsl:variable name="failure-text" as="xs:string"
                                             select="exactly-one(descendant::h:th[contains-token(@class, 'emphasis')])/string()"/>

--- a/test/xqs/phases-xqs.xspec
+++ b/test/xqs/phases-xqs.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="phases-xqs.sch">
-    <x:param name="phase">P1</x:param>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="phases-xqs.sch">
+    <x:param name="phase" as="xs:string">P1</x:param>
     <x:scenario label="Phase P1 includes title check but not subtitle check">
         <x:context>
             <section/>

--- a/test/xqs/run-tests-with-basex.xpl
+++ b/test/xqs/run-tests-with-basex.xpl
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:c="http://www.w3.org/ns/xproc-step"
-            xmlns:h="http://www.w3.org/1999/xhtml"
-            xmlns:x="http://www.jenitennison.com/xslt/xspec"
-            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-            xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-            name="run-tests-with-basex"
-            type="x:run-tests-with-basex"
-            version="3.1">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
+   xmlns:h="http://www.w3.org/1999/xhtml" xmlns:x="http://www.jenitennison.com/xslt/xspec"
+   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   xmlns:map="http://www.w3.org/2005/xpath-functions/map" name="run-tests-with-basex"
+   type="x:run-tests-with-basex" version="3.1">
 
    <p:documentation>
       <p>This pipeline executes all .xspec files in the test/xqs directory.</p>
-      <p>NOTE: This pipeline depends on the BaseX extension to XML Calabash 3 (v3.0.14 or later).</p>
+      <p>NOTE: This pipeline depends on the BaseX extension to XML Calabash 3 (v3.0.14 or
+         later).</p>
       <p><b>Input ports:</b> None.</p>
       <p><b>Output ports:</b> None. This pipeline raises an error if any tests fail.</p>
       <p>'xspec-home' option: Directory of XSpec. Default: Root of this XSpec installation.</p>
@@ -45,7 +42,8 @@
          <p:choose>
             <p:when test="$test-type eq 'schematron'">
                <!-- Test for Schematron schema with XQuery language binding -->
-               <p:identity message="&#10;--- Case #{ $idx }: { $test-filename } (test for Schematron) ---"/>
+               <p:identity
+                  message="&#10;--- Case #{ $idx }: { $test-filename } (test for Schematron) ---"/>
                <x:run-schematron-xqs>
                   <p:with-input pipe="result@test-file"/>
                   <p:with-option name="xspec-home" select="$xspec-home-to-use"/>
@@ -55,7 +53,8 @@
             </p:when>
             <p:when test="$test-type eq 'xproc'">
                <!-- Test for XProc -->
-               <p:identity message="&#10;--- Case #{ $idx }: { $test-filename } (test for XProc) ---"/>
+               <p:identity
+                  message="&#10;--- Case #{ $idx }: { $test-filename } (test for XProc) ---"/>
                <x:run-xproc>
                   <p:with-input pipe="result@test-file"/>
                   <p:with-option name="xspec-home" select="$xspec-home-to-use"/>
@@ -63,7 +62,8 @@
             </p:when>
             <p:otherwise>
                <!-- Test for XQuery -->
-               <p:identity message="&#10;--- Case #{ $idx }: { $test-filename } (test for XQuery) ---"/>
+               <p:identity
+                  message="&#10;--- Case #{ $idx }: { $test-filename } (test for XQuery) ---"/>
                <x:run-xquery>
                   <p:with-input pipe="result@test-file"/>
                   <p:with-option name="xspec-home" select="$xspec-home-to-use"/>
@@ -75,13 +75,12 @@
          <p:xslt name="check-html-report">
             <p:with-input port="stylesheet">
                <p:inline>
-                  <xsl:stylesheet version="3.0"
-                     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  <xsl:stylesheet version="3.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"
                      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                      xmlns:h="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all">
                      <xsl:param name="test-type" as="xs:string" required="yes"/>
                      <xsl:mode on-no-match="shallow-skip"/>
-                     <xsl:template match="/">
+                     <xsl:template match="/" as="element(message)*">
                         <!-- $failure-text should be 'failed:&#160;' followed by the number of failures -->
                         <xsl:variable name="failure-text" as="xs:string"
                            select="exactly-one(descendant::h:th[contains-token(@class, 'emphasis')])/string()"/>
@@ -96,7 +95,9 @@
                         <xsl:if test="($test-type eq 'schematron') and
                            empty(//h:body/h:p/text()[.='Schematron: '])">
                            <message>
-                              <xsl:value-of select="concat($xspec-file, ' report header does not indicate schema')"/>
+                              <xsl:value-of
+                                 select="concat($xspec-file, ' report header does not indicate schema')"
+                              />
                            </message>
                         </xsl:if>
                      </xsl:template>

--- a/tutorial/namespaces/namespace-demo.xsl
+++ b/tutorial/namespaces/namespace-demo.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://www.w3.org/1999/xhtml"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xpath-default-namespace="http://docbook.org/ns/docbook"
     version="3.0">
@@ -11,8 +12,8 @@
         XLink namespace is also in use.
     -->
 
-    <xsl:template match="link">  <!-- Matches DocBook 'link' -->
-        <a href="{@xlink:href}"> <!-- Produces XHTML 'a' -->
+    <xsl:template match="link" as="element(h:a)">  <!-- Matches DocBook 'link' -->
+        <a href="{@xlink:href}">                   <!-- Produces XHTML 'a' -->
             <xsl:apply-templates/>
         </a>
     </xsl:template>

--- a/tutorial/schematron-xqs/demo-02-PhaseA.xspec
+++ b/tutorial/schematron-xqs/demo-02-PhaseA.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="demo-02.sch">
-    <x:param name="phase">PhaseA</x:param>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="demo-02.sch">
+    <x:param name="phase" as="xs:string">PhaseA</x:param>
     <x:scenario label="Pattern 1">
         <x:context href="demo-02.xml"/>
         <x:expect-assert id="t1-1" role="warn"/>

--- a/tutorial/schematron-xqs/demo-02-PhaseB.xspec
+++ b/tutorial/schematron-xqs/demo-02-PhaseB.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="demo-02.sch">
-    <x:param name="phase">PhaseB</x:param>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" schematron="demo-02.sch">
+    <x:param name="phase" as="xs:string">PhaseB</x:param>
     <x:scenario label="Pattern 2">
         <x:context href="demo-02.xml"/>
         <x:expect-assert id="t2-1" role="error"/>

--- a/tutorial/schematron/demo-02-PhaseA.xspec
+++ b/tutorial/schematron/demo-02-PhaseA.xspec
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:schxslt="http://dmaus.name/ns/2023/schxslt"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="demo-02.sch">
-    <x:param name="schxslt:phase">PhaseA</x:param>
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    schematron="demo-02.sch">
+    <x:param name="schxslt:phase" as="xs:string">PhaseA</x:param>
     <x:scenario label="Pattern 1">
         <x:context href="demo-02.xml"/>
         <x:expect-assert id="t1-1" role="warn"/>

--- a/tutorial/schematron/demo-02-PhaseB.xspec
+++ b/tutorial/schematron/demo-02-PhaseB.xspec
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:schxslt="http://dmaus.name/ns/2023/schxslt"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec" schematron="demo-02.sch">
-    <x:param name="schxslt:phase">PhaseB</x:param>
+    xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    schematron="demo-02.sch">
+    <x:param name="schxslt:phase" as="xs:string">PhaseB</x:param>
     <x:scenario label="Pattern 2">
         <x:context href="demo-02.xml"/>
         <x:expect-assert id="t2-1" role="error"/>


### PR DESCRIPTION
Fixes #2337.

I also did some code reformatting (with Oxygen 28.1) while I was in certain files.

This PR depends on #2341, so the first commit (a56134ec487230a30d5178ad19f31cb8fef4b85b) is the same as in #2341.