### PR TITLE
test(report): update comments in coverage test XSLT files for Saxon 12.9

### DIFF
--- a/docs/xslt-code-coverage-by-element.md
+++ b/docs/xslt-code-coverage-by-element.md
@@ -37,7 +37,7 @@ The following list describes the rules used to determine the coverage status of 
 
 ## Saxon Version(s) Reflected in this Document
 
-12.4
+12.9
 
 ## xsl:accept
 

--- a/test/end-to-end/cases-coverage/coverage-statistics.xsl
+++ b/test/end-to-end/cases-coverage/coverage-statistics.xsl
@@ -4,8 +4,8 @@
   <!--
       Test Coverage Report Statistics Test
   -->
-  <xsl:include href="coverage-statisticsA.xsl" />
-  <xsl:include href="coverage-statisticsB.xsl" />
+  <xsl:include href="coverage-statisticsA.xsl" />                              <!-- Expected ignored -->
+  <xsl:include href="coverage-statisticsB.xsl" />                              <!-- Expected ignored -->
 
   <xsl:template name="Template01">
     <xsl:param name="param01" as="xs:integer" />
@@ -16,7 +16,7 @@
     </xsl:if>
     <!-- Twenty Two -->
     <xsl:if test="$param01 eq 22">
-      <result>Twenty  Two</result>
+      <result>Twenty  Two</result>                                             <!-- Expected miss -->
     </xsl:if>
     <!-- Thirty three -->
     <xsl:if test="$param01 eq 33">

--- a/test/end-to-end/cases-coverage/coverage-statisticsA.xsl
+++ b/test/end-to-end/cases-coverage/coverage-statisticsA.xsl
@@ -9,7 +9,7 @@
 
     <xsl:if test="$number eq 0">
      '0 Supplied'
-    </xsl:if>
+    </xsl:if>                                                                  <!-- Expected unknown - '0 Supplied' -->
 
     <xsl:sequence select="$number * 2" />
   </xsl:function>

--- a/test/end-to-end/cases-coverage/coverage_by-child-nodes.xsl
+++ b/test/end-to-end/cases-coverage/coverage_by-child-nodes.xsl
@@ -1,82 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet exclude-result-prefixes="#all" version="3.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-	<xsl:template as="element(hit)+" name="test">
+  <xsl:template as="element(hit)+" name="test">
+    <!--
+        'hit' or 'miss' of these nodes is determined by child nodes.
+    -->
+    <!--
+        xsl:for-each
+    -->
+    <xsl:for-each select="1">
+      <hit />
+    </xsl:for-each>
 
-		<!--
-			'hit' or 'miss' of these nodes is determined by child nodes.
-		-->
+    <xsl:for-each select="()">                                                 <!-- Expected miss -->
+      <xsl:message terminate="yes" />                                          <!-- Expected miss -->
+    </xsl:for-each>                                                            <!-- Expected miss -->
+    <!--
+        xsl:for-each-group
+    -->
+    <xsl:for-each-group group-by="." select="1">
+      <hit />
+    </xsl:for-each-group>
 
-		<!--
-			xsl:for-each
-		-->
+    <xsl:for-each-group group-by="." select="()">                              <!-- Expected miss -->
+      <xsl:message terminate="yes" />                                          <!-- Expected miss -->
+    </xsl:for-each-group>                                                      <!-- Expected miss -->
+    <!--
+        xsl:matching-substring
+        xsl:non-matching-substring
+    -->
+    <xsl:analyze-string regex="a" select="'a'">
+      <xsl:matching-substring>
+        <hit />
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>                                             <!-- Expected miss -->
+        <xsl:message terminate="yes" />                                        <!-- Expected miss -->
+      </xsl:non-matching-substring>                                            <!-- Expected miss -->
+    </xsl:analyze-string>
 
-		<xsl:for-each select="1">
-			<hit />
-		</xsl:for-each>
+    <xsl:analyze-string regex="b" select="'a'">
+      <xsl:matching-substring>                                                 <!-- Expected miss -->
+        <xsl:message terminate="yes" />                                        <!-- Expected miss -->
+      </xsl:matching-substring>                                                <!-- Expected miss -->
+      <xsl:non-matching-substring>
+        <hit />
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
+    <!--
+        xsl:otherwise
+        xsl:when
+    -->
+    <xsl:choose>
+      <xsl:when test="1 lt 2">
+        <hit />
+      </xsl:when>
+      <xsl:otherwise>                                                          <!-- Expected miss -->
+        <xsl:message terminate="yes" />                                        <!-- Expected miss -->
+      </xsl:otherwise>                                                         <!-- Expected miss -->
+    </xsl:choose>
 
-		<xsl:for-each select="()">
-			<xsl:message terminate="yes" />
-		</xsl:for-each>
-
-		<!--
-			xsl:for-each-group
-		-->
-
-		<xsl:for-each-group group-by="." select="1">
-			<hit />
-		</xsl:for-each-group>
-
-		<xsl:for-each-group group-by="." select="()">
-			<xsl:message terminate="yes" />
-		</xsl:for-each-group>
-
-		<!--
-			xsl:matching-substring
-			xsl:non-matching-substring
-		-->
-
-		<xsl:analyze-string regex="a" select="'a'">
-			<xsl:matching-substring>
-				<hit />
-			</xsl:matching-substring>
-			<xsl:non-matching-substring>
-				<xsl:message terminate="yes" />
-			</xsl:non-matching-substring>
-		</xsl:analyze-string>
-
-		<xsl:analyze-string regex="b" select="'a'">
-			<xsl:matching-substring>
-				<xsl:message terminate="yes" />
-			</xsl:matching-substring>
-			<xsl:non-matching-substring>
-				<hit />
-			</xsl:non-matching-substring>
-		</xsl:analyze-string>
-
-		<!--
-			xsl:otherwise
-			xsl:when
-		-->
-
-		<xsl:choose>
-			<xsl:when test="1 lt 2">
-				<hit />
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:message terminate="yes" />
-			</xsl:otherwise>
-		</xsl:choose>
-
-		<xsl:choose>
-			<xsl:when test="2 lt 1">
-				<xsl:message terminate="yes" />
-			</xsl:when>
-			<xsl:otherwise>
-				<hit />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
-
+    <xsl:choose>
+      <xsl:when test="2 lt 1">                                                 <!-- Expected miss -->
+        <xsl:message terminate="yes" />                                        <!-- Expected miss -->
+      </xsl:when>                                                              <!-- Expected miss -->
+      <xsl:otherwise>
+        <hit />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage-statistics-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage-statistics-coverage.html
@@ -72,8 +72,8 @@
 04: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 05: <span class="comment">      Test Coverage Report Statistics Test</span>
 06: <span class="comment">  --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="coverage-statisticsA.xsl" /&gt;</span>
-08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="coverage-statisticsB.xsl" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="coverage-statisticsA.xsl" /&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="coverage-statisticsB.xsl" /&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 09: 
 10: <span class="whitespace">  </span><span class="hit">&lt;xsl:template name="Template01"&gt;</span>
 11: <span class="whitespace">    </span><span class="hit">&lt;xsl:param name="param01" as="xs:integer" /&gt;</span>
@@ -84,7 +84,7 @@
 16: <span class="whitespace">    </span><span class="hit">&lt;/xsl:if&gt;</span>
 17: <span class="whitespace">    </span><span class="comment">&lt;!-- Twenty Two --&gt;</span>
 18: <span class="whitespace">    </span><span class="hit">&lt;xsl:if test="$param01 eq 22"&gt;</span>
-19: <span class="whitespace">      </span><span class="missed">&lt;result&gt;</span><span class="missed">Twenty  Two</span><span class="missed">&lt;/result&gt;</span>
+19: <span class="whitespace">      </span><span class="missed">&lt;result&gt;</span><span class="missed">Twenty  Two</span><span class="missed">&lt;/result&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 20: <span class="whitespace">    </span><span class="hit">&lt;/xsl:if&gt;</span>
 21: <span class="whitespace">    </span><span class="comment">&lt;!-- Thirty three --&gt;</span>
 22: <span class="whitespace">    </span><span class="hit">&lt;xsl:if test="$param01 eq 33"&gt;</span>
@@ -107,7 +107,7 @@
 09: 
 10: <span class="whitespace">    </span><span class="hit">&lt;xsl:if test="$number eq 0"&gt;</span>
 11: <span class="unknown">     '0 Supplied'</span>
-12: <span class="unknown">    </span><span class="hit">&lt;/xsl:if&gt;</span>
+12: <span class="unknown">    </span><span class="hit">&lt;/xsl:if&gt;</span><span class="whitespace">                                                                  </span><span class="comment">&lt;!-- Expected unknown - '0 Supplied' --&gt;</span>
 13: 
 14: <span class="whitespace">    </span><span class="hit">&lt;xsl:sequence select="$number * 2" /&gt;</span>
 15: <span class="whitespace">  </span><span class="hit">&lt;/xsl:function&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.html
@@ -34,7 +34,7 @@
                <th class="totals">hit<br />17</th>
                <th class="totals emphasis">missed<br />12</th>
                <th class="totals">unknown<br />0</th>
-               <th class="totals">lines<br />83</th>
+               <th class="totals">lines<br />72</th>
             </tr>
          </thead>
          <tbody>
@@ -44,7 +44,7 @@
                <th class="totals">17</th>
                <th class="totals">12</th>
                <th class="totals">0</th>
-               <th class="totals">83</th>
+               <th class="totals">72</th>
             </tr>
          </tbody>
       </table>
@@ -52,87 +52,76 @@
          <h2 class="successful">module: coverage_by-child-nodes.xsl<span class="scenario-totals">hit: 17 / missed: 12 / unknown: 0</span></h2>
          <pre class="xspecCoverage">01: <span class="ignored">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
 02: <span class="ignored">&lt;xsl:stylesheet exclude-result-prefixes="#all" version="3.0"</span>
-03: <span class="ignored">	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
+03: <span class="ignored">xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;</span>
 04: 
-05: <span class="whitespace">	</span><span class="hit">&lt;xsl:template as="element(hit)+" name="test"&gt;</span>
-06: 
-07: <span class="whitespace">		</span><span class="comment">&lt;!--</span>
-08: <span class="comment">			'hit' or 'miss' of these nodes is determined by child nodes.</span>
-09: <span class="comment">		--&gt;</span>
-10: 
-11: <span class="whitespace">		</span><span class="comment">&lt;!--</span>
-12: <span class="comment">			xsl:for-each</span>
-13: <span class="comment">		--&gt;</span>
-14: 
-15: <span class="whitespace">		</span><span class="hit">&lt;xsl:for-each select="1"&gt;</span>
-16: <span class="whitespace">			</span><span class="hit">&lt;hit /&gt;</span>
-17: <span class="whitespace">		</span><span class="hit">&lt;/xsl:for-each&gt;</span>
-18: 
-19: <span class="whitespace">		</span><span class="missed">&lt;xsl:for-each select="()"&gt;</span>
-20: <span class="whitespace">			</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-21: <span class="whitespace">		</span><span class="missed">&lt;/xsl:for-each&gt;</span>
-22: 
-23: <span class="whitespace">		</span><span class="comment">&lt;!--</span>
-24: <span class="comment">			xsl:for-each-group</span>
-25: <span class="comment">		--&gt;</span>
-26: 
-27: <span class="whitespace">		</span><span class="hit">&lt;xsl:for-each-group group-by="." select="1"&gt;</span>
-28: <span class="whitespace">			</span><span class="hit">&lt;hit /&gt;</span>
-29: <span class="whitespace">		</span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
-30: 
-31: <span class="whitespace">		</span><span class="missed">&lt;xsl:for-each-group group-by="." select="()"&gt;</span>
-32: <span class="whitespace">			</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-33: <span class="whitespace">		</span><span class="missed">&lt;/xsl:for-each-group&gt;</span>
-34: 
-35: <span class="whitespace">		</span><span class="comment">&lt;!--</span>
-36: <span class="comment">			xsl:matching-substring</span>
-37: <span class="comment">			xsl:non-matching-substring</span>
-38: <span class="comment">		--&gt;</span>
-39: 
-40: <span class="whitespace">		</span><span class="hit">&lt;xsl:analyze-string regex="a" select="'a'"&gt;</span>
-41: <span class="whitespace">			</span><span class="hit">&lt;xsl:matching-substring&gt;</span>
-42: <span class="whitespace">				</span><span class="hit">&lt;hit /&gt;</span>
-43: <span class="whitespace">			</span><span class="hit">&lt;/xsl:matching-substring&gt;</span>
-44: <span class="whitespace">			</span><span class="missed">&lt;xsl:non-matching-substring&gt;</span>
-45: <span class="whitespace">				</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-46: <span class="whitespace">			</span><span class="missed">&lt;/xsl:non-matching-substring&gt;</span>
-47: <span class="whitespace">		</span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
-48: 
-49: <span class="whitespace">		</span><span class="hit">&lt;xsl:analyze-string regex="b" select="'a'"&gt;</span>
-50: <span class="whitespace">			</span><span class="missed">&lt;xsl:matching-substring&gt;</span>
-51: <span class="whitespace">				</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-52: <span class="whitespace">			</span><span class="missed">&lt;/xsl:matching-substring&gt;</span>
-53: <span class="whitespace">			</span><span class="hit">&lt;xsl:non-matching-substring&gt;</span>
-54: <span class="whitespace">				</span><span class="hit">&lt;hit /&gt;</span>
-55: <span class="whitespace">			</span><span class="hit">&lt;/xsl:non-matching-substring&gt;</span>
-56: <span class="whitespace">		</span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
-57: 
-58: <span class="whitespace">		</span><span class="comment">&lt;!--</span>
-59: <span class="comment">			xsl:otherwise</span>
-60: <span class="comment">			xsl:when</span>
-61: <span class="comment">		--&gt;</span>
+05: <span class="whitespace">  </span><span class="hit">&lt;xsl:template as="element(hit)+" name="test"&gt;</span>
+06: <span class="whitespace">    </span><span class="comment">&lt;!--</span>
+07: <span class="comment">        'hit' or 'miss' of these nodes is determined by child nodes.</span>
+08: <span class="comment">    --&gt;</span>
+09: <span class="whitespace">    </span><span class="comment">&lt;!--</span>
+10: <span class="comment">        xsl:for-each</span>
+11: <span class="comment">    --&gt;</span>
+12: <span class="whitespace">    </span><span class="hit">&lt;xsl:for-each select="1"&gt;</span>
+13: <span class="whitespace">      </span><span class="hit">&lt;hit /&gt;</span>
+14: <span class="whitespace">    </span><span class="hit">&lt;/xsl:for-each&gt;</span>
+15: 
+16: <span class="whitespace">    </span><span class="missed">&lt;xsl:for-each select="()"&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+17: <span class="whitespace">      </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+18: <span class="whitespace">    </span><span class="missed">&lt;/xsl:for-each&gt;</span><span class="whitespace">                                                            </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+19: <span class="whitespace">    </span><span class="comment">&lt;!--</span>
+20: <span class="comment">        xsl:for-each-group</span>
+21: <span class="comment">    --&gt;</span>
+22: <span class="whitespace">    </span><span class="hit">&lt;xsl:for-each-group group-by="." select="1"&gt;</span>
+23: <span class="whitespace">      </span><span class="hit">&lt;hit /&gt;</span>
+24: <span class="whitespace">    </span><span class="hit">&lt;/xsl:for-each-group&gt;</span>
+25: 
+26: <span class="whitespace">    </span><span class="missed">&lt;xsl:for-each-group group-by="." select="()"&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+27: <span class="whitespace">      </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+28: <span class="whitespace">    </span><span class="missed">&lt;/xsl:for-each-group&gt;</span><span class="whitespace">                                                      </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+29: <span class="whitespace">    </span><span class="comment">&lt;!--</span>
+30: <span class="comment">        xsl:matching-substring</span>
+31: <span class="comment">        xsl:non-matching-substring</span>
+32: <span class="comment">    --&gt;</span>
+33: <span class="whitespace">    </span><span class="hit">&lt;xsl:analyze-string regex="a" select="'a'"&gt;</span>
+34: <span class="whitespace">      </span><span class="hit">&lt;xsl:matching-substring&gt;</span>
+35: <span class="whitespace">        </span><span class="hit">&lt;hit /&gt;</span>
+36: <span class="whitespace">      </span><span class="hit">&lt;/xsl:matching-substring&gt;</span>
+37: <span class="whitespace">      </span><span class="missed">&lt;xsl:non-matching-substring&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+38: <span class="whitespace">        </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+39: <span class="whitespace">      </span><span class="missed">&lt;/xsl:non-matching-substring&gt;</span><span class="whitespace">                                            </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+40: <span class="whitespace">    </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
+41: 
+42: <span class="whitespace">    </span><span class="hit">&lt;xsl:analyze-string regex="b" select="'a'"&gt;</span>
+43: <span class="whitespace">      </span><span class="missed">&lt;xsl:matching-substring&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+44: <span class="whitespace">        </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+45: <span class="whitespace">      </span><span class="missed">&lt;/xsl:matching-substring&gt;</span><span class="whitespace">                                                </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+46: <span class="whitespace">      </span><span class="hit">&lt;xsl:non-matching-substring&gt;</span>
+47: <span class="whitespace">        </span><span class="hit">&lt;hit /&gt;</span>
+48: <span class="whitespace">      </span><span class="hit">&lt;/xsl:non-matching-substring&gt;</span>
+49: <span class="whitespace">    </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
+50: <span class="whitespace">    </span><span class="comment">&lt;!--</span>
+51: <span class="comment">        xsl:otherwise</span>
+52: <span class="comment">        xsl:when</span>
+53: <span class="comment">    --&gt;</span>
+54: <span class="whitespace">    </span><span class="hit">&lt;xsl:choose&gt;</span>
+55: <span class="whitespace">      </span><span class="hit">&lt;xsl:when test="1 lt 2"&gt;</span>
+56: <span class="whitespace">        </span><span class="hit">&lt;hit /&gt;</span>
+57: <span class="whitespace">      </span><span class="hit">&lt;/xsl:when&gt;</span>
+58: <span class="whitespace">      </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="whitespace">                                                          </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+59: <span class="whitespace">        </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+60: <span class="whitespace">      </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+61: <span class="whitespace">    </span><span class="hit">&lt;/xsl:choose&gt;</span>
 62: 
-63: <span class="whitespace">		</span><span class="hit">&lt;xsl:choose&gt;</span>
-64: <span class="whitespace">			</span><span class="hit">&lt;xsl:when test="1 lt 2"&gt;</span>
-65: <span class="whitespace">				</span><span class="hit">&lt;hit /&gt;</span>
-66: <span class="whitespace">			</span><span class="hit">&lt;/xsl:when&gt;</span>
-67: <span class="whitespace">			</span><span class="missed">&lt;xsl:otherwise&gt;</span>
-68: <span class="whitespace">				</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-69: <span class="whitespace">			</span><span class="missed">&lt;/xsl:otherwise&gt;</span>
-70: <span class="whitespace">		</span><span class="hit">&lt;/xsl:choose&gt;</span>
-71: 
-72: <span class="whitespace">		</span><span class="hit">&lt;xsl:choose&gt;</span>
-73: <span class="whitespace">			</span><span class="missed">&lt;xsl:when test="2 lt 1"&gt;</span>
-74: <span class="whitespace">				</span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span>
-75: <span class="whitespace">			</span><span class="missed">&lt;/xsl:when&gt;</span>
-76: <span class="whitespace">			</span><span class="hit">&lt;xsl:otherwise&gt;</span>
-77: <span class="whitespace">				</span><span class="hit">&lt;hit /&gt;</span>
-78: <span class="whitespace">			</span><span class="hit">&lt;/xsl:otherwise&gt;</span>
-79: <span class="whitespace">		</span><span class="hit">&lt;/xsl:choose&gt;</span>
-80: <span class="whitespace">	</span><span class="hit">&lt;/xsl:template&gt;</span>
-81: 
-82: <span class="ignored">&lt;/xsl:stylesheet&gt;</span>
-83: </pre>
+63: <span class="whitespace">    </span><span class="hit">&lt;xsl:choose&gt;</span>
+64: <span class="whitespace">      </span><span class="missed">&lt;xsl:when test="2 lt 1"&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+65: <span class="whitespace">        </span><span class="missed">&lt;xsl:message terminate="yes" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+66: <span class="whitespace">      </span><span class="missed">&lt;/xsl:when&gt;</span><span class="whitespace">                                                              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+67: <span class="whitespace">      </span><span class="hit">&lt;xsl:otherwise&gt;</span>
+68: <span class="whitespace">        </span><span class="hit">&lt;hit /&gt;</span>
+69: <span class="whitespace">      </span><span class="hit">&lt;/xsl:otherwise&gt;</span>
+70: <span class="whitespace">    </span><span class="hit">&lt;/xsl:choose&gt;</span>
+71: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
+72: <span class="ignored">&lt;/xsl:stylesheet&gt;</span></pre>
       </div>
    </body>
 </html>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.xml
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/coverage_by-child-nodes-coverage.xml
@@ -5,39 +5,39 @@
    <traceable traceableId="0"
               class="net.sf.saxon.expr.instruct.NamedTemplate"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}template"/>
-   <hit lineNumber="5" columnNumber="47" moduleId="0" traceableId="0"/>
+   <hit lineNumber="5" columnNumber="48" moduleId="0" traceableId="0"/>
    <traceable traceableId="1" class="net.sf.saxon.expr.CardinalityChecker"/>
-   <hit lineNumber="15" columnNumber="28" moduleId="0" traceableId="1"/>
+   <hit lineNumber="12" columnNumber="30" moduleId="0" traceableId="1"/>
    <traceable traceableId="2" class="net.sf.saxon.expr.instruct.Block"/>
-   <hit lineNumber="15" columnNumber="28" moduleId="0" traceableId="2"/>
+   <hit lineNumber="12" columnNumber="30" moduleId="0" traceableId="2"/>
    <traceable traceableId="3"
               class="net.sf.saxon.expr.instruct.ForEach"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each"/>
-   <hit lineNumber="15" columnNumber="28" moduleId="0" traceableId="3"/>
+   <hit lineNumber="12" columnNumber="30" moduleId="0" traceableId="3"/>
    <traceable traceableId="4" class="net.sf.saxon.expr.instruct.FixedElement"/>
-   <hit lineNumber="16" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="13" columnNumber="14" moduleId="0" traceableId="4"/>
    <traceable traceableId="5"
               class="net.sf.saxon.expr.instruct.ForEachGroup"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}for-each-group"/>
-   <hit lineNumber="27" columnNumber="47" moduleId="0" traceableId="5"/>
-   <hit lineNumber="28" columnNumber="11" moduleId="0" traceableId="4"/>
+   <hit lineNumber="22" columnNumber="49" moduleId="0" traceableId="5"/>
+   <hit lineNumber="23" columnNumber="14" moduleId="0" traceableId="4"/>
    <traceable traceableId="6" class="net.sf.saxon.expr.ItemChecker"/>
-   <hit lineNumber="40" columnNumber="46" moduleId="0" traceableId="6"/>
+   <hit lineNumber="33" columnNumber="48" moduleId="0" traceableId="6"/>
    <traceable traceableId="7"
               class="net.sf.saxon.expr.instruct.AnalyzeString"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}analyze-string"/>
-   <hit lineNumber="40" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="42" columnNumber="12" moduleId="0" traceableId="4"/>
-   <hit lineNumber="49" columnNumber="46" moduleId="0" traceableId="6"/>
-   <hit lineNumber="49" columnNumber="46" moduleId="0" traceableId="7"/>
-   <hit lineNumber="54" columnNumber="12" moduleId="0" traceableId="4"/>
+   <hit lineNumber="33" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="35" columnNumber="16" moduleId="0" traceableId="4"/>
+   <hit lineNumber="42" columnNumber="48" moduleId="0" traceableId="6"/>
+   <hit lineNumber="42" columnNumber="48" moduleId="0" traceableId="7"/>
+   <hit lineNumber="47" columnNumber="16" moduleId="0" traceableId="4"/>
    <traceable traceableId="8"
               class="net.sf.saxon.expr.instruct.Choose"
               uqname="Q{http://www.w3.org/1999/XSL/Transform}choose"/>
-   <hit lineNumber="63" columnNumber="15" moduleId="0" traceableId="8"/>
-   <hit lineNumber="65" columnNumber="12" moduleId="0" traceableId="4"/>
-   <hit lineNumber="72" columnNumber="15" moduleId="0" traceableId="8"/>
-   <hit lineNumber="77" columnNumber="12" moduleId="0" traceableId="4"/>
+   <hit lineNumber="54" columnNumber="17" moduleId="0" traceableId="8"/>
+   <hit lineNumber="56" columnNumber="16" moduleId="0" traceableId="4"/>
+   <hit lineNumber="63" columnNumber="17" moduleId="0" traceableId="8"/>
+   <hit lineNumber="68" columnNumber="16" moduleId="0" traceableId="4"/>
    <util utilId="0" uri="../../../../../src/common/report-sequence.xsl"/>
    <util utilId="1" uri="../../../../../src/common/common-utils.xsl"/>
    <util utilId="2" uri="../../../../../src/common/deep-equal.xsl"/>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-accept-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-accept-01-coverage.html
@@ -66,7 +66,7 @@
 14: <span class="ignored">                    package-version="*"&gt;</span><span class="whitespace">                                       </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 15: <span class="whitespace">       </span><span class="ignored">&lt;xsl:accept component="function" names="csv:preprocess-field#1"</span>
 16: <span class="ignored">                   visibility="private" /&gt;</span><span class="whitespace">                                     </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-17: <span class="whitespace">   </span><span class="ignored">&lt;/xsl:use-package&gt;</span>
+17: <span class="whitespace">   </span><span class="ignored">&lt;/xsl:use-package&gt;</span><span class="whitespace">                                                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 18: 
 19: <span class="whitespace">   </span><span class="comment">&lt;!-- example input "file"  --&gt;</span>
 20: <span class="whitespace">   </span><span class="hit">&lt;xsl:variable name="input" as="xs:string"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-global-context-item-01-coverage.html
@@ -55,7 +55,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:global-context-item Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:global-context-item use="required" as="item()" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:global-context-item use="required" as="item()" /&gt;</span><span class="whitespace">                       </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: <span class="whitespace">  </span><span class="comment">&lt;!-- Put the context item in a global variable --&gt;</span>
 08: <span class="whitespace">  </span><span class="hit">&lt;xsl:variable name="globalVariable" select="." /&gt;</span>
 09: 

--- a/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-override-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/external_xsl-override-01-coverage.html
@@ -75,8 +75,8 @@
 23: <span class="whitespace">           </span><span class="missed">&lt;xsl:template match="root" mode="csv:post-process"&gt;</span><span class="whitespace">                 </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 24: <span class="whitespace">               </span><span class="missed">&lt;csv&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 25: <span class="whitespace">                   </span><span class="missed">&lt;xsl:apply-templates mode="csv:post-process"/&gt;</span><span class="whitespace">              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-26: <span class="whitespace">               </span><span class="missed">&lt;/csv&gt;</span>
-27: <span class="whitespace">           </span><span class="missed">&lt;/xsl:template&gt;</span>
+26: <span class="whitespace">               </span><span class="missed">&lt;/csv&gt;</span><span class="whitespace">                                                          </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+27: <span class="whitespace">           </span><span class="missed">&lt;/xsl:template&gt;</span><span class="whitespace">                                                     </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 28: 
 29: <span class="whitespace">           </span><span class="comment">&lt;!-- add an extra attribute that uses the context item --&gt;</span>
 30: <span class="whitespace">           </span><span class="ignored">&lt;xsl:attribute-set name="csv:field-attributes"</span>
@@ -85,7 +85,7 @@
 33: <span class="ignored">                              select="if (. castable as xs:decimal)</span>
 34: <span class="ignored">                                      then 'numeric'</span>
 35: <span class="ignored">                                      else 'string'"/&gt;</span><span class="whitespace">                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
-36: <span class="whitespace">           </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+36: <span class="whitespace">           </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 37: 
 38: <span class="whitespace">           </span><span class="comment">&lt;!-- use semicolon not comma between fields --&gt;</span>
 39: <span class="whitespace">           </span><span class="hit">&lt;xsl:variable name="csv:field-separator"</span>
@@ -103,8 +103,8 @@
 51: <span class="hit">                                     then $norm-line</span>
 52: <span class="hit">                                     else ()"/&gt;</span>
 53: <span class="whitespace">           </span><span class="hit">&lt;/xsl:function&gt;</span>
-54: <span class="whitespace">       </span><span class="ignored">&lt;/xsl:override&gt;</span>
-55: <span class="whitespace">   </span><span class="ignored">&lt;/xsl:use-package&gt;</span>
+54: <span class="whitespace">       </span><span class="ignored">&lt;/xsl:override&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+55: <span class="whitespace">   </span><span class="ignored">&lt;/xsl:use-package&gt;</span><span class="whitespace">                                                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 56: 
 57: <span class="whitespace">   </span><span class="comment">&lt;!-- example input "file"  --&gt;</span>
 58: <span class="whitespace">   </span><span class="hit">&lt;xsl:variable name="input" as="xs:string"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-analyze-string-01-coverage.html
@@ -79,11 +79,11 @@
 27: <span class="whitespace">        </span><span class="missed">&lt;/xsl:matching-substring&gt;</span><span class="whitespace">                                              </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 28: <span class="whitespace">        </span><span class="hit">&lt;xsl:non-matching-substring&gt;</span>
 29: <span class="whitespace">          </span><span class="hit">&lt;node type="non-matching-substring"&gt;</span>
-30: <span class="whitespace">            </span><span class="hit">&lt;xsl:sequence select="string('No match')"/&gt;</span><span class="whitespace">                        </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+30: <span class="whitespace">            </span><span class="hit">&lt;xsl:sequence select="string('No match')"/&gt;</span>
 31: <span class="whitespace">          </span><span class="hit">&lt;/node&gt;</span>
 32: <span class="whitespace">        </span><span class="hit">&lt;/xsl:non-matching-substring&gt;</span>
 33: <span class="whitespace">      </span><span class="hit">&lt;/xsl:analyze-string&gt;</span>
-34: <span class="whitespace">      </span>
+34: 
 35: <span class="whitespace">      </span><span class="comment">&lt;!-- Test cases for unknown status of xsl:matching-substring and xsl:non-matching-substring --&gt;</span>
 36: <span class="whitespace">      </span><span class="comment">&lt;!-- regex matches string so non-matching-substring not executed --&gt;</span>
 37: <span class="whitespace">      </span><span class="hit">&lt;node type="matching-substring executed unknown, non-matching-substring unexecuted unknown"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-imports-01-coverage.html
@@ -64,9 +64,9 @@
 04: <span class="comment">      xsl:apply-imports Coverage Test Case (see xsl-apply-imports-01A.xsl as well)</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- Import stylesheet --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-apply-imports-01A.xsl" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-apply-imports-01A.xsl" /&gt;</span><span class="whitespace">                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 08: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:mode for this test --&gt;</span>
-09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="applyImportsMode" /&gt;</span>
+09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="applyImportsMode" /&gt;</span><span class="whitespace">                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 10: <span class="whitespace">  </span><span class="comment">&lt;!-- Main Stylesheet--&gt;</span>
 11: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-apply-imports"&gt;</span>
 12: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-apply-templates-01-coverage.html
@@ -73,7 +73,7 @@
 21: <span class="whitespace">    </span><span class="hit">&lt;/node&gt;</span>
 22: <span class="whitespace">  </span><span class="hit">&lt;/xsl:template&gt;</span>
 23: 
-24: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" /&gt;</span>
+24: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" /&gt;</span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 25: 
 26: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="applyTemplateNode" mode="mode-with-matching-template"&gt;</span>
 27: <span class="whitespace">    </span><span class="hit">&lt;node type="apply-templates-mode-with-matching-template"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-01-coverage.html
@@ -56,19 +56,19 @@
 04: <span class="comment">      xsl:attribute Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- Single xsl:attribute in xsl:attribute-set --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="type"&gt;</span>
-08: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type"&gt;</span><span class="ignored">attribute</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-09: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="type"&gt;</span><span class="whitespace">                                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+08: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type"&gt;</span><span class="ignored">attribute</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                       </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+09: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 10: 
 11: <span class="whitespace">  </span><span class="comment">&lt;!-- Two xsl:attribute in xsl:attribute-set --&gt;</span>
-12: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="types"&gt;</span>
-13: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type1"&gt;</span>
-14: <span class="whitespace">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute1</span><span class="ignored">&lt;/xsl:text&gt;</span>
-15: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-16: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type2"&gt;</span>
-17: <span class="whitespace">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute2</span><span class="ignored">&lt;/xsl:text&gt;</span>
-18: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-19: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+12: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="types"&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+13: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type1"&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+14: <span class="whitespace">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute1</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+15: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+16: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="type2"&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+17: <span class="whitespace">      </span><span class="ignored">&lt;xsl:text&gt;</span><span class="ignored">attribute2</span><span class="ignored">&lt;/xsl:text&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+18: <span class="whitespace">    </span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                                                           </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+19: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 20: 
 21: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-attribute"&gt;</span>
 22: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-attribute-set-01-coverage.html
@@ -56,21 +56,21 @@
 04: <span class="comment">      xsl:attribute-set Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- Single attribute --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet01"&gt;</span>
-08: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr01"&gt;</span><span class="ignored">attr01</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-09: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet01"&gt;</span><span class="whitespace">                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+08: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr01"&gt;</span><span class="ignored">attr01</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+09: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 10: <span class="whitespace">  </span><span class="comment">&lt;!-- Multiple attributes--&gt;</span>
-11: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet02"&gt;</span>
-12: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr02A"&gt;</span><span class="ignored">attr02A</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-13: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr02B"&gt;</span><span class="ignored">attr02B</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-14: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+11: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet02"&gt;</span><span class="whitespace">                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+12: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr02A"&gt;</span><span class="ignored">attr02A</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                      </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+13: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr02B"&gt;</span><span class="ignored">attr02B</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                      </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+14: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 15: <span class="whitespace">  </span><span class="comment">&lt;!-- Including another attribute set --&gt;</span>
-16: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B"&gt;</span>
-17: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr03A"&gt;</span><span class="ignored">attr03A</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-18: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
-19: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03B"&gt;</span>
-20: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr03B"&gt;</span><span class="ignored">attr03B</span><span class="ignored">&lt;/xsl:attribute&gt;</span>
-21: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span>
+16: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B"&gt;</span><span class="whitespace">        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+17: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr03A"&gt;</span><span class="ignored">attr03A</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                      </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+18: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+19: <span class="whitespace">  </span><span class="ignored">&lt;xsl:attribute-set name="attrSet03B"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+20: <span class="whitespace">    </span><span class="ignored">&lt;xsl:attribute name="attr03B"&gt;</span><span class="ignored">attr03B</span><span class="ignored">&lt;/xsl:attribute&gt;</span><span class="whitespace">                      </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+21: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:attribute-set&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 22: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
 23: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-attribute-set"&gt;</span>
 24: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-character-map-01-coverage.html
@@ -57,16 +57,16 @@
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- character map does not do any mapping changes (confident that it is used in Saxon).</span>
 07: <span class="comment">       But xspec doesn't do character-map without some additional effort (which isn't done here)--&gt;</span>
-08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:character-map name="charMap01" use-character-maps="charMap01A"&gt;</span>
-09: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="0" string="0" /&gt;</span>
-10: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="&amp;#xE003;" string="3" /&gt;</span>
-11: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
+08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:character-map name="charMap01" use-character-maps="charMap01A"&gt;</span><span class="whitespace">         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+09: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="0" string="0" /&gt;</span><span class="whitespace">                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+10: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="&amp;#xE003;" string="3" /&gt;</span><span class="whitespace">                   </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+11: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 12: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:character-map included in one above --&gt;</span>
-13: <span class="whitespace">  </span><span class="ignored">&lt;xsl:character-map name="charMap01A"&gt;</span>
-14: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="1" string="1" /&gt;</span>
-15: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span>
+13: <span class="whitespace">  </span><span class="ignored">&lt;xsl:character-map name="charMap01A"&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+14: <span class="whitespace">    </span><span class="ignored">&lt;xsl:output-character character="1" string="1" /&gt;</span><span class="whitespace">                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+15: <span class="whitespace">  </span><span class="ignored">&lt;/xsl:character-map&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 16: 
-17: <span class="whitespace">  </span><span class="ignored">&lt;xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" /&gt;</span>
+17: <span class="whitespace">  </span><span class="ignored">&lt;xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" /&gt;</span><span class="whitespace">  </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 18: 
 19: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-character-map"&gt;</span>
 20: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-decimal-format-01-coverage.html
@@ -55,7 +55,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:decimal-format Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:decimal-format name="decFormat01" digit="?" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:decimal-format name="decFormat01" digit="?" /&gt;</span><span class="whitespace">                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
 08: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-decimal-format"&gt;</span>
 09: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-import-01-coverage.html
@@ -63,7 +63,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:import Coverage Test Case (See imported stylesheet)</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-import-01A.xsl" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-import-01A.xsl" /&gt;</span><span class="whitespace">                                     </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-import"&gt;</span>
 08: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
 09: <span class="whitespace">      </span><span class="comment">&lt;!-- Call template in imported stylesheet --&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-include-01-coverage.html
@@ -72,8 +72,8 @@
 04: <span class="comment">      xsl:include Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:include --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01A.xsl" /&gt;</span>
-08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01B.xsl" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01A.xsl" /&gt;</span><span class="whitespace">                                   </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+08: <span class="whitespace">  </span><span class="ignored">&lt;xsl:include href="xsl-include-01B.xsl" /&gt;</span><span class="whitespace">                                   </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 09: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
 10: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-include"&gt;</span>
 11: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-iterate-01-coverage.html
@@ -187,10 +187,10 @@
 135: <span class="whitespace">      </span><span class="comment">&lt;!-- xsl:iterate with xsl:on-completion not executed but unknown status --&gt;</span>
 136: <span class="whitespace">      </span><span class="hit">&lt;node type="iterate/on-completion unexecuted unknown"&gt;</span>
 137: <span class="whitespace">        </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
-138: <span class="whitespace">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-139: <span class="whitespace">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="whitespace">                                                </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-140: <span class="whitespace">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-141: <span class="whitespace">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="whitespace">                                                   </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+138: <span class="whitespace">          </span><span class="unknown">&lt;xsl:on-completion&gt;</span><span class="whitespace">                                                  </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+139: <span class="whitespace">            </span><span class="unknown">&lt;xsl:where-populated&gt;</span><span class="whitespace">                                              </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+140: <span class="whitespace">            </span><span class="unknown">&lt;/xsl:where-populated&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+141: <span class="whitespace">          </span><span class="unknown">&lt;/xsl:on-completion&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 142: <span class="whitespace">          </span><span class="hit">&lt;xsl:if test=". &amp;gt; 150"&gt;</span>
 143: <span class="whitespace">            </span><span class="hit">&lt;xsl:break /&gt;</span>
 144: <span class="whitespace">          </span><span class="hit">&lt;/xsl:if&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-key-01-coverage.html
@@ -56,7 +56,7 @@
 04: <span class="comment">      xsl:key Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- xsl:key declaration --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:key name="key01" match="node" use="@type" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:key name="key01" match="node" use="@type" /&gt;</span><span class="whitespace">                            </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 08: <span class="whitespace">  </span><span class="comment">&lt;!-- Main template --&gt;</span>
 09: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-key"&gt;</span>
 10: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-mode-01-coverage.html
@@ -55,10 +55,10 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:mode Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="modeUsed" /&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode on-multiple-match="fail" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="modeUsed" /&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode on-multiple-match="fail" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 08: <span class="whitespace">  </span><span class="comment">&lt;!-- Mode not used --&gt;</span>
-09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="modeNotUsed" /&gt;</span>
+09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="modeNotUsed" /&gt;</span><span class="whitespace">                                              </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 10: 
 11: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-mode"&gt;</span>
 12: <span class="whitespace">      </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-namespace-alias-01-coverage.html
@@ -56,7 +56,7 @@
 04: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 05: <span class="comment">      xsl:namespace-alias Coverage Test Case</span>
 06: <span class="comment">  --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" /&gt;</span><span class="whitespace">       </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 08: 
 09: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-namespace-alias"&gt;</span>
 10: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-next-match-01-coverage.html
@@ -64,9 +64,9 @@
 04: <span class="comment">      xsl:next-match Coverage Test Case - See imported template as well</span>
 05: <span class="comment">  --&gt;</span>
 06: <span class="whitespace">  </span><span class="comment">&lt;!-- Import stylesheet with lower priority template --&gt;</span>
-07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-next-match-01A.xsl" /&gt;</span>
+07: <span class="whitespace">  </span><span class="ignored">&lt;xsl:import href="xsl-next-match-01A.xsl" /&gt;</span><span class="whitespace">                                 </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 08: <span class="whitespace">  </span><span class="comment">&lt;!-- Use a mode for matching --&gt;</span>
-09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="nextMatch" /&gt;</span>
+09: <span class="whitespace">  </span><span class="ignored">&lt;xsl:mode name="nextMatch" /&gt;</span><span class="whitespace">                                                </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 10: <span class="whitespace">  </span><span class="comment">&lt;!-- Variable with the node to be processed --&gt;</span>
 11: <span class="whitespace">  </span><span class="hit">&lt;xsl:variable name="nextMatchNodes"&gt;</span>
 12: <span class="whitespace">    </span><span class="hit">&lt;node&gt;</span><span class="hit">content for built-in template</span><span class="hit">&lt;/node&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-output-01-coverage.html
@@ -55,7 +55,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:output Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:output method="xml" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:output method="xml" /&gt;</span><span class="whitespace">                                                  </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: 
 08: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-output"&gt;</span>
 09: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-param-01-coverage.html
@@ -136,15 +136,15 @@
 084: <span class="whitespace">      </span><span class="comment">&lt;!--Iterate param with multiline sequence constructor --&gt;</span>
 085: <span class="whitespace">      </span><span class="hit">&lt;xsl:iterate select="node"&gt;</span>
 086: <span class="whitespace">        </span><span class="hit">&lt;xsl:param name="iterateParamDocNode01"&gt;</span>
-087: <span class="whitespace">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span>
-088: <span class="whitespace">          </span><span class="missed">&lt;xsl:choose&gt;</span>
-089: <span class="whitespace">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span>
-090: <span class="whitespace">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span>
-091: <span class="whitespace">            </span><span class="missed">&lt;/xsl:when&gt;</span>
-092: <span class="whitespace">            </span><span class="missed">&lt;xsl:otherwise&gt;</span>
+087: <span class="whitespace">          </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">1</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                               </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+088: <span class="whitespace">          </span><span class="missed">&lt;xsl:choose&gt;</span><span class="whitespace">                                                         </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+089: <span class="whitespace">            </span><span class="missed">&lt;xsl:when test="1 eq 1"&gt;</span><span class="whitespace">                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+090: <span class="whitespace">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">5</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                           </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+091: <span class="whitespace">            </span><span class="missed">&lt;/xsl:when&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+092: <span class="whitespace">            </span><span class="missed">&lt;xsl:otherwise&gt;</span><span class="whitespace">                                                    </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 093: <span class="whitespace">              </span><span class="missed">&lt;xsl:text&gt;</span><span class="missed">99</span><span class="missed">&lt;/xsl:text&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
-094: <span class="whitespace">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span>
-095: <span class="whitespace">          </span><span class="missed">&lt;/xsl:choose&gt;</span>
+094: <span class="whitespace">            </span><span class="missed">&lt;/xsl:otherwise&gt;</span><span class="whitespace">                                                   </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
+095: <span class="whitespace">          </span><span class="missed">&lt;/xsl:choose&gt;</span><span class="whitespace">                                                        </span><span class="comment">&lt;!-- Expected miss --&gt;</span>
 096: <span class="whitespace">        </span><span class="hit">&lt;/xsl:param&gt;</span>
 097: <span class="whitespace">        </span><span class="hit">&lt;xsl:param name="iterateParamAs01" as="xs:integer" select="15" /&gt;</span>
 098: <span class="whitespace">        </span><span class="hit">&lt;node type="param - iterate"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-preserve-space-01-coverage.html
@@ -55,7 +55,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:preserve-space Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:preserve-space elements="*" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:preserve-space elements="*" /&gt;</span><span class="whitespace">                                          </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: 
 08: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-preserve-space"&gt;</span>
 09: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sequence-01-coverage.html
@@ -59,7 +59,7 @@
 07: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>
 08: <span class="whitespace">      </span><span class="comment">&lt;!-- Using select attribute --&gt;</span>
 09: <span class="whitespace">      </span><span class="hit">&lt;node type="sequence"&gt;</span>
-10: <span class="whitespace">        </span><span class="hit">&lt;xsl:sequence select="'100'" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
+10: <span class="whitespace">        </span><span class="hit">&lt;xsl:sequence select="'100'" /&gt;</span>
 11: <span class="whitespace">      </span><span class="hit">&lt;/node&gt;</span>
 12: <span class="whitespace">      </span><span class="comment">&lt;!-- Using sequence constructor --&gt;</span>
 13: <span class="whitespace">      </span><span class="hit">&lt;node type="sequence"&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-sort-01-coverage.html
@@ -107,7 +107,7 @@
 055: <span class="whitespace">              </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span><span class="whitespace">                                    </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 056: <span class="whitespace">            </span><span class="unknown">&lt;/xsl:when&gt;</span><span class="whitespace">                                                      </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 057: <span class="whitespace">            </span><span class="unknown">&lt;xsl:otherwise&gt;</span><span class="whitespace">                                                  </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
-058: <span class="whitespace">              </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span>
+058: <span class="whitespace">              </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span><span class="whitespace">                                    </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 059: <span class="whitespace">            </span><span class="unknown">&lt;/xsl:otherwise&gt;</span><span class="whitespace">                                                 </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 060: <span class="whitespace">          </span><span class="hit">&lt;/xsl:choose&gt;</span>
 061: <span class="whitespace">        </span><span class="hit">&lt;/xsl:sort&gt;</span>
@@ -121,7 +121,7 @@
 069: <span class="whitespace">      </span><span class="hit">&lt;xsl:apply-templates mode="sortMode"&gt;</span>
 070: <span class="whitespace">        </span><span class="hit">&lt;xsl:sort&gt;</span>
 071: <span class="whitespace">          </span><span class="hit">&lt;xsl:value-of&gt;</span>
-072: <span class="whitespace">            </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span>
+072: <span class="whitespace">            </span><span class="unknown">&lt;xsl:value-of select="." /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 073: <span class="whitespace">            </span><span class="unknown">&lt;xsl:copy-of select="()" /&gt;</span><span class="whitespace">                                        </span><span class="comment">&lt;!-- Expected unknown --&gt;</span>
 074: <span class="whitespace">          </span><span class="hit">&lt;/xsl:value-of&gt;</span>
 075: <span class="whitespace">        </span><span class="hit">&lt;/xsl:sort&gt;</span>

--- a/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
+++ b/test/end-to-end/cases-coverage/expected/stylesheet/xsl-strip-space-01-coverage.html
@@ -55,7 +55,7 @@
 03: <span class="whitespace">  </span><span class="comment">&lt;!--</span>
 04: <span class="comment">      xsl:strip-space Coverage Test Case</span>
 05: <span class="comment">  --&gt;</span>
-06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:strip-space elements="*" /&gt;</span>
+06: <span class="whitespace">  </span><span class="ignored">&lt;xsl:strip-space elements="*" /&gt;</span><span class="whitespace">                                             </span><span class="comment">&lt;!-- Expected ignored --&gt;</span>
 07: 
 08: <span class="whitespace">  </span><span class="hit">&lt;xsl:template match="xsl-strip-space"&gt;</span>
 09: <span class="whitespace">    </span><span class="hit">&lt;root&gt;</span>

--- a/test/end-to-end/cases-coverage/external_xsl-accept-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-accept-01.xsl
@@ -14,7 +14,7 @@
                     package-version="*">                                       <!-- Expected ignored -->
        <xsl:accept component="function" names="csv:preprocess-field#1"
                    visibility="private" />                                     <!-- Expected ignored -->
-   </xsl:use-package>
+   </xsl:use-package>                                                          <!-- Expected ignored -->
 
    <!-- example input "file"  -->
    <xsl:variable name="input" as="xs:string">

--- a/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-global-context-item-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:global-context-item Coverage Test Case
   -->
-  <xsl:global-context-item use="required" as="item()" />
+  <xsl:global-context-item use="required" as="item()" />                       <!-- Expected ignored -->
   <!-- Put the context item in a global variable -->
   <xsl:variable name="globalVariable" select="." />
 

--- a/test/end-to-end/cases-coverage/external_xsl-override-01.xsl
+++ b/test/end-to-end/cases-coverage/external_xsl-override-01.xsl
@@ -23,8 +23,8 @@
            <xsl:template match="root" mode="csv:post-process">                 <!-- Expected miss -->
                <csv>                                                           <!-- Expected miss -->
                    <xsl:apply-templates mode="csv:post-process"/>              <!-- Expected miss -->
-               </csv>
-           </xsl:template>
+               </csv>                                                          <!-- Expected miss -->
+           </xsl:template>                                                     <!-- Expected miss -->
 
            <!-- add an extra attribute that uses the context item -->
            <xsl:attribute-set name="csv:field-attributes"
@@ -33,7 +33,7 @@
                               select="if (. castable as xs:decimal)
                                       then 'numeric'
                                       else 'string'"/>                         <!-- Expected ignored -->
-           </xsl:attribute-set>
+           </xsl:attribute-set>                                                <!-- Expected ignored -->
 
            <!-- use semicolon not comma between fields -->
            <xsl:variable name="csv:field-separator"
@@ -51,8 +51,8 @@
                                      then $norm-line
                                      else ()"/>
            </xsl:function>
-       </xsl:override>
-   </xsl:use-package>
+       </xsl:override>                                                         <!-- Expected ignored -->
+   </xsl:use-package>                                                          <!-- Expected ignored -->
 
    <!-- example input "file"  -->
    <xsl:variable name="input" as="xs:string">

--- a/test/end-to-end/cases-coverage/xsl-analyze-string-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-analyze-string-01.xsl
@@ -27,11 +27,11 @@
         </xsl:matching-substring>                                              <!-- Expected miss -->
         <xsl:non-matching-substring>
           <node type="non-matching-substring">
-            <xsl:sequence select="string('No match')"/>                        <!-- Expected unknown -->
+            <xsl:sequence select="string('No match')"/>
           </node>
         </xsl:non-matching-substring>
       </xsl:analyze-string>
-      
+
       <!-- Test cases for unknown status of xsl:matching-substring and xsl:non-matching-substring -->
       <!-- regex matches string so non-matching-substring not executed -->
       <node type="matching-substring executed unknown, non-matching-substring unexecuted unknown">

--- a/test/end-to-end/cases-coverage/xsl-apply-imports-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-imports-01.xsl
@@ -4,9 +4,9 @@
       xsl:apply-imports Coverage Test Case (see xsl-apply-imports-01A.xsl as well)
   -->
   <!-- Import stylesheet -->
-  <xsl:import href="xsl-apply-imports-01A.xsl" />
+  <xsl:import href="xsl-apply-imports-01A.xsl" />                              <!-- Expected ignored -->
   <!-- xsl:mode for this test -->
-  <xsl:mode name="applyImportsMode" />
+  <xsl:mode name="applyImportsMode" />                                         <!-- Expected ignored -->
   <!-- Main Stylesheet-->
   <xsl:template match="xsl-apply-imports">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-apply-templates-01.xsl
@@ -21,7 +21,7 @@
     </node>
   </xsl:template>
 
-  <xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" />
+  <xsl:mode name="mode-without-explicit-template-with-xsl-mode" on-no-match="shallow-copy" /><!-- Expected ignored -->
 
   <xsl:template match="applyTemplateNode" mode="mode-with-matching-template">
     <node type="apply-templates-mode-with-matching-template">

--- a/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-attribute-01.xsl
@@ -4,19 +4,19 @@
       xsl:attribute Coverage Test Case
   -->
   <!-- Single xsl:attribute in xsl:attribute-set -->
-  <xsl:attribute-set name="type">
-    <xsl:attribute name="type">attribute</xsl:attribute>
-  </xsl:attribute-set>
+  <xsl:attribute-set name="type">                                              <!-- Expected ignored -->
+    <xsl:attribute name="type">attribute</xsl:attribute>                       <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
 
   <!-- Two xsl:attribute in xsl:attribute-set -->
-  <xsl:attribute-set name="types">
-    <xsl:attribute name="type1">
-      <xsl:text>attribute1</xsl:text>
-    </xsl:attribute>
-    <xsl:attribute name="type2">
-      <xsl:text>attribute2</xsl:text>
-    </xsl:attribute>
-  </xsl:attribute-set>
+  <xsl:attribute-set name="types">                                             <!-- Expected ignored -->
+    <xsl:attribute name="type1">                                               <!-- Expected ignored -->
+      <xsl:text>attribute1</xsl:text>                                          <!-- Expected ignored -->
+    </xsl:attribute>                                                           <!-- Expected ignored -->
+    <xsl:attribute name="type2">                                               <!-- Expected ignored -->
+      <xsl:text>attribute2</xsl:text>                                          <!-- Expected ignored -->
+    </xsl:attribute>                                                           <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
 
   <xsl:template match="xsl-attribute">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-attribute-set-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-attribute-set-01.xsl
@@ -4,21 +4,21 @@
       xsl:attribute-set Coverage Test Case
   -->
   <!-- Single attribute -->
-  <xsl:attribute-set name="attrSet01">
-    <xsl:attribute name="attr01">attr01</xsl:attribute>
-  </xsl:attribute-set>
+  <xsl:attribute-set name="attrSet01">                                         <!-- Expected ignored -->
+    <xsl:attribute name="attr01">attr01</xsl:attribute>                        <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
   <!-- Multiple attributes-->
-  <xsl:attribute-set name="attrSet02">
-    <xsl:attribute name="attr02A">attr02A</xsl:attribute>
-    <xsl:attribute name="attr02B">attr02B</xsl:attribute>
-  </xsl:attribute-set>
+  <xsl:attribute-set name="attrSet02">                                         <!-- Expected ignored -->
+    <xsl:attribute name="attr02A">attr02A</xsl:attribute>                      <!-- Expected ignored -->
+    <xsl:attribute name="attr02B">attr02B</xsl:attribute>                      <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
   <!-- Including another attribute set -->
-  <xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B">
-    <xsl:attribute name="attr03A">attr03A</xsl:attribute>
-  </xsl:attribute-set>
-  <xsl:attribute-set name="attrSet03B">
-    <xsl:attribute name="attr03B">attr03B</xsl:attribute>
-  </xsl:attribute-set>
+  <xsl:attribute-set name="attrSet03A" use-attribute-sets="attrSet03B">        <!-- Expected ignored -->
+    <xsl:attribute name="attr03A">attr03A</xsl:attribute>                      <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
+  <xsl:attribute-set name="attrSet03B">                                        <!-- Expected ignored -->
+    <xsl:attribute name="attr03B">attr03B</xsl:attribute>                      <!-- Expected ignored -->
+  </xsl:attribute-set>                                                         <!-- Expected ignored -->
   <!-- Main template -->
   <xsl:template match="xsl-attribute-set">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-character-map-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-character-map-01.xsl
@@ -5,16 +5,16 @@
   -->
   <!-- character map does not do any mapping changes (confident that it is used in Saxon).
        But xspec doesn't do character-map without some additional effort (which isn't done here)-->
-  <xsl:character-map name="charMap01" use-character-maps="charMap01A">
-    <xsl:output-character character="0" string="0" />
-    <xsl:output-character character="&#xE003;" string="3" />
-  </xsl:character-map>
+  <xsl:character-map name="charMap01" use-character-maps="charMap01A">         <!-- Expected ignored -->
+    <xsl:output-character character="0" string="0" />                          <!-- Expected ignored -->
+    <xsl:output-character character="&#xE003;" string="3" />                   <!-- Expected ignored -->
+  </xsl:character-map>                                                         <!-- Expected ignored -->
   <!-- xsl:character-map included in one above -->
-  <xsl:character-map name="charMap01A">
-    <xsl:output-character character="1" string="1" />
-  </xsl:character-map>
+  <xsl:character-map name="charMap01A">                                        <!-- Expected ignored -->
+    <xsl:output-character character="1" string="1" />                          <!-- Expected ignored -->
+  </xsl:character-map>                                                         <!-- Expected ignored -->
 
-  <xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" />
+  <xsl:output use-character-maps="charMap01" method="xml" encoding="utf-8" />  <!-- Expected ignored -->
 
   <xsl:template match="xsl-character-map">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-decimal-format-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-decimal-format-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:decimal-format Coverage Test Case
   -->
-  <xsl:decimal-format name="decFormat01" digit="?" />
+  <xsl:decimal-format name="decFormat01" digit="?" />                          <!-- Expected ignored -->
   <!-- Main template -->
   <xsl:template match="xsl-decimal-format">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-import-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-import-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:import Coverage Test Case (See imported stylesheet)
   -->
-  <xsl:import href="xsl-import-01A.xsl" />
+  <xsl:import href="xsl-import-01A.xsl" />                                     <!-- Expected ignored -->
   <xsl:template match="xsl-import">
     <root>
       <!-- Call template in imported stylesheet -->

--- a/test/end-to-end/cases-coverage/xsl-include-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-include-01.xsl
@@ -4,8 +4,8 @@
       xsl:include Coverage Test Case
   -->
   <!-- xsl:include -->
-  <xsl:include href="xsl-include-01A.xsl" />
-  <xsl:include href="xsl-include-01B.xsl" />
+  <xsl:include href="xsl-include-01A.xsl" />                                   <!-- Expected ignored -->
+  <xsl:include href="xsl-include-01B.xsl" />                                   <!-- Expected ignored -->
   <!-- Main template -->
   <xsl:template match="xsl-include">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-iterate-01.xsl
@@ -135,10 +135,10 @@
       <!-- xsl:iterate with xsl:on-completion not executed but unknown status -->
       <node type="iterate/on-completion unexecuted unknown">
         <xsl:iterate select="node">
-          <xsl:on-completion>                                                    <!-- Expected unknown -->
-            <xsl:where-populated>                                                <!-- Expected unknown -->
-            </xsl:where-populated>                                               <!-- Expected unknown -->
-          </xsl:on-completion>                                                   <!-- Expected unknown -->
+          <xsl:on-completion>                                                  <!-- Expected unknown -->
+            <xsl:where-populated>                                              <!-- Expected unknown -->
+            </xsl:where-populated>                                             <!-- Expected unknown -->
+          </xsl:on-completion>                                                 <!-- Expected unknown -->
           <xsl:if test=". &gt; 150">
             <xsl:break />
           </xsl:if>

--- a/test/end-to-end/cases-coverage/xsl-key-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-key-01.xsl
@@ -4,7 +4,7 @@
       xsl:key Coverage Test Case
   -->
   <!-- xsl:key declaration -->
-  <xsl:key name="key01" match="node" use="@type" />
+  <xsl:key name="key01" match="node" use="@type" />                            <!-- Expected ignored -->
   <!-- Main template -->
   <xsl:template match="xsl-key">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-mode-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-mode-01.xsl
@@ -3,10 +3,10 @@
   <!--
       xsl:mode Coverage Test Case
   -->
-  <xsl:mode name="modeUsed" />
-  <xsl:mode on-multiple-match="fail" />
+  <xsl:mode name="modeUsed" />                                                 <!-- Expected ignored -->
+  <xsl:mode on-multiple-match="fail" />                                        <!-- Expected ignored -->
   <!-- Mode not used -->
-  <xsl:mode name="modeNotUsed" />
+  <xsl:mode name="modeNotUsed" />                                              <!-- Expected ignored -->
 
   <xsl:template match="xsl-mode">
       <root>

--- a/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-namespace-alias-01.xsl
@@ -4,7 +4,7 @@
   <!--
       xsl:namespace-alias Coverage Test Case
   -->
-  <xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" />
+  <xsl:namespace-alias stylesheet-prefix="myxslt" result-prefix="xsl" />       <!-- Expected ignored -->
 
   <xsl:template match="xsl-namespace-alias">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-next-match-01.xsl
@@ -4,9 +4,9 @@
       xsl:next-match Coverage Test Case - See imported template as well
   -->
   <!-- Import stylesheet with lower priority template -->
-  <xsl:import href="xsl-next-match-01A.xsl" />
+  <xsl:import href="xsl-next-match-01A.xsl" />                                 <!-- Expected ignored -->
   <!-- Use a mode for matching -->
-  <xsl:mode name="nextMatch" />
+  <xsl:mode name="nextMatch" />                                                <!-- Expected ignored -->
   <!-- Variable with the node to be processed -->
   <xsl:variable name="nextMatchNodes">
     <node>content for built-in template</node>

--- a/test/end-to-end/cases-coverage/xsl-output-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-output-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:output Coverage Test Case
   -->
-  <xsl:output method="xml" />
+  <xsl:output method="xml" />                                                  <!-- Expected ignored -->
 
   <xsl:template match="xsl-output">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-param-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-param-01.xsl
@@ -84,15 +84,15 @@
       <!--Iterate param with multiline sequence constructor -->
       <xsl:iterate select="node">
         <xsl:param name="iterateParamDocNode01">
-          <xsl:text>1</xsl:text>
-          <xsl:choose>
-            <xsl:when test="1 eq 1">
-              <xsl:text>5</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
+          <xsl:text>1</xsl:text>                                               <!-- Expected miss -->
+          <xsl:choose>                                                         <!-- Expected miss -->
+            <xsl:when test="1 eq 1">                                           <!-- Expected miss -->
+              <xsl:text>5</xsl:text>                                           <!-- Expected miss -->
+            </xsl:when>                                                        <!-- Expected miss -->
+            <xsl:otherwise>                                                    <!-- Expected miss -->
               <xsl:text>99</xsl:text>                                          <!-- Expected miss -->
-            </xsl:otherwise>
-          </xsl:choose>
+            </xsl:otherwise>                                                   <!-- Expected miss -->
+          </xsl:choose>                                                        <!-- Expected miss -->
         </xsl:param>
         <xsl:param name="iterateParamAs01" as="xs:integer" select="15" />
         <node type="param - iterate">

--- a/test/end-to-end/cases-coverage/xsl-preserve-space-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-preserve-space-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:preserve-space Coverage Test Case
   -->
-  <xsl:preserve-space elements="*" />
+  <xsl:preserve-space elements="*" />                                          <!-- Expected ignored -->
 
   <xsl:template match="xsl-preserve-space">
     <root>

--- a/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sequence-01.xsl
@@ -7,7 +7,7 @@
     <root>
       <!-- Using select attribute -->
       <node type="sequence">
-        <xsl:sequence select="'100'" />                                        <!-- Expected unknown -->
+        <xsl:sequence select="'100'" />
       </node>
       <!-- Using sequence constructor -->
       <node type="sequence">

--- a/test/end-to-end/cases-coverage/xsl-sort-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-sort-01.xsl
@@ -55,7 +55,7 @@
               <xsl:value-of select="." />                                    <!-- Expected unknown -->
             </xsl:when>                                                      <!-- Expected unknown -->
             <xsl:otherwise>                                                  <!-- Expected unknown -->
-              <xsl:value-of select="." />
+              <xsl:value-of select="." />                                    <!-- Expected unknown -->
             </xsl:otherwise>                                                 <!-- Expected unknown -->
           </xsl:choose>
         </xsl:sort>
@@ -69,7 +69,7 @@
       <xsl:apply-templates mode="sortMode">
         <xsl:sort>
           <xsl:value-of>
-            <xsl:value-of select="." />
+            <xsl:value-of select="." />                                        <!-- Expected unknown -->
             <xsl:copy-of select="()" />                                        <!-- Expected unknown -->
           </xsl:value-of>
         </xsl:sort>

--- a/test/end-to-end/cases-coverage/xsl-strip-space-01.xsl
+++ b/test/end-to-end/cases-coverage/xsl-strip-space-01.xsl
@@ -3,7 +3,7 @@
   <!--
       xsl:strip-space Coverage Test Case
   -->
-  <xsl:strip-space elements="*" />
+  <xsl:strip-space elements="*" />                                             <!-- Expected ignored -->
 
   <xsl:template match="xsl-strip-space">
     <root>


### PR DESCRIPTION
This pull request contains the test updates by @birdya22 from the ZIP-file linked from #2130. (In subsequent commits, I made one further test update and one version number update in a related Markdown file.) The updates make the end-to-end code coverage tests easier to understand because code comments indicate the expected status (with Saxon 12.9) of nodes that aren't "hit".

Thanks, @birdya22 !

Fixes #2130.