### PR TITLE
fix(schematron): simplify template-to-wiki link

### DIFF
--- a/templates/schematron.xspec
+++ b/templates/schematron.xspec
@@ -2,7 +2,7 @@
 <!--
     * Update /x:description/@schematron which should point to the Schematron file being tested.
     * Write your test scenario.
-      See https://github.com/xspec/xspec/wiki/Writing-Scenarios-for-Schematron#writing-tests for details.
+      See https://github.com/xspec/xspec/wiki/Writing-Scenarios-for-Schematron for details.
 -->
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
     schematron="path/to/my-schematron.sch">


### PR DESCRIPTION
The template should link to the [Writing Scenarios for Schematron](https://github.com/xspec/xspec/wiki/Writing-Scenarios-for-Schematron) wiki page as a whole. The page used to have a "Writing Tests" heading that wasn't the first heading, but that is no longer the case (see May 6, 2021 edits).