### PR TITLE
fix: check for mixed usage of position per x:call

### DIFF
--- a/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
+++ b/src/compiler/base/compile/compile-child-scenarios-or-expects.xsl
@@ -81,6 +81,8 @@
       <xsl:variable name="new-call" as="element(x:call)?">
          <xsl:choose>
             <xsl:when test="x:call">
+               <xsl:sequence select="local:param-position-implicit-explicit-error(x:call)"/>
+
                <xsl:copy select="x:call">
                   <xsl:sequence select="($call, .) ! attribute()" />
 
@@ -186,6 +188,21 @@
          select="$owner/x:param/@position ! xs:integer(.)" />
       <xsl:for-each select="$positions[subsequence($positions, 1, position() - 1) = .][1]">
          <xsl:text expand-text="yes">Duplicate parameter position, {.}, used in {name($owner)}.</xsl:text>
+      </xsl:for-each>
+   </xsl:function>
+
+   <!-- Raises an error if x:param/@position existence is mixed for an individual x:call -->
+   <xsl:function name="local:param-position-implicit-explicit-error" as="empty-sequence()">
+      <xsl:param name="owner" as="element(x:call)" />
+      <xsl:for-each select="$owner">
+         <xsl:if test="exists(x:param/@position) and exists(x:param[not(@position)])">
+            <xsl:message terminate="yes">
+               <xsl:call-template name="x:prefix-diag-message">
+                  <xsl:with-param name="message" expand-text="1"
+                     >{name(.)} uses @position on some but not all {name(x:param[1])}.</xsl:with-param>
+               </xsl:call-template>
+            </xsl:message>
+         </xsl:if>
       </xsl:for-each>
    </xsl:function>
 

--- a/test/bad-position/mixed_explicit-implicit.xspec
+++ b/test/bad-position/mixed_explicit-implicit.xspec
@@ -3,6 +3,8 @@
 	xml:base="../" xmlns:my="http://example.org/ns/my"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
+	<!-- This file is used in rnc.bats, param-position-implicit-explicit.xspec,
+		and param-position-implicit-explicit_stylesheet.xspec -->
 	<x:scenario label="function-param positions (explicit one followed by implicit one)">
 		<x:call function="my:subtract">
 			<x:param position="1" select="2" />

--- a/test/bad-position/mixed_implicit-explicit.xspec
+++ b/test/bad-position/mixed_implicit-explicit.xspec
@@ -3,6 +3,8 @@
 	xml:base="../" xmlns:my="http://example.org/ns/my"
 	xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
+	<!-- This file is used in rnc.bats, param-position-implicit-explicit.xspec,
+		and param-position-implicit-explicit_stylesheet.xspec -->
 	<x:scenario label="function-param positions (implicit one followed by explicit one)">
 		<x:call function="my:subtract">
 			<x:param select="2" />

--- a/test/param-position-implicit-explicit.xspec
+++ b/test/param-position-implicit-explicit.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    xmlns:local="urn:x-xspec:compiler:base:compile:compile-child-scenarios-or-expects:local"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="../src/compiler/compile-xquery-tests.xsl">
+
+    <x:scenario label="x:call[@function] whose parameters omit and then specify @position"
+        catch="yes">
+        <x:context mode="local:compile-scenarios-or-expects"
+            href="bad-position/mixed_explicit-implicit.xspec" select="//x:scenario"/>
+        <x:expect label="should raise a compiler error" result-type="map(*)"
+            test="$x:result?err?value/node()" as="text()"
+            >ERROR in x:call (under 'function-param positions (explicit one followed by implicit one)'): x:call uses @position on some but not all x:param.</x:expect>
+    </x:scenario>
+    <x:scenario label="x:call[@function] whose parameters specify and then omit @position"
+        catch="yes">
+        <x:context mode="local:compile-scenarios-or-expects"
+            href="bad-position/mixed_implicit-explicit.xspec" select="//x:scenario"/>
+        <x:expect label="should raise a compiler error" result-type="map(*)"
+            test="$x:result?err?value/node()" as="text()"
+            >ERROR in x:call (under 'function-param positions (implicit one followed by explicit one)'): x:call uses @position on some but not all x:param.</x:expect>
+    </x:scenario>
+</x:description>

--- a/test/param-position-implicit-explicit_stylesheet.xspec
+++ b/test/param-position-implicit-explicit_stylesheet.xspec
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="../src/compiler/compile-xslt-tests.xsl">
+
+    <!-- Same scenarios, but operating in compiler for XSLT test -->
+    <x:import href="param-position-implicit-explicit.xspec"/>
+</x:description>


### PR DESCRIPTION
Fixes #2403.

By the way, some of the other `test/bad-position/*.xspec` files are tested in the Bats test suite, but I chose to make ordinary XSpec tests for the error checking using `catch="yes"`. Advantages:

- XSpec files are cross-platform, whereas Bats test cases have to be written separately for Windows and Linux/macOS
- `x:import` makes it easy to reuse the testing code for the XSLT compiler vs. the XQuery compiler
- The Ant testing harness in this repo runs XSpec tests in parallel, faster than Bats test cases
- I could be biased :) but I find XSpec test scenarios nicer to read and write than Bats test cases

If I have some spare time, I might gradually migrate some other error-checking test cases in the Bats test suite to ordinary XSpec tests.