### PR TITLE
fix(schematron): import scenario with nesting

### DIFF
--- a/src/schematron/schut-to-xspec.xsl
+++ b/src/schematron/schut-to-xspec.xsl
@@ -177,7 +177,7 @@
         priority="2"
         use-when="$sch-impl-name ne 'xqs'">
         <xsl:copy>
-            <xsl:next-match/>
+            <xsl:call-template name="context-interior"/>
         </xsl:copy>
     </xsl:template>
 
@@ -194,7 +194,7 @@
             and also in the result of the match="@location" mode="make-predicate" template. -->
         <xsl:element name="{x:xspec-name('variable',.)}" namespace="{namespace-uri()}">
             <xsl:attribute name="name" select="'Q{' || namespace-uri() || '}context'"/>
-            <xsl:next-match/>
+            <xsl:call-template name="context-interior"/>
         </xsl:element>
 
         <!-- Form x:call with these parameters:
@@ -223,41 +223,6 @@
                 </xsl:element>
             </xsl:if>
         </xsl:element>
-    </xsl:template>
-
-    <!--
-        x:context mode="x:gather-specs", invoked by xsl:next-match from priority="2" template rule
-
-        Express x:context as one of these:
-        a) x:call, for XQuery-based Schematron implementation
-        b) Possibly modified x:context, for XSLT-based Schematron implementation
-    -->
-    <xsl:template match="x:context" as="node()*" mode="x:gather-specs" priority="1">
-        <xsl:apply-templates select="attribute()" mode="#current" />
-        <xsl:where-populated>
-            <xsl:attribute name="select">
-                <!-- The "skeleton" Schematron implementation requires a document node -->
-                <xsl:choose>
-                    <xsl:when test="@select">
-                        <xsl:text expand-text="yes">if (({@select}) => {x:known-UQName('wrap:wrappable-sequence')}())</xsl:text>
-                        <xsl:text expand-text="yes"> then {x:known-UQName('wrap:wrap-nodes')}(({@select}))</xsl:text>
-
-                        <!-- Some Schematron implementations might possibly be able to handle
-                            non-document nodes. Just generate a warning and pass @select as is. -->
-                        <xsl:text expand-text="yes"> else trace(({@select}), 'WARNING: Failed to wrap {name()}/@select')</xsl:text>
-                    </xsl:when>
-
-                    <xsl:when test="not(@href)">
-                        <xsl:text>self::document-node()</xsl:text>
-                    </xsl:when>
-
-                    <!-- If x:context has @href but no @select, no need to construct @select in output,
-                        so xsl:otherwise is omitted and xsl:where-populated produces nothing. -->
-                </xsl:choose>
-            </xsl:attribute>
-        </xsl:where-populated>
-
-        <xsl:apply-templates select="node()" mode="#current" />
     </xsl:template>
 
     <xsl:template match="x:expect-assert" as="element(x:expect)" mode="x:gather-specs">
@@ -402,6 +367,40 @@
     <!--
         Named templates
     -->
+
+    <!--
+        This template combines with its caller to express x:context as one of these:
+        a) x:call, for XQuery-based Schematron implementation
+        b) Possibly modified x:context, for XSLT-based Schematron implementation
+    -->
+    <xsl:template name="context-interior" as="node()*">
+        <xsl:context-item as="element(x:context)" use="required"/>
+        <xsl:apply-templates select="attribute()" mode="#current" />
+        <xsl:where-populated>
+            <xsl:attribute name="select">
+                <!-- The "skeleton" Schematron implementation requires a document node -->
+                <xsl:choose>
+                    <xsl:when test="@select">
+                        <xsl:text expand-text="yes">if (({@select}) => {x:known-UQName('wrap:wrappable-sequence')}())</xsl:text>
+                        <xsl:text expand-text="yes"> then {x:known-UQName('wrap:wrap-nodes')}(({@select}))</xsl:text>
+                        
+                        <!-- Some Schematron implementations might possibly be able to handle
+                            non-document nodes. Just generate a warning and pass @select as is. -->
+                        <xsl:text expand-text="yes"> else trace(({@select}), 'WARNING: Failed to wrap {name()}/@select')</xsl:text>
+                    </xsl:when>
+                    
+                    <xsl:when test="not(@href)">
+                        <xsl:text>self::document-node()</xsl:text>
+                    </xsl:when>
+                    
+                    <!-- If x:context has @href but no @select, no need to construct @select in output,
+                        so xsl:otherwise is omitted and xsl:where-populated produces nothing. -->
+                </xsl:choose>
+            </xsl:attribute>
+        </xsl:where-populated>
+        
+        <xsl:apply-templates select="node()" mode="#current" />
+    </xsl:template>
 
     <xsl:template name="create-expect" as="element(x:expect)">
         <!-- Context item is a Schematron-specific x:expect-* element -->

--- a/test/schematron-parent.xspec
+++ b/test/schematron-parent.xspec
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="schematron/schematron-01.sch">
+    <x:import href="schematron/schematron-imported.xspec"/>
+</x:description>

--- a/test/schematron/schematron-imported.xspec
+++ b/test/schematron/schematron-imported.xspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec">
+    <x:scenario label="outer scenario">
+        <x:context href="schematron-01.xml"/>
+        <x:scenario label="inner scenario">
+            <x:expect-not-assert id="a001"/>
+        </x:scenario>
+    </x:scenario>
+</x:description>


### PR DESCRIPTION
If a test for an XSLT-based Schematron schema imports another XSpec file in which `x:context` and the verification elements are at different hierarchy levels, the generated XSpec-for-XSLT file doesn't come out right.

Symptom 1: `ERROR in x:scenario ('outer scenario inner scenario'): There are x:expect but no x:call or x:context has been given`

Symptom 2: In the generated file `schematron-parent-sch-preprocessed.xspec`, the outer scenario is missing its `x:context` child element. That's what leads to the run-time error in Symptom 1.

This pull request fixes the problem by using a named template (moved to a different spot within the file, which makes the diffs look a bit noisier) reached via `xsl:call-template`, instead of a template rule reached via `xsl:next-match`. In the original arrangement, the template rule was taking effect when it should not have.

I believe this bug originated in XSpec v3.3.