### PR TITLE
build(maven): restore pom.xml to 4.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xspec</groupId>
   <artifactId>xspec</artifactId>
-  <version>4.0.3</version>
+  <version>4.1-SNAPSHOT</version>
 
   <name>XSpec implementation</name>
   <description>A unit test framework for XSLT, XQuery, Schematron, and XProc </description>


### PR DESCRIPTION
After releasing v4.0.3 from the `main` branch, we now want to continue v4.1 development on that branch. We need to restore `4.1-SNAPSHOT` to that branch's `pom.xml` file.