### PR TITLE
fix(report): coverage reporting for accumulators (Saxon 12.9)

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -63,14 +63,14 @@ The following list describes the rules used to determine the coverage status of 
 
 ## xsl:accumulator-rule
 
-|          |                                    |
-| -------- | ---------------------------------- |
-| CATEGORY |                                    |
-| PARENT   | xsl:accumulator                    |
-| CHILDREN |                                    |
-| CONTENT  |                                    |
-| TRACE    | Yes                                |
-| RULE     | Use Trace Data                     |
+|          |                 |
+| -------- | --------------- |
+| CATEGORY |                 |
+| PARENT   | xsl:accumulator |
+| CHILDREN |                 |
+| CONTENT  |                 |
+| TRACE    | Yes             |
+| RULE     | Use Trace Data  |
 
 #### Comment
 

--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -59,7 +59,7 @@ The following list describes the rules used to determine the coverage status of 
 | CHILDREN | xsl:accumulator-rule                       |
 | CONTENT  |                                            |
 | TRACE    | No                                         |
-| RULE     | Always Ignore                              |
+| RULE     | Use Descendant Data                        |
 
 ## xsl:accumulator-rule
 
@@ -69,8 +69,8 @@ The following list describes the rules used to determine the coverage status of 
 | PARENT   | xsl:accumulator                    |
 | CHILDREN |                                    |
 | CONTENT  |                                    |
-| TRACE    | No                                 |
-| RULE     | Ignore Element and All Descendants |
+| TRACE    | Yes                                |
+| RULE     | Use Trace Data                     |
 
 #### Comment
 

--- a/src/reporter/coverage-compute-status.xsl
+++ b/src/reporter/coverage-compute-status.xsl
@@ -61,7 +61,6 @@
         | XSLT:package
 
         | XSLT:accept
-        | XSLT:accumulator
         | XSLT:attribute-set
         | XSLT:character-map
         | XSLT:decimal-format
@@ -118,8 +117,7 @@
 
     <!-- Ignore Element and All Descendants -->
     <xsl:template match="
-        XSLT:attribute-set/XSLT:attribute/descendant-or-self::node()
-        | XSLT:accumulator-rule/descendant-or-self::node()"
+        XSLT:attribute-set/XSLT:attribute/descendant-or-self::node()"
         as="xs:string"
         mode="coverage"
         priority="20">
@@ -129,7 +127,8 @@
     <!-- Use Descendant Data -->
     <xsl:template
         match="
-        XSLT:assert[child::node()]
+        XSLT:accumulator
+        | XSLT:assert[child::node()]
         | XSLT:catch
         | XSLT:fallback
         | XSLT:map

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -32,9 +32,9 @@
                <th></th>
                <th class="totals">used</th>
                <th class="totals">hit<br />11</th>
-               <th class="totals emphasis">missed<br />7</th>
+               <th class="totals emphasis">missed<br />2</th>
                <th class="totals">unknown<br />0</th>
-               <th class="totals">lines<br />47</th>
+               <th class="totals">lines<br />39</th>
             </tr>
          </thead>
          <tbody>
@@ -42,14 +42,14 @@
                <th><a href="#module1">xsl-accumulator-01.xsl</a></th>
                <th class="totals">yes</th>
                <th class="totals">11</th>
-               <th class="totals">7</th>
+               <th class="totals">2</th>
                <th class="totals">0</th>
-               <th class="totals">47</th>
+               <th class="totals">39</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-accumulator-01.xsl<span class="scenario-totals">hit: 11 / missed: 7 / unknown: 0</span></h2>
+         <h2 class="successful">module: xsl-accumulator-01.xsl<span class="scenario-totals">hit: 11 / missed: 2 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
@@ -65,38 +65,30 @@
 13: <span class="whitespace">  </span><span class="missed">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span><span class="whitespace">                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 14: <span class="whitespace">    </span><span class="missed">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span><span class="whitespace">                </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 15: <span class="whitespace">  </span><span class="missed">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-16: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:accumulator rules are higher priority than xsl:assert rule --&gt;</span>
-17: <span class="whitespace">  </span><span class="missed">&lt;xsl:accumulator name="accumulatorVsAssert" initial-value="()"&gt;</span><span class="whitespace">              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-18: <span class="whitespace">    </span><span class="missed">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-19: <span class="whitespace">      </span><span class="missed">&lt;xsl:assert test="true()"&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-20: <span class="whitespace">        </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">cannot get here</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                   </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-21: <span class="whitespace">      </span><span class="missed">&lt;/xsl:assert&gt;</span><span class="whitespace">                                                            </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-22: <span class="whitespace">    </span><span class="missed">&lt;/xsl:accumulator-rule&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-23: <span class="whitespace">  </span><span class="missed">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-24: 
-25: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:mode for accumulator --&gt;</span>
-26: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span><span class="whitespace">           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-27: <span class="whitespace">  </span><span class="comment">&lt;!-- Make accumulator applicable in default mode, too, so that</span>
-28: <span class="comment">    xsl-accumulator-01.xspec can run with run-as="external" or</span>
-29: <span class="comment">    when imported by a test with that setting. --&gt;</span>
-30: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" /&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-31: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
-32: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
-33: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
-34: <span class="whitespace">      </span><span class="comment">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
-35: <span class="whitespace">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
-36: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
-37: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-38: <span class="whitespace">  </span><span class="comment">&lt;!-- used in xsl:accumulator test --&gt;</span>
-39: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
-40: <span class="whitespace">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
-41: <span class="whitespace">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
-42: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
-43: <span class="whitespace">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
-44: <span class="whitespace">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
-45: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
-46: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
-47: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
+16: 
+17: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:mode for accumulator --&gt;</span>
+18: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span><span class="whitespace">           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+19: <span class="whitespace">  </span><span class="comment">&lt;!-- Make accumulator applicable in default mode, too, so that</span>
+20: <span class="comment">    xsl-accumulator-01.xspec can run with run-as="external" or</span>
+21: <span class="comment">    when imported by a test with that setting. --&gt;</span>
+22: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" /&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+23: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
+24: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-accumulator"&gt;</span>
+25: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
+26: <span class="whitespace">      </span><span class="comment">&lt;!-- Process nodes used in xsl:accumulator --&gt;</span>
+27: <span class="whitespace">      </span><span class="hit">&lt;xsl:apply-templates select="*" mode="accumulator" /&gt;</span>
+28: <span class="whitespace">    </span><span class="hit">&lt;/root&gt;</span>
+29: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+30: <span class="whitespace">  </span><span class="comment">&lt;!-- used in xsl:accumulator test --&gt;</span>
+31: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="node" mode="accumulator"&gt;</span>
+32: <span class="whitespace">    </span><span class="hit">&lt;node type="accumulator before"&gt;</span>
+33: <span class="whitespace">      </span><span class="hit">&lt;xsl:value-of select="accumulator-before('accumulatorTest')" /&gt;</span>
+34: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
+35: <span class="whitespace">    </span><span class="hit">&lt;node type="accumulator after"&gt;</span>
+36: <span class="whitespace">      </span><span class="hit">&lt;xsl:value-of select="accumulator-after('accumulatorTest')" /&gt;</span>
+37: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
+38: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+39: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.html
@@ -31,8 +31,8 @@
             <tr>
                <th></th>
                <th class="totals">used</th>
-               <th class="totals">hit<br />8</th>
-               <th class="totals emphasis">missed<br />0</th>
+               <th class="totals">hit<br />11</th>
+               <th class="totals emphasis">missed<br />7</th>
                <th class="totals">unknown<br />0</th>
                <th class="totals">lines<br />47</th>
             </tr>
@@ -41,39 +41,39 @@
             <tr class="successful">
                <th><a href="#module1">xsl-accumulator-01.xsl</a></th>
                <th class="totals">yes</th>
-               <th class="totals">8</th>
-               <th class="totals">0</th>
+               <th class="totals">11</th>
+               <th class="totals">7</th>
                <th class="totals">0</th>
                <th class="totals">47</th>
             </tr>
          </tbody>
       </table>
       <div id="module1">
-         <h2 class="successful">module: xsl-accumulator-01.xsl<span class="scenario-totals">hit: 8 / missed: 0 / unknown: 0</span></h2>
+         <h2 class="successful">module: xsl-accumulator-01.xsl<span class="scenario-totals">hit: 11 / missed: 7 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"&gt;</span>
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">       xsl:accumulator Test Case</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:accumulator --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span><span class="whitespace">                   </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-08: <span class="whitespace">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-09: <span class="whitespace">      </span><span class="ignored">&lt;xsl:value-of select="$value + 1" /&gt;</span><span class="whitespace">                                     </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-10: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-11: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+07: <span class="whitespace">  </span><span class="hit">&lt;xsl:accumulator name="accumulatorTest" initial-value="0"&gt;</span>
+08: <span class="whitespace">    </span><span class="hit">&lt;xsl:accumulator-rule match="node"&gt;</span>
+09: <span class="whitespace">      </span><span class="hit">&lt;xsl:value-of select="$value + 1" /&gt;</span>
+10: <span class="whitespace">    </span><span class="hit">&lt;/xsl:accumulator-rule&gt;</span>
+11: <span class="whitespace">  </span><span class="hit">&lt;/xsl:accumulator&gt;</span>
 12: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:accumulator not used --&gt;</span>
-13: <span class="whitespace">  </span><span class="ignored">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span><span class="whitespace">                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-14: <span class="whitespace">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span><span class="whitespace">                </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-15: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+13: <span class="whitespace">  </span><span class="missed">&lt;xsl:accumulator name="dummy01" initial-value="0"&gt;</span><span class="whitespace">                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+14: <span class="whitespace">    </span><span class="missed">&lt;xsl:accumulator-rule match="node()" select="$value + 1" /&gt;</span><span class="whitespace">                </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+15: <span class="whitespace">  </span><span class="missed">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 16: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:accumulator rules are higher priority than xsl:assert rule --&gt;</span>
-17: <span class="whitespace">  </span><span class="ignored">&lt;xsl:accumulator name="accumulatorVsAssert" initial-value="()"&gt;</span><span class="whitespace">              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-18: <span class="whitespace">    </span><span class="ignored">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-19: <span class="whitespace">      </span><span class="ignored">&lt;xsl:assert test="true()"&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-20: <span class="whitespace">        </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">cannot get here</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="whitespace">                                   </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-21: <span class="whitespace">      </span><span class="ignored">&lt;/xsl:assert&gt;</span><span class="whitespace">                                                            </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-22: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:accumulator-rule&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-23: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-24: <span class="whitespace"> </span>
+17: <span class="whitespace">  </span><span class="missed">&lt;xsl:accumulator name="accumulatorVsAssert" initial-value="()"&gt;</span><span class="whitespace">              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+18: <span class="whitespace">    </span><span class="missed">&lt;xsl:accumulator-rule match="node"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+19: <span class="whitespace">      </span><span class="missed">&lt;xsl:assert test="true()"&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+20: <span class="whitespace">        </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">cannot get here</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                   </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+21: <span class="whitespace">      </span><span class="missed">&lt;/xsl:assert&gt;</span><span class="whitespace">                                                            </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+22: <span class="whitespace">    </span><span class="missed">&lt;/xsl:accumulator-rule&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+23: <span class="whitespace">  </span><span class="missed">&lt;/xsl:accumulator&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+24: 
 25: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:mode for accumulator --&gt;</span>
 26: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode use-accumulators="accumulatorTest" name="accumulator" /&gt;</span><span class="whitespace">           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 27: <span class="whitespace">  </span><span class="comment">&lt;!-- Make accumulator applicable in default mode, too, so that</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-accumulator-01-coverage.xml
@@ -5,25 +5,25 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.TemplateRule"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="32" columnNumber="41" moduleId="0" traceableId="0"/>
+   <hit lineNumber="24" columnNumber="41" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="33" columnNumber="11" moduleId="0" traceableId="1"/>
+   <hit lineNumber="25" columnNumber="11" moduleId="0" traceableId="1"/>
    <traceable traceableId="2"
               class="net.sf.saxon.expr.instruct.ApplyTemplates"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}apply-templates"/>
-   <hit lineNumber="35" columnNumber="60" moduleId="0" traceableId="2"/>
-   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="27" columnNumber="60" moduleId="0" traceableId="2"/>
+   <hit lineNumber="31" columnNumber="49" moduleId="0" traceableId="0"/>
    <traceable traceableId="3" class="net.sf.saxon.expr.instruct.Block"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="1"/>
    <traceable traceableId="4"
               class="net.sf.saxon.expr.instruct.FixedAttribute"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}attribute"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.ValueOf"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}value-of"/>
-   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="5"/>
+   <hit lineNumber="33" columnNumber="70" moduleId="0" traceableId="5"/>
    <traceable traceableId="6" class="net.sf.saxon.expr.accum.AccumulatorRule"/>
    <hit lineNumber="8" columnNumber="40" moduleId="0" traceableId="6"/>
    <hit lineNumber="9" columnNumber="43" moduleId="0" traceableId="5"/>
@@ -31,25 +31,25 @@
    <hit lineNumber="9" columnNumber="43" moduleId="0" traceableId="5"/>
    <hit lineNumber="8" columnNumber="40" moduleId="0" traceableId="6"/>
    <hit lineNumber="9" columnNumber="43" moduleId="0" traceableId="5"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="4"/>
-   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="5"/>
-   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="4"/>
-   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="5"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="4"/>
-   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="5"/>
-   <hit lineNumber="39" columnNumber="49" moduleId="0" traceableId="0"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="3"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="1"/>
-   <hit lineNumber="40" columnNumber="37" moduleId="0" traceableId="4"/>
-   <hit lineNumber="41" columnNumber="70" moduleId="0" traceableId="5"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="1"/>
-   <hit lineNumber="43" columnNumber="36" moduleId="0" traceableId="4"/>
-   <hit lineNumber="44" columnNumber="69" moduleId="0" traceableId="5"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="69" moduleId="0" traceableId="5"/>
+   <hit lineNumber="31" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="33" columnNumber="70" moduleId="0" traceableId="5"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="69" moduleId="0" traceableId="5"/>
+   <hit lineNumber="31" columnNumber="49" moduleId="0" traceableId="0"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="3"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="1"/>
+   <hit lineNumber="32" columnNumber="37" moduleId="0" traceableId="4"/>
+   <hit lineNumber="33" columnNumber="70" moduleId="0" traceableId="5"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="1"/>
+   <hit lineNumber="35" columnNumber="36" moduleId="0" traceableId="4"/>
+   <hit lineNumber="36" columnNumber="69" moduleId="0" traceableId="5"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
@@ -4,24 +4,24 @@
        xsl:accumulator Test Case
   -->
   <!-- xsl:accumulator -->
-  <xsl:accumulator name="accumulatorTest" initial-value="0">                   <!-- Expected ignored -->
-    <xsl:accumulator-rule match="node">                                        <!-- Expected ignored -->
-      <xsl:value-of select="$value + 1" />                                     <!-- Expected ignored -->
-    </xsl:accumulator-rule>                                                    <!-- Expected ignored -->
-  </xsl:accumulator>                                                           <!-- Expected ignored -->
+  <xsl:accumulator name="accumulatorTest" initial-value="0">
+    <xsl:accumulator-rule match="node">
+      <xsl:value-of select="$value + 1" />
+    </xsl:accumulator-rule>
+  </xsl:accumulator>
   <!-- xsl:accumulator not used -->
-  <xsl:accumulator name="dummy01" initial-value="0">                           <!-- Expected ignored -->
-    <xsl:accumulator-rule match="node()" select="$value + 1" />                <!-- Expected ignored -->
-  </xsl:accumulator>                                                           <!-- Expected ignored -->
+  <xsl:accumulator name="dummy01" initial-value="0">                           <!-- Expected miss -->
+    <xsl:accumulator-rule match="node()" select="$value + 1" />                <!-- Expected miss -->
+  </xsl:accumulator>                                                           <!-- Expected miss -->
   <!-- xsl:accumulator rules are higher priority than xsl:assert rule -->
-  <xsl:accumulator name="accumulatorVsAssert" initial-value="()">              <!-- Expected ignored -->
-    <xsl:accumulator-rule match="node">                                        <!-- Expected ignored -->
-      <xsl:assert test="true()">                                               <!-- Expected ignored -->
-        <xsl:text>cannot get here</xsl:text>                                   <!-- Expected ignored -->
-      </xsl:assert>                                                            <!-- Expected ignored -->
-    </xsl:accumulator-rule>                                                    <!-- Expected ignored -->
-  </xsl:accumulator>                                                           <!-- Expected ignored -->
- 
+  <xsl:accumulator name="accumulatorVsAssert" initial-value="()">              <!-- Expected miss -->
+    <xsl:accumulator-rule match="node">                                        <!-- Expected miss -->
+      <xsl:assert test="true()">                                               <!-- Expected miss -->
+        <xsl:text>cannot get here</xsl:text>                                   <!-- Expected miss -->
+      </xsl:assert>                                                            <!-- Expected miss -->
+    </xsl:accumulator-rule>                                                    <!-- Expected miss -->
+  </xsl:accumulator>                                                           <!-- Expected miss -->
+
   <!-- xsl:mode for accumulator -->
   <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />           <!-- Expected ignored -->
   <!-- Make accumulator applicable in default mode, too, so that

--- a/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-accumulator-01.xsl
@@ -13,14 +13,6 @@
   <xsl:accumulator name="dummy01" initial-value="0">                           <!-- Expected miss -->
     <xsl:accumulator-rule match="node()" select="$value + 1" />                <!-- Expected miss -->
   </xsl:accumulator>                                                           <!-- Expected miss -->
-  <!-- xsl:accumulator rules are higher priority than xsl:assert rule -->
-  <xsl:accumulator name="accumulatorVsAssert" initial-value="()">              <!-- Expected miss -->
-    <xsl:accumulator-rule match="node">                                        <!-- Expected miss -->
-      <xsl:assert test="true()">                                               <!-- Expected miss -->
-        <xsl:text>cannot get here</xsl:text>                                   <!-- Expected miss -->
-      </xsl:assert>                                                            <!-- Expected miss -->
-    </xsl:accumulator-rule>                                                    <!-- Expected miss -->
-  </xsl:accumulator>                                                           <!-- Expected miss -->
 
   <!-- xsl:mode for accumulator -->
   <xsl:mode use-accumulators="accumulatorTest" name="accumulator" />           <!-- Expected ignored -->


### PR DESCRIPTION
This pull request contains the XSLT change, test updates, and documentation updates by @birdya22 from the ZIP-file linked from #2128. (In a subsequent commit, I removed some now-unneeded lines of the test file and regenerated the end-to-end expected result files.)

The XSLT change takes advantage of Saxon 12.6+ tracing of `xsl:accumulator-rule`, so accumulator code isn't all marked as "unknown" in the report.

Thanks, @birdya22 !

Fixes #2128.