### PR TITLE
docs(xproc): add BaseX harness content to XProc 1 archive readme

### DIFF
--- a/misc/archive/src/harnesses/README.md
+++ b/misc/archive/src/harnesses/README.md
@@ -1,6 +1,6 @@
 This page archives the instructions for the XSpec test harnesses that use XProc 1 with Saxon or BaseX. These harnesses worked as of XSpec v4.0.3 but are no longer being tested or supported.
 
-## Run an XSpec test with XProc version 1
+## Run an XSpec test with XProc version 1 and Saxon
 
 As an example, this description uses [XML Calabash 1](https://xmlcalabash.com/archive-1.x/) with the Saxon XProc harness ([for XSLT](https://github.com/xspec/xspec/blob/main/misc/archive/src/harnesses/saxon/saxon-xslt-harness.xproc) or [for XQuery](https://github.com/xspec/xspec/blob/main/misc/archive/src/harnesses/saxon/saxon-xquery-harness.xproc)). Harnesses for BaseX are also [available](https://github.com/xspec/xspec/tree/main/misc/archive/src/harnesses).
 
@@ -95,3 +95,99 @@ As an example, this description uses [XML Calabash 1](https://xmlcalabash.com/ar
    ```console
    INFO : misc/archive/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1
    ```
+
+## Run an XSpec test with XProc version 1 and BaseX
+
+The XSpec distribution has dedicated XProc 1 harnesses for BaseX, described next.
+
+### Dependencies
+
+[XML Calabash 1](https://www.xmlcalabash.com/archive-1.x/) is used here as an example; follow [these instructions](https://github.com/xspec/xspec/wiki/Running-with-XProc#run-an-xspec-test-with-xproc-version-1) to set up XML Calabash and store the XML Calabash jar file in a local directory (e.g. `~/xml/xmlcalabash` for Linux/macOS or `C:\xmlcalabash` for Windows).
+
+### Run an XSpec test for XQuery with BaseX standalone
+
+1. Download the [ZIP package of BaseX](https://basex.org/download/) and extract it to a local directory (e.g. `~/xml/basex` for Linux/macOS or `C:\basex` for Windows).
+
+1. Make sure a required version of [Java Runtime Environment](Requirements#java) is installed, e.g.:
+
+   ```console
+   java -version
+   ```
+
+1. Make sure XSpec is available in a local path (e.g. `~/xml/xspec` for Linux/macOS or `C:\xspec` for Windows).
+1. Navigate to your XSpec directory.
+1. Run an XSpec test for XQuery as follows:
+
+   For Linux/macOS:
+
+   ```bash
+   java -jar ~/xml/xmlcalabash/xmlcalabash-1.2.5-99.jar \
+        -i source=tutorial/xquery-tutorial.xspec \
+        -p xspec-home=file:/home/myself/xml/xspec/ \
+        -p basex-jar=/home/myself/xml/basex/BaseX.jar \
+        -o result=tutorial/xquery-tutorial-result.html \
+        misc/archive/src/harnesses/basex/basex-standalone-xquery-harness.xproc
+   ```
+
+   For Windows:
+
+   ```winbatch
+   java -jar C:\xmlcalabash\xmlcalabash-1.2.5-99.jar ^
+        -i source=tutorial/xquery-tutorial.xspec ^
+        -p xspec-home=file:///C:/xspec/ ^
+        -p basex-jar=C:\basex\BaseX.jar ^
+        -o result=tutorial/xquery-tutorial-result.html ^
+        misc\archive\src\harnesses\basex\basex-standalone-xquery-harness.xproc
+   ```
+
+   where:
+
+   - `-jar` is the XML Calabash jar file
+   - `-i source` is the input port with the XSpec test for XQuery to be executed
+   - `-o result` is the output port where the HTML report will be stored
+   - `-p xspec-home` is the absolute URI of the XSpec installation
+   - `-p basex-jar` is the jar file of BaseX
+   - `basex-standalone-xquery-harness.xproc` is the XProc harness for BaseX standalone
+
+The output result from the command line may look like this:
+
+```console
+INFO : misc/archive/src/harnesses/harness-lib.xpl:267:45:passed: 1 / pending: 0 / failed: 0 / total: 1
+```
+
+And the HTML report file is created in the location specified by `-o result=`.
+
+### Run an XSpec test for XQuery with BaseX server
+
+To run XSpec with BaseX server using its RESTful API, run XProc just like [the steps with BaseX standalone](#run-an-xspec-test-for-xquery-with-basex-standalone) but with these differences:
+
+- Instead of the `basex-jar` parameter, provide `endpoint`, `username`, `password` and `auth-method`
+- Instead of the `basex-standalone-xquery-harness.xproc` harness, use `basex-server-xquery-harness.xproc`
+
+For Linux/macOS:
+
+```bash
+java -jar ~/xml/xmlcalabash/xmlcalabash-1.2.5-99.jar \
+     -i source=tutorial/xquery-tutorial.xspec \
+     -p xspec-home=file:/home/myself/xml/xspec/ \
+     -p endpoint=http://localhost:8984/rest \
+     -p username=admin \
+     -p password=admin \
+     -p auth-method=Basic \
+     -o result=tutorial/xquery-tutorial-result.html \
+     misc/archive/src/harnesses/basex/basex-server-xquery-harness.xproc
+```
+
+For Windows:
+
+```winbatch
+java -jar C:\xmlcalabash\xmlcalabash-1.2.5-99.jar ^
+     -i source=tutorial/xquery-tutorial.xspec ^
+     -p xspec-home=file:///C:/xspec/ ^
+     -p endpoint=http://localhost:8984/rest ^
+     -p username=admin ^
+     -p password=admin ^
+     -p auth-method=Basic ^
+     -o result=tutorial/xquery-tutorial-result.html ^
+     misc\archive\src\harnesses\basex\basex-server-xquery-harness.xproc
+```

--- a/misc/archive/src/harnesses/README.md
+++ b/misc/archive/src/harnesses/README.md
@@ -191,3 +191,4 @@ java -jar C:\xmlcalabash\xmlcalabash-1.2.5-99.jar ^
      -o result=tutorial/xquery-tutorial-result.html ^
      misc\archive\src\harnesses\basex\basex-server-xquery-harness.xproc
 ```
+(Note: For BaseX 10.0 and later, specify `localhost:8080` instead of `localhost:8984` in the commands above.)

--- a/misc/archive/src/harnesses/README.md
+++ b/misc/archive/src/harnesses/README.md
@@ -141,7 +141,6 @@ The XSpec distribution has dedicated XProc 1 harnesses for BaseX, described next
    ```
 
    where:
-
    - `-jar` is the XML Calabash jar file
    - `-i source` is the input port with the XSpec test for XQuery to be executed
    - `-o result` is the output port where the HTML report will be stored
@@ -191,4 +190,5 @@ java -jar C:\xmlcalabash\xmlcalabash-1.2.5-99.jar ^
      -o result=tutorial/xquery-tutorial-result.html ^
      misc\archive\src\harnesses\basex\basex-server-xquery-harness.xproc
 ```
+
 (Note: For BaseX 10.0 and later, specify `localhost:8080` instead of `localhost:8984` in the commands above.)


### PR DESCRIPTION
This pull request is a follow-up to #2391.

- "Run an XSpec test with XProc version 1 and BaseX" section is from the Running-with-BaseX.md wiki page
- I updated paths to the harness files to reflect the `misc/archive/` location
- I ran the sample commands on Windows using XML Calabash 1.5.7-120 and BaseX 12.0.
 
In the case of the server harness, I first started the server using
```
set BASEX_HOME=%BASEX_JAR%\..
"%BASEX_HOME%\bin\basexhttp.bat" -S
```
and then, in the java command, changed the port number to 8080 because that's what BaseX uses starting from [version 10.0](https://github.com/BaseXdb/basex/blob/main/CHANGELOG).


I will remove the [XProc 1](https://github.com/xspec/xspec/wiki/Running-with-BaseX#xproc-1) section of the Running with BaseX wiki page after merging this PR.