### PR TITLE
ci(deps): bump BaseX from 12.2 to 12.4

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -10,7 +10,7 @@ ANT_VERSION=1.10.14
 APACHE_XMLRESOLVER_VERSION=1.2
 
 # Latest BaseX
-BASEX_VERSION=12.2
+BASEX_VERSION=12.4
 
 # Do not perform Maven package by default
 DO_MAVEN_PACKAGE=


### PR DESCRIPTION
From https://github.com/BaseXdb/basex/blob/main/CHANGELOG

```
VERSION 12.4 (May 28, 2025) --------------------------------------------

  XQUERY FUNCTIONS
  - XQuery Module, parallelization: for-each, fork-any, reduce
  - String Module: new functions for ngrams & token set/sort ratio
  - Binary Module: bin:rotate, functions for counting & settings bits
  - Archive Module: improved support for different encodings
  - Database Module, DB creation: support for binary & value resources

  XQUERY PERFORMANCE
  - index rewritings for numeric predicates: //city[@code = 12763]
  - evaluate loop-invariant predicates only once
  - faster sorting of primitive value sequences
  - callback functions: improved type propagation

  FIXES & TWEAKS
  - parsing of CSV files with empty lines
  - command-line: newline added after the result of a query
  - error feedback: improved 'did you mean' suggestions
  - GUI: higher trace output limits

VERSION 12.3 (April 16, 2025) ------------------------------------------

 XQUERY 4.0
 - JNodes: XPath traversal in map/array structures
 - Improved string representation of function items
 - XML, JSON: canonical serialization
 - Namespace declarations: support for 'fixed' and '##any'

 XQUERY
 - HTML Parsing without parser: wrap HTML contents as string value
 - file:delete: raise no error if target does not exist
 - file:copy: Preserve capitalization of target path

 GUI
 - Support for FlatLaf Look and Feels
 - Editor: Improved closing of tags

 FIXES, PERFORMANCE
 - xquery:fork-join was fixed
 - info/debugging strings: increased output length
 - numerous tweaks to take advantage of recent JVMs
 - fn:path: caching of repeatedly accessed steps
```

Version 12.4 fixes the issue with 12.3 that obstructed #2308.