### PR TITLE
fix(report): coverage for xsl:on-empty, xsl:on-non-empty (Saxon 12.9)

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -746,41 +746,35 @@ Tested as part of xsl:iterate.
 
 ## xsl:on-empty
 
-|          |                        |
-| -------- | ---------------------- |
-| CATEGORY | Instruction            |
-| PARENT   |                        |
-| CHILDREN |                        |
-| CONTENT  |                        |
-| TRACE    | No                     |
-| RULE     | Element Specific - TBD |
+|          |                                                                     |
+| -------- | ------------------------------------------------------------------- |
+| CATEGORY | Instruction                                                         |
+| PARENT   |                                                                     |
+| CHILDREN |                                                                     |
+| CONTENT  |                                                                     |
+| TRACE    | No                                                                  |
+| RULE     | Use Trace Data if select attribute. Otherwise, Use Descendant Data. |
 
 #### Comment
 
-With the select attribute, XSpec trace indicates column 0.
-
+With a `select` attribute the select expression may be traced, but the xsl:on-empty element is not.
 With a sequence constructor, the children are traced but the xsl:on-empty element is not.
-
-May change in the next release of Saxon due to this issue: https://saxonica.plan.io/issues/6428
 
 ## xsl:on-non-empty
 
-|          |                        |
-| -------- | ---------------------- |
-| CATEGORY | Instruction            |
-| PARENT   |                        |
-| CHILDREN |                        |
-| CONTENT  |                        |
-| TRACE    | Partly                 |
-| RULE     | Element Specific - TBD |
+|          |                                                                     |
+| -------- | ------------------------------------------------------------------- |
+| CATEGORY | Instruction                                                         |
+| PARENT   |                                                                     |
+| CHILDREN |                                                                     |
+| CONTENT  |                                                                     |
+| TRACE    | No                                                                  |
+| RULE     | Use Trace Data if select attribute. Otherwise, Use Descendant Data. |
 
 #### Comment
 
-Column 0 in xspec trace. Not in Saxon trace.
-
-There is a Saxonica issue (https://saxonica.plan.io/issues/6428) that it outputs the contents of xsl:on-non-empty when the parent is actually empty if tracing is enabled.
-
-Suggest it is marked as 'unknown' including the children until the Saxon issue is fixed.
+With a `select` attribute the select expression may be traced, but the xsl:on-empty element is not.
+With a sequence constructor, the children are traced but the xsl:on-non-empty element is not.
 
 ## xsl:otherwise
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -137,6 +137,8 @@
         | XSLT:matching-substring
         | XSLT:non-matching-substring
         | XSLT:on-completion
+        | XSLT:on-empty[not(exists(@select))]
+        | XSLT:on-non-empty[not(exists(@select))]
         | XSLT:perform-sort
         | XSLT:otherwise
         | XSLT:try[not(exists(@select))]
@@ -379,8 +381,6 @@
         | XSLT:merge-source
         | XSLT:non-matching-substring
         | XSLT:on-completion
-        | XSLT:on-empty
-        | XSLT:on-non-empty
         | XSLT:otherwise
         | XSLT:perform-sort[@select]
         | XSLT:perform-sort[XSLT:sort][count(*) = 1]

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -31,8 +31,8 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />10</th>
-               <th class="totals emphasis">missed<br />4</th>
+               <th class="totals">hit<br />11</th>
+               <th class="totals emphasis">missed<br />3</th>
                <th class="totals">unknown<br />0</th>
                <th class="totals">lines<br />27</th>
             </tr>
@@ -41,15 +41,15 @@
             <tr class="successful">
                <th><a href="#module1">xsl-on-empty-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">10</th>
-               <th class="totals">4</th>
+               <th class="totals">11</th>
+               <th class="totals">3</th>
                <th class="totals">0</th>
                <th class="totals">27</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-on-empty-01.xsl<span class="scenario-totals">hit: 10 / missed: 4 / unknown: 0</span></h2>
+         <h2 class="successful">module: xsl-on-empty-01.xsl<span class="scenario-totals">hit: 11 / missed: 3 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -63,9 +63,9 @@
 11: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
 12: <span class="whitespace">      </span><span class="comment">&lt;!-- Using sequence constructor --&gt;</span>
 13: <span class="whitespace">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
-14: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-empty&gt;</span>
+14: <span class="whitespace">        </span><span class="hit">&lt;xsl:on-empty&gt;</span>
 15: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
-16: <span class="whitespace">        </span><span class="missed">&lt;/xsl:on-empty&gt;</span>
+16: <span class="whitespace">        </span><span class="hit">&lt;/xsl:on-empty&gt;</span>
 17: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
 18: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-empty--&gt;</span>
 19: <span class="whitespace">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.html
@@ -31,25 +31,25 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />11</th>
-               <th class="totals emphasis">missed<br />3</th>
+               <th class="totals">hit<br />14</th>
+               <th class="totals emphasis">missed<br />4</th>
                <th class="totals">unknown<br />0</th>
-               <th class="totals">lines<br />27</th>
+               <th class="totals">lines<br />32</th>
             </tr>
          </thead>
          <tbody>
             <tr class="successful">
                <th><a href="#module1">xsl-on-empty-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">11</th>
-               <th class="totals">3</th>
+               <th class="totals">14</th>
+               <th class="totals">4</th>
                <th class="totals">0</th>
-               <th class="totals">27</th>
+               <th class="totals">32</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-on-empty-01.xsl<span class="scenario-totals">hit: 11 / missed: 3 / unknown: 0</span></h2>
+         <h2 class="successful">module: xsl-on-empty-01.xsl<span class="scenario-totals">hit: 14 / missed: 4 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -67,16 +67,21 @@
 15: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">200</span><span class="hit">&lt;/xsl:text&gt;</span>
 16: <span class="whitespace">        </span><span class="hit">&lt;/xsl:on-empty&gt;</span>
 17: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
-18: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-empty--&gt;</span>
+18: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-empty, using select attribute--&gt;</span>
 19: <span class="whitespace">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
 20: <span class="whitespace">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
-21: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-empty&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-22: <span class="whitespace">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">300</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-23: <span class="whitespace">        </span><span class="missed">&lt;/xsl:on-empty&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-24: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
-25: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
-26: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-27: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+21: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-empty select="300 idiv 2"/&gt;</span><span class="whitespace">                                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+22: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
+23: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-empty, using sequence constructor --&gt;</span>
+24: <span class="whitespace">      </span><span class="hit">&lt;node type="on-empty"&gt;</span>
+25: <span class="whitespace">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">400</span><span class="hit">&lt;/xsl:text&gt;</span>
+26: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-empty&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+27: <span class="whitespace">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">400</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+28: <span class="whitespace">        </span><span class="missed">&lt;/xsl:on-empty&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+29: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
+30: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
+31: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+32: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-empty-01-coverage.xml
@@ -28,6 +28,10 @@
    <traceable traceableId="6" class="net.sf.saxon.expr.instruct.ConditionalBlock"/>
    <hit lineNumber="20" columnNumber="19" moduleId="0" traceableId="6"/>
    <hit lineNumber="20" columnNumber="19" moduleId="0" traceableId="5"/>
+   <hit lineNumber="24" columnNumber="29" moduleId="0" traceableId="1"/>
+   <hit lineNumber="24" columnNumber="29" moduleId="0" traceableId="3"/>
+   <hit lineNumber="25" columnNumber="19" moduleId="0" traceableId="6"/>
+   <hit lineNumber="25" columnNumber="19" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -31,8 +31,8 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />15</th>
-               <th class="totals emphasis">missed<br />6</th>
+               <th class="totals">hit<br />17</th>
+               <th class="totals emphasis">missed<br />4</th>
                <th class="totals">unknown<br />0</th>
                <th class="totals">lines<br />35</th>
             </tr>
@@ -41,15 +41,15 @@
             <tr class="successful">
                <th><a href="#module1">xsl-on-non-empty-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">15</th>
-               <th class="totals">6</th>
+               <th class="totals">17</th>
+               <th class="totals">4</th>
                <th class="totals">0</th>
                <th class="totals">35</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-on-non-empty-01.xsl<span class="scenario-totals">hit: 15 / missed: 6 / unknown: 0</span></h2>
+         <h2 class="successful">module: xsl-on-non-empty-01.xsl<span class="scenario-totals">hit: 17 / missed: 4 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -60,22 +60,22 @@
 08: <span class="whitespace">      </span><span class="comment">&lt;!-- Using select attribute --&gt;</span>
 09: <span class="whitespace">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
 10: <span class="whitespace">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">1</span><span class="hit">&lt;/xsl:text&gt;</span>
-11: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-non-empty select="'00'" /&gt;</span>
+11: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-non-empty select="'00'" /&gt;</span><span class="whitespace">                                     </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 12: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
 13: <span class="whitespace">      </span><span class="comment">&lt;!-- Using sequence constructor --&gt;</span>
 14: <span class="whitespace">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
 15: <span class="whitespace">        </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">2</span><span class="hit">&lt;/xsl:text&gt;</span>
-16: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span>
+16: <span class="whitespace">        </span><span class="hit">&lt;xsl:on-non-empty&gt;</span>
 17: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">00</span><span class="hit">&lt;/xsl:text&gt;</span>
-18: <span class="whitespace">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span>
+18: <span class="whitespace">        </span><span class="hit">&lt;/xsl:on-non-empty&gt;</span>
 19: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
-20: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty --&gt;</span><span class="comment">&lt;!-- Need to check if comments below affect the outcome - trace does. See https://saxonica.plan.io/issues/6428 --&gt;</span>
+20: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty --&gt;</span>
 21: <span class="whitespace">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
-22: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span><span class="whitespace">                                                     </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-23: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-24: <span class="whitespace">        </span><span class="missed">&lt;/xsl:on-non-empty&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+22: <span class="whitespace">        </span><span class="hit">&lt;xsl:on-non-empty&gt;</span>
+23: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>
+24: <span class="whitespace">        </span><span class="hit">&lt;/xsl:on-non-empty&gt;</span>
 25: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
-26: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty but static analysis cannot make that judgment --&gt;</span><span class="whitespace"> </span>
+26: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty but static analysis cannot make that judgment --&gt;</span>
 27: <span class="whitespace">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
 28: <span class="whitespace">        </span><span class="hit">&lt;xsl:sequence select="@nonexistent-attribute" /&gt;</span>
 29: <span class="whitespace">        </span><span class="missed">&lt;xsl:on-non-empty&gt;</span><span class="whitespace">                                                     </span><span class="comment">&lt;!-- Expected miss --&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-on-non-empty-01-coverage.html
@@ -69,7 +69,7 @@
 17: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">00</span><span class="hit">&lt;/xsl:text&gt;</span>
 18: <span class="whitespace">        </span><span class="hit">&lt;/xsl:on-non-empty&gt;</span>
 19: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
-20: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty --&gt;</span>
+20: <span class="whitespace">      </span><span class="comment">&lt;!-- NOT on-non-empty (intuitively, xsl:on-non-empty should be missed but Saxon traces the xsl:text) --&gt;</span>
 21: <span class="whitespace">      </span><span class="hit">&lt;node type="on-non-empty"&gt;</span>
 22: <span class="whitespace">        </span><span class="hit">&lt;xsl:on-non-empty&gt;</span>
 23: <span class="whitespace">          </span><span class="hit">&lt;xsl:text&gt;</span><span class="hit">300</span><span class="hit">&lt;/xsl:text&gt;</span>

--- a/test/end-to-end/cases-coverage/xsl-on-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-empty-01.xsl
@@ -15,11 +15,16 @@
           <xsl:text>200</xsl:text>
         </xsl:on-empty>
       </node>
-      <!-- NOT on-empty-->
+      <!-- NOT on-empty, using select attribute-->
       <node type="on-empty">
         <xsl:text>300</xsl:text>
+        <xsl:on-empty select="300 idiv 2"/>                                    <!-- Expected miss -->
+      </node>
+      <!-- NOT on-empty, using sequence constructor -->
+      <node type="on-empty">
+        <xsl:text>400</xsl:text>
         <xsl:on-empty>                                                         <!-- Expected miss -->
-          <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
+          <xsl:text>400</xsl:text>                                             <!-- Expected miss -->
         </xsl:on-empty>                                                        <!-- Expected miss -->
       </node>
     </root>

--- a/test/end-to-end/cases-coverage/xsl-on-empty-01.xspec
+++ b/test/end-to-end/cases-coverage/xsl-on-empty-01.xspec
@@ -13,6 +13,7 @@
             <node type="on-empty">100</node>
             <node type="on-empty">200</node>
             <node type="on-empty">300</node>
+            <node type="on-empty">400</node>
          </root>
       </x:expect>
    </x:scenario>

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
@@ -8,7 +8,7 @@
       <!-- Using select attribute -->
       <node type="on-non-empty">
         <xsl:text>1</xsl:text>
-        <xsl:on-non-empty select="'00'" />
+        <xsl:on-non-empty select="'00'" />                                     <!-- Expected miss -->
       </node>
       <!-- Using sequence constructor -->
       <node type="on-non-empty">
@@ -17,13 +17,13 @@
           <xsl:text>00</xsl:text>
         </xsl:on-non-empty>
       </node>
-      <!-- NOT on-non-empty --><!-- Need to check if comments below affect the outcome - trace does. See https://saxonica.plan.io/issues/6428 -->
+      <!-- NOT on-non-empty -->
       <node type="on-non-empty">
-        <xsl:on-non-empty>                                                     <!-- Expected miss -->
-          <xsl:text>300</xsl:text>                                             <!-- Expected miss -->
-        </xsl:on-non-empty>                                                    <!-- Expected miss -->
+        <xsl:on-non-empty>
+          <xsl:text>300</xsl:text>
+        </xsl:on-non-empty>
       </node>
-      <!-- NOT on-non-empty but static analysis cannot make that judgment --> 
+      <!-- NOT on-non-empty but static analysis cannot make that judgment -->
       <node type="on-non-empty">
         <xsl:sequence select="@nonexistent-attribute" />
         <xsl:on-non-empty>                                                     <!-- Expected miss -->

--- a/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-on-non-empty-01.xsl
@@ -17,7 +17,7 @@
           <xsl:text>00</xsl:text>
         </xsl:on-non-empty>
       </node>
-      <!-- NOT on-non-empty -->
+      <!-- NOT on-non-empty (intuitively, xsl:on-non-empty should be missed but Saxon traces the xsl:text) -->
       <node type="on-non-empty">
         <xsl:on-non-empty>
           <xsl:text>300</xsl:text>


### PR DESCRIPTION
This pull request contains the XSLT change, test updates, and documentation update by @birdya22 from the ZIP-file linked from #2131. The XSLT change, which is adapted to Saxon 12.9, makes the coverage status of `xsl:on-empty` and `xsl:on-non-empty` follow

- These elements' own trace data, if the `select` attribute is present, or
- Their descendants' trace data otherwise.

Thanks, @birdya22 !

I made two minor additions in the 2nd and 3rd commits.

Fixes #2131.