### PR TITLE
build(maven): bump pom.xml to 4.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>4.0.2</version>
+  <version>4.1-SNAPSHOT</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery, Schematron, and XProc </description>


### PR DESCRIPTION
As per our [workflow](https://github.com/xspec/xspec/wiki/Release-Workflow), this pull request increases the version of the XSpec release and adds the snapshot suffix.

As usual, this should be the first pull request to be merged into `main` in order to start the development of XSpec v4.1.