### PR TITLE
ci: skip oxygen testing on Java 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         exclude:
           - os: macos-latest
             env: oxygen
+          - java: 17
+            env: oxygen
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
According to Oxygen XML Editor 28.1 documentation pages about [Windows](https://www.oxygenxml.com/doc/versions/28.1/ug-editor/topics/eppo-installation-windows.html#eppo-installation-windows__dlentry_otm_bgk_54b) and [Linux](https://www.oxygenxml.com/doc/versions/28.1/ug-editor/topics/eppo-installation-linux.html#eppo-installation-linux__dlentry_bxm_bgk_54b), the product officially supports only Java 21. This pull request removes testing configurations for the "oxygen" + Java 17 combination.

