### PR TITLE
fix(schematron): fix catch="yes" in Schematron validation via SchXslt2

### DIFF
--- a/src/schematron/schut-to-xslt.xsl
+++ b/src/schematron/schut-to-xslt.xsl
@@ -139,6 +139,14 @@
 				<xsl:sequence select="$common-options-map" />
 				<xsl:map-entry key="'source-node'" select="$step2-transformed-doc" />
 				<xsl:map-entry key="'stylesheet-node'" select="$step3-wrapper-doc" />
+				<xsl:map-entry key="'stylesheet-params'">
+					<xsl:map>
+						<!-- Use solution of https://codeberg.org/SchXslt/schxslt2/issues/55 to preserve
+							XSpec catch="yes" behavior instead of having SchXslt2 handle caught errors. --> 
+						<xsl:map-entry key="QName('http://dmaus.name/ns/2023/schxslt','handle-dynamic-errors')"
+							select="false()" />
+					</xsl:map>
+				</xsl:map-entry>
 			</xsl:map>
 		</xsl:variable>
 		<!--<xsl:message select="'Performing Step 3'" />-->

--- a/test/catch_schematron.xspec
+++ b/test/catch_schematron.xspec
@@ -17,14 +17,12 @@
 			<x:scenario label="validation-scenario">
 				<x:scenario label="Error in SUT">
 					<x:like label="validation-dynamic-error" />
-					<x:pending label="Requires update of SchXslt2 and XSpec">
-						<x:expect label="err:code and its type" select="xs:QName('my-error-code')"
-							test="$x:result?err?code treat as xs:QName" />
-						<x:expect label="err:description and its type" select="'my error description'"
-							test="$x:result?err?description treat as xs:string" />
-						<x:expect label="err:value and its type" select="'my', 'error', 'object'"
-							test="$x:result?err?value treat as xs:string+" />
-					</x:pending>
+					<x:expect label="err:code and its type" select="xs:QName('my-error-code')"
+						test="$x:result?err?code treat as xs:QName" />
+					<x:expect label="err:description and its type" select="'my error description'"
+						test="$x:result?err?description treat as xs:string" />
+					<x:expect label="err:value and its type" select="'my', 'error', 'object'"
+						test="$x:result?err?value treat as xs:string+" />
 					
 					<!-- The error is raised by fn:error() at a line in the schema (XQS) or the
 						compiled schema (SchXslt2) -->


### PR DESCRIPTION
Closes #2367. Of the two items that are listed in that issue's description, #2369 is item 1, and this pull request is item 2.

