### PR TITLE
ci: remove Saxon 11 from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [17, 21]
-        env: [saxon-13, saxon-12, oxygen, saxon-11]
+        env: [saxon-13, saxon-12, oxygen]
         exclude:
           - os: macos-latest
-            env: saxon-11
+            env: oxygen
 
     steps:
       - uses: actions/checkout@v7

--- a/test/ci/env/saxon-11.env
+++ b/test/ci/env/saxon-11.env
@@ -1,6 +1,0 @@
-#
-# Latest Saxon 11
-#
-SAXON_URL=https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/11/Java
-SAXON_VERSION=11.7
-XMLCALABASH_VERSION=1.5.7-110

--- a/test/saxon-custom-options/test.xspec
+++ b/test/saxon-custom-options/test.xspec
@@ -12,12 +12,9 @@
 
 		<x:scenario label="strip-space=yes and xinclude=yes">
 			<x:call function="exactly-one">
-				<!-- ws-only-text-copy.xml is identical to ws-only-text.xml. In Saxon 11,
-				the test fails if the same XML file is read with and without the URI
-				query parameter in the same test session.-->
 				<!-- Use of XML catalog demonstrates compatibility with
 					RECOGNIZE_URI_QUERY_PARAMETERS in Saxon 11 and later -->
-				<x:param href="catalog-01:/ws-only-text-copy.xml?strip-space=yes;xinclude=yes" />
+				<x:param href="catalog-01:/ws-only-text.xml?strip-space=yes;xinclude=yes" />
 			</x:call>
 			<x:expect label="Whitespace-only text nodes are stripped" select="'AB'"
 				test="string($x:result)" />

--- a/test/saxon-custom-options/ws-only-text-copy.xml
+++ b/test/saxon-custom-options/ws-only-text-copy.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xi:include href="ws-only-text.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Following #2379, this PR removes Saxon 11 from GitHub Actions, which means XSpec no longer supports Saxon 11.

There is not much code specifically designed for Saxon 11. I included one cleanup commit in this PR (73b0e986314bc7e95a04f110b1cd63be3c60a46b) instead of making a separate PR.

Fixes #2195.
