### PR TITLE
test(xquery): loosen BaseX server test case on Windows

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1352,7 +1352,7 @@
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
     rem Next verify_line is flexible because retries occur often on Windows and affect output lines
-    call :verify_line * r "..*:passed: 128 / pending: 0 / failed: 0 / total: 128"
+    call :verify_line -1 r "..*:passed: 128 / pending: 0 / failed: 0 / total: 128"
 
     rem HTML report file should be created and its charset should be UTF-8 #72
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1351,8 +1351,8 @@
         -p xspec-home="file:///%PARENT_DIR_ABS:\=/%/" ^
         ..\src\harnesses\basex\basex-server-xquery-harness.xproc
     call :verify_retval 0
-    call :verify_line_count 3
-    call :verify_line 3 r "..*:passed: 128 / pending: 0 / failed: 0 / total: 128"
+    rem Next verify_line is flexible because retries occur often on Windows and affect output lines
+    call :verify_line * r "..*:passed: 128 / pending: 0 / failed: 0 / total: 128"
 
     rem HTML report file should be created and its charset should be UTF-8 #72
     call :run java -cp "%SAXON_CP%" net.sf.saxon.Transform ^


### PR DESCRIPTION
Restarts often occur with the BaseX server test case on Windows. When that happens, the number of lines of output differs, and the line containing the pass/fail information is different. With this change, the test case still passes even if a retry occurred.

Corresponding Linux/macOS test remains strict. Empirically, I'm seeing much fewer retries on those platforms.

This change is surely not the best way to address the problem, but I'm not familiar enough with the issue to know a better approach. Having to repeatedly redo local test runs or the GitHub and Azure jobs has lately been wasting a lot of time (my time, computer time). Meanwhile, running tests under a server architecture using XProc version 1 is likely a low-frequency use case. I want to say that testing that use case loosely on Windows and more strictly on Linux/macOS is good enough.
