### PR TITLE
test: remove Apache resolver from Bats test cases for CLI 

### DIFF
--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1993,22 +1993,14 @@
 
 	<!--
 		SAXON_HOME (CLI)
-		
-			* Saxon 10 and earlier: XSpec should find Apache XML Resolver jar (hardcoded as 'xml-resolver-1.2.jar') in same directory as Saxon jar file.
-			* Saxon 11 and later: XSpec does not care about XMLResolver.org XML Resolver jar file location. XSpec user should make sure it's available.
+			Note: In Saxon 11 and later, XSpec does not care about XMLResolver.org XML Resolver jar file location. XSpec user should make sure it's available.
 	-->
 
-	<case name="invoking xspec using SAXON_HOME finds Saxon jar and XML Catalog Resolver jar">
+	<case name="invoking xspec using SAXON_HOME finds Saxon jar">
     rem Set up SAXON_HOME
     set "SAXON_HOME=%WORK_DIR%\saxon %RANDOM%"
     call :mkdir "%SAXON_HOME%"
     call :copy "%SAXON_JAR%" "%SAXON_HOME%"
-
-    rem Apache XML Resolver
-    if not "%SAXON_VERSION:~0,3%"=="10." set APACHE_XMLRESOLVER_JAR=
-    if defined APACHE_XMLRESOLVER_JAR (
-        call :copy "%APACHE_XMLRESOLVER_JAR%" "%SAXON_HOME%\xml-resolver-1.2.jar"
-    )
 
     rem Unset SAXON_CP, otherwise SAXON_HOME is ignored.
     set SAXON_CP=
@@ -2021,19 +2013,14 @@
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;catalog\01\catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
-    if defined APACHE_XMLRESOLVER_JAR (
-        call :verify_retval 0
-        call :verify_line 21 x "passed: 5 / pending: 0 / failed: 0 / total: 5"
-    ) else (
-        rem If Java located net.sf.saxon.Transform.main, then it means CLI constructed SAXON_CP from SAXON_HOME successfully.
-        rem ClassNotFoundException for org.xmlresolver.Resolver is expected, as XMLResolver.org XML Resolver jar is missing
-        rem from SAXON_HOME/lib/ subdirectory deliberately.
-        call :verify_retval 1
-        call :verify_line * x "Creating Test Runner..."
-        call :verify_line * r "Exception in thread "
-        call :verify_line * r "	at net\.sf\.saxon\.Transform\.main\("
-        call :verify_line * r "Caused by: java\.lang\.ClassNotFoundException: org\.xmlresolver\.Resolver"
-    )
+    rem If Java located net.sf.saxon.Transform.main, then it means CLI constructed SAXON_CP from SAXON_HOME successfully.
+    rem ClassNotFoundException for org.xmlresolver.Resolver is expected, as XMLResolver.org XML Resolver jar is missing
+    rem from SAXON_HOME/lib/ subdirectory deliberately.
+    call :verify_retval 1
+    call :verify_line * x "Creating Test Runner..."
+    call :verify_line * r "Exception in thread "
+    call :verify_line * r "	at net\.sf\.saxon\.Transform\.main\("
+    call :verify_line * r "Caused by: java\.lang\.ClassNotFoundException: org\.xmlresolver\.Resolver"
 	</case>
 
 	<!--

--- a/test/win-bats/collection.xml
+++ b/test/win-bats/collection.xml
@@ -1740,7 +1740,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         "%SPACE_DIR%\catalog-01_stylesheet.xspec"
@@ -1755,7 +1754,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         -q ^
@@ -1771,7 +1769,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml" ^
         -s ^
@@ -1787,7 +1784,6 @@
     call :copy catalog\catalog-03* "%SPACE_DIR%"
     call :copy catalog\03          "%SPACE_DIR%\03"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "catalog\03\catalog-public.xml;%SPACE_DIR%\03\catalog-rewriteURI.xml" ^
         -s ^
@@ -1819,7 +1815,6 @@
 	-->
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with -catalog file URI (XSLT)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         catalog\catalog-01_stylesheet.xspec
@@ -1828,7 +1823,6 @@
 	</case>
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with -catalog file URI (XQuery)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -q ^
@@ -1838,7 +1832,6 @@
 	</case>
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with -catalog file URI (Schematron)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml" ^
         -s ^
@@ -1848,7 +1841,6 @@
 	</case>
 
 	<case ifdef="BASEX_JAR" name="CLI with -catalog file URI (Schematron via XQS)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "file:///%CD:\=/%/catalog/03/catalog-public.xml;file:///%CD:\=/%/catalog/03/catalog-rewriteURI.xml" ^
         -s ^
@@ -1880,7 +1872,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat "%SPACE_DIR%\catalog-01_stylesheet.xspec"
@@ -1895,7 +1886,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -q "%SPACE_DIR%\catalog-01_query.xspec"
@@ -1910,7 +1900,6 @@
     call :copy catalog\catalog-01* "%SPACE_DIR%"
     call :copy catalog\01          "%SPACE_DIR%\01"
 
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-public.xml;%SPACE_DIR%\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "%SPACE_DIR%\catalog-01_schematron.xspec"
@@ -1940,7 +1929,6 @@
 	-->
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with XML_CATALOG file URI (XSLT)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat "catalog\catalog-01_stylesheet.xspec"
@@ -1949,7 +1937,6 @@
 	</case>
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with XML_CATALOG file URI (XQuery)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -q "catalog\catalog-01_query.xspec"
@@ -1958,7 +1945,6 @@
 	</case>
 
 	<case ifdef="SAXON_BUG_7127_FIXED" name="CLI with XML_CATALOG file URI (Schematron)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=file:///%CD:\=/%/catalog/01/catalog-public.xml;file:///%CD:\=/%/catalog/01/catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "catalog\catalog-01_schematron.xspec"
@@ -1982,7 +1968,6 @@
 	-->
 
 	<case name="$x:xspec-uri with file imported via XML Catalog (XSLT)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat "catalog\catalog-01_xspec-uri.xspec"
@@ -1991,7 +1976,6 @@
 	</case>
 
 	<case name="$x:xspec-uri with file imported via XML Catalog (XQuery)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -q "catalog\catalog-01_xspec-uri.xspec"
@@ -2000,7 +1984,6 @@
 	</case>
 
 	<case name="$x:xspec-uri with file imported via XML Catalog (Schematron)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     set "XML_CATALOG=catalog\01\catalog-rewriteURI.xml"
 
     call :run ..\bin\xspec.bat -s "catalog\catalog-01_xspec-uri.xspec"
@@ -2060,7 +2043,6 @@
 	-->
 
 	<case name="Catalog Saxon bug 3025 (CLI)">
-    set "SAXON_CP=%SAXON_CP%;%APACHE_XMLRESOLVER_JAR%"
     call :run ..\bin\xspec.bat ^
         -catalog "%CD%\catalog\02\catalog.xml" ^
         catalog\catalog-02.xspec

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2349,24 +2349,14 @@ load bats-helper
 
 #
 # SAXON_HOME (CLI)
-#
-#     * Saxon 10 and earlier: XSpec should find Apache XML Resolver jar (hardcoded as 'xml-resolver-1.2.jar') in same directory as Saxon jar file.
-#     * Saxon 11 and later: XSpec does not care about XMLResolver.org XML Resolver jar file location. XSpec user should make sure it's available.
+#     Note: In Saxon 11 and later, XSpec does not care about XMLResolver.org XML Resolver jar file location. XSpec user should make sure it's available.
 #
 
-@test "invoking xspec using SAXON_HOME finds Saxon jar and Apache XML Resolver jar" {
+@test "invoking xspec using SAXON_HOME finds Saxon jar" {
     # Set up SAXON_HOME
     export SAXON_HOME="${work_dir}/saxon ${RANDOM}"
     mkdir "${SAXON_HOME}"
     cp "${SAXON_JAR}" "${SAXON_HOME}"
-
-    # Apache XML Resolver
-    if [ "${SAXON_VERSION:0:3}" != "10." ]; then
-        unset APACHE_XMLRESOLVER_JAR
-    fi
-    if [ -n "${APACHE_XMLRESOLVER_JAR}" ]; then
-        cp "${APACHE_XMLRESOLVER_JAR}" "${SAXON_HOME}/xml-resolver-1.2.jar"
-    fi
 
     # Unset SAXON_CP, otherwise SAXON_HOME is ignored.
     unset SAXON_CP
@@ -2381,18 +2371,13 @@ load bats-helper
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_stylesheet.xspec
-    if [ -n "${APACHE_XMLRESOLVER_JAR}" ]; then
-        [ "$status" -eq 0 ]
-        [ "${lines[20]}" = "passed: 5 / pending: 0 / failed: 0 / total: 5" ]
-    else
-        # If Java located net.sf.saxon.Transform.main, then it means CLI constructed SAXON_CP from SAXON_HOME successfully.
-        # ClassNotFoundException for org.xmlresolver.Resolver (Saxon 12) or org.xmlresolver.ResolverConfiguration (Saxon 13)
-        # is expected, as XMLResolver.org XML Resolver jar is missing from SAXON_HOME/lib/ subdirectory deliberately.
-        [ "$status" -eq 1 ]
-        assert_regex "${output}" $'\n''Creating Test Runner\.\.\.'$'\n''Exception in thread '
-        assert_regex "${output}" $'\n\t''at net\.sf\.saxon\.Transform\.main\('
-        assert_regex "${output}" $'\n''Caused by: java\.lang\.ClassNotFoundException: org\.xmlresolver\.Resolver(Configuration)?'$'\n'
-    fi
+    # If Java located net.sf.saxon.Transform.main, then it means CLI constructed SAXON_CP from SAXON_HOME successfully.
+    # ClassNotFoundException for org.xmlresolver.Resolver (Saxon 12) or org.xmlresolver.ResolverConfiguration (Saxon 13)
+    # is expected, as XMLResolver.org XML Resolver jar is missing from SAXON_HOME/lib/ subdirectory deliberately.
+    [ "$status" -eq 1 ]
+    assert_regex "${output}" $'\n''Creating Test Runner\.\.\.'$'\n''Exception in thread '
+    assert_regex "${output}" $'\n\t''at net\.sf\.saxon\.Transform\.main\('
+    assert_regex "${output}" $'\n''Caused by: java\.lang\.ClassNotFoundException: org\.xmlresolver\.Resolver(Configuration)?'$'\n'
 }
 
 #

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -2006,7 +2006,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         "${space_dir}/catalog-01_stylesheet.xspec"
@@ -2028,7 +2027,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         -q \
@@ -2051,7 +2049,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml" \
         -s \
@@ -2073,7 +2070,6 @@ load bats-helper
     cp catalog/catalog-03* "${space_dir}"
     cp catalog/03/* "${space_dir}/03"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "catalog/03/catalog-public.xml;${space_dir}/03/catalog-rewriteURI.xml" \
         -s \
@@ -2116,7 +2112,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         catalog/catalog-01_stylesheet.xspec
@@ -2129,7 +2124,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -q \
@@ -2143,7 +2137,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml" \
         -s \
@@ -2156,7 +2149,6 @@ load bats-helper
     if [ -z "${BASEX_JAR}" ]; then
         skip "BASEX_JAR is not defined"
     fi
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "file:${PWD}/catalog/03/catalog-public.xml;file:${PWD}/catalog/03/catalog-rewriteURI.xml" \
         -s \
@@ -2199,7 +2191,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh "${space_dir}/catalog-01_stylesheet.xspec"
@@ -2221,7 +2212,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -q "${space_dir}/catalog-01_query.xspec"
@@ -2243,7 +2233,6 @@ load bats-helper
     cp catalog/catalog-01* "${space_dir}"
     cp catalog/01/* "${space_dir}/01"
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-public.xml;${space_dir}/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -s "${space_dir}/catalog-01_schematron.xspec"
@@ -2284,7 +2273,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh "catalog/catalog-01_stylesheet.xspec"
@@ -2297,7 +2285,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -q "catalog/catalog-01_query.xspec"
@@ -2310,7 +2297,6 @@ load bats-helper
         skip "Saxon bug 7127"
     fi
 
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="file:${PWD}/catalog/01/catalog-public.xml;file:${PWD}/catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -s "catalog/catalog-01_schematron.xspec"
@@ -2338,7 +2324,6 @@ load bats-helper
 #
 
 @test "$x:xspec-uri with file imported via XML Catalog (XSLT)" {
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh "catalog/catalog-01_xspec-uri.xspec"
@@ -2347,7 +2332,6 @@ load bats-helper
 }
 
 @test "$x:xspec-uri with file imported via XML Catalog (XQuery)" {
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -q "catalog/catalog-01_xspec-uri.xspec"
@@ -2356,7 +2340,6 @@ load bats-helper
 }
 
 @test "$x:xspec-uri with file imported via XML Catalog (Schematron)" {
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     export XML_CATALOG="catalog/01/catalog-rewriteURI.xml"
 
     myrun ../bin/xspec.sh -s "catalog/catalog-01_xspec-uri.xspec"
@@ -2419,7 +2402,6 @@ load bats-helper
 #
 
 @test "Catalog Saxon bug 3025 (CLI)" {
-    export SAXON_CP="${SAXON_CP}:${APACHE_XMLRESOLVER_JAR}"
     myrun ../bin/xspec.sh \
         -catalog "${PWD}/catalog/02/catalog.xml" \
         catalog/catalog-02.xspec


### PR DESCRIPTION
Similar to https://github.com/xspec/xspec/issues/2301#issuecomment-4314611140 but applying to `xspec.bat` and `xspec.sh` (command line interface, CLI): Saxon 12 and 13 come with [XML resolver](https://github.com/xmlresolver/xmlresolver). I wondered if this XML resolver could be used with the XSpec command scripts and if the [Prerequisite](https://github.com/xspec/xspec/wiki/XML-Catalog-Support) listed in the Wiki, https://repo1.maven.org/maven2/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar is not needed.

In this pull request, 86e3804513f8662e793e17304f08590503e60539 stops adding the Apache resolver to the classpath in all the test cases that use `xspec.bat`/`xspec.sh`. The test cases still pass. a26a45746c5e2ef937fe31383df6b5c716215162 is not related except that the word Apache drew my eye and I realized some code was outdated.

Unless there is a reason to keep adding the Apache resolver to the classpath and telling CLI users to do so, we should adopt this PR and update the [XML Catalog Support](https://github.com/xspec/xspec/wiki/XML-Catalog-Support) page.