### PR TITLE
test: test XProc 3 harness with catalogs

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -599,24 +599,6 @@
     call :verify_line 8 x "passed: 12 / pending: 0 / failed: 0 / total: 12"
 	</case>
 
-	<case ifdef="XMLCALABASH3_JAR" name="XProc 3 harness using catalog instead of xspec-home, XSLT/XQuery (#1832)">
-    call :run java -jar "%XMLCALABASH3_JAR%" ^
-        --input:source=../tutorial/escape-for-regex.xspec ^
-        --output:result="file:///%WORK_DIR:\=/%/catalog-xproc3-xslt-test-result_%RANDOM%.html" ^
-        --catalog:../catalog.xml ^
-        ..\src\xproc3\run-xslt.xpl
-    call :verify_retval 0
-    call :verify_line -1 x "passed: 5 / pending: 0 / failed: 1 / total: 6"
-
-    call :run java -jar "%XMLCALABASH3_JAR%" ^
-        --input:source=../tutorial/xquery-tutorial.xspec ^
-        --output:result="file:///%WORK_DIR:\=/%/catalog-xproc3-xquery-test-result_%RANDOM%.html" ^
-        --catalog:../catalog.xml ^
-        ..\src\xproc3\run-xquery.xpl
-    call :verify_retval 0
-    call :verify_line -1 x "passed: 1 / pending: 0 / failed: 0 / total: 1"
-	</case>
-
 	<case ifdef="XMLCALABASH3_JAR" name="XProc 3 harness options">
     call :run java -jar "%XMLCALABASH3_JAR%" xproc\run-xproc-cases.xpl cases-dir=harness-cases\
     call :verify_retval 0
@@ -902,18 +884,6 @@
         --configuration:../src/xproc3/schematron-xqs/xmlcalabash3-config.xml ^
         xqs\run-tests-with-basex.xpl test-dir=../../tutorial/schematron-xqs/
     call :verify_line * r "--- Testing completed with no failures! ---"
-	</case>
-
-	<case ifdef="BASEX_JAR XMLCALABASH3_JAR XMLCALABASH3_DIR" name="XProc 3 harness using catalog instead of xspec-home, Schematron with XQS">
-    call :run java -cp "%XMLCALABASH3_JAR%;%XMLCALABASH3_DIR%\extra\*" ^
-        com.xmlcalabash.app.Main ^
-        --configuration:../src/xproc3/schematron-xqs/xmlcalabash3-config.xml ^
-        --input:source=xqs/phases-xqs.xspec ^
-        --output:result="file:///%WORK_DIR:\=/%/catalog-xproc3-schematron-xqs-test-result_%RANDOM%.html" ^
-        --catalog:../catalog.xml ^
-        ..\src\xproc3\schematron-xqs\run-schematron-xqs.xpl
-    call :verify_retval 0
-    call :verify_line -1 x "passed: 2 / pending: 0 / failed: 0 / total: 2"
 	</case>
 
     <!--

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -623,6 +623,62 @@
     call :verify_line * r "--- Testing completed with no failures! ---"
 	</case>
 
+	<!--
+		Catalog file URI (XProc 3)
+		
+			Test multiple 'catalog' command-line options with URIs (relative and absolute)
+	-->
+
+	<case ifdef="XMLCALABASH3_JAR" name="XProc 3 harness with catalog file URI (XSLT)">
+    call :run java -jar "%XMLCALABASH3_JAR%" ^
+        --catalog:"catalog/01/catalog-public.xml" ^
+        --catalog:"file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        --catalog:"../catalog.xml" ^
+        --input:source="%CD%\catalog\catalog-01_stylesheet.xspec" ^
+        --output:result="file:///%WORK_DIR:\=/%/catalog-file-path-xproc3-xslt-test-result_%RANDOM%.html" ^
+        ..\src\xproc3\run-xslt.xpl
+    call :verify_retval 0
+    call :verify_line -1 x "passed: 5 / pending: 0 / failed: 0 / total: 5"
+	</case>
+
+	<case ifdef="XMLCALABASH3_JAR" name="XProc 3 harness with catalog file URI (XQuery)">
+    call :run java -jar "%XMLCALABASH3_JAR%" ^
+        --catalog:"catalog/01/catalog-public.xml" ^
+        --catalog:"file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        --catalog:"../catalog.xml" ^
+        --input:source="%CD%\catalog\catalog-01_query.xspec" ^
+        --output:result="file:///%WORK_DIR:\=/%/catalog-file-path-xproc3-xquery-test-result_%RANDOM%.html" ^
+        ..\src\xproc3\run-xquery.xpl
+    call :verify_retval 0
+    call :verify_line -1 x "passed: 3 / pending: 0 / failed: 0 / total: 3"
+	</case>
+
+	<case ifdef="BASEX_JAR XMLCALABASH3_JAR XMLCALABASH3_DIR" name="XProc 3 harness with catalog file URI (Schematron via XQS)">
+    call :run java -cp "%XMLCALABASH3_JAR%;%XMLCALABASH3_DIR%\extra\*" ^
+        com.xmlcalabash.app.Main ^
+        --configuration:../src/xproc3/schematron-xqs/xmlcalabash3-config.xml ^
+        --catalog:"catalog/03/catalog-public.xml" ^
+        --catalog:"file:///%CD:\=/%/catalog/03/catalog-rewriteURI.xml" ^
+        --catalog:"../catalog.xml" ^
+        --input:source="%CD%\catalog\catalog-03_schematron-xqs.xspec" ^
+        --output:result="file:///%WORK_DIR:\=/%/catalog-file-path-xproc3-schematron-xqs-test-result_%RANDOM%.html" ^
+        ..\src\xproc3\schematron-xqs\run-schematron-xqs.xpl
+    call :verify_retval 0
+    call :verify_line -1 x "passed: 4 / pending: 0 / failed: 0 / total: 4"
+	</case>
+
+	<case ifdef="XMLCALABASH3_JAR" name="XProc 3 harness with catalog file URI (XProc)">
+    call :run java -jar "%XMLCALABASH3_JAR%" ^
+        --catalog:"catalog/01/catalog-public.xml" ^
+        --catalog:"file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
+        --catalog:"../catalog.xml" ^
+        --input:source="%CD%\catalog\catalog-01_xproc.xspec" ^
+        --output:result="file:///%WORK_DIR:\=/%/catalog-file-path-xproc3-xproc-test-result_%RANDOM%.html" ^
+        ..\src\xproc3\xproc-testing\run-xproc.xpl
+    call :verify_retval 0
+    call :verify_line -1 x "passed: 6 / pending: 0 / failed: 0 / total: 6"
+	</case>
+
     <!--
          JUnit (XProc 3 - Saxon (XSLT))
     -->
@@ -1910,7 +1966,7 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%XMLCALABASH3_JAR%;%APACHE_XMLRESOLVER_JAR%"
+    set "SAXON_CP=%XMLCALABASH3_JAR%"
     call :run ..\bin\xspec.bat -p ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         "%SPACE_DIR%\catalog-01_xproc.xspec"
@@ -1965,7 +2021,7 @@
 	</case>
 
 	<case ifdef="XMLCALABASH3_JAR" name="CLI with -catalog file URI (XProc)">
-    set "SAXON_CP=%XMLCALABASH3_JAR%;%APACHE_XMLRESOLVER_JAR%"
+    set "SAXON_CP=%XMLCALABASH3_JAR%"
     call :run ..\bin\xspec.bat -p ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         catalog\catalog-01_xproc.xspec
@@ -2031,7 +2087,7 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%XMLCALABASH3_JAR%;%APACHE_XMLRESOLVER_JAR%"
+    set "SAXON_CP=%XMLCALABASH3_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -p "%SPACE_DIR%\catalog-01_xproc.xspec"
@@ -2073,7 +2129,7 @@
 	</case>
 
 	<case ifdef="XMLCALABASH3_JAR" name="CLI with XML_CATALOG file URI (XProc)">
-    set "SAXON_CP=%XMLCALABASH3_JAR%;%APACHE_XMLRESOLVER_JAR%"
+    set "SAXON_CP=%XMLCALABASH3_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -p "catalog\catalog-01_xproc.xspec"

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -677,30 +677,6 @@ load bats-helper
     [ "${lines[7]}" = "passed: 12 / pending: 0 / failed: 0 / total: 12" ]
 }
 
-@test "XProc 3 harness using catalog instead of xspec-home, XSLT/XQuery (#1832)" {
-    if [ -z "${XMLCALABASH3_JAR}" ]; then
-        skip "XMLCALABASH3_JAR is not defined"
-    fi
-
-    myrun java -jar "${XMLCALABASH3_JAR}" \
-        --input:source=../tutorial/escape-for-regex.xspec \
-        --output:result="file:${work_dir}/catalog-xproc3-xslt-test-result_${RANDOM}.html" \
-        --catalog:../catalog.xml \
-        ../src/xproc3/run-xslt.xpl
-
-    [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 1]}" = "passed: 5 / pending: 0 / failed: 1 / total: 6" ]
-
-    myrun java -jar "${XMLCALABASH3_JAR}" \
-        --input:source=../tutorial/xquery-tutorial.xspec \
-        --output:result="file:${work_dir}/catalog-xproc3-xquery-test-result_${RANDOM}.html" \
-        --catalog:../catalog.xml \
-        ../src/xproc3/run-xquery.xpl
-
-    [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 1]}" = "passed: 1 / pending: 0 / failed: 0 / total: 1" ]
-}
-
 @test "XProc 3 harness options" {
     if [ -z "${XMLCALABASH3_JAR}" ]; then
         skip "XMLCALABASH3_JAR is not defined"
@@ -1064,30 +1040,6 @@ load bats-helper
         xqs/run-tests-with-basex.xpl test-dir=../../tutorial/schematron-xqs/
 
     assert_regex "${output}" $'\n''--- Testing completed with no failures! ---'$'\n'
-}
-
-@test "XProc 3 harness using catalog instead of xspec-home, Schematron with XQS" {
-    if [ -z "${XMLCALABASH3_JAR}" ]; then
-        skip "XMLCALABASH3_JAR is not defined"
-    fi
-    if [ -z "${XMLCALABASH3_DIR}" ]; then
-        skip "XMLCALABASH3_DIR is not defined"
-    fi
-    if [ -z "${BASEX_JAR}" ]; then
-        skip "BASEX_JAR is not defined"
-    fi
-
-    # Run series of tests, and return error messages if anything fails
-    myrun java -cp "${XMLCALABASH3_JAR}:${XMLCALABASH3_DIR}/extra/*" \
-        com.xmlcalabash.app.Main \
-        --configuration:../src/xproc3/schematron-xqs/xmlcalabash3-config.xml \
-        --input:source=xqs/phases-xqs.xspec \
-        --output:result="file:${work_dir}/catalog-xproc3-schematron-xqs-test-result_${RANDOM}.html" \
-        --catalog:../catalog.xml \
-        ../src/xproc3/schematron-xqs/run-schematron-xqs.xpl
-
-    [ "$status" -eq 0 ]
-    [ "${lines[${#lines[@]} - 1]}" = "passed: 2 / pending: 0 / failed: 0 / total: 2" ]
 }
 
 #

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -712,6 +712,85 @@ load bats-helper
 }
 
 #
+# Catalog file URI (XProc 3)
+#
+#     Test multiple 'catalog' command-line options with URIs (relative and absolute)
+#
+
+@test "XProc 3 harness with catalog file URI (XSLT)" {
+    if [ -z "${XMLCALABASH3_JAR}" ]; then
+        skip "XMLCALABASH3_JAR is not defined"
+    fi
+
+    myrun java -jar "${XMLCALABASH3_JAR}" \
+        --catalog:"catalog/01/catalog-public.xml" \
+        --catalog:"file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        --catalog:"../catalog.xml" \
+        --input:source="${PWD}/catalog/catalog-01_stylesheet.xspec" \
+        --output:result="file:${work_dir}/catalog-file-path-xproc3-xslt-test-result_${RANDOM}.html" \
+        ../src/xproc3/run-xslt.xpl
+
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]} - 1]}" = "passed: 5 / pending: 0 / failed: 0 / total: 5" ]
+}
+
+@test "XProc 3 harness with catalog file URI (XQuery)" {
+    if [ -z "${XMLCALABASH3_JAR}" ]; then
+        skip "XMLCALABASH3_JAR is not defined"
+    fi
+
+    myrun java -jar "${XMLCALABASH3_JAR}" \
+        --catalog:"catalog/01/catalog-public.xml" \
+        --catalog:"file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        --catalog:"../catalog.xml" \
+        --input:source="${PWD}/catalog/catalog-01_query.xspec" \
+        --output:result="file:${work_dir}/catalog-file-path-xproc3-xquery-test-result_${RANDOM}.html" \
+        ../src/xproc3/run-xquery.xpl
+
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]} - 1]}" = "passed: 3 / pending: 0 / failed: 0 / total: 3" ]
+}
+
+@test "XProc 3 harness with catalog file URI (Schematron via XQS)" {
+    if [ -z "${XMLCALABASH3_JAR}" ]; then
+        skip "XMLCALABASH3_JAR is not defined"
+    fi
+    if [ -z "${BASEX_JAR}" ]; then
+        skip "BASEX_JAR is not defined"
+    fi
+
+    myrun java -cp "${XMLCALABASH3_JAR}:${XMLCALABASH3_DIR}/extra/*" \
+        com.xmlcalabash.app.Main \
+        --configuration:../src/xproc3/schematron-xqs/xmlcalabash3-config.xml \
+        --catalog:"catalog/03/catalog-public.xml" \
+        --catalog:"file:${PWD}/catalog/03/catalog-rewriteURI.xml" \
+        --catalog:"../catalog.xml" \
+        --input:source="${PWD}/catalog/catalog-03_schematron-xqs.xspec" \
+        --output:result="file:${work_dir}/catalog-file-path-xproc3-schematron-xqs-test-result_${RANDOM}.html" \
+        ../src/xproc3/schematron-xqs/run-schematron-xqs.xpl
+
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]} - 1]}" = "passed: 4 / pending: 0 / failed: 0 / total: 4" ]
+}
+
+@test "XProc 3 harness with catalog file URI (XProc)" {
+    if [ -z "${XMLCALABASH3_JAR}" ]; then
+        skip "XMLCALABASH3_JAR is not defined"
+    fi
+
+    myrun java -jar "${XMLCALABASH3_JAR}" \
+        --catalog:"catalog/01/catalog-public.xml" \
+        --catalog:"file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
+        --catalog:"../catalog.xml" \
+        --input:source="${PWD}/catalog/catalog-01_xproc.xspec" \
+        --output:result="file:${work_dir}/catalog-file-path-xproc3-xproc-test-result_${RANDOM}.html" \
+        ../src/xproc3/xproc-testing/run-xproc.xpl
+
+    [ "$status" -eq 0 ]
+    [ "${lines[${#lines[@]} - 1]}" = "passed: 6 / pending: 0 / failed: 0 / total: 6" ]
+}
+
+#
 # JUnit (XProc 3 - Saxon (XSLT))
 #
 
@@ -2191,7 +2270,7 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${XMLCALABASH3_JAR}:${APACHE_XMLRESOLVER_JAR}"
+    export SAXON_CP="${XMLCALABASH3_JAR}"
     myrun ../bin/xspec.sh -p \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         "${space_dir}/catalog-01_xproc.xspec"
@@ -2253,7 +2332,7 @@ load bats-helper
         skip "XMLCALABASH3_JAR is not defined"
     fi
 
-    export SAXON_CP="${XMLCALABASH3_JAR}:${APACHE_XMLRESOLVER_JAR}"
+    export SAXON_CP="${XMLCALABASH3_JAR}"
     myrun ../bin/xspec.sh -p \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_xproc.xspec
@@ -2335,7 +2414,7 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${XMLCALABASH3_JAR}:${APACHE_XMLRESOLVER_JAR}"
+    export SAXON_CP="${XMLCALABASH3_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -p "${space_dir}/catalog-01_xproc.xspec"
@@ -2381,7 +2460,7 @@ load bats-helper
         skip "XMLCALABASH3_JAR is not defined"
     fi
 
-    export SAXON_CP="${XMLCALABASH3_JAR}:${APACHE_XMLRESOLVER_JAR}"
+    export SAXON_CP="${XMLCALABASH3_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -p "catalog/catalog-01_xproc.xspec"


### PR DESCRIPTION
This purpose of this PR is to address the two items in the bulleted list at bottom of https://github.com/xspec/xspec/issues/2301#issuecomment-4314611140. Commit 880c8c94fb4e6a9662305ef043e3fd9f7da7b232 accomplishes that.

Also, cf2821390fe90c31aa48d16d80d3c68b61528ccc removes test cases specifically for using the XSpec catalog instead of providing the `xspec-home` step option, because the newly added test cases do the same thing. Having separate test cases for user catalogs vs. XSpec catalog has some value but I don't think it's very high. The bats test cases are so numerous that I'd rather economize.

(This PR's diffs are easier to understand if you look at the two commits' diffs separately.)

Cc: @birdya22 