### PR TITLE
feat(oxygen): transformation scenario to test Schematron using XProc

### DIFF
--- a/xspec.framework
+++ b/xspec.framework
@@ -619,6 +619,181 @@
 									</xprocOption-array>
 								</field>
 								<field name="xprocParameters">
+									<xprocParameterPort-array>
+										<xprocParameterPort>
+											<field name="portName">
+												<String>*</String>
+											</field>
+											<field name="parameters">
+												<xprocParameter-array/>
+											</field>
+										</xprocParameterPort>
+									</xprocParameterPort-array>
+								</field>
+								<field name="configFile">
+									<String></String>
+								</field>
+								<field name="advancedOptionsMap">
+									<null/>
+								</field>
+								<field name="name">
+									<String>XSpec for Schematron using XProc and XSLT</String>
+								</field>
+								<field name="baseURL">
+									<null/>
+								</field>
+								<field name="footerURL">
+									<null/>
+								</field>
+								<field name="fOPMethod">
+									<null/>
+								</field>
+								<field name="fOProcessorName">
+									<null/>
+								</field>
+								<field name="headerURL">
+									<null/>
+								</field>
+								<field name="inputXSLURL">
+									<String>${framework}/src/xproc3/run-schematron.xpl</String>
+								</field>
+								<field name="inputXMLURL">
+									<String></String>
+								</field>
+								<field name="defaultScenario">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="isFOPPerforming">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="type">
+									<String>XPROC</String>
+								</field>
+								<field name="saveAs">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="openInBrowser">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="outputResource">
+									<null/>
+								</field>
+								<field name="openOtherLocationInBrowser">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="locationToOpenInBrowserURL">
+									<String>${cfdu}/${cfn}-result.html</String>
+								</field>
+								<field name="openInEditor">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInHTMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInXMLPane">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="showInSVGPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInResultSetPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="useXSLTInput">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="xsltParams">
+									<list/>
+								</field>
+								<field name="cascadingStylesheets">
+									<String-array/>
+								</field>
+								<field name="xslTransformer">
+									<String>XML Calabash 3.X</String>
+								</field>
+								<field name="extensionURLs">
+									<String-array/>
+								</field>
+							</xprocScenario>
+							<xprocScenario>
+								<field name="inputPorts">
+									<xprocInputPort-array>
+										<xprocInputPort>
+											<field name="urls">
+												<String-array>
+													<String>${currentFileURL}</String>
+												</String-array>
+											</field>
+											<field name="portName">
+												<String>source</String>
+											</field>
+										</xprocInputPort>
+									</xprocInputPort-array>
+								</field>
+								<field name="outputPorts">
+									<xprocOutputPort-array>
+										<xprocOutputPort>
+											<field name="url">
+												<String>${cfdu}/${cfn}-result.html</String>
+											</field>
+											<field name="showInSequenceView">
+												<Boolean>false</Boolean>
+											</field>
+											<field name="portName">
+												<String>result</String>
+											</field>
+										</xprocOutputPort>
+									</xprocOutputPort-array>
+								</field>
+								<field name="xprocOptions">
+									<xprocOption-array>
+										<xprocOption>
+											<field name="namespaceURI">
+												<String></String>
+											</field>
+											<field name="localName">
+												<String>xspec-home</String>
+											</field>
+											<field name="value">
+												<String>${framework}/</String>
+											</field>
+										</xprocOption>
+										<xprocOption>
+											<field name="namespaceURI">
+												<String></String>
+											</field>
+											<field name="localName">
+												<String>force-focus</String>
+											</field>
+											<field name="value">
+												<String></String>
+											</field>
+										</xprocOption>
+										<xprocOption>
+											<field name="namespaceURI">
+												<String></String>
+											</field>
+											<field name="localName">
+												<String>html-report-theme</String>
+											</field>
+											<field name="value">
+												<String>default</String>
+											</field>
+										</xprocOption>
+										<xprocOption>
+											<field name="namespaceURI">
+												<String></String>
+											</field>
+											<field name="localName">
+												<String>inline-css</String>
+											</field>
+											<field name="value">
+												<String>false</String>
+											</field>
+										</xprocOption>
+									</xprocOption-array>
+								</field>
+								<field name="xprocParameters">
 									<xprocParameterPort-array/>
 								</field>
 								<field name="configFile">


### PR DESCRIPTION
This pull request adds an XProc-based transformation scenario to the Oxygen framework for XSpec. The new transformation scenario runs an XSpec test for a Schematron schema that has an XSLT-based query binding.

I sanity-checked the new transformation scenario interactively on Windows, including using the GUI to modify some option values: `html-report-theme`, `schxslt2-transpiler`, and `junit-enabled`.

The Oxygen and XML Calabash versions I tried were:

- Oxygen 28.0, which includes XML Calabash 3.0.25
- Oxygen 28.1, which includes XML Calabash 3.0.38

Here's how I modified the framework file in this PR:

1. In Oxygen 28.1 document type associations, duplicated the "XSpec for XProc using XProc" transformation scenario. Gave the copy a new name and pointed it to the `run-schematron.xpl` pipeline.
2. Removed the `parameters` option that isn't present in `run-schematron.xpl`.

Cc: @birdya22 , @martian-a
