### PR TITLE
refactor: refactor XQuery and XSLT tutorial modules

### DIFF
--- a/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.xml
+++ b/test/end-to-end/cases/expected/stylesheet/force-focus_escape-for-regex-result.xml
@@ -8,9 +8,9 @@
              pending="force focus">
       <label>No escaping</label>
       <input-wrap xmlns="">
-         <x:call xmlns:functx="http://www.functx.com"
+         <x:call xmlns:er="x-urn:tutorial:xslt-tutorial"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                 function="functx:escape-for-regex">
+                 function="er:escape-for-regex">
             <x:param select="'Hello'"/>
          </x:call>
       </input-wrap>
@@ -23,15 +23,15 @@
              pending="force focus">
       <label>Test simple patterns</label>
       <input-wrap xmlns="">
-         <x:call xmlns:functx="http://www.functx.com"
+         <x:call xmlns:er="x-urn:tutorial:xslt-tutorial"
                  xmlns:x="http://www.jenitennison.com/xslt/xspec"
-                 function="functx:escape-for-regex"/>
+                 function="er:escape-for-regex"/>
       </input-wrap>
       <scenario id="scenario2-scenario1"
                 xspec="../../../../../tutorial/escape-for-regex.xspec">
          <label>When encountering parentheses</label>
          <input-wrap xmlns="">
-            <x:call xmlns:functx="http://www.functx.com"
+            <x:call xmlns:er="x-urn:tutorial:xslt-tutorial"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">
                <x:param select="'(Hello)'"/>
             </x:call>
@@ -47,7 +47,7 @@
                 pending="force focus">
          <label>When encountering a whitespace character class</label>
          <input-wrap xmlns="">
-            <x:call xmlns:functx="http://www.functx.com"
+            <x:call xmlns:er="x-urn:tutorial:xslt-tutorial"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">
                <x:param select="'\sHello'"/>
             </x:call>
@@ -65,7 +65,7 @@
              pending="force focus">
       <label>When processing a list of phrases</label>
       <input-wrap xmlns="">
-         <x:context xmlns:functx="http://www.functx.com"
+         <x:context xmlns:er="x-urn:tutorial:xslt-tutorial"
                     xmlns:x="http://www.jenitennison.com/xslt/xspec">
             <phrases>
                <phrase>Hello!</phrase>

--- a/tutorial/escape-for-regex.xsl
+++ b/tutorial/escape-for-regex.xsl
@@ -1,24 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:functx="http://www.functx.com" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:er="x-urn:tutorial:xslt-tutorial" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="#all" version="3.0">
 
-    <!-- The functx:escape-for-regex function escapes a string that you wish to be taken 
-         literally rather than treated like a regular expression. This is useful when, 
-         for example, you are calling the built-in fn:replace function and you want any 
-         periods or parentheses to be treated like literal characters rather than regex 
-         special characters. 
-         From: http://www.xsltfunctions.com/xsl/functx_escape-for-regex.html
+    <!--
+        The er:escape-for-regex function escapes regex special characters that
+        you want the fn:replace function to interpret literally.
+        Inspired by https://www.datypic.com/xsl/functx_escape-for-regex.html
     -->
-    <xsl:function name="functx:escape-for-regex" as="xs:string">
-        <xsl:param name="arg" as="xs:string?"/>
+    <xsl:function name="er:escape-for-regex" as="xs:string">
+        <xsl:param name="arg" as="xs:string?" />
 
-        <xsl:sequence
-            select=" 
-            replace($arg,
-            '(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')
-            "
-        />
+        <xsl:variable name="escaped-chars" as="xs:string+" select="
+                ('.', '[', ']', '\', '|', '-', '^', '$', '?', '*', '+', '{', '}',
+                '(', ')') ! concat('\', .)" />
+        <xsl:variable name="pattern" as="xs:string"
+            select="concat('(', string-join($escaped-chars, '|'), ')')" />
+        <xsl:sequence select="replace($arg, $pattern, '\\$1')" />
     </xsl:function>
 
 
@@ -27,7 +25,7 @@
     <xsl:mode on-no-match="shallow-copy" on-multiple-match="fail" />
 
     <xsl:template match="phrase" as="element(phrase)">
-        <xsl:variable name="escaped-text" as="xs:string" select="functx:escape-for-regex(.)" />
+        <xsl:variable name="escaped-text" as="xs:string" select="er:escape-for-regex(.)" />
         <xsl:copy>
             <xsl:attribute name="status" select="if (. = $escaped-text) then 'changed' else 'same'" />
             <xsl:value-of select="$escaped-text" />

--- a/tutorial/escape-for-regex.xspec
+++ b/tutorial/escape-for-regex.xspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-               xmlns:functx="http://www.functx.com"
+               xmlns:er="x-urn:tutorial:xslt-tutorial"
                stylesheet="escape-for-regex.xsl">
 
    <!--
@@ -21,7 +21,7 @@
    -->
    <x:scenario label="No escaping">
       <!-- call the function with the string 'Hello' -->
-      <x:call function="functx:escape-for-regex">
+      <x:call function="er:escape-for-regex">
          <x:param select="'Hello'"/>
       </x:call>
 
@@ -37,7 +37,7 @@
    -->
    <x:scenario label="Test simple patterns">
       <!-- call the function -->
-      <x:call function="functx:escape-for-regex" />
+      <x:call function="er:escape-for-regex" />
 
       <!-- first sub-scenario -->
       <x:scenario label="When encountering parentheses">

--- a/tutorial/xquery-tutorial.xqm
+++ b/tutorial/xquery-tutorial.xqm
@@ -1,12 +1,10 @@
-module namespace functx = "http://www.functx.com";
+module namespace cf = "x-urn:tutorial:xquery-tutorial";
 
 (:
     Capitalizes the first character of a string
-    From: http://www.xqueryfunctions.com/xq/functx_capitalize-first.html
 :)
-declare function functx:capitalize-first
-($arg as xs:string?) as xs:string? {
+declare function cf:capitalize-first
+($arg as xs:string?) as xs:string {
     
-    concat(upper-case(substring($arg, 1, 1)),
-    substring($arg, 2))
+    analyze-string($arg, '^.')/(upper-case(fn:match) || fn:non-match)
 };

--- a/tutorial/xquery-tutorial.xspec
+++ b/tutorial/xquery-tutorial.xspec
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" 
-               xmlns:functx="http://www.functx.com"
-               query="http://www.functx.com" 
+               xmlns:cf="x-urn:tutorial:xquery-tutorial"
+               query="x-urn:tutorial:xquery-tutorial" 
                query-at="xquery-tutorial.xqm">
 
   <x:scenario label="Calling function capitalize-first">
-    <x:call function="functx:capitalize-first">
+    <x:call function="cf:capitalize-first">
       <x:param select="'hello'"/>
     </x:call>
 


### PR DESCRIPTION
This pull request was motivated by part of #2357 (including https://github.com/xspec/xspec/issues/2357#issuecomment-4731166198 and other comments dated June 17-21, 2026). Saxon 13.0 includes an XML Resolver version that, for the XQuery tutorial module in this repo, tries to find the actual XQuery code at the Internet location `http://www.functx.com` specified in the module URI. Making that operation successful in a machine with Internet access requires extra steps that would distract from the purpose of the new-user tutorial.

As a remedy, this pull request avoids a module URI that has the form of an Internet location potentially containing an XQuery module. Because the original tutorial code is third-party and we can't just change the module URI without reading and abiding by the license terms, this pull request replaces the third-party code with original code that will then belong to this repo. I'm open to other implementation ideas that don't involve interpreting software license terms.

After this change is on the `main` branch, I'll return to #2379 and revisit https://github.com/xspec/xspec/pull/2379/changes/14d55afc353495d1b5f806e4a394900c526afc7c there, because some of the workarounds will no longer be necessary.

The wiki page that discuss the XQuery and XSLT tutorials will also require minor updates.