### PR TITLE
fix(xproc): error code with default namespace in c:error

### DIFF
--- a/src/compiler/xproc/in-scope-steps/error-code-attr-to-qname.xpl
+++ b/src/compiler/xproc/in-scope-steps/error-code-attr-to-qname.xpl
@@ -21,15 +21,23 @@
         <p:variable name="in-scope-prefixes" select="in-scope-prefixes($this-error)" as="xs:string*"/>
         <p:variable name="code" select="string($this-error/@code)" as="xs:string"/>
         <p:variable name="tokenized" select="tokenize($code, ':')" as="xs:string*"/>
-        <!-- Empirically, XML Calabash (v3.0.38) seems to use only unprefixed and prefixed names,
-            so not all the branches of the if/then/else clause come up in practice. -->
+        <!-- Maybe not all branches of the if/then/else clause come up in practice.
+            Empirically, the cases seen are as follows, for an error code in p:error that is:
+
+            a) Prefixed => c:error uses prefixed name
+            b) In null namespace  => c:error uses unprefixed name and no xmlns="..."
+            c) In non-null namespace but user provided no prefix =>
+               In XML Calabash (v.0.50), c:error uses prefixed name with processor-generated prefix
+               In MorganaXProc-IIIee (v1.8.14), c:error uses unprefixed name and xmlns="..."
+                   binding to error code's namespace URI
+        -->
         <p:variable name="code-as-QName" as="xs:QName?" select="
             if ($code eq '')
             then ()
             else if (matches($code, $regex-for-UQName) (: URI-qualified name :))
             then QName(replace($code, $regex-for-UQName, '$1'), replace($code, $regex-for-UQName, '$2'))
-            else if (count($tokenized) eq 1 and ($code castable as xs:QName) (: Unprefixed :))
-            then xs:QName($code)
+            else if (count($tokenized) eq 1 and ($code castable as xs:QName) (: Unprefixed, possibly default namespace :))
+            then resolve-QName($code, $this-error)
             else if ((count($tokenized) eq 2) and ($tokenized[1] = $in-scope-prefixes) (: Prefixed :))
             then resolve-QName($code, $this-error)
             else () (: Unrecognized content :)

--- a/test/xproc/cases/dynamic-errors.xspec
+++ b/test/xproc/cases/dynamic-errors.xspec
@@ -86,6 +86,15 @@
             select="QName('x-urn:test:xproc:steplibrary', 'error-from-my-xproc-step')"/>
     </x:scenario>
 
+    <x:scenario label="If p:error uses error code in null namespace" catch="yes">
+        <x:call step="s:p-error-or-document">
+            <x:option name="error-msg" select="'Message'"/>
+        </x:call>
+        <x:expect label="the error code is still verifiable as QName"
+            test="$x:result?err?code treat as xs:QName"
+            select="QName('', 'error-from-my-xproc-step')"/>
+    </x:scenario>
+
     <x:scenario label="If error document has two @line values (requires XML Calabash v3.0.40),"
         catch="yes">
         <x:call step="s:line-num-in-cx-input-location"/>


### PR DESCRIPTION
If user's `p:error` code has no prefix but is in non-null namespace, the MorganaXProc-IIIee (v1.8.14) `<c:error>` element provides the local part in an attribute and binds the element's default namespace to the error code's namespace URI. XML Calabash does it differently, generating its own prefix so the attribute can use a prefixed code.

This pull request accommodates both patterns. Without this change, the XSpec `$x:result?err?code` value does not reflect the error code's namespace URI if the XProc processor is MorganaXProc.

The `dynamic-errors.xspec` test file already includes this case, but I added a scenario for the null namespace situation.