### PR TITLE
ci(deps): bump XMLResolver.org XML Resolver from 6.0.23 to 6.1.0

### DIFF
--- a/test/ci/env/global.env
+++ b/test/ci/env/global.env
@@ -20,4 +20,4 @@ XMLCALABASH3_VERSION=
 
 # Latest XMLResolver.org XML Resolver
 # Required by XML Calabash, even when not required by Saxon.
-XMLRESOLVERORG_XMLRESOLVER_VERSION=6.0.23
+XMLRESOLVERORG_XMLRESOLVER_VERSION=6.1.0


### PR DESCRIPTION
This pull request makes the `saxon-12` and `saxon-13` testing environments use XML Resolver 6.1.0.

The `oxygen` testing environment is unchanged. 