### PR TITLE
test(xproc): catalog usage tests no longer pending

### DIFF
--- a/test/catalog/01/imported_xproc.xspec
+++ b/test/catalog/01/imported_xproc.xspec
@@ -12,7 +12,7 @@
 				label="DTD fixed attribute should take effect via DOCTYPE resolved with catalog"
 				select="'1.0'" test="$x:result/root/@dtd-version/string()" />
 		</x:scenario>
-		<x:scenario label="x:input with href and without select" pending="TODO when XProc has catalog access">
+		<x:scenario label="x:input with href and without select">
 			<x:call step="mirror:identity">
 				<x:input port="source" href="catalog-01:/example.xml" />
 			</x:call>
@@ -30,7 +30,7 @@
 			<x:expect port="xproc-result" label="x:expect with href should be Success"
 				href="example.xml" />
 		</x:scenario>
-		<x:scenario label="x:input with href and without select" pending="TODO when XProc has catalog access">
+		<x:scenario label="x:input with href and without select">
 			<x:call step="mirror:identity">
 				<x:input port="source" href="example.xml" />
 			</x:call>

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1631,7 +1631,7 @@
         -Dcatalog="test\catalog\01\catalog-public.xml;%CD%\catalog\01\catalog-rewriteURI.xml" ^
         -Dxspec.xml="%CD%\catalog\catalog-01_xproc.xspec"
     call :verify_retval 0
-    call :verify_line -16 x "     [xslt] passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line -16 x "     [xslt] passed: 6 / pending: 0 / failed: 0 / total: 6"
     call :verify_line -2  x "BUILD SUCCESSFUL"
 	</case>
 
@@ -1708,7 +1708,7 @@
         -Dcatalog.is.uri=true ^
         -Dxspec.xml="%CD%\catalog\catalog-01_xproc.xspec"
     call :verify_retval 0
-    call :verify_line -16 x "     [xslt] passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line -16 x "     [xslt] passed: 6 / pending: 0 / failed: 0 / total: 6"
     call :verify_line -2  x "BUILD SUCCESSFUL"
 	</case>
 
@@ -1915,7 +1915,7 @@
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         "%SPACE_DIR%\catalog-01_xproc.xspec"
     call :verify_retval 0
-    call :verify_line 25 x "passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line 25 x "passed: 6 / pending: 0 / failed: 0 / total: 6"
 	</case>
 
 	<!--
@@ -1970,7 +1970,7 @@
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         catalog\catalog-01_xproc.xspec
     call :verify_retval 0
-    call :verify_line 25 x "passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line 25 x "passed: 6 / pending: 0 / failed: 0 / total: 6"
 	</case>
 
 	<!--
@@ -2036,7 +2036,7 @@
 
     call :run ..\bin\xspec.bat -p "%SPACE_DIR%\catalog-01_xproc.xspec"
     call :verify_retval 0
-    call :verify_line 25 x "passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line 25 x "passed: 6 / pending: 0 / failed: 0 / total: 6"
 	</case>
 
 	<!--
@@ -2078,7 +2078,7 @@
 
     call :run ..\bin\xspec.bat -p "catalog\catalog-01_xproc.xspec"
     call :verify_retval 0
-    call :verify_line 25 x "passed: 4 / pending: 2 / failed: 0 / total: 6"
+    call :verify_line 25 x "passed: 6 / pending: 0 / failed: 0 / total: 6"
 	</case>
 
 	<!--

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1879,7 +1879,7 @@ load bats-helper
         -Dcatalog="test/catalog/01/catalog-public.xml;${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -Dxspec.xml="${PWD}/catalog/catalog-01_xproc.xspec"
     [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 16]}" = "     [xslt] passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[${#lines[@]} - 16]}" = "     [xslt] passed: 6 / pending: 0 / failed: 0 / total: 6" ]
     [ "${lines[${#lines[@]} - 2]}" = "BUILD SUCCESSFUL" ]
 }
 
@@ -1963,7 +1963,7 @@ load bats-helper
         -Dcatalog.is.uri=true \
         -Dxspec.xml="${PWD}/catalog/catalog-01_xproc.xspec"
     [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 16]}" = "     [xslt] passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[${#lines[@]} - 16]}" = "     [xslt] passed: 6 / pending: 0 / failed: 0 / total: 6" ]
     [ "${lines[${#lines[@]} - 2]}" = "BUILD SUCCESSFUL" ]
 }
 
@@ -2196,7 +2196,7 @@ load bats-helper
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         "${space_dir}/catalog-01_xproc.xspec"
     [ "$status" -eq 0 ]
-    [ "${lines[24]}" = "passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[24]}" = "passed: 6 / pending: 0 / failed: 0 / total: 6" ]
 }
 
 #
@@ -2258,7 +2258,7 @@ load bats-helper
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_xproc.xspec
     [ "$status" -eq 0 ]
-    [ "${lines[24]}" = "passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[24]}" = "passed: 6 / pending: 0 / failed: 0 / total: 6" ]
 }
 
 #
@@ -2340,7 +2340,7 @@ load bats-helper
 
     myrun ../bin/xspec.sh -p "${space_dir}/catalog-01_xproc.xspec"
     [ "$status" -eq 0 ]
-    [ "${lines[24]}" = "passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[24]}" = "passed: 6 / pending: 0 / failed: 0 / total: 6" ]
 }
 
 #
@@ -2386,7 +2386,7 @@ load bats-helper
 
     myrun ../bin/xspec.sh -p "catalog/catalog-01_xproc.xspec"
     [ "$status" -eq 0 ]
-    [ "${lines[24]}" = "passed: 4 / pending: 2 / failed: 0 / total: 6" ]
+    [ "${lines[24]}" = "passed: 6 / pending: 0 / failed: 0 / total: 6" ]
 }
 
 #


### PR DESCRIPTION
In tests for XProc with catalog usage, some verifications were pending at first. They now work, so this pull request removes the `pending` attributes.